### PR TITLE
tests: Switch CI to Debian Trixie

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -522,7 +522,7 @@ jobs:
       # Our runner has 16 cores (nproc).
       # We limit parallelism only to avoid exhausting disk space and memory
       # resources, not to save CPU resources.
-      PARALLEL_INTEGRATION_TESTS_NUM: 12
+      PARALLEL_INTEGRATION_TESTS_NUM: 1
     runs-on: garm-jammy-16
     steps:
       - name: Code checkout
@@ -559,7 +559,7 @@ jobs:
       # Our runner has 16 cores (nproc).
       # We limit parallelism only to avoid exhausting disk space and memory
       # resources, not to save CPU resources.
-      PARALLEL_INTEGRATION_TESTS_NUM: 12
+      PARALLEL_INTEGRATION_TESTS_NUM: 1
     strategy:
       fail-fast: false
       matrix:

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -303,7 +303,7 @@ pub(crate) fn test_cpu_topology(
     packages: u8,
     use_fw: bool,
 ) {
-    let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
     let total_vcpus = threads_per_core * cores_per_package * packages;
     let direct_kernel_boot_path = direct_kernel_boot_path();
@@ -422,7 +422,7 @@ pub(crate) fn test_cpu_topology(
 
 #[allow(unused_variables)]
 pub(crate) fn _test_guest_numa_nodes(acpi: bool) {
-    let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
     let api_socket = temp_api_path(&guest.tmp_dir);
     #[cfg(target_arch = "x86_64")]
@@ -529,7 +529,7 @@ pub(crate) fn test_vhost_user_net(
     generate_host_mac: bool,
     client_mode_daemon: bool,
 ) {
-    let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
     let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -700,7 +700,7 @@ pub(crate) fn test_vhost_user_blk(
     direct: bool,
     prepare_vhost_user_blk_daemon: Option<&PrepareBlkDaemon>,
 ) {
-    let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
     let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -842,7 +842,7 @@ pub(crate) fn test_boot_from_vhost_user_blk(
     direct: bool,
     prepare_vhost_user_blk_daemon: Option<&PrepareBlkDaemon>,
 ) {
-    let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
 
     let kernel_path = direct_kernel_boot_path();
@@ -911,7 +911,7 @@ pub(crate) fn _test_virtio_fs(
     use_generic_vhost_user: bool,
     pci_segment: Option<u16>,
 ) {
-    let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
     let api_socket = temp_api_path(&guest.tmp_dir);
     let event_path = temp_event_monitor_path(&guest.tmp_dir);
@@ -1150,7 +1150,7 @@ pub(crate) fn _test_virtio_fs(
 }
 
 pub(crate) fn test_virtio_pmem(discard_writes: bool, specify_size: bool) {
-    let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
 
     let kernel_path = direct_kernel_boot_path();
@@ -1291,7 +1291,7 @@ pub(crate) fn test_memory_mergeable(mergeable: bool) {
     // We assume the number of shared pages in the rest of the system to be constant
     let ksm_ps_init = get_ksm_pages_shared();
 
-    let disk_config1 = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let disk_config1 = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let guest1 = Guest::new(Box::new(disk_config1));
     let mut child1 = GuestCommand::new(&guest1)
         .default_cpus()
@@ -1317,7 +1317,7 @@ pub(crate) fn test_memory_mergeable(mergeable: bool) {
 
     let ksm_ps_guest1 = get_ksm_pages_shared();
 
-    let disk_config2 = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let disk_config2 = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let guest2 = Guest::new(Box::new(disk_config2));
     let mut child2 = GuestCommand::new(&guest2)
         .default_cpus()
@@ -1363,7 +1363,7 @@ pub(crate) fn test_memory_mergeable(mergeable: bool) {
 // interface attached to the virtual IOMMU since this is the one used to
 // send all commands through SSH.
 pub(crate) fn _test_virtio_iommu(_acpi: bool /* not needed on x86_64 */) {
-    let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
 
     #[cfg(target_arch = "x86_64")]

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -303,7 +303,7 @@ pub(crate) fn test_cpu_topology(
     packages: u8,
     use_fw: bool,
 ) {
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
     let total_vcpus = threads_per_core * cores_per_package * packages;
     let direct_kernel_boot_path = direct_kernel_boot_path();
@@ -422,7 +422,7 @@ pub(crate) fn test_cpu_topology(
 
 #[allow(unused_variables)]
 pub(crate) fn _test_guest_numa_nodes(acpi: bool) {
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
     let api_socket = temp_api_path(&guest.tmp_dir);
     #[cfg(target_arch = "x86_64")]
@@ -529,7 +529,7 @@ pub(crate) fn test_vhost_user_net(
     generate_host_mac: bool,
     client_mode_daemon: bool,
 ) {
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
     let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -700,7 +700,7 @@ pub(crate) fn test_vhost_user_blk(
     direct: bool,
     prepare_vhost_user_blk_daemon: Option<&PrepareBlkDaemon>,
 ) {
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
     let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -842,7 +842,7 @@ pub(crate) fn test_boot_from_vhost_user_blk(
     direct: bool,
     prepare_vhost_user_blk_daemon: Option<&PrepareBlkDaemon>,
 ) {
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
 
     let kernel_path = direct_kernel_boot_path();
@@ -911,7 +911,7 @@ pub(crate) fn _test_virtio_fs(
     use_generic_vhost_user: bool,
     pci_segment: Option<u16>,
 ) {
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
     let api_socket = temp_api_path(&guest.tmp_dir);
     let event_path = temp_event_monitor_path(&guest.tmp_dir);
@@ -1150,7 +1150,7 @@ pub(crate) fn _test_virtio_fs(
 }
 
 pub(crate) fn test_virtio_pmem(discard_writes: bool, specify_size: bool) {
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
 
     let kernel_path = direct_kernel_boot_path();
@@ -1291,7 +1291,7 @@ pub(crate) fn test_memory_mergeable(mergeable: bool) {
     // We assume the number of shared pages in the rest of the system to be constant
     let ksm_ps_init = get_ksm_pages_shared();
 
-    let disk_config1 = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config1 = GuestDiskConfig::new(OS_IMAGE.to_string());
     let guest1 = Guest::new(Box::new(disk_config1));
     let mut child1 = GuestCommand::new(&guest1)
         .default_cpus()
@@ -1317,7 +1317,7 @@ pub(crate) fn test_memory_mergeable(mergeable: bool) {
 
     let ksm_ps_guest1 = get_ksm_pages_shared();
 
-    let disk_config2 = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config2 = GuestDiskConfig::new(OS_IMAGE.to_string());
     let guest2 = Guest::new(Box::new(disk_config2));
     let mut child2 = GuestCommand::new(&guest2)
         .default_cpus()
@@ -1363,7 +1363,7 @@ pub(crate) fn test_memory_mergeable(mergeable: bool) {
 // interface attached to the virtual IOMMU since this is the one used to
 // send all commands through SSH.
 pub(crate) fn _test_virtio_iommu(_acpi: bool /* not needed on x86_64 */) {
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let guest = Guest::new(Box::new(disk_config));
 
     #[cfg(target_arch = "x86_64")]

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -874,7 +874,7 @@ pub(crate) fn vm_state(api_socket: &str) -> String {
 }
 
 pub(crate) fn make_virtio_block_guest(factory: &GuestFactory, image_name: &str) -> Guest {
-    let disk_config = UbuntuDiskConfig::new(image_name.to_string());
+    let disk_config = GuestDiskConfig::new(image_name.to_string());
     factory.create_guest(Box::new(disk_config)).with_cpu(4)
 }
 

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -11599,35 +11599,37 @@ mod aarch64_acpi {
 
     #[test]
     fn test_simple_launch_acpi() {
-        let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
 
-        vec![Box::new(jammy)].drain(..).for_each(|disk_config| {
-            let guest = Guest::new(disk_config);
+        vec![Box::new(disk_config)]
+            .drain(..)
+            .for_each(|disk_config| {
+                let guest = Guest::new(disk_config);
 
-            let mut child = GuestCommand::new(&guest)
-                .default_cpus()
-                .default_memory()
-                .args(["--kernel", edk2_path().to_str().unwrap()])
-                .default_disks()
-                .default_net()
-                .args(["--serial", "tty", "--console", "off"])
-                .capture_output()
-                .spawn()
-                .unwrap();
+                let mut child = GuestCommand::new(&guest)
+                    .default_cpus()
+                    .default_memory()
+                    .args(["--kernel", edk2_path().to_str().unwrap()])
+                    .default_disks()
+                    .default_net()
+                    .args(["--serial", "tty", "--console", "off"])
+                    .capture_output()
+                    .spawn()
+                    .unwrap();
 
-            let r = std::panic::catch_unwind(|| {
-                guest.wait_vm_boot().unwrap();
+                let r = std::panic::catch_unwind(|| {
+                    guest.wait_vm_boot().unwrap();
 
-                assert_eq!(guest.get_cpu_count().unwrap_or_default(), 1);
-                assert!(guest.get_total_memory().unwrap_or_default() > 400_000);
-                assert_eq!(guest.get_pci_bridge_class().unwrap_or_default(), "0x060000");
+                    assert_eq!(guest.get_cpu_count().unwrap_or_default(), 1);
+                    assert!(guest.get_total_memory().unwrap_or_default() > 400_000);
+                    assert_eq!(guest.get_pci_bridge_class().unwrap_or_default(), "0x060000");
+                });
+
+                let _ = child.kill();
+                let output = child.wait_with_output().unwrap();
+
+                handle_child_output(r, &output);
             });
-
-            let _ = child.kill();
-            let output = child.wait_with_output().unwrap();
-
-            handle_child_output(r, &output);
-        });
     }
 
     #[test]

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -52,21 +52,21 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_jammy_hypervisor_fw() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME)
-            .with_kernel(fw_path(FwType::RustHypervisorFirmware));
+        let guest =
+            basic_regular_guest!(OS_IMAGE).with_kernel(fw_path(FwType::RustHypervisorFirmware));
         _test_simple_launch(&guest);
     }
 
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_jammy_ovmf() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_kernel(fw_path(FwType::Ovmf));
+        let guest = basic_regular_guest!(OS_IMAGE).with_kernel(fw_path(FwType::Ovmf));
         _test_simple_launch(&guest);
     }
 
     #[test]
     fn test_multi_cpu() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_multi_cpu(&guest);
     }
 
@@ -90,7 +90,7 @@ mod common_parallel {
     #[cfg(target_arch = "x86_64")]
     #[cfg(not(feature = "mshv"))]
     fn test_cpu_physical_bits() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let max_phys_bits: u8 = 36;
         let mut child = GuestCommand::new(&guest)
@@ -124,7 +124,7 @@ mod common_parallel {
     }
 
     fn _test_nested_virtualization(nested: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config)).with_nested(nested);
         let mut child = GuestCommand::new(&guest)
             .default_cpus()
@@ -170,20 +170,20 @@ mod common_parallel {
 
     #[test]
     fn test_cpu_affinity() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_cpu(2);
+        let guest = basic_regular_guest!(OS_IMAGE).with_cpu(2);
         _test_cpu_affinity(&guest);
     }
 
     #[test]
     fn test_virtio_queue_affinity() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_cpu(4);
+        let guest = basic_regular_guest!(OS_IMAGE).with_cpu(4);
         _test_virtio_queue_affinity(&guest);
     }
 
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_large_vm() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
         cmd.args(["--cpus", "boot=48"])
@@ -222,7 +222,7 @@ mod common_parallel {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_huge_memory() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
         cmd.default_cpus()
@@ -249,14 +249,14 @@ mod common_parallel {
 
     #[test]
     fn test_power_button() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_power_button(&guest);
     }
 
     #[test]
     #[cfg(not(feature = "mshv"))] // See #7456
     fn test_user_defined_memory_regions() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -342,7 +342,7 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_iommu_segments() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         // Prepare another disk file for the virtio-disk device
@@ -419,25 +419,25 @@ mod common_parallel {
 
     #[test]
     fn test_pci_msi() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_pci_msi(&guest);
     }
 
     #[test]
     fn test_virtio_net_ctrl_queue() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_virtio_net_ctrl_queue(&guest);
     }
 
     #[test]
     fn test_pci_multiple_segments() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_pci_multiple_segments(&guest, MAX_NUM_PCI_SEGMENTS, 15u16);
     }
 
     #[test]
     fn test_pci_multiple_segments_numa_node() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         #[cfg(target_arch = "x86_64")]
@@ -530,14 +530,14 @@ mod common_parallel {
 
     #[test]
     fn test_direct_kernel_boot() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_direct_kernel_boot(&guest);
     }
 
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_direct_kernel_boot_bzimage() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let mut kernel_path = direct_kernel_boot_path();
@@ -582,24 +582,21 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_io_uring() {
-        let guest =
-            make_virtio_block_guest(&GuestFactory::new_regular_guest_factory(), JAMMY_IMAGE_NAME);
+        let guest = make_virtio_block_guest(&GuestFactory::new_regular_guest_factory(), OS_IMAGE);
         _test_virtio_block(&guest, false, true, false, false, ImageType::Raw);
     }
 
     #[test]
     fn test_virtio_block_aio() {
-        let guest =
-            make_virtio_block_guest(&GuestFactory::new_regular_guest_factory(), JAMMY_IMAGE_NAME)
-                .with_cpu(4);
+        let guest = make_virtio_block_guest(&GuestFactory::new_regular_guest_factory(), OS_IMAGE)
+            .with_cpu(4);
         _test_virtio_block(&guest, true, false, false, false, ImageType::Raw);
     }
 
     #[test]
     fn test_virtio_block_sync() {
-        let guest =
-            make_virtio_block_guest(&GuestFactory::new_regular_guest_factory(), JAMMY_IMAGE_NAME)
-                .with_cpu(4);
+        let guest = make_virtio_block_guest(&GuestFactory::new_regular_guest_factory(), OS_IMAGE)
+            .with_cpu(4);
         _test_virtio_block(&guest, true, true, false, false, ImageType::Raw);
     }
 
@@ -645,7 +642,7 @@ mod common_parallel {
     //   - the BLKDISCARD / BLKZEROOUT additions to the VirtioBlock seccomp
     //     whitelist (any of these would otherwise SIGSYS the device thread).
     fn _test_virtio_block_blkdev(disable_io_uring: bool, disable_aio: bool) {
-        let focal = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let focal = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(focal));
         let loopdev = LoopDev::new(guest.tmp_dir.as_path(), 64);
         let kernel_path = direct_kernel_boot_path();
@@ -840,7 +837,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -849,7 +846,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2_zlib() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2_ZLIB.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2_ZLIB.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -860,7 +857,7 @@ mod common_parallel {
     fn test_virtio_block_qcow2_zstd() {
         let guest = make_virtio_block_guest(
             &GuestFactory::new_regular_guest_factory(),
-            JAMMY_IMAGE_NAME_QCOW2_ZSTD,
+            OS_IMAGE_QCOW2_ZSTD,
         );
         _test_virtio_block(&guest, false, false, true, false, ImageType::Qcow2);
     }
@@ -869,7 +866,7 @@ mod common_parallel {
     fn test_virtio_block_qcow2_backing_zstd_file() {
         let guest = make_virtio_block_guest(
             &GuestFactory::new_regular_guest_factory(),
-            JAMMY_IMAGE_NAME_QCOW2_BACKING_ZSTD_FILE,
+            OS_IMAGE_QCOW2_BACKING_ZSTD_FILE,
         );
         _test_virtio_block(&guest, false, false, true, true, ImageType::Qcow2);
     }
@@ -878,7 +875,7 @@ mod common_parallel {
     fn test_virtio_block_qcow2_backing_uncompressed_file() {
         let guest = make_virtio_block_guest(
             &GuestFactory::new_regular_guest_factory(),
-            JAMMY_IMAGE_NAME_QCOW2_BACKING_UNCOMPRESSED_FILE,
+            OS_IMAGE_QCOW2_BACKING_UNCOMPRESSED_FILE,
         );
         _test_virtio_block(&guest, false, false, true, true, ImageType::Qcow2);
     }
@@ -887,7 +884,7 @@ mod common_parallel {
     fn test_virtio_block_qcow2_backing_raw_file() {
         let guest = make_virtio_block_guest(
             &GuestFactory::new_regular_guest_factory(),
-            JAMMY_IMAGE_NAME_QCOW2_BACKING_RAW_FILE,
+            OS_IMAGE_QCOW2_BACKING_RAW_FILE,
         );
         _test_virtio_block(&guest, false, false, true, true, ImageType::Qcow2);
     }
@@ -908,7 +905,7 @@ mod common_parallel {
     where
         F: FnOnce(&Guest) + std::panic::UnwindSafe,
     {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -1505,7 +1502,7 @@ mod common_parallel {
         // Regression test for #8007.
         // Place the QCOW2 OS image on a 4096 byte sector filesystem so
         // O_DIRECT forces 4096 byte alignment on all I/O buffers.
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = edk2_path();
 
@@ -1591,7 +1588,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2_dirty_bit_unclean_shutdown() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -1654,7 +1651,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2_dirty_bit_clean_shutdown() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -1713,7 +1710,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2_corrupt_bit_rejected_for_write() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -1769,7 +1766,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2_corrupt_bit_allowed_readonly() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -1845,8 +1842,8 @@ mod common_parallel {
 
         let mut raw_file_path = workload_path.clone();
         let mut vhd_file_path = workload_path;
-        raw_file_path.push(JAMMY_IMAGE_NAME);
-        vhd_file_path.push(JAMMY_IMAGE_NAME_VHD);
+        raw_file_path.push(OS_IMAGE);
+        vhd_file_path.push(OS_IMAGE_VHD);
 
         // Generate VHD file from RAW file
         std::process::Command::new("qemu-img")
@@ -1859,10 +1856,8 @@ mod common_parallel {
             .arg(vhd_file_path.to_str().unwrap())
             .output()
             .expect("Expect generating VHD image from RAW image");
-        let guest = make_virtio_block_guest(
-            &GuestFactory::new_regular_guest_factory(),
-            JAMMY_IMAGE_NAME_VHD,
-        );
+        let guest =
+            make_virtio_block_guest(&GuestFactory::new_regular_guest_factory(), OS_IMAGE_VHD);
         _test_virtio_block(&guest, false, false, false, false, ImageType::FixedVhd);
     }
 
@@ -1873,8 +1868,8 @@ mod common_parallel {
 
         let mut raw_file_path = workload_path.clone();
         let mut vhdx_file_path = workload_path;
-        raw_file_path.push(JAMMY_IMAGE_NAME);
-        vhdx_file_path.push(JAMMY_IMAGE_NAME_VHDX);
+        raw_file_path.push(OS_IMAGE);
+        vhdx_file_path.push(OS_IMAGE_VHDX);
 
         // Generate dynamic VHDX file from RAW file
         std::process::Command::new("qemu-img")
@@ -1886,22 +1881,20 @@ mod common_parallel {
             .arg(vhdx_file_path.to_str().unwrap())
             .output()
             .expect("Expect generating dynamic VHDx image from RAW image");
-        let guest = make_virtio_block_guest(
-            &GuestFactory::new_regular_guest_factory(),
-            JAMMY_IMAGE_NAME_VHDX,
-        );
+        let guest =
+            make_virtio_block_guest(&GuestFactory::new_regular_guest_factory(), OS_IMAGE_VHDX);
         _test_virtio_block(&guest, false, false, true, false, ImageType::Vhdx);
     }
 
     #[test]
     fn test_virtio_block_dynamic_vhdx_expand() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_virtio_block_dynamic_vhdx_expand(&guest);
     }
 
     #[test]
     fn test_virtio_block_direct_and_firmware() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         // The OS disk must be copied to a location that is not backed by
@@ -2025,14 +2018,14 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_split_irqchip() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_split_irqchip(&guest);
     }
 
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_dmi_serial_number() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
 
         _test_dmi_serial_number(&guest);
     }
@@ -2040,21 +2033,21 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_dmi_uuid() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_dmi_uuid(&guest);
     }
 
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_dmi_oem_strings() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_dmi_oem_strings(&guest);
     }
 
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_dmi_system_and_chassis() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_dmi_system_and_chassis(&guest);
     }
 
@@ -2100,7 +2093,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_rtc() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let kernel_path = direct_kernel_boot_path();
@@ -2174,7 +2167,7 @@ mod common_parallel {
 
     #[test]
     fn test_boot_from_virtio_pmem() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let kernel_path = direct_kernel_boot_path();
@@ -2229,14 +2222,14 @@ mod common_parallel {
 
     #[test]
     fn test_multiple_network_interfaces() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_multiple_network_interfaces(&guest);
     }
 
     #[test]
     #[cfg(target_arch = "aarch64")]
     fn test_pmu_on() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut child = GuestCommand::new(&guest)
             .default_cpus()
@@ -2272,13 +2265,13 @@ mod common_parallel {
 
     #[test]
     fn test_serial_off() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_serial_off(&guest);
     }
 
     #[test]
     fn test_serial_null() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
         #[cfg(target_arch = "x86_64")]
@@ -2331,7 +2324,7 @@ mod common_parallel {
 
     #[test]
     fn test_serial_tty() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let kernel_path = direct_kernel_boot_path();
@@ -2390,7 +2383,7 @@ mod common_parallel {
 
     #[test]
     fn test_serial_file() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let serial_path = guest.tmp_dir.as_path().join("serial-output");
@@ -2458,7 +2451,7 @@ mod common_parallel {
 
     #[test]
     fn test_pty_interaction() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         let serial_option = if cfg!(target_arch = "x86_64") {
@@ -2504,7 +2497,7 @@ mod common_parallel {
 
     #[test]
     fn test_serial_socket_interaction() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let serial_socket = guest.tmp_dir.as_path().join("serial.socket");
         let serial_socket_pty = guest.tmp_dir.as_path().join("serial.pty");
@@ -2574,13 +2567,13 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_console() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_virtio_console(&guest);
     }
 
     #[test]
     fn test_console_file() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_console_file(&guest);
     }
 
@@ -2600,7 +2593,7 @@ mod common_parallel {
     fn test_vfio() {
         setup_vfio_network_interfaces();
 
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new_from_ip_range(Box::new(disk_config), "172.18", 0);
 
         let mut workload_path = dirs::home_dir().unwrap();
@@ -2855,30 +2848,29 @@ mod common_parallel {
 
     #[test]
     fn test_direct_kernel_boot_noacpi() {
-        let mut guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let mut guest = basic_regular_guest!(OS_IMAGE);
         guest.kernel_cmdline = Some(format!("{DIRECT_KERNEL_BOOT_CMDLINE} acpi=off"));
         _test_direct_kernel_boot_noacpi(&guest);
     }
 
     #[test]
     fn test_virtio_vsock() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_virtio_vsock(&guest, false);
     }
 
     #[test]
     fn test_virtio_vsock_hotplug() {
         #[cfg(target_arch = "x86_64")]
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         #[cfg(target_arch = "aarch64")]
-        let guest =
-            basic_regular_guest!(JAMMY_IMAGE_NAME).with_kernel_path(edk2_path().to_str().unwrap());
+        let guest = basic_regular_guest!(OS_IMAGE).with_kernel_path(edk2_path().to_str().unwrap());
         _test_virtio_vsock(&guest, true);
     }
 
     #[test]
     fn test_api_http_shutdown() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_cpu(4);
+        let guest = basic_regular_guest!(OS_IMAGE).with_cpu(4);
 
         let target_api = TargetApi::new_http_api(&guest.tmp_dir);
         _test_api_shutdown(&target_api, &guest);
@@ -2886,7 +2878,7 @@ mod common_parallel {
 
     #[test]
     fn test_api_http_delete() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_cpu(4);
+        let guest = basic_regular_guest!(OS_IMAGE).with_cpu(4);
 
         let target_api = TargetApi::new_http_api(&guest.tmp_dir);
         _test_api_delete(&target_api, &guest);
@@ -2894,7 +2886,7 @@ mod common_parallel {
 
     #[test]
     fn test_api_http_pause_resume() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_cpu(4);
+        let guest = basic_regular_guest!(OS_IMAGE).with_cpu(4);
 
         let target_api = TargetApi::new_http_api(&guest.tmp_dir);
         _test_api_pause_resume(&target_api, &guest);
@@ -2902,7 +2894,7 @@ mod common_parallel {
 
     #[test]
     fn test_api_http_create_boot() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_cpu(4);
+        let guest = basic_regular_guest!(OS_IMAGE).with_cpu(4);
 
         let target_api = TargetApi::new_http_api(&guest.tmp_dir);
         _test_api_create_boot(&target_api, &guest);
@@ -2925,10 +2917,9 @@ mod common_parallel {
     // rescan.
     fn test_pci_bar_reprogramming() {
         #[cfg(target_arch = "aarch64")]
-        let guest =
-            basic_regular_guest!(JAMMY_IMAGE_NAME).with_kernel_path(edk2_path().to_str().unwrap());
+        let guest = basic_regular_guest!(OS_IMAGE).with_kernel_path(edk2_path().to_str().unwrap());
         #[cfg(target_arch = "x86_64")]
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_pci_bar_reprogramming(&guest);
     }
 
@@ -2941,7 +2932,7 @@ mod common_parallel {
     #[cfg(not(feature = "mshv"))] // See issue #7435
     #[cfg(target_arch = "x86_64")]
     fn test_cpu_hotplug() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         let console_str = "console=ttyS0";
@@ -3025,7 +3016,7 @@ mod common_parallel {
     #[test]
     #[cfg_attr(target_arch = "aarch64", ignore = "See #8187")]
     fn test_memory_hotplug() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -3112,7 +3103,7 @@ mod common_parallel {
     #[test]
     #[cfg(not(feature = "mshv"))] // See #7456
     fn test_virtio_mem() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -3190,7 +3181,7 @@ mod common_parallel {
     #[cfg(target_arch = "x86_64")]
     // Test both vCPU and memory resizing together
     fn test_resize() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -3249,8 +3240,7 @@ mod common_parallel {
     #[test]
     fn test_memory_overhead() {
         let guest_memory_size_kb: u32 = 512 * 1024;
-        let guest =
-            basic_regular_guest!(JAMMY_IMAGE_NAME).with_memory(&format!("{guest_memory_size_kb}K"));
+        let guest = basic_regular_guest!(OS_IMAGE).with_memory(&format!("{guest_memory_size_kb}K"));
         _test_memory_overhead(&guest, guest_memory_size_kb);
     }
 
@@ -3260,7 +3250,7 @@ mod common_parallel {
     // the path for the hotplug disk is not pre-added to Landlock rules, this
     // the test will result in a failure.
     fn test_landlock() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_landlock(&guest);
     }
 
@@ -3270,21 +3260,20 @@ mod common_parallel {
         let kernel_path = direct_kernel_boot_path();
         #[cfg(target_arch = "aarch64")]
         let kernel_path = edk2_path();
-        let guest =
-            basic_regular_guest!(JAMMY_IMAGE_NAME).with_kernel_path(kernel_path.to_str().unwrap());
+        let guest = basic_regular_guest!(OS_IMAGE).with_kernel_path(kernel_path.to_str().unwrap());
         _test_disk_hotplug(&guest, false);
     }
 
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_disk_hotplug_with_landlock() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_disk_hotplug(&guest, true);
     }
 
     #[test]
     fn test_disk_resize() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -3394,7 +3383,7 @@ mod common_parallel {
 
     #[test]
     fn test_disk_resize_qcow2() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -3647,7 +3636,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_topology() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         let test_disk_path = guest.tmp_dir.as_path().join("test.img");
 
         let output = exec_host_command_output(
@@ -3673,7 +3662,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_direct_io_block_device_alignment_4k() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -3759,7 +3748,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_direct_io_file_backed_alignment_4k() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4003,7 +3992,7 @@ mod common_parallel {
         verify_disk: bool,
         disable_io_uring: bool,
     ) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4228,7 +4217,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_write_zeroes_unmap_raw() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let test_disk_path = guest.tmp_dir.as_path().join("write_zeroes_unmap_test.raw");
@@ -4326,7 +4315,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_discard_loop_device() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4435,7 +4424,7 @@ mod common_parallel {
         // gracefully even under repeated attempts.
         //
         // DM topology follows the same pattern used by WindowsDiskConfig.
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4635,7 +4624,7 @@ mod common_parallel {
         verify_disk: bool,
         disable_io_uring: bool,
     ) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4841,7 +4830,7 @@ mod common_parallel {
         const TEST_DISK_SIZE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
         const INITIAL_ALLOCATION_THRESHOLD: u64 = 1024 * 1024;
 
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4956,7 +4945,7 @@ mod common_parallel {
     fn test_virtio_block_sparse_off_qcow2() {
         const TEST_DISK_SIZE: &str = "2G";
 
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -5059,7 +5048,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_balloon_deflate_on_oom() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let kernel_path = direct_kernel_boot_path();
@@ -5121,7 +5110,7 @@ mod common_parallel {
     #[test]
     #[cfg(not(feature = "mshv"))] // See #7456
     fn test_virtio_balloon_free_page_reporting() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         //Let's start a 4G guest with balloon occupied 2G memory
@@ -5193,7 +5182,7 @@ mod common_parallel {
     }
 
     fn _test_pmem_hotplug(pci_segment: Option<u16>) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -5323,8 +5312,7 @@ mod common_parallel {
         let kernel_path = direct_kernel_boot_path();
         #[cfg(target_arch = "aarch64")]
         let kernel_path = edk2_path();
-        let guest =
-            basic_regular_guest!(JAMMY_IMAGE_NAME).with_kernel_path(kernel_path.to_str().unwrap());
+        let guest = basic_regular_guest!(OS_IMAGE).with_kernel_path(kernel_path.to_str().unwrap());
 
         _test_net_hotplug(&guest, MAX_NUM_PCI_SEGMENTS, None);
     }
@@ -5335,14 +5323,13 @@ mod common_parallel {
         let kernel_path = direct_kernel_boot_path();
         #[cfg(target_arch = "aarch64")]
         let kernel_path = edk2_path();
-        let guest =
-            basic_regular_guest!(JAMMY_IMAGE_NAME).with_kernel_path(kernel_path.to_str().unwrap());
+        let guest = basic_regular_guest!(OS_IMAGE).with_kernel_path(kernel_path.to_str().unwrap());
         _test_net_hotplug(&guest, MAX_NUM_PCI_SEGMENTS, Some(15));
     }
 
     #[test]
     fn test_initramfs() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut workload_path = dirs::home_dir().unwrap();
         workload_path.push("workloads");
@@ -5391,14 +5378,14 @@ mod common_parallel {
 
     #[test]
     fn test_counters() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_counters(&guest);
     }
 
     #[test]
     #[cfg(feature = "guest_debug")]
     fn test_coredump() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -5446,7 +5433,7 @@ mod common_parallel {
     #[test]
     #[cfg(feature = "guest_debug")]
     fn test_coredump_no_pause() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -5482,37 +5469,37 @@ mod common_parallel {
 
     #[test]
     fn test_pvpanic() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_pvpanic(&guest);
     }
 
     #[test]
     fn test_tap_from_fd() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_cpu(2);
+        let guest = basic_regular_guest!(OS_IMAGE).with_cpu(2);
         _test_tap_from_fd(&guest);
     }
 
     #[test]
     #[cfg_attr(target_arch = "aarch64", ignore = "See #5443")]
     fn test_macvtap() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_cpu(2);
+        let guest = basic_regular_guest!(OS_IMAGE).with_cpu(2);
         _test_macvtap(&guest, false, "guestmacvtap0", "hostmacvtap0");
     }
 
     #[test]
     #[cfg_attr(target_arch = "aarch64", ignore = "See #5443")]
     fn test_macvtap_hotplug() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_cpu(2);
+        let guest = basic_regular_guest!(OS_IMAGE).with_cpu(2);
         _test_macvtap(&guest, true, "guestmacvtap1", "hostmacvtap1");
     }
 
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_ovs_dpdk() {
-        let disk_config1 = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config1 = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest1 = Guest::new(Box::new(disk_config1));
 
-        let disk_config2 = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config2 = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest2 = Guest::new(Box::new(disk_config2));
         let api_socket_source = format!("{}.1", temp_api_path(&guest2.tmp_dir));
 
@@ -5718,7 +5705,7 @@ mod common_parallel {
 
     #[test]
     fn test_vfio_user() {
-        let jammy_image = JAMMY_IMAGE_NAME.to_string();
+        let jammy_image = OS_IMAGE.to_string();
         let disk_config = UbuntuDiskConfig::new(jammy_image);
         let guest = Guest::new(Box::new(disk_config));
 
@@ -5807,7 +5794,7 @@ mod common_parallel {
         // Before trying to run the test, verify the vdpa_sim_blk module is correctly loaded.
         assert!(exec_host_command_status("lsmod | grep vdpa_sim_blk").success());
 
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_cpu(2);
+        let guest = basic_regular_guest!(OS_IMAGE).with_cpu(2);
         _test_vdpa_block(&guest);
     }
 
@@ -5819,7 +5806,7 @@ mod common_parallel {
             return;
         }
 
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let kernel_path = direct_kernel_boot_path();
@@ -5909,7 +5896,7 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_tpm() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let (mut swtpm_command, swtpm_socket_path) = prepare_swtpm_daemon(&guest.tmp_dir);
@@ -5973,7 +5960,7 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_double_tty() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
         let api_socket = temp_api_path(&guest.tmp_dir);
@@ -6025,7 +6012,7 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_nmi() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         let event_path = temp_event_monitor_path(&guest.tmp_dir);
@@ -6073,7 +6060,7 @@ mod common_parallel {
     // It also verifies dynamic hotplug allocation reuses freed PCI device ID holes.
     #[test]
     fn test_pci_device_id() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -6248,7 +6235,7 @@ mod common_parallel {
     #[test]
     // Test that adding a duplicate PCI device ID fails
     fn test_duplicate_pci_device_id() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -6326,7 +6313,7 @@ mod common_parallel {
     #[test]
     // Test that requesting an invalid device ID fails.
     fn test_invalid_pci_device_id() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -6413,7 +6400,7 @@ mod common_parallel {
     // Note: This test does not use vsock as we can't create two identical vsock on the same host.
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration(upgrade_test: bool, local: bool, paused: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -6587,7 +6574,7 @@ mod common_parallel {
     //    this disk is not known to the destination VM this step will fail.
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_with_landlock() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let net_id = "net123";
@@ -6819,7 +6806,7 @@ mod common_parallel {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_tcp(connections: NonZeroU32) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -7019,7 +7006,7 @@ mod common_parallel {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_tcp_timeout(timeout_strategy: TimeoutStrategy) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let net_id = "net1337";
@@ -7258,7 +7245,7 @@ mod common_parallel {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_virtio_fs(local: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -7455,7 +7442,7 @@ mod dbus_api {
     // booted again.
     #[test]
     fn test_api_dbus_and_http_interleaved() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let dbus_api = TargetApi::new_dbus_api(&guest.tmp_dir);
         let http_api = TargetApi::new_http_api(&guest.tmp_dir);
@@ -7520,7 +7507,7 @@ mod dbus_api {
 
     #[test]
     fn test_api_dbus_create_boot() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -7531,7 +7518,7 @@ mod dbus_api {
 
     #[test]
     fn test_api_dbus_shutdown() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -7542,7 +7529,7 @@ mod dbus_api {
 
     #[test]
     fn test_api_dbus_delete() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -7553,7 +7540,7 @@ mod dbus_api {
 
     #[test]
     fn test_api_dbus_pause_resume() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -7574,7 +7561,7 @@ mod ivshmem {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_ivshmem(local: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -7762,7 +7749,7 @@ mod ivshmem {
 
     #[test]
     fn test_ivshmem() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -7818,7 +7805,7 @@ mod ivshmem {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_ivshmem() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -8080,7 +8067,7 @@ mod snapshot_restore_common {
     }
 
     pub(crate) fn _test_snapshot_restore(use_hotplug: bool, use_resume_option: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -8381,7 +8368,7 @@ mod snapshot_restore_common {
         memory_zone_config: &[&str],
         min_total_memory_kib: u32,
     ) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -8520,7 +8507,7 @@ mod snapshot_restore_common {
     }
 
     pub(crate) fn _test_snapshot_restore_devices(pvpanic: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -8689,7 +8676,7 @@ mod common_sequential {
     #[cfg(not(feature = "mshv"))] // See issue #7437
     #[ignore = "See #6970"]
     fn test_snapshot_restore_with_fd() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -8922,7 +8909,7 @@ mod common_sequential {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_virtio_fs() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -9083,7 +9070,7 @@ mod common_sequential {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_balloon(upgrade_test: bool, local: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -9287,7 +9274,7 @@ mod common_sequential {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_numa(upgrade_test: bool, local: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -9544,10 +9531,10 @@ mod common_sequential {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_ovs_dpdk(upgrade_test: bool, local: bool) {
-        let ovs_disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let ovs_disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let ovs_guest = Guest::new(Box::new(ovs_disk_config));
 
-        let migration_disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let migration_disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let migration_guest = Guest::new(Box::new(migration_disk_config));
         let src_api_socket = temp_api_path(&migration_guest.tmp_dir);
 
@@ -9733,7 +9720,7 @@ mod common_sequential {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_watchdog(upgrade_test: bool, local: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -9942,7 +9929,7 @@ mod common_sequential {
 
     #[test]
     fn test_watchdog() {
-        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_regular_guest!(OS_IMAGE);
         _test_watchdog(&guest);
     }
 
@@ -11612,7 +11599,7 @@ mod aarch64_acpi {
 
     #[test]
     fn test_simple_launch_acpi() {
-        let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
 
         vec![Box::new(jammy)].drain(..).for_each(|disk_config| {
             let guest = Guest::new(disk_config);
@@ -11665,7 +11652,7 @@ mod aarch64_acpi {
 
     #[test]
     fn test_power_button_acpi() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_kernel_path(edk2_path().to_str().unwrap());
@@ -11706,7 +11693,7 @@ mod rate_limiter {
     }
 
     fn _test_rate_limiter_net(rx: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let num_queues = 2;
@@ -11775,7 +11762,7 @@ mod rate_limiter {
         let bw_refill_time = 1000; // ms
         let limit_rate = (bw_size * 1000) as f64 / bw_refill_time as f64;
 
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         let test_img_dir = TempDir::new_with_prefix("/var/tmp/ch").unwrap();
@@ -11862,7 +11849,7 @@ mod rate_limiter {
         let bw_refill_time = 1000; // ms
         let limit_rate = (bw_size * 1000) as f64 / bw_refill_time as f64;
 
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         let test_img_dir = TempDir::new_with_prefix("/var/tmp/ch").unwrap();
@@ -11999,7 +11986,7 @@ mod fw_cfg {
     #[test]
     #[cfg_attr(feature = "mshv", ignore = "See #7434")]
     fn test_fw_cfg() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
 
@@ -12047,7 +12034,7 @@ mod fw_cfg {
     #[test]
     #[cfg_attr(feature = "mshv", ignore = "See #7434")]
     fn test_fw_cfg_string() {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
 

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -32,7 +32,7 @@ use common::utils::*;
 
 macro_rules! basic_regular_guest {
     ($image_name:expr) => {{
-        let disk_config = UbuntuDiskConfig::new($image_name.to_string());
+        let disk_config = GuestDiskConfig::new($image_name.to_string());
         GuestFactory::new_regular_guest_factory().create_guest(Box::new(disk_config))
     }};
 }
@@ -90,7 +90,7 @@ mod common_parallel {
     #[cfg(target_arch = "x86_64")]
     #[cfg(not(feature = "mshv"))]
     fn test_cpu_physical_bits() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let max_phys_bits: u8 = 36;
         let mut child = GuestCommand::new(&guest)
@@ -124,7 +124,7 @@ mod common_parallel {
     }
 
     fn _test_nested_virtualization(nested: bool) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config)).with_nested(nested);
         let mut child = GuestCommand::new(&guest)
             .default_cpus()
@@ -183,7 +183,7 @@ mod common_parallel {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_large_vm() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
         cmd.args(["--cpus", "boot=48"])
@@ -222,7 +222,7 @@ mod common_parallel {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_huge_memory() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
         cmd.default_cpus()
@@ -256,7 +256,7 @@ mod common_parallel {
     #[test]
     #[cfg(not(feature = "mshv"))] // See #7456
     fn test_user_defined_memory_regions() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -342,7 +342,7 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_iommu_segments() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         // Prepare another disk file for the virtio-disk device
@@ -437,7 +437,7 @@ mod common_parallel {
 
     #[test]
     fn test_pci_multiple_segments_numa_node() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         #[cfg(target_arch = "x86_64")]
@@ -537,7 +537,7 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_direct_kernel_boot_bzimage() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let mut kernel_path = direct_kernel_boot_path();
@@ -642,7 +642,7 @@ mod common_parallel {
     //   - the BLKDISCARD / BLKZEROOUT additions to the VirtioBlock seccomp
     //     whitelist (any of these would otherwise SIGSYS the device thread).
     fn _test_virtio_block_blkdev(disable_io_uring: bool, disable_aio: bool) {
-        let focal = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let focal = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(focal));
         let loopdev = LoopDev::new(guest.tmp_dir.as_path(), 64);
         let kernel_path = direct_kernel_boot_path();
@@ -837,7 +837,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -846,7 +846,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2_zlib() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2_ZLIB.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE_QCOW2_ZLIB.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -905,7 +905,7 @@ mod common_parallel {
     where
         F: FnOnce(&Guest) + std::panic::UnwindSafe,
     {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -1502,7 +1502,7 @@ mod common_parallel {
         // Regression test for #8007.
         // Place the QCOW2 OS image on a 4096 byte sector filesystem so
         // O_DIRECT forces 4096 byte alignment on all I/O buffers.
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = edk2_path();
 
@@ -1588,7 +1588,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2_dirty_bit_unclean_shutdown() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -1651,7 +1651,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2_dirty_bit_clean_shutdown() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -1710,7 +1710,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2_corrupt_bit_rejected_for_write() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -1766,7 +1766,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_qcow2_corrupt_bit_allowed_readonly() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE_QCOW2.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE_QCOW2.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -1894,7 +1894,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_direct_and_firmware() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         // The OS disk must be copied to a location that is not backed by
@@ -2093,7 +2093,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_rtc() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let kernel_path = direct_kernel_boot_path();
@@ -2167,7 +2167,7 @@ mod common_parallel {
 
     #[test]
     fn test_boot_from_virtio_pmem() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let kernel_path = direct_kernel_boot_path();
@@ -2229,7 +2229,7 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "aarch64")]
     fn test_pmu_on() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut child = GuestCommand::new(&guest)
             .default_cpus()
@@ -2271,7 +2271,7 @@ mod common_parallel {
 
     #[test]
     fn test_serial_null() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
         #[cfg(target_arch = "x86_64")]
@@ -2324,7 +2324,7 @@ mod common_parallel {
 
     #[test]
     fn test_serial_tty() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let kernel_path = direct_kernel_boot_path();
@@ -2383,7 +2383,7 @@ mod common_parallel {
 
     #[test]
     fn test_serial_file() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let serial_path = guest.tmp_dir.as_path().join("serial-output");
@@ -2451,7 +2451,7 @@ mod common_parallel {
 
     #[test]
     fn test_pty_interaction() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         let serial_option = if cfg!(target_arch = "x86_64") {
@@ -2497,7 +2497,7 @@ mod common_parallel {
 
     #[test]
     fn test_serial_socket_interaction() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let serial_socket = guest.tmp_dir.as_path().join("serial.socket");
         let serial_socket_pty = guest.tmp_dir.as_path().join("serial.pty");
@@ -2593,7 +2593,7 @@ mod common_parallel {
     fn test_vfio() {
         setup_vfio_network_interfaces();
 
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new_from_ip_range(Box::new(disk_config), "172.18", 0);
 
         let mut workload_path = dirs::home_dir().unwrap();
@@ -2932,7 +2932,7 @@ mod common_parallel {
     #[cfg(not(feature = "mshv"))] // See issue #7435
     #[cfg(target_arch = "x86_64")]
     fn test_cpu_hotplug() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         let console_str = "console=ttyS0";
@@ -3016,7 +3016,7 @@ mod common_parallel {
     #[test]
     #[cfg_attr(target_arch = "aarch64", ignore = "See #8187")]
     fn test_memory_hotplug() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -3103,7 +3103,7 @@ mod common_parallel {
     #[test]
     #[cfg(not(feature = "mshv"))] // See #7456
     fn test_virtio_mem() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -3181,7 +3181,7 @@ mod common_parallel {
     #[cfg(target_arch = "x86_64")]
     // Test both vCPU and memory resizing together
     fn test_resize() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -3273,7 +3273,7 @@ mod common_parallel {
 
     #[test]
     fn test_disk_resize() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -3383,7 +3383,7 @@ mod common_parallel {
 
     #[test]
     fn test_disk_resize_qcow2() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -3662,7 +3662,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_direct_io_block_device_alignment_4k() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -3748,7 +3748,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_direct_io_file_backed_alignment_4k() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -3992,7 +3992,7 @@ mod common_parallel {
         verify_disk: bool,
         disable_io_uring: bool,
     ) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4217,7 +4217,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_write_zeroes_unmap_raw() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let test_disk_path = guest.tmp_dir.as_path().join("write_zeroes_unmap_test.raw");
@@ -4315,7 +4315,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_block_discard_loop_device() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4424,7 +4424,7 @@ mod common_parallel {
         // gracefully even under repeated attempts.
         //
         // DM topology follows the same pattern used by WindowsDiskConfig.
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4624,7 +4624,7 @@ mod common_parallel {
         verify_disk: bool,
         disable_io_uring: bool,
     ) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4830,7 +4830,7 @@ mod common_parallel {
         const TEST_DISK_SIZE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
         const INITIAL_ALLOCATION_THRESHOLD: u64 = 1024 * 1024;
 
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -4945,7 +4945,7 @@ mod common_parallel {
     fn test_virtio_block_sparse_off_qcow2() {
         const TEST_DISK_SIZE: &str = "2G";
 
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -5048,7 +5048,7 @@ mod common_parallel {
 
     #[test]
     fn test_virtio_balloon_deflate_on_oom() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let kernel_path = direct_kernel_boot_path();
@@ -5110,7 +5110,7 @@ mod common_parallel {
     #[test]
     #[cfg(not(feature = "mshv"))] // See #7456
     fn test_virtio_balloon_free_page_reporting() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         //Let's start a 4G guest with balloon occupied 2G memory
@@ -5182,7 +5182,7 @@ mod common_parallel {
     }
 
     fn _test_pmem_hotplug(pci_segment: Option<u16>) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -5329,7 +5329,7 @@ mod common_parallel {
 
     #[test]
     fn test_initramfs() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut workload_path = dirs::home_dir().unwrap();
         workload_path.push("workloads");
@@ -5385,7 +5385,7 @@ mod common_parallel {
     #[test]
     #[cfg(feature = "guest_debug")]
     fn test_coredump() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -5433,7 +5433,7 @@ mod common_parallel {
     #[test]
     #[cfg(feature = "guest_debug")]
     fn test_coredump_no_pause() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -5496,10 +5496,10 @@ mod common_parallel {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_ovs_dpdk() {
-        let disk_config1 = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config1 = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest1 = Guest::new(Box::new(disk_config1));
 
-        let disk_config2 = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config2 = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest2 = Guest::new(Box::new(disk_config2));
         let api_socket_source = format!("{}.1", temp_api_path(&guest2.tmp_dir));
 
@@ -5706,7 +5706,7 @@ mod common_parallel {
     #[test]
     fn test_vfio_user() {
         let jammy_image = OS_IMAGE.to_string();
-        let disk_config = UbuntuDiskConfig::new(jammy_image);
+        let disk_config = GuestDiskConfig::new(jammy_image);
         let guest = Guest::new(Box::new(disk_config));
 
         let spdk_nvme_dir = guest.tmp_dir.as_path().join("test-vfio-user");
@@ -5806,7 +5806,7 @@ mod common_parallel {
             return;
         }
 
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let kernel_path = direct_kernel_boot_path();
@@ -5896,7 +5896,7 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_tpm() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let (mut swtpm_command, swtpm_socket_path) = prepare_swtpm_daemon(&guest.tmp_dir);
@@ -5960,7 +5960,7 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_double_tty() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
         let api_socket = temp_api_path(&guest.tmp_dir);
@@ -6012,7 +6012,7 @@ mod common_parallel {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_nmi() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         let event_path = temp_event_monitor_path(&guest.tmp_dir);
@@ -6060,7 +6060,7 @@ mod common_parallel {
     // It also verifies dynamic hotplug allocation reuses freed PCI device ID holes.
     #[test]
     fn test_pci_device_id() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -6235,7 +6235,7 @@ mod common_parallel {
     #[test]
     // Test that adding a duplicate PCI device ID fails
     fn test_duplicate_pci_device_id() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -6313,7 +6313,7 @@ mod common_parallel {
     #[test]
     // Test that requesting an invalid device ID fails.
     fn test_invalid_pci_device_id() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         #[cfg(target_arch = "x86_64")]
@@ -6400,7 +6400,7 @@ mod common_parallel {
     // Note: This test does not use vsock as we can't create two identical vsock on the same host.
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration(upgrade_test: bool, local: bool, paused: bool) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -6574,7 +6574,7 @@ mod common_parallel {
     //    this disk is not known to the destination VM this step will fail.
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_with_landlock() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let net_id = "net123";
@@ -6806,7 +6806,7 @@ mod common_parallel {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_tcp(connections: NonZeroU32) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -7006,7 +7006,7 @@ mod common_parallel {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_tcp_timeout(timeout_strategy: TimeoutStrategy) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let net_id = "net1337";
@@ -7245,7 +7245,7 @@ mod common_parallel {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_virtio_fs(local: bool) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -7442,7 +7442,7 @@ mod dbus_api {
     // booted again.
     #[test]
     fn test_api_dbus_and_http_interleaved() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let dbus_api = TargetApi::new_dbus_api(&guest.tmp_dir);
         let http_api = TargetApi::new_http_api(&guest.tmp_dir);
@@ -7507,7 +7507,7 @@ mod dbus_api {
 
     #[test]
     fn test_api_dbus_create_boot() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -7518,7 +7518,7 @@ mod dbus_api {
 
     #[test]
     fn test_api_dbus_shutdown() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -7529,7 +7529,7 @@ mod dbus_api {
 
     #[test]
     fn test_api_dbus_delete() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -7540,7 +7540,7 @@ mod dbus_api {
 
     #[test]
     fn test_api_dbus_pause_resume() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_cpu(4);
@@ -7555,13 +7555,13 @@ mod ivshmem {
     use std::fs::remove_dir_all;
     use std::process::Command;
 
-    use test_infra::{Guest, GuestCommand, UbuntuDiskConfig, handle_child_output, kill_child};
+    use test_infra::{Guest, GuestCommand, GuestDiskConfig, handle_child_output, kill_child};
 
     use crate::*;
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_ivshmem(local: bool) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -7749,7 +7749,7 @@ mod ivshmem {
 
     #[test]
     fn test_ivshmem() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -7805,7 +7805,7 @@ mod ivshmem {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_ivshmem() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -8067,7 +8067,7 @@ mod snapshot_restore_common {
     }
 
     pub(crate) fn _test_snapshot_restore(use_hotplug: bool, use_resume_option: bool) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -8368,7 +8368,7 @@ mod snapshot_restore_common {
         memory_zone_config: &[&str],
         min_total_memory_kib: u32,
     ) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -8507,7 +8507,7 @@ mod snapshot_restore_common {
     }
 
     pub(crate) fn _test_snapshot_restore_devices(pvpanic: bool) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -8676,7 +8676,7 @@ mod common_sequential {
     #[cfg(not(feature = "mshv"))] // See issue #7437
     #[ignore = "See #6970"]
     fn test_snapshot_restore_with_fd() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -8909,7 +8909,7 @@ mod common_sequential {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_virtio_fs() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
 
@@ -9070,7 +9070,7 @@ mod common_sequential {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_balloon(upgrade_test: bool, local: bool) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -9274,7 +9274,7 @@ mod common_sequential {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_numa(upgrade_test: bool, local: bool) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -9531,10 +9531,10 @@ mod common_sequential {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_ovs_dpdk(upgrade_test: bool, local: bool) {
-        let ovs_disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let ovs_disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let ovs_guest = Guest::new(Box::new(ovs_disk_config));
 
-        let migration_disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let migration_disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let migration_guest = Guest::new(Box::new(migration_disk_config));
         let src_api_socket = temp_api_path(&migration_guest.tmp_dir);
 
@@ -9720,7 +9720,7 @@ mod common_sequential {
 
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_watchdog(upgrade_test: bool, local: bool) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
         let console_text = String::from("On a branch floating down river a cricket, singing.");
@@ -11207,7 +11207,7 @@ mod vfio {
     }
 
     fn test_nvidia_card_memory_hotplug(hotplug_method: &str, iommufd: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
+        let disk_config = GuestDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -11277,7 +11277,7 @@ mod vfio {
     }
 
     fn test_nvidia_card_pci_hotplug_common(iommufd: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
+        let disk_config = GuestDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -11329,7 +11329,7 @@ mod vfio {
     }
 
     fn test_nvidia_card_reboot_common(iommufd: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
+        let disk_config = GuestDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -11378,7 +11378,7 @@ mod vfio {
     }
 
     fn test_nvidia_card_iommu_address_width_common(iommufd: bool) {
-        let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
+        let disk_config = GuestDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -11439,7 +11439,7 @@ mod vfio {
             return;
         };
 
-        let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
+        let disk_config = GuestDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let mut child = GuestCommand::new(&guest)
@@ -11493,7 +11493,7 @@ mod vfio {
             return;
         }
 
-        let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
+        let disk_config = GuestDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
@@ -11599,7 +11599,7 @@ mod aarch64_acpi {
 
     #[test]
     fn test_simple_launch_acpi() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
 
         vec![Box::new(disk_config)]
             .drain(..)
@@ -11654,7 +11654,7 @@ mod aarch64_acpi {
 
     #[test]
     fn test_power_button_acpi() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = GuestFactory::new_regular_guest_factory()
             .create_guest(Box::new(disk_config))
             .with_kernel_path(edk2_path().to_str().unwrap());
@@ -11695,7 +11695,7 @@ mod rate_limiter {
     }
 
     fn _test_rate_limiter_net(rx: bool) {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
 
         let num_queues = 2;
@@ -11764,7 +11764,7 @@ mod rate_limiter {
         let bw_refill_time = 1000; // ms
         let limit_rate = (bw_size * 1000) as f64 / bw_refill_time as f64;
 
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         let test_img_dir = TempDir::new_with_prefix("/var/tmp/ch").unwrap();
@@ -11851,7 +11851,7 @@ mod rate_limiter {
         let bw_refill_time = 1000; // ms
         let limit_rate = (bw_size * 1000) as f64 / bw_refill_time as f64;
 
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
         let test_img_dir = TempDir::new_with_prefix("/var/tmp/ch").unwrap();
@@ -11988,7 +11988,7 @@ mod fw_cfg {
     #[test]
     #[cfg_attr(feature = "mshv", ignore = "See #7434")]
     fn test_fw_cfg() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
 
@@ -12036,7 +12036,7 @@ mod fw_cfg {
     #[test]
     #[cfg_attr(feature = "mshv", ignore = "See #7434")]
     fn test_fw_cfg_string() {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let mut cmd = GuestCommand::new(&guest);
 

--- a/cloud-hypervisor/tests/integration_cvm.rs
+++ b/cloud-hypervisor/tests/integration_cvm.rs
@@ -28,21 +28,21 @@ mod common_cvm {
 
     #[test]
     fn test_jammy_simple_launch() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
 
         _test_simple_launch(&guest);
     }
 
     #[test]
     fn test_api_http_create_boot() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME).with_cpu(4);
+        let guest = basic_cvm_guest!(OS_IMAGE).with_cpu(4);
         let target_api = TargetApi::new_http_api(&guest.tmp_dir);
         _test_api_create_boot(&target_api, &guest);
     }
 
     #[test]
     fn test_api_http_shutdown() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME).with_cpu(4);
+        let guest = basic_cvm_guest!(OS_IMAGE).with_cpu(4);
 
         let target_api = TargetApi::new_http_api(&guest.tmp_dir);
         _test_api_shutdown(&target_api, &guest);
@@ -50,50 +50,50 @@ mod common_cvm {
 
     #[test]
     fn test_api_http_delete() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         let target_api = TargetApi::new_http_api(&guest.tmp_dir);
         _test_api_delete(&target_api, &guest);
     }
 
     #[test]
     fn test_power_button() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_power_button(&guest);
     }
 
     #[test]
     fn test_virtio_vsock() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_virtio_vsock(&guest, false);
     }
 
     #[test]
     fn test_multi_cpu() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_multi_cpu(&guest);
     }
 
     #[test]
     fn test_cpu_affinity() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME).with_cpu(2);
+        let guest = basic_cvm_guest!(OS_IMAGE).with_cpu(2);
         _test_cpu_affinity(&guest);
     }
 
     #[test]
     fn test_virtio_queue_affinity() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME).with_cpu(4);
+        let guest = basic_cvm_guest!(OS_IMAGE).with_cpu(4);
         _test_virtio_queue_affinity(&guest);
     }
 
     #[test]
     fn test_pci_msi() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_pci_msi(&guest);
     }
 
     #[test]
     fn test_virtio_net_ctrl_queue() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_virtio_net_ctrl_queue(&guest);
     }
 
@@ -102,40 +102,34 @@ mod common_cvm {
         // Use 8 segments to test the multiple segment support since it's more than the default 6
         //  supported by Linux
         // IGVM file used by Sev-Snp Guest now support up to 8 segments, so we can use 8 segments for testing.
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_pci_multiple_segments(&guest, NUM_PCI_SEGMENTS, 5);
     }
 
     #[test]
     fn test_direct_kernel_boot() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_direct_kernel_boot(&guest);
     }
 
     #[test]
     fn test_virtio_block_io_uring() {
-        let guest = make_virtio_block_guest(
-            &GuestFactory::new_confidential_guest_factory(),
-            JAMMY_IMAGE_NAME,
-        );
+        let guest =
+            make_virtio_block_guest(&GuestFactory::new_confidential_guest_factory(), OS_IMAGE);
         _test_virtio_block(&guest, false, true, false, false, ImageType::Raw);
     }
 
     #[test]
     fn test_virtio_block_aio() {
-        let guest = make_virtio_block_guest(
-            &GuestFactory::new_confidential_guest_factory(),
-            JAMMY_IMAGE_NAME,
-        );
+        let guest =
+            make_virtio_block_guest(&GuestFactory::new_confidential_guest_factory(), OS_IMAGE);
         _test_virtio_block(&guest, true, false, false, false, ImageType::Raw);
     }
 
     #[test]
     fn test_virtio_block_sync() {
-        let guest = make_virtio_block_guest(
-            &GuestFactory::new_confidential_guest_factory(),
-            JAMMY_IMAGE_NAME,
-        );
+        let guest =
+            make_virtio_block_guest(&GuestFactory::new_confidential_guest_factory(), OS_IMAGE);
         _test_virtio_block(&guest, true, true, false, false, ImageType::Raw);
     }
 
@@ -143,7 +137,7 @@ mod common_cvm {
     fn test_virtio_block_qcow2() {
         let guest = make_virtio_block_guest(
             &GuestFactory::new_confidential_guest_factory(),
-            JAMMY_IMAGE_NAME_QCOW2,
+            OS_IMAGE_QCOW2,
         );
         _test_virtio_block(&guest, false, false, true, false, ImageType::Qcow2);
     }
@@ -152,7 +146,7 @@ mod common_cvm {
     fn test_virtio_block_qcow2_zlib() {
         let guest = make_virtio_block_guest(
             &GuestFactory::new_confidential_guest_factory(),
-            JAMMY_IMAGE_NAME_QCOW2_ZLIB,
+            OS_IMAGE_QCOW2_ZLIB,
         );
         _test_virtio_block(&guest, false, false, true, false, ImageType::Qcow2);
     }
@@ -161,7 +155,7 @@ mod common_cvm {
     fn test_virtio_block_qcow2_zstd() {
         let guest = make_virtio_block_guest(
             &GuestFactory::new_confidential_guest_factory(),
-            JAMMY_IMAGE_NAME_QCOW2_ZSTD,
+            OS_IMAGE_QCOW2_ZSTD,
         );
         _test_virtio_block(&guest, false, false, true, false, ImageType::Qcow2);
     }
@@ -170,7 +164,7 @@ mod common_cvm {
     fn test_virtio_block_qcow2_backing_zstd_file() {
         let guest = make_virtio_block_guest(
             &GuestFactory::new_confidential_guest_factory(),
-            JAMMY_IMAGE_NAME_QCOW2_BACKING_ZSTD_FILE,
+            OS_IMAGE_QCOW2_BACKING_ZSTD_FILE,
         );
 
         _test_virtio_block(&guest, false, false, true, true, ImageType::Qcow2);
@@ -180,7 +174,7 @@ mod common_cvm {
     fn test_virtio_block_qcow2_backing_uncompressed_file() {
         let guest = make_virtio_block_guest(
             &GuestFactory::new_confidential_guest_factory(),
-            JAMMY_IMAGE_NAME_QCOW2_BACKING_UNCOMPRESSED_FILE,
+            OS_IMAGE_QCOW2_BACKING_UNCOMPRESSED_FILE,
         );
 
         _test_virtio_block(&guest, false, false, true, true, ImageType::Qcow2);
@@ -190,136 +184,135 @@ mod common_cvm {
     fn test_virtio_block_qcow2_backing_raw_file() {
         let guest = make_virtio_block_guest(
             &GuestFactory::new_confidential_guest_factory(),
-            JAMMY_IMAGE_NAME_QCOW2_BACKING_RAW_FILE,
+            OS_IMAGE_QCOW2_BACKING_RAW_FILE,
         );
         _test_virtio_block(&guest, false, false, true, true, ImageType::Qcow2);
     }
 
     #[test]
     fn test_virtio_block_dynamic_vhdx_expand() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_virtio_block_dynamic_vhdx_expand(&guest);
     }
 
     #[test]
     fn test_split_irqchip() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_split_irqchip(&guest);
     }
 
     #[test]
     fn test_dmi_uuid() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_dmi_uuid(&guest);
     }
 
     #[test]
     fn test_dmi_oem_strings() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_dmi_oem_strings(&guest);
     }
 
     #[test]
     fn test_dmi_system_and_chassis() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_dmi_system_and_chassis(&guest);
     }
 
     #[test]
     fn test_multiple_network_interfaces() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_multiple_network_interfaces(&guest);
     }
 
     #[test]
     fn test_serial_off() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_serial_off(&guest);
     }
 
     #[test]
     fn test_virtio_console() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_virtio_console(&guest);
     }
 
     #[test]
     fn test_console_file() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_console_file(&guest);
     }
 
     #[test]
     fn test_direct_kernel_boot_noacpi() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_direct_kernel_boot_noacpi(&guest);
     }
 
     #[test]
     fn test_pci_bar_reprogramming() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_pci_bar_reprogramming(&guest);
     }
 
     #[test]
     fn test_memory_overhead() {
         let guest_memory_size_kb: u32 = 512 * 1024;
-        let guest =
-            basic_cvm_guest!(JAMMY_IMAGE_NAME).with_memory(&format!("{guest_memory_size_kb}K"));
+        let guest = basic_cvm_guest!(OS_IMAGE).with_memory(&format!("{guest_memory_size_kb}K"));
         _test_memory_overhead(&guest, guest_memory_size_kb);
     }
 
     #[test]
     fn test_landlock() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_landlock(&guest);
     }
 
     #[test]
     fn test_disk_hotplug() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_disk_hotplug(&guest, false);
     }
 
     #[test]
     fn test_net_hotplug() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_net_hotplug(&guest, NUM_PCI_SEGMENTS, None);
     }
 
     #[test]
     fn test_counters() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_counters(&guest);
     }
 
     #[test]
     fn test_watchdog() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_watchdog(&guest);
     }
 
     #[test]
     fn test_pvpanic() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        let guest = basic_cvm_guest!(OS_IMAGE);
         _test_pvpanic(&guest);
     }
 
     #[test]
     fn test_tap_from_fd() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME).with_cpu(2);
+        let guest = basic_cvm_guest!(OS_IMAGE).with_cpu(2);
         _test_tap_from_fd(&guest);
     }
 
     #[test]
     fn test_macvtap() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME).with_cpu(2);
+        let guest = basic_cvm_guest!(OS_IMAGE).with_cpu(2);
         _test_macvtap(&guest, false, "guestmacvtap0", "hostmacvtap0");
     }
 
     #[test]
     fn test_macvtap_hotplug() {
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME).with_cpu(2);
+        let guest = basic_cvm_guest!(OS_IMAGE).with_cpu(2);
         _test_macvtap(&guest, true, "guestmacvtap1", "hostmacvtap1");
     }
 
@@ -327,7 +320,7 @@ mod common_cvm {
     fn test_vdpa_block() {
         assert!(exec_host_command_status("lsmod | grep vdpa_sim_blk").success());
 
-        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME).with_cpu(2);
+        let guest = basic_cvm_guest!(OS_IMAGE).with_cpu(2);
         _test_vdpa_block(&guest);
     }
 }

--- a/cloud-hypervisor/tests/integration_cvm.rs
+++ b/cloud-hypervisor/tests/integration_cvm.rs
@@ -21,7 +21,7 @@ mod common_cvm {
     use super::*;
     macro_rules! basic_cvm_guest {
         ($image_name:expr) => {{
-            let disk_config = UbuntuDiskConfig::new($image_name.to_string());
+            let disk_config = GuestDiskConfig::new($image_name.to_string());
             GuestFactory::new_confidential_guest_factory().create_guest(Box::new(disk_config))
         }};
     }

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -134,7 +134,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     let test_timeout = control.test_timeout;
     let (rx, bandwidth) = control.net_control.unwrap();
 
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let mut guest = performance_test_new_guest(Box::new(disk_config), control);
 
     let num_queues = control.num_queues.unwrap();
@@ -174,7 +174,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
 }
 
 pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let mut guest = performance_test_new_guest(Box::new(disk_config), control);
 
     let num_queues = control.num_queues.unwrap();
@@ -321,7 +321,7 @@ fn measure_boot_time(cmd: &mut GuestCommand, test_timeout: u32) -> Result<f64, E
 
 pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = performance_test_new_guest(Box::new(disk_config), control);
         let mut cmd = GuestCommand::new(&guest);
 
@@ -345,7 +345,7 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
 
 pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = performance_test_new_guest(Box::new(disk_config), control);
         let mut cmd = GuestCommand::new(&guest);
         let c = cmd
@@ -383,7 +383,7 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
     let bandwidth = block_control.bandwidth;
     let test_file = block_control.test_file;
 
-    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
     let mut guest = performance_test_new_guest(Box::new(disk_config), control);
     let api_socket = guest
         .tmp_dir
@@ -524,7 +524,7 @@ fn measure_restore_time(
 
 pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
-        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let disk_config = GuestDiskConfig::new(OS_IMAGE.to_string());
         let guest = performance_test_new_guest(Box::new(disk_config), control);
         let api_socket_source = String::from(
             guest

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -134,7 +134,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     let test_timeout = control.test_timeout;
     let (rx, bandwidth) = control.net_control.unwrap();
 
-    let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let mut guest = performance_test_new_guest(Box::new(jammy), control);
 
     let num_queues = control.num_queues.unwrap();
@@ -174,7 +174,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
 }
 
 pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
-    let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let mut guest = performance_test_new_guest(Box::new(jammy), control);
 
     let num_queues = control.num_queues.unwrap();
@@ -321,7 +321,7 @@ fn measure_boot_time(cmd: &mut GuestCommand, test_timeout: u32) -> Result<f64, E
 
 pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
-        let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = performance_test_new_guest(Box::new(jammy), control);
         let mut cmd = GuestCommand::new(&guest);
 
@@ -345,7 +345,7 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
 
 pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
-        let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = performance_test_new_guest(Box::new(jammy), control);
         let mut cmd = GuestCommand::new(&guest);
         let c = cmd
@@ -383,7 +383,7 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
     let bandwidth = block_control.bandwidth;
     let test_file = block_control.test_file;
 
-    let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+    let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
     let mut guest = performance_test_new_guest(Box::new(jammy), control);
     let api_socket = guest
         .tmp_dir
@@ -524,7 +524,7 @@ fn measure_restore_time(
 
 pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
-        let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
         let guest = performance_test_new_guest(Box::new(jammy), control);
         let api_socket_source = String::from(
             guest

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -134,8 +134,8 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     let test_timeout = control.test_timeout;
     let (rx, bandwidth) = control.net_control.unwrap();
 
-    let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
-    let mut guest = performance_test_new_guest(Box::new(jammy), control);
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let mut guest = performance_test_new_guest(Box::new(disk_config), control);
 
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -174,8 +174,8 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
 }
 
 pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
-    let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
-    let mut guest = performance_test_new_guest(Box::new(jammy), control);
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let mut guest = performance_test_new_guest(Box::new(disk_config), control);
 
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -321,8 +321,8 @@ fn measure_boot_time(cmd: &mut GuestCommand, test_timeout: u32) -> Result<f64, E
 
 pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
-        let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
-        let guest = performance_test_new_guest(Box::new(jammy), control);
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let guest = performance_test_new_guest(Box::new(disk_config), control);
         let mut cmd = GuestCommand::new(&guest);
 
         let c = cmd
@@ -345,8 +345,8 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
 
 pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
-        let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
-        let guest = performance_test_new_guest(Box::new(jammy), control);
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let guest = performance_test_new_guest(Box::new(disk_config), control);
         let mut cmd = GuestCommand::new(&guest);
         let c = cmd
             .default_cpus()
@@ -383,8 +383,8 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
     let bandwidth = block_control.bandwidth;
     let test_file = block_control.test_file;
 
-    let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
-    let mut guest = performance_test_new_guest(Box::new(jammy), control);
+    let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+    let mut guest = performance_test_new_guest(Box::new(disk_config), control);
     let api_socket = guest
         .tmp_dir
         .as_path()
@@ -524,8 +524,8 @@ fn measure_restore_time(
 
 pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
-        let jammy = UbuntuDiskConfig::new(OS_IMAGE.to_string());
-        let guest = performance_test_new_guest(Box::new(jammy), control);
+        let disk_config = UbuntuDiskConfig::new(OS_IMAGE.to_string());
+        let guest = performance_test_new_guest(Box::new(disk_config), control);
         let api_socket_source = String::from(
             guest
                 .tmp_dir

--- a/scripts/build-custom-image.sh
+++ b/scripts/build-custom-image.sh
@@ -5,28 +5,95 @@ set -ex
 
 #VFIO_CUSTOM_IMAGE="-vfio"
 
-mkdir -p custom-image
-pushd custom-image || exit
-wget -N https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
-export IMAGE_NAME_BASE=noble-server-cloudimg-amd64
-qemu-img convert -p -f qcow2 -O raw $IMAGE_NAME_BASE.img $IMAGE_NAME_BASE.raw
+ARCH=$(uname -m)
+case "$ARCH" in
+x86_64)
+    IMAGE_ARCH="amd64"
+    ;;
+aarch64)
+    IMAGE_ARCH="arm64"
+    ;;
+*)
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+install_deps() {
+    if command -v apt-get &>/dev/null; then
+        sudo apt-get update
+        sudo apt-get install -y qemu-utils wget
+        if [ -n "$VFIO_CUSTOM_IMAGE" ]; then
+            sudo apt-get install -y gdisk parted e2fsprogs
+        fi
+    elif command -v dnf &>/dev/null; then
+        sudo dnf install -y qemu-img wget
+        if [ -n "$VFIO_CUSTOM_IMAGE" ]; then
+            sudo dnf install -y gdisk parted e2fsprogs
+        fi
+    elif command -v yum &>/dev/null; then
+        sudo yum install -y qemu-img wget
+        if [ -n "$VFIO_CUSTOM_IMAGE" ]; then
+            sudo yum install -y gdisk parted e2fsprogs
+        fi
+    else
+        echo "Unsupported package manager"
+        exit 1
+    fi
+}
+
+install_deps
+
+mkdir -p /tmp/custom-image
+pushd /tmp/custom-image || exit
+
+export IMAGE_NAME_BASE=debian-13-generic-${IMAGE_ARCH}
+
+cleanup() {
+    if mountpoint -q mnt; then
+        # Kill any processes with roots or open files under mnt/
+        sudo fuser -sk mnt/ 2>/dev/null || true
+        mountpoint -q mnt/sys && sudo umount mnt/sys
+        mountpoint -q mnt/dev/pts && sudo umount mnt/dev/pts
+        mountpoint -q mnt/dev && sudo umount mnt/dev
+        # /proc may be lazily unmounted but still holding references
+        grep -q "$PWD/mnt/proc" /proc/mounts 2>/dev/null && sudo umount -l mnt/proc
+        mountpoint -q mnt/proc && sudo umount -l mnt/proc
+        sudo umount mnt || sudo umount -l mnt
+    fi
+    EXISTING_LOOP=$(losetup -j "$PWD/$IMAGE_NAME_BASE.raw" -O NAME --noheadings 2>/dev/null | head -1)
+    if [ -n "$EXISTING_LOOP" ]; then
+        sudo losetup -d "$EXISTING_LOOP"
+    fi
+}
+cleanup
+
+wget -N https://cloud.debian.org/images/cloud/trixie/latest/${IMAGE_NAME_BASE}.qcow2
+qemu-img convert -p -f qcow2 -O raw $IMAGE_NAME_BASE.qcow2 $IMAGE_NAME_BASE.raw
 if [ -n "$VFIO_CUSTOM_IMAGE" ]; then
     qemu-img resize -f raw "$IMAGE_NAME_BASE.raw" 10G
     sudo sgdisk -e "$IMAGE_NAME_BASE.raw"
     sudo parted "$IMAGE_NAME_BASE.raw" resizepart 1 10737MB
 fi
 mkdir -p mnt
-export ROOTFS=/dev/mapper/$(sudo kpartx -v -a $IMAGE_NAME_BASE.raw | grep "p1 " | cut -f 3 -d " ")
+LOOP_DEV=$(sudo losetup --partscan -f --show $IMAGE_NAME_BASE.raw)
+export ROOTFS="${LOOP_DEV}p1"
 if [ -n "$VFIO_CUSTOM_IMAGE" ]; then
     sudo e2fsck -f "$ROOTFS"
     sudo resize2fs "$ROOTFS"
 fi
 sudo mount $ROOTFS mnt
 sudo mv mnt/etc/resolv.conf mnt/etc/resolv.conf.backup
+sudo cp -L /etc/resolv.conf mnt/etc/resolv.conf
 
 touch extra_commands
 
-if [ -n "$VFIO_CUSTOM_IMAGE" ]; then
+GUEST_PACKAGES="fio iperf iperf3 socat stress tpm2-tools kexec-tools"
+if [ "$IMAGE_ARCH" = "amd64" ]; then
+    GUEST_PACKAGES="$GUEST_PACKAGES cpuid"
+fi
+
+if [ -n "$VFIO_CUSTOM_IMAGE" ] && [ "$IMAGE_ARCH" = "amd64" ]; then
     cat >extra_commands <<EOF
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
     sudo dpkg -i cuda-keyring_1.1-1_all.deb
@@ -35,19 +102,34 @@ if [ -n "$VFIO_CUSTOM_IMAGE" ]; then
 EOF
 fi
 
+APT_PROXY_CONF="APT::Sandbox::User \"root\";
+"
+if [ -n "${http_proxy:-$HTTP_PROXY}" ]; then
+    APT_PROXY_CONF="${APT_PROXY_CONF}Acquire::http::Proxy \"${http_proxy:-$HTTP_PROXY}\";
+"
+fi
+if [ -n "${https_proxy:-$HTTPS_PROXY}" ]; then
+    APT_PROXY_CONF="${APT_PROXY_CONF}Acquire::https::Proxy \"${https_proxy:-$HTTPS_PROXY}\";
+"
+fi
+
+echo "$APT_PROXY_CONF" | sudo tee mnt/etc/apt/apt.conf.d/99proxy >/dev/null
+
 cat >script <<EOF
 #!/bin/bash
 set -xe
 mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+mount -t devtmpfs devtmpfs /dev
 mount -t devpts devpts /dev/pts
-echo "nameserver 1.1.1.1" > /etc/resolv.conf
 export DEBIAN_FRONTEND=noninteractive
 apt update
-apt install -y fio iperf iperf3 socat stress cpuid tpm2-tools kexec-tools
-apt remove -y --purge snapd pollinate
+apt install -y $GUEST_PACKAGES
+apt clean
 source extra_commands
 umount /dev/pts
-umount /proc
+umount /sys
+umount -l /proc
 history -c
 exit
 EOF
@@ -55,9 +137,17 @@ EOF
 sudo cp script extra_commands mnt
 sudo chmod +x mnt/script
 sudo chroot mnt ./script
+sudo rm -f mnt/etc/apt/apt.conf.d/99proxy
 sudo mv mnt/etc/resolv.conf.backup mnt/etc/resolv.conf
-sudo umount mnt
+sudo fuser -sk mnt/ 2>/dev/null || true
+mountpoint -q mnt/dev/pts && sudo umount mnt/dev/pts
+mountpoint -q mnt/dev && sudo umount mnt/dev
+mountpoint -q mnt/sys && sudo umount mnt/sys
+mountpoint -q mnt/proc && sudo umount mnt/proc
+mountpoint -q mnt && sudo umount mnt
 sudo kpartx -d $IMAGE_NAME_BASE.raw
-cp $IMAGE_NAME_BASE.raw $IMAGE_NAME_BASE-custom$VFIO_CUSTOM_IMAGE-$(date "+%Y%m%d")-0.raw
-qemu-img convert -p -f raw -O qcow2 $IMAGE_NAME_BASE-custom$VFIO_CUSTOM_IMAGE-$(date "+%Y%m%d")-0.raw $IMAGE_NAME_BASE-custom$VFIO_CUSTOM_IMAGE-$(date "+%Y%m%d")-0.qcow2
+
+DATE_STAMP=$(date "+%Y%m%d")
+qemu-img convert -p -f raw -O qcow2 $IMAGE_NAME_BASE.raw $IMAGE_NAME_BASE-custom$VFIO_CUSTOM_IMAGE-${DATE_STAMP}-0.qcow2
+mv $IMAGE_NAME_BASE.raw $IMAGE_NAME_BASE-custom$VFIO_CUSTOM_IMAGE-${DATE_STAMP}-0.raw
 popd || exit

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -10,10 +10,10 @@ source "$(dirname "$0")"/common-aarch64.sh
 WORKLOADS_LOCK="$WORKLOADS_DIR/integration_test.lock"
 
 update_workloads() {
-    GUEST_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.qcow2"
+    GUEST_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME="debian-13-generic-arm64-custom-20260602-0.qcow2"
     GUEST_OS_QCOW2_UNCOMPRESSED_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME"
 
-    GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.raw"
+    GUEST_OS_RAW_IMAGE_NAME="debian-13-generic-arm64-custom-20260602-0.raw"
     GUEST_OS_RAW_IMAGE="$WORKLOADS_DIR/$GUEST_OS_RAW_IMAGE_NAME"
 
     for required in "$GUEST_OS_QCOW2_UNCOMPRESSED_IMAGE" \
@@ -37,7 +37,7 @@ update_workloads() {
         popd || exit
     fi
 
-    GUEST_OS_QCOW2_ZLIB_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-zlib.qcow2"
+    GUEST_OS_QCOW2_ZLIB_FILE_IMAGE_NAME="debian-13-generic-arm64-custom-20260602-0-zlib.qcow2"
     GUEST_OS_QCOW2_ZLIB_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW2_ZLIB_FILE_IMAGE_NAME"
     if [ ! -f "$GUEST_OS_QCOW2_ZLIB_FILE_IMAGE" ]; then
         pushd "$WORKLOADS_DIR" || exit
@@ -46,7 +46,7 @@ update_workloads() {
         popd || exit
     fi
 
-    GUEST_OS_QCOW2_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-zstd.qcow2"
+    GUEST_OS_QCOW2_ZSTD_FILE_IMAGE_NAME="debian-13-generic-arm64-custom-20260602-0-zstd.qcow2"
     GUEST_OS_QCOW2_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW2_ZSTD_FILE_IMAGE_NAME"
     if [ ! -f "$GUEST_OS_QCOW2_ZSTD_FILE_IMAGE" ]; then
         pushd "$WORKLOADS_DIR" || exit
@@ -55,7 +55,7 @@ update_workloads() {
         popd || exit
     fi
 
-    GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-backing-zstd.qcow2"
+    GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME="debian-13-generic-arm64-custom-20260602-0-backing-zstd.qcow2"
     GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME"
     if [ ! -f "$GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE" ]; then
         pushd "$WORKLOADS_DIR" || exit
@@ -63,7 +63,7 @@ update_workloads() {
         popd || exit
     fi
 
-    GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-backing-uncompressed.qcow2"
+    GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME="debian-13-generic-arm64-custom-20260602-0-backing-uncompressed.qcow2"
     GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME"
     if [ ! -f "$GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE" ]; then
         pushd "$WORKLOADS_DIR" || exit
@@ -73,7 +73,7 @@ update_workloads() {
         popd || exit
     fi
 
-    GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-backing-raw.qcow2"
+    GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME="debian-13-generic-arm64-custom-20260602-0-backing-raw.qcow2"
     GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME"
     if [ ! -f "$GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE" ]; then
         pushd "$WORKLOADS_DIR" || exit

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -10,13 +10,13 @@ source "$(dirname "$0")"/common-aarch64.sh
 WORKLOADS_LOCK="$WORKLOADS_DIR/integration_test.lock"
 
 update_workloads() {
-    JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.qcow2"
-    JAMMY_OS_QCOW2_UNCOMPRESSED_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME"
+    GUEST_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.qcow2"
+    GUEST_OS_QCOW2_UNCOMPRESSED_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME"
 
-    JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.raw"
-    JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
+    GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.raw"
+    GUEST_OS_RAW_IMAGE="$WORKLOADS_DIR/$GUEST_OS_RAW_IMAGE_NAME"
 
-    for required in "$JAMMY_OS_QCOW2_UNCOMPRESSED_IMAGE" \
+    for required in "$GUEST_OS_QCOW2_UNCOMPRESSED_IMAGE" \
         "$WORKLOADS_DIR/CLOUDHV_EFI.fd" \
         "$WORKLOADS_DIR/cloud-hypervisor-static-aarch64" \
         "$WORKLOADS_DIR/alpine-minirootfs-aarch64.tar.gz" \
@@ -31,55 +31,55 @@ update_workloads() {
         cp /usr/local/bin/virtiofsd "$WORKLOADS_DIR/virtiofsd"
     fi
 
-    if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
+    if [ ! -f "$GUEST_OS_RAW_IMAGE" ]; then
         pushd "$WORKLOADS_DIR" || exit
-        time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
+        time qemu-img convert -p -f qcow2 -O raw $GUEST_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME $GUEST_OS_RAW_IMAGE_NAME || exit 1
         popd || exit
     fi
 
-    JAMMY_OS_QCOW2_ZLIB_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-zlib.qcow2"
-    JAMMY_OS_QCOW2_ZLIB_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW2_ZLIB_FILE_IMAGE_NAME"
-    if [ ! -f "$JAMMY_OS_QCOW2_ZLIB_FILE_IMAGE" ]; then
+    GUEST_OS_QCOW2_ZLIB_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-zlib.qcow2"
+    GUEST_OS_QCOW2_ZLIB_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW2_ZLIB_FILE_IMAGE_NAME"
+    if [ ! -f "$GUEST_OS_QCOW2_ZLIB_FILE_IMAGE" ]; then
         pushd "$WORKLOADS_DIR" || exit
         time qemu-img convert -c -f raw -O qcow2 -o compression_type=zlib \
-            "$JAMMY_OS_RAW_IMAGE" $JAMMY_OS_QCOW2_ZLIB_FILE_IMAGE_NAME
+            "$GUEST_OS_RAW_IMAGE" $GUEST_OS_QCOW2_ZLIB_FILE_IMAGE_NAME
         popd || exit
     fi
 
-    JAMMY_OS_QCOW2_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-zstd.qcow2"
-    JAMMY_OS_QCOW2_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW2_ZSTD_FILE_IMAGE_NAME"
-    if [ ! -f "$JAMMY_OS_QCOW2_ZSTD_FILE_IMAGE" ]; then
+    GUEST_OS_QCOW2_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-zstd.qcow2"
+    GUEST_OS_QCOW2_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW2_ZSTD_FILE_IMAGE_NAME"
+    if [ ! -f "$GUEST_OS_QCOW2_ZSTD_FILE_IMAGE" ]; then
         pushd "$WORKLOADS_DIR" || exit
         time qemu-img convert -c -f raw -O qcow2 -o compression_type=zstd \
-            "$JAMMY_OS_RAW_IMAGE" $JAMMY_OS_QCOW2_ZSTD_FILE_IMAGE_NAME
+            "$GUEST_OS_RAW_IMAGE" $GUEST_OS_QCOW2_ZSTD_FILE_IMAGE_NAME
         popd || exit
     fi
 
-    JAMMY_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-backing-zstd.qcow2"
-    JAMMY_OS_QCOW_BACKING_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME"
-    if [ ! -f "$JAMMY_OS_QCOW_BACKING_ZSTD_FILE_IMAGE" ]; then
+    GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-backing-zstd.qcow2"
+    GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME"
+    if [ ! -f "$GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE" ]; then
         pushd "$WORKLOADS_DIR" || exit
-        time qemu-img create -f qcow2 -b "$JAMMY_OS_QCOW2_ZSTD_FILE_IMAGE" -F qcow2 $JAMMY_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME
+        time qemu-img create -f qcow2 -b "$GUEST_OS_QCOW2_ZSTD_FILE_IMAGE" -F qcow2 $GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME
         popd || exit
     fi
 
-    JAMMY_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-backing-uncompressed.qcow2"
-    JAMMY_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME"
-    if [ ! -f "$JAMMY_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE" ]; then
-        pushd "$WORKLOADS_DIR" || exit
-        time qemu-img create -f qcow2 \
-            -b "$JAMMY_OS_QCOW2_UNCOMPRESSED_IMAGE" \
-            -F qcow2 $JAMMY_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME
-        popd || exit
-    fi
-
-    JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-backing-raw.qcow2"
-    JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME"
-    if [ ! -f "$JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE" ]; then
+    GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-backing-uncompressed.qcow2"
+    GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME"
+    if [ ! -f "$GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE" ]; then
         pushd "$WORKLOADS_DIR" || exit
         time qemu-img create -f qcow2 \
-            -b "$JAMMY_OS_RAW_IMAGE" \
-            -F raw $JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME
+            -b "$GUEST_OS_QCOW2_UNCOMPRESSED_IMAGE" \
+            -F qcow2 $GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME
+        popd || exit
+    fi
+
+    GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-backing-raw.qcow2"
+    GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME"
+    if [ ! -f "$GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE" ]; then
+        pushd "$WORKLOADS_DIR" || exit
+        time qemu-img create -f qcow2 \
+            -b "$GUEST_OS_RAW_IMAGE" \
+            -F raw $GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME
         popd || exit
     fi
 

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -10,13 +10,13 @@ source "$(dirname "$0")"/common-aarch64.sh
 WORKLOADS_LOCK="$WORKLOADS_DIR/integration_test.lock"
 
 update_workloads() {
-    JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.raw"
-    JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
-
     JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.qcow2"
     JAMMY_OS_QCOW2_UNCOMPRESSED_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME"
 
-    for required in "$JAMMY_OS_RAW_IMAGE" "$JAMMY_OS_QCOW2_UNCOMPRESSED_IMAGE" \
+    JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.raw"
+    JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
+
+    for required in "$JAMMY_OS_QCOW2_UNCOMPRESSED_IMAGE" \
         "$WORKLOADS_DIR/CLOUDHV_EFI.fd" \
         "$WORKLOADS_DIR/cloud-hypervisor-static-aarch64" \
         "$WORKLOADS_DIR/alpine-minirootfs-aarch64.tar.gz" \
@@ -29,6 +29,12 @@ update_workloads() {
 
     if [ ! -f "$WORKLOADS_DIR/virtiofsd" ]; then
         cp /usr/local/bin/virtiofsd "$WORKLOADS_DIR/virtiofsd"
+    fi
+
+    if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
+        pushd "$WORKLOADS_DIR" || exit
+        time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
+        popd || exit
     fi
 
     JAMMY_OS_QCOW2_ZLIB_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-zlib.qcow2"

--- a/scripts/run_integration_tests_cvm.sh
+++ b/scripts/run_integration_tests_cvm.sh
@@ -15,14 +15,14 @@ process_common_args "$@"
 test_features="--features mshv,igvm,sev_snp"
 build_features="mshv,igvm,sev_snp"
 
-GUEST_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
+GUEST_OS_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0.qcow2"
 GUEST_OS_IMAGE="$WORKLOADS_DIR/$GUEST_OS_IMAGE_NAME"
 if [ ! -f "$GUEST_OS_IMAGE" ]; then
     echo "Missing: $GUEST_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test cvm"
     exit 1
 fi
 
-GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+GUEST_OS_RAW_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0.raw"
 GUEST_OS_RAW_IMAGE="$WORKLOADS_DIR/$GUEST_OS_RAW_IMAGE_NAME"
 if [ ! -f "$GUEST_OS_RAW_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit

--- a/scripts/run_integration_tests_cvm.sh
+++ b/scripts/run_integration_tests_cvm.sh
@@ -15,18 +15,18 @@ process_common_args "$@"
 test_features="--features mshv,igvm,sev_snp"
 build_features="mshv,igvm,sev_snp"
 
-JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
-JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_IMAGE" ]; then
-    echo "Missing: $JAMMY_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test cvm"
+GUEST_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
+GUEST_OS_IMAGE="$WORKLOADS_DIR/$GUEST_OS_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_IMAGE" ]; then
+    echo "Missing: $GUEST_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test cvm"
     exit 1
 fi
 
-JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
-JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
+GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+GUEST_OS_RAW_IMAGE="$WORKLOADS_DIR/$GUEST_OS_RAW_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_RAW_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
-    time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_IMAGE_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
+    time qemu-img convert -p -f qcow2 -O raw $GUEST_OS_IMAGE_NAME $GUEST_OS_RAW_IMAGE_NAME || exit 1
     popd || exit
 fi
 

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -18,14 +18,14 @@ if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
 
-GUEST_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
+GUEST_OS_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0.qcow2"
 GUEST_OS_IMAGE="$WORKLOADS_DIR/$GUEST_OS_IMAGE_NAME"
 if [ ! -f "$GUEST_OS_IMAGE" ]; then
     echo "Missing: $GUEST_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test rate-limiter"
     exit 1
 fi
 
-GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+GUEST_OS_RAW_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0.raw"
 GUEST_OS_RAW_IMAGE="$WORKLOADS_DIR/$GUEST_OS_RAW_IMAGE_NAME"
 if [ ! -f "$GUEST_OS_RAW_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -18,18 +18,18 @@ if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
 
-JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
-JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_IMAGE" ]; then
-    echo "Missing: $JAMMY_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test rate-limiter"
+GUEST_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
+GUEST_OS_IMAGE="$WORKLOADS_DIR/$GUEST_OS_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_IMAGE" ]; then
+    echo "Missing: $GUEST_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test rate-limiter"
     exit 1
 fi
 
-JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
-JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
+GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+GUEST_OS_RAW_IMAGE="$WORKLOADS_DIR/$GUEST_OS_RAW_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_RAW_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
-    time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_IMAGE_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
+    time qemu-img convert -p -f qcow2 -O raw $GUEST_OS_IMAGE_NAME $GUEST_OS_RAW_IMAGE_NAME || exit 1
     popd || exit
 fi
 

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -21,12 +21,12 @@ fi
 
 # if migratable version is set to override the default
 FW="$WORKLOADS_DIR/hypervisor-fw"
-JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
-JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
-JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
-JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
+GUEST_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
+GUEST_OS_IMAGE="$WORKLOADS_DIR/$GUEST_OS_IMAGE_NAME"
+GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+GUEST_OS_RAW_IMAGE="$WORKLOADS_DIR/$GUEST_OS_RAW_IMAGE_NAME"
 
-for required in "$FW" "$WORKLOADS_DIR/CLOUDHV.fd" "$JAMMY_OS_IMAGE" \
+for required in "$FW" "$WORKLOADS_DIR/CLOUDHV.fd" "$GUEST_OS_IMAGE" \
     "$WORKLOADS_DIR/vmlinux-x86_64" "$WORKLOADS_DIR/bzImage-x86_64" \
     "$WORKLOADS_DIR/alpine-minirootfs-x86_64.tar.gz" \
     "$WORKLOADS_DIR/cloud-hypervisor-static"; do
@@ -36,57 +36,57 @@ for required in "$FW" "$WORKLOADS_DIR/CLOUDHV.fd" "$JAMMY_OS_IMAGE" \
     fi
 done
 
-if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
+if [ ! -f "$GUEST_OS_RAW_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
-    time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_IMAGE_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
+    time qemu-img convert -p -f qcow2 -O raw $GUEST_OS_IMAGE_NAME $GUEST_OS_RAW_IMAGE_NAME || exit 1
     popd || exit
 fi
 
-JAMMY_OS_QCOW_ZLIB_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-zlib.qcow2"
-JAMMY_OS_QCOW_ZLIB_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW_ZLIB_FILE_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_QCOW_ZLIB_FILE_IMAGE" ]; then
+GUEST_OS_QCOW_ZLIB_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-zlib.qcow2"
+GUEST_OS_QCOW_ZLIB_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_ZLIB_FILE_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_QCOW_ZLIB_FILE_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
     time qemu-img convert -c -f raw -O qcow2 -o compression_type=zlib \
-        "$JAMMY_OS_RAW_IMAGE" $JAMMY_OS_QCOW_ZLIB_FILE_IMAGE_NAME
+        "$GUEST_OS_RAW_IMAGE" $GUEST_OS_QCOW_ZLIB_FILE_IMAGE_NAME
     popd || exit
 fi
 
-JAMMY_OS_QCOW_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-zstd.qcow2"
-JAMMY_OS_QCOW_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW_ZSTD_FILE_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_QCOW_ZSTD_FILE_IMAGE" ]; then
+GUEST_OS_QCOW_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-zstd.qcow2"
+GUEST_OS_QCOW_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_ZSTD_FILE_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_QCOW_ZSTD_FILE_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
     time qemu-img convert -c -f raw -O qcow2 -o compression_type=zstd \
-        "$JAMMY_OS_RAW_IMAGE" $JAMMY_OS_QCOW_ZSTD_FILE_IMAGE_NAME
+        "$GUEST_OS_RAW_IMAGE" $GUEST_OS_QCOW_ZSTD_FILE_IMAGE_NAME
     popd || exit
 fi
 
-JAMMY_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-backing-zstd.qcow2"
-JAMMY_OS_QCOW_BACKING_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_QCOW_BACKING_ZSTD_FILE_IMAGE" ]; then
+GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-backing-zstd.qcow2"
+GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
     time qemu-img create -f qcow2 \
-        -b "$JAMMY_OS_QCOW_ZSTD_FILE_IMAGE" \
-        -F qcow2 $JAMMY_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME
+        -b "$GUEST_OS_QCOW_ZSTD_FILE_IMAGE" \
+        -F qcow2 $GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME
     popd || exit
 fi
 
-JAMMY_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-backing-uncompressed.qcow2"
-JAMMY_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE" ]; then
+GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-backing-uncompressed.qcow2"
+GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
     time qemu-img create -f qcow2 \
-        -b "$JAMMY_OS_IMAGE" \
-        -F qcow2 $JAMMY_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME
+        -b "$GUEST_OS_IMAGE" \
+        -F qcow2 $GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME
     popd || exit
 fi
 
-JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-backing-raw.qcow2"
-JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE" ]; then
+GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-backing-raw.qcow2"
+GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
     time qemu-img create -f qcow2 \
-        -b "$JAMMY_OS_RAW_IMAGE" \
-        -F raw $JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME
+        -b "$GUEST_OS_RAW_IMAGE" \
+        -F raw $GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME
     popd || exit
 fi
 
@@ -148,7 +148,7 @@ VFIO_DIR="$WORKLOADS_DIR/vfio"
 VFIO_DISK_IMAGE="$WORKLOADS_DIR/vfio.img"
 rm -rf "$VFIO_DIR" "$VFIO_DISK_IMAGE"
 mkdir -p "$VFIO_DIR"
-cp "$JAMMY_OS_RAW_IMAGE" "$VFIO_DIR"
+cp "$GUEST_OS_RAW_IMAGE" "$VFIO_DIR"
 cp "$FW" "$VFIO_DIR"
 cp "$VMLINUX_IMAGE" "$VFIO_DIR" || exit 1
 

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -21,9 +21,9 @@ fi
 
 # if migratable version is set to override the default
 FW="$WORKLOADS_DIR/hypervisor-fw"
-GUEST_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
+GUEST_OS_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0.qcow2"
 GUEST_OS_IMAGE="$WORKLOADS_DIR/$GUEST_OS_IMAGE_NAME"
-GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+GUEST_OS_RAW_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0.raw"
 GUEST_OS_RAW_IMAGE="$WORKLOADS_DIR/$GUEST_OS_RAW_IMAGE_NAME"
 
 for required in "$FW" "$WORKLOADS_DIR/CLOUDHV.fd" "$GUEST_OS_IMAGE" \
@@ -42,7 +42,7 @@ if [ ! -f "$GUEST_OS_RAW_IMAGE" ]; then
     popd || exit
 fi
 
-GUEST_OS_QCOW_ZLIB_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-zlib.qcow2"
+GUEST_OS_QCOW_ZLIB_FILE_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0-zlib.qcow2"
 GUEST_OS_QCOW_ZLIB_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_ZLIB_FILE_IMAGE_NAME"
 if [ ! -f "$GUEST_OS_QCOW_ZLIB_FILE_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
@@ -51,7 +51,7 @@ if [ ! -f "$GUEST_OS_QCOW_ZLIB_FILE_IMAGE" ]; then
     popd || exit
 fi
 
-GUEST_OS_QCOW_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-zstd.qcow2"
+GUEST_OS_QCOW_ZSTD_FILE_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0-zstd.qcow2"
 GUEST_OS_QCOW_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_ZSTD_FILE_IMAGE_NAME"
 if [ ! -f "$GUEST_OS_QCOW_ZSTD_FILE_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
@@ -60,7 +60,7 @@ if [ ! -f "$GUEST_OS_QCOW_ZSTD_FILE_IMAGE" ]; then
     popd || exit
 fi
 
-GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-backing-zstd.qcow2"
+GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0-backing-zstd.qcow2"
 GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE_NAME"
 if [ ! -f "$GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
@@ -70,7 +70,7 @@ if [ ! -f "$GUEST_OS_QCOW_BACKING_ZSTD_FILE_IMAGE" ]; then
     popd || exit
 fi
 
-GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-backing-uncompressed.qcow2"
+GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0-backing-uncompressed.qcow2"
 GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE_NAME"
 if [ ! -f "$GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
@@ -80,7 +80,7 @@ if [ ! -f "$GUEST_OS_QCOW_BACKING_UNCOMPRESSED_FILE_IMAGE" ]; then
     popd || exit
 fi
 
-GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-backing-raw.qcow2"
+GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0-backing-raw.qcow2"
 GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE="$WORKLOADS_DIR/$GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE_NAME"
 if [ ! -f "$GUEST_OS_QCOW_BACKING_RAW_FILE_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -21,11 +21,11 @@ if [ "$VM_TYPE" = "confidential" ]; then
 fi
 
 if [ "${TEST_ARCH}" == "aarch64" ]; then
-    GUEST_OS_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.qcow2"
-    GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.raw"
+    GUEST_OS_IMAGE_NAME="debian-13-generic-arm64-custom-20260602-0.qcow2"
+    GUEST_OS_RAW_IMAGE_NAME="debian-13-generic-arm64-custom-20260602-0.raw"
 else
-    GUEST_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
-    GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+    GUEST_OS_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0.qcow2"
+    GUEST_OS_RAW_IMAGE_NAME="debian-13-generic-amd64-custom-20260602-0.raw"
 fi
 
 GUEST_OS_IMAGE="$WORKLOADS_DIR/$GUEST_OS_IMAGE_NAME"

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -21,23 +21,23 @@ if [ "$VM_TYPE" = "confidential" ]; then
 fi
 
 if [ "${TEST_ARCH}" == "aarch64" ]; then
-    JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.qcow2"
-    JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.raw"
+    GUEST_OS_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.qcow2"
+    GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.raw"
 else
-    JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
-    JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+    GUEST_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
+    GUEST_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
 fi
 
-JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_IMAGE" ]; then
-    echo "Missing: $JAMMY_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test metrics"
+GUEST_OS_IMAGE="$WORKLOADS_DIR/$GUEST_OS_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_IMAGE" ]; then
+    echo "Missing: $GUEST_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test metrics"
     exit 1
 fi
 
-JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
+GUEST_OS_RAW_IMAGE="$WORKLOADS_DIR/$GUEST_OS_RAW_IMAGE_NAME"
+if [ ! -f "$GUEST_OS_RAW_IMAGE" ]; then
     pushd "$WORKLOADS_DIR" || exit
-    time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_IMAGE_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
+    time qemu-img convert -p -f qcow2 -O raw $GUEST_OS_IMAGE_NAME $GUEST_OS_RAW_IMAGE_NAME || exit 1
     popd || exit
 fi
 

--- a/scripts/sha1sums-aarch64-common
+++ b/scripts/sha1sums-aarch64-common
@@ -1,4 +1,0 @@
-e4addb6e212a298144f9eb0eb6e36019d013f0e7  alpine-minirootfs-aarch64.tar.gz
-7118f4d4cad18c8357bc2ad9824a50f9a82a860a  jammy-server-cloudimg-arm64-custom-20220329-0.qcow2
-1f2b71be43b8f748f01306c4454e5c921343faa4  jammy-server-cloudimg-arm64-custom-20220329-0.raw
-ce3656987f9e4238ef8afbd65fca219460c1f767  CLOUDHV_EFI.fd

--- a/scripts/sha1sums-x86_64
+++ b/scripts/sha1sums-x86_64
@@ -1,3 +1,0 @@
-d4a44acc6014d5f83dea1c625c43d677a95fa75f alpine-minirootfs-x86_64.tar.gz
-540ac358429305d7aa94e15363665d1c9d845982 hypervisor-fw
-fb2e6834cc482c80a45766f6dcf12474f4fcb74e CLOUDHV.fd

--- a/scripts/sha1sums-x86_64-common
+++ b/scripts/sha1sums-x86_64-common
@@ -1,2 +1,0 @@
-5f10738920efb74f0bf854cadcd1b1fd544e49c8 jammy-server-cloudimg-amd64-custom-20241017-0.qcow2
-c1dfbe7abde400e675844568dbe9d3914222f6de jammy-server-cloudimg-amd64-custom-20241017-0.raw

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -363,23 +363,3 @@ copy_to_image() {
     mount_and_exec "$IMG" "$MOUNT_DIR" /bin/bash -c "$COPY_COMMAND"
     return $?
 }
-
-# Download x86 guest images
-download_x86_guest_images() {
-    JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
-    JAMMY_OS_IMAGE_URL="https://ch-images.azureedge.net/$JAMMY_OS_IMAGE_NAME"
-    JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
-    if [ ! -f "$JAMMY_OS_IMAGE" ]; then
-        pushd "$WORKLOADS_DIR" || exit
-        time wget --quiet $JAMMY_OS_IMAGE_URL || exit 1
-        popd || exit
-    fi
-
-    JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
-    JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
-    if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
-        pushd "$WORKLOADS_DIR" || exit
-        time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_IMAGE_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
-        popd || exit
-    fi
-}

--- a/scripts/test_assets.yaml
+++ b/scripts/test_assets.yaml
@@ -32,12 +32,6 @@ assets:
     arch: [x86_64]
     test: [integration, cvm, rate-limiter, metrics]
 
-  - filename: jammy-server-cloudimg-arm64-custom-20220329-0.raw
-    url: https://ch-images.azureedge.net/jammy-server-cloudimg-arm64-custom-20220329-0.raw
-    sha1: 1f2b71be43b8f748f01306c4454e5c921343faa4
-    arch: [aarch64]
-    test: [integration]
-
   - filename: jammy-server-cloudimg-arm64-custom-20220329-0.qcow2
     url: https://ch-images.azureedge.net/jammy-server-cloudimg-arm64-custom-20220329-0.qcow2
     sha1: 7118f4d4cad18c8357bc2ad9824a50f9a82a860a

--- a/scripts/test_assets.yaml
+++ b/scripts/test_assets.yaml
@@ -26,15 +26,15 @@ assets:
     test: [integration, windows]
 
   # Guest images
-  - filename: jammy-server-cloudimg-amd64-custom-20241017-0.qcow2
-    url: https://ch-images.azureedge.net/jammy-server-cloudimg-amd64-custom-20241017-0.qcow2
-    sha1: 5f10738920efb74f0bf854cadcd1b1fd544e49c8
+  - filename: debian-13-generic-amd64-custom-20260602-0.qcow2
+    url: https://ch-images.azureedge.net/debian-13-generic-amd64-custom-20260602-0.qcow2
+    sha1: e52d54c0f9d1289b7c3205ed8b94f05f394a3682
     arch: [x86_64]
     test: [integration, cvm, rate-limiter, metrics]
 
-  - filename: jammy-server-cloudimg-arm64-custom-20220329-0.qcow2
-    url: https://ch-images.azureedge.net/jammy-server-cloudimg-arm64-custom-20220329-0.qcow2
-    sha1: 7118f4d4cad18c8357bc2ad9824a50f9a82a860a
+  - filename: debian-13-generic-arm64-custom-20260602-0.qcow2
+    url: https://ch-images.azureedge.net/debian-13-generic-arm64-custom-20260602-0.qcow2
+    sha1: 1c2153bf32c81ff9eddc5d62f5cd4fce1fc28b7c
     arch: [aarch64]
     test: [integration]
 

--- a/test_data/cloud-init/ubuntu/ci/network-config
+++ b/test_data/cloud-init/ubuntu/ci/network-config
@@ -5,28 +5,38 @@ ethernets:
       macaddress: 12:34:56:78:90:ab
     addresses:
     - 192.168.2.2/25
-    gateway4: 192.168.2.1
+    routes:
+    - to: default
+      via: 192.168.2.1
   id1:
     match:
       macaddress: de:ad:be:ef:12:34
     addresses:
     - 192.168.2.3/25
-    gateway4: 192.168.2.1
+    routes:
+    - to: default
+      via: 192.168.2.1
   id2:
     match:
       macaddress: de:ad:be:ef:34:56
     addresses:
     - 192.168.2.4/25
-    gateway4: 192.168.2.1
+    routes:
+    - to: default
+      via: 192.168.2.1
   id3:
     match:
       macaddress: de:ad:be:ef:56:78
     addresses:
     - 192.168.2.5/25
-    gateway4: 192.168.2.1
+    routes:
+    - to: default
+      via: 192.168.2.1
   id4:
     match:
       macaddress: de:ad:be:ef:78:90
     addresses:
     - 192.168.2.130/25
-    gateway4: 192.168.2.129
+    routes:
+    - to: default
+      via: 192.168.2.129

--- a/test_data/cloud-init/ubuntu/ci/user-data
+++ b/test_data/cloud-init/ubuntu/ci/user-data
@@ -11,10 +11,17 @@ ssh_pwauth: True
 
 runcmd:
   - [ systemctl, daemon-reload]
+  - [ systemctl, restart, sshd]
   - [ systemctl, enable, notify-booted.service]
   - [ systemctl, start, --no-block, notify-booted.service ]
 
 write_files:
+  -
+    path: /etc/ssh/sshd_config.d/99-disable-penalties.conf
+    permissions: 0644
+    content: |
+        PerSourcePenalties no
+
   -
     path: /etc/systemd/system/vfio.service
     permissions: 0644
@@ -47,7 +54,7 @@ write_files:
         # 1G ram requires 512 pages
         echo 512 | sudo tee /proc/sys/vm/nr_hugepages
         sudo chmod a+rwX /dev/hugepages
-        /mnt/cloud-hypervisor --kernel /mnt/vmlinux-x86_64 --cmdline "console=hvc0 reboot=k panic=1 nomodules root=/dev/vda1 VFIOTAG" --disk path=/mnt/jammy-server-cloudimg-amd64-custom-20241017-0.raw path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,hugepages=on --device path=/sys/bus/pci/devices/0000:00:05.0/ path=/sys/bus/pci/devices/0000:00:07.0/ path=/sys/bus/pci/devices/0000:00:08.0/ --api-socket=/tmp/ch_api.sock
+        /mnt/cloud-hypervisor --kernel /mnt/vmlinux-x86_64 --cmdline "console=hvc0 reboot=k panic=1 nomodules root=/dev/vda1 VFIOTAG" --disk path=/mnt/debian-13-generic-amd64-custom-20260602-0.raw path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,hugepages=on --device path=/sys/bus/pci/devices/0000:00:05.0/ path=/sys/bus/pci/devices/0000:00:07.0/ path=/sys/bus/pci/devices/0000:00:08.0/ --api-socket=/tmp/ch_api.sock
 
   -
     path: /etc/systemd/system/notify-booted.service

--- a/test_data/cloud-init/ubuntu/local/network-config
+++ b/test_data/cloud-init/ubuntu/local/network-config
@@ -4,4 +4,6 @@ ethernets:
     match:
        macaddress: 12:34:56:78:90:ab
     addresses: [192.168.249.2/24]
-    gateway4: 192.168.249.1
+    routes:
+    - to: default
+      via: 192.168.249.1

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2599,19 +2599,19 @@ pub const MAX_NUM_PCI_SEGMENTS: u16 = 96;
 pub mod x86_64 {
     pub const JAMMY_VFIO_IMAGE_NAME: &str =
         "jammy-server-cloudimg-amd64-custom-vfio-20241012-0.raw";
-    pub const JAMMY_IMAGE_NAME: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.raw";
-    pub const JAMMY_IMAGE_NAME_VHD: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.vhd";
-    pub const JAMMY_IMAGE_NAME_VHDX: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.vhdx";
-    pub const JAMMY_IMAGE_NAME_QCOW2: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.qcow2";
-    pub const JAMMY_IMAGE_NAME_QCOW2_ZLIB: &str =
+    pub const OS_IMAGE: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.raw";
+    pub const OS_IMAGE_VHD: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.vhd";
+    pub const OS_IMAGE_VHDX: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.vhdx";
+    pub const OS_IMAGE_QCOW2: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.qcow2";
+    pub const OS_IMAGE_QCOW2_ZLIB: &str =
         "jammy-server-cloudimg-amd64-custom-20241017-0-zlib.qcow2";
-    pub const JAMMY_IMAGE_NAME_QCOW2_ZSTD: &str =
+    pub const OS_IMAGE_QCOW2_ZSTD: &str =
         "jammy-server-cloudimg-amd64-custom-20241017-0-zstd.qcow2";
-    pub const JAMMY_IMAGE_NAME_QCOW2_BACKING_ZSTD_FILE: &str =
+    pub const OS_IMAGE_QCOW2_BACKING_ZSTD_FILE: &str =
         "jammy-server-cloudimg-amd64-custom-20241017-0-backing-zstd.qcow2";
-    pub const JAMMY_IMAGE_NAME_QCOW2_BACKING_UNCOMPRESSED_FILE: &str =
+    pub const OS_IMAGE_QCOW2_BACKING_UNCOMPRESSED_FILE: &str =
         "jammy-server-cloudimg-amd64-custom-20241017-0-backing-uncompressed.qcow2";
-    pub const JAMMY_IMAGE_NAME_QCOW2_BACKING_RAW_FILE: &str =
+    pub const OS_IMAGE_QCOW2_BACKING_RAW_FILE: &str =
         "jammy-server-cloudimg-amd64-custom-20241017-0-backing-raw.qcow2";
     pub const WINDOWS_IMAGE_NAME: &str = "windows-server-2025-amd64-1.raw";
     pub const OVMF_NAME: &str = "CLOUDHV.fd";
@@ -2623,19 +2623,19 @@ pub use x86_64::*;
 
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64 {
-    pub const JAMMY_IMAGE_NAME: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.raw";
-    pub const JAMMY_IMAGE_NAME_VHD: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.vhd";
-    pub const JAMMY_IMAGE_NAME_VHDX: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.vhdx";
-    pub const JAMMY_IMAGE_NAME_QCOW2: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.qcow2";
-    pub const JAMMY_IMAGE_NAME_QCOW2_ZLIB: &str =
+    pub const OS_IMAGE: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.raw";
+    pub const OS_IMAGE_VHD: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.vhd";
+    pub const OS_IMAGE_VHDX: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.vhdx";
+    pub const OS_IMAGE_QCOW2: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.qcow2";
+    pub const OS_IMAGE_QCOW2_ZLIB: &str =
         "jammy-server-cloudimg-arm64-custom-20220329-0-zlib.qcow2";
-    pub const JAMMY_IMAGE_NAME_QCOW2_ZSTD: &str =
+    pub const OS_IMAGE_QCOW2_ZSTD: &str =
         "jammy-server-cloudimg-arm64-custom-20220329-0-zstd.qcow2";
-    pub const JAMMY_IMAGE_NAME_QCOW2_BACKING_ZSTD_FILE: &str =
+    pub const OS_IMAGE_QCOW2_BACKING_ZSTD_FILE: &str =
         "jammy-server-cloudimg-arm64-custom-20220329-0-backing-zstd.qcow2";
-    pub const JAMMY_IMAGE_NAME_QCOW2_BACKING_UNCOMPRESSED_FILE: &str =
+    pub const OS_IMAGE_QCOW2_BACKING_UNCOMPRESSED_FILE: &str =
         "jammy-server-cloudimg-arm64-custom-20220329-0-backing-uncompressed.qcow2";
-    pub const JAMMY_IMAGE_NAME_QCOW2_BACKING_RAW_FILE: &str =
+    pub const OS_IMAGE_QCOW2_BACKING_RAW_FILE: &str =
         "jammy-server-cloudimg-arm64-custom-20220329-0-backing-raw.qcow2";
     pub const WINDOWS_IMAGE_NAME: &str = "windows-11-iot-enterprise-aarch64.raw";
     pub const OVMF_NAME: &str = "CLOUDHV_EFI.fd";

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -339,15 +339,15 @@ pub trait DiskConfig {
 }
 
 #[derive(Clone)]
-pub struct UbuntuDiskConfig {
+pub struct GuestDiskConfig {
     osdisk_path: String,
     cloudinit_path: String,
     image_name: String,
 }
 
-impl UbuntuDiskConfig {
+impl GuestDiskConfig {
     pub fn new(image_name: String) -> Self {
-        UbuntuDiskConfig {
+        GuestDiskConfig {
             image_name,
             osdisk_path: String::new(),
             cloudinit_path: String::new(),
@@ -438,7 +438,7 @@ fn workspace_root() -> PathBuf {
     panic!("Could not find workspace root");
 }
 
-impl DiskConfig for UbuntuDiskConfig {
+impl DiskConfig for GuestDiskConfig {
     fn prepare_cloudinit(&self, tmp_dir: &TempDir, network: &GuestNetworkConfig) -> String {
         let cloudinit_file_path =
             String::from(tmp_dir.as_path().join("cloudinit").to_str().unwrap());

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2599,20 +2599,18 @@ pub const MAX_NUM_PCI_SEGMENTS: u16 = 96;
 pub mod x86_64 {
     pub const JAMMY_VFIO_IMAGE_NAME: &str =
         "jammy-server-cloudimg-amd64-custom-vfio-20241012-0.raw";
-    pub const OS_IMAGE: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.raw";
-    pub const OS_IMAGE_VHD: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.vhd";
-    pub const OS_IMAGE_VHDX: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.vhdx";
-    pub const OS_IMAGE_QCOW2: &str = "jammy-server-cloudimg-amd64-custom-20241017-0.qcow2";
-    pub const OS_IMAGE_QCOW2_ZLIB: &str =
-        "jammy-server-cloudimg-amd64-custom-20241017-0-zlib.qcow2";
-    pub const OS_IMAGE_QCOW2_ZSTD: &str =
-        "jammy-server-cloudimg-amd64-custom-20241017-0-zstd.qcow2";
+    pub const OS_IMAGE: &str = "debian-13-generic-amd64-custom-20260602-0.raw";
+    pub const OS_IMAGE_VHD: &str = "debian-13-generic-amd64-custom-20260602-0.vhd";
+    pub const OS_IMAGE_VHDX: &str = "debian-13-generic-amd64-custom-20260602-0.vhdx";
+    pub const OS_IMAGE_QCOW2: &str = "debian-13-generic-amd64-custom-20260602-0.qcow2";
+    pub const OS_IMAGE_QCOW2_ZLIB: &str = "debian-13-generic-amd64-custom-20260602-0-zlib.qcow2";
+    pub const OS_IMAGE_QCOW2_ZSTD: &str = "debian-13-generic-amd64-custom-20260602-0-zstd.qcow2";
     pub const OS_IMAGE_QCOW2_BACKING_ZSTD_FILE: &str =
-        "jammy-server-cloudimg-amd64-custom-20241017-0-backing-zstd.qcow2";
+        "debian-13-generic-amd64-custom-20260602-0-backing-zstd.qcow2";
     pub const OS_IMAGE_QCOW2_BACKING_UNCOMPRESSED_FILE: &str =
-        "jammy-server-cloudimg-amd64-custom-20241017-0-backing-uncompressed.qcow2";
+        "debian-13-generic-amd64-custom-20260602-0-backing-uncompressed.qcow2";
     pub const OS_IMAGE_QCOW2_BACKING_RAW_FILE: &str =
-        "jammy-server-cloudimg-amd64-custom-20241017-0-backing-raw.qcow2";
+        "debian-13-generic-amd64-custom-20260602-0-backing-raw.qcow2";
     pub const WINDOWS_IMAGE_NAME: &str = "windows-server-2025-amd64-1.raw";
     pub const OVMF_NAME: &str = "CLOUDHV.fd";
     pub const GREP_SERIAL_IRQ_CMD: &str = "grep -c 'IO-APIC.*ttyS0' /proc/interrupts || true";
@@ -2623,20 +2621,18 @@ pub use x86_64::*;
 
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64 {
-    pub const OS_IMAGE: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.raw";
-    pub const OS_IMAGE_VHD: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.vhd";
-    pub const OS_IMAGE_VHDX: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.vhdx";
-    pub const OS_IMAGE_QCOW2: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.qcow2";
-    pub const OS_IMAGE_QCOW2_ZLIB: &str =
-        "jammy-server-cloudimg-arm64-custom-20220329-0-zlib.qcow2";
-    pub const OS_IMAGE_QCOW2_ZSTD: &str =
-        "jammy-server-cloudimg-arm64-custom-20220329-0-zstd.qcow2";
+    pub const OS_IMAGE: &str = "debian-13-generic-arm64-custom-20260602-0.raw";
+    pub const OS_IMAGE_VHD: &str = "debian-13-generic-arm64-custom-20260602-0.vhd";
+    pub const OS_IMAGE_VHDX: &str = "debian-13-generic-arm64-custom-20260602-0.vhdx";
+    pub const OS_IMAGE_QCOW2: &str = "debian-13-generic-arm64-custom-20260602-0.qcow2";
+    pub const OS_IMAGE_QCOW2_ZLIB: &str = "debian-13-generic-arm64-custom-20260602-0-zlib.qcow2";
+    pub const OS_IMAGE_QCOW2_ZSTD: &str = "debian-13-generic-arm64-custom-20260602-0-zstd.qcow2";
     pub const OS_IMAGE_QCOW2_BACKING_ZSTD_FILE: &str =
-        "jammy-server-cloudimg-arm64-custom-20220329-0-backing-zstd.qcow2";
+        "debian-13-generic-arm64-custom-20260602-0-backing-zstd.qcow2";
     pub const OS_IMAGE_QCOW2_BACKING_UNCOMPRESSED_FILE: &str =
-        "jammy-server-cloudimg-arm64-custom-20220329-0-backing-uncompressed.qcow2";
+        "debian-13-generic-arm64-custom-20260602-0-backing-uncompressed.qcow2";
     pub const OS_IMAGE_QCOW2_BACKING_RAW_FILE: &str =
-        "jammy-server-cloudimg-arm64-custom-20220329-0-backing-raw.qcow2";
+        "debian-13-generic-arm64-custom-20260602-0-backing-raw.qcow2";
     pub const WINDOWS_IMAGE_NAME: &str = "windows-11-iot-enterprise-aarch64.raw";
     pub const OVMF_NAME: &str = "CLOUDHV_EFI.fd";
     pub const GREP_SERIAL_IRQ_CMD: &str = "grep -c 'GICv3.*uart-pl011' /proc/interrupts || true";


### PR DESCRIPTION
- **scripts: Improve image building script**
- **tests: Use more generic name for guest OS image constant**
- **tests: Remove last vestiges of "jammy" variable**
- **tests: Rename UbuntuDiskConfig to GuestDiskConfig**
- **scripts: Delete now unused sha1sum files**
- **tests: Only download QCOW2 image**
- **scripts: Remove download_x86_guest_images()**
- **scripts: Use more generic name for guest OS image in scripts**
- **tests: Switch guest OS over to Debian Trixie**
