### PR TITLE
vm-migration: Add migration protocol versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "test_infra",
  "thiserror",
  "tracer",
+ "vm-migration",
  "vmm",
  "vmm-sys-util",
  "wait-timeout",

--- a/cloud-hypervisor/Cargo.toml
+++ b/cloud-hypervisor/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { workspace = true }
 signal-hook = { workspace = true }
 thiserror = { workspace = true }
 tracer = { path = "../tracer" }
+vm-migration = { path = "../vm-migration" }
 vmm = { path = "../vmm" }
 vmm-sys-util = { workspace = true }
 zbus = { version = "5.15.0", optional = true }

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -880,6 +880,11 @@ fn main() {
 
     if cmd_arguments.get_flag("version") {
         println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILD_VERSION"));
+        let migration_protocol_versions = vm_migration::protocol::supported_protocol_versions()
+            .map(|version| version.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("Migration Protocol Versions: {migration_protocol_versions}");
 
         if cmd_arguments.get_count("v") != 0 {
             println!("Enabled features: {:?}", vmm::feature_list());

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -211,3 +211,40 @@ migration process. Via the API or `ch-remote`, you may specify:
   The number of parallel TCP connections to use for migration.
   Must be between `1` and `128`. Defaults to `1`.
   Multiple connections are not supported with local UNIX-socket migration.
+
+## Version Compatibility
+
+Cloud Hypervisor live migration compatibility has two dimensions: the
+Cloud Hypervisor version and the migration protocol version.
+
+Cloud Hypervisor uses a versioned migration protocol for the messages exchanged
+between source and destination. Each Cloud Hypervisor release sends its current
+migration protocol version and accepts that version plus the immediately
+previous protocol version.
+
+This means migration is supported from an older protocol version to the same or
+next protocol version. If the source and destination are more than one migration
+protocol version apart, the VM must be migrated through an intermediate
+Cloud Hypervisor version first.
+
+### Technical Details
+
+The source sends its migration protocol version in the initial `Start` request.
+The destination accepts the migration only if that protocol version is supported.
+A zeroed `Start` command header is handled as protocol `v0`, so older
+deployments that do not explicitly send a protocol version remain compatible.
+
+The migration protocol version covers the protocol spoken after a migration
+connection has been established. Examples include adding a mandatory migration
+command, changing the order of migration protocol messages, or changing the
+framing or encoding of protocol command payloads.
+
+The migration protocol version does not cover migration transport setup. For
+example, choosing TCP vs. UNIX sockets or opening the initial connection needs
+separate compatibility handling.
+
+Migration protocol versioning is separate from snapshot state compatibility.
+Device and VM state changes still need to be handled by the respective snapshot
+serialization/deserialization code. That compatibility is Cloud Hypervisor
+version dependent, but it is not the responsibility of migration protocol
+versioning.

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -73,8 +73,22 @@
 //!    Source->>Destination: Complete
 //!    Destination-->>Source: OK
 //! ```
+//!
+//! ## Protocol Versioning
+//!
+//! `Start` carries the sender's migration protocol version.
+//! A zeroed version field is treated as legacy protocol `v0`.
+//!
+//! The destination validates that version and replies with a plain `OK` or
+//! `Error`.
+//!
+//! Only the current and immediately previous protocol versions are
+//! supported. Compatibility is one-way, from older protocol versions
+//! to newer ones.
 
 use std::io::{Read, Write};
+use std::mem::size_of;
+use std::ops::RangeInclusive;
 use std::{mem, slice};
 
 use itertools::Itertools;
@@ -127,18 +141,33 @@ pub enum Command {
     CompletePaused = 8,
 }
 
+/// Newest migration protocol version sent by this implementation.
+pub const CURRENT_PROTOCOL_VERSION: u16 = 0;
+
+/// Returns the current migration protocol version and the previous version, if any.
+pub fn supported_protocol_versions() -> RangeInclusive<u16> {
+    CURRENT_PROTOCOL_VERSION.saturating_sub(1)..=CURRENT_PROTOCOL_VERSION
+}
+
 #[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct Request {
     command: Command,
-    padding: [u8; 6],
-    length: u64, // Length of payload for command excluding the Request struct
+    command_headers: [u8; 6],
+    /// Length of payload for command excluding the Request struct
+    length: u64,
 }
 
 // SAFETY: Request contains a series of integers with no implicit padding
 unsafe impl ByteValued for Request {}
 
 impl Request {
+    fn encode_sender_version(version: u16) -> [u8; 6] {
+        let mut command_headers = [0; 6];
+        command_headers[..size_of::<u16>()].copy_from_slice(&version.to_le_bytes());
+        command_headers
+    }
+
     pub fn new(command: Command, length: u64) -> Self {
         Self {
             command,
@@ -148,7 +177,11 @@ impl Request {
     }
 
     pub fn start() -> Self {
-        Self::new(Command::Start, 0)
+        Self {
+            command: Command::Start,
+            command_headers: Self::encode_sender_version(CURRENT_PROTOCOL_VERSION),
+            length: 0,
+        }
     }
 
     pub fn state(length: u64) -> Self {
@@ -187,6 +220,10 @@ impl Request {
 
     pub fn length(&self) -> u64 {
         self.length
+    }
+
+    pub fn command_headers(&self) -> &[u8; 6] {
+        &self.command_headers
     }
 
     pub fn read_from(fd: &mut dyn Read) -> Result<Request, MigratableError> {
@@ -485,7 +522,21 @@ impl MemoryRangeTable {
 
 #[cfg(test)]
 mod unit_tests {
-    use crate::protocol::{MemoryRange, MemoryRangeTable};
+    use crate::protocol::{Command, MemoryRange, MemoryRangeTable, Request};
+
+    #[test]
+    fn test_start_request_ignores_residual_command_headers_bytes() {
+        let request = Request {
+            command: Command::Start,
+            command_headers: [1, 0, 0xaa, 0xbb, 0xcc, 0xdd],
+            length: 0,
+        };
+
+        assert_eq!(
+            u16::from_le_bytes([request.command_headers()[0], request.command_headers()[1]]),
+            1
+        );
+    }
 
     #[test]
     fn test_memory_range_table_from_dirty_ranges_iter() {

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -91,6 +91,7 @@ use std::mem::size_of;
 use std::ops::RangeInclusive;
 use std::{mem, slice};
 
+use anyhow::anyhow;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use vm_memory::ByteValued;
@@ -224,6 +225,26 @@ impl Request {
 
     pub fn command_headers(&self) -> &[u8; 6] {
         &self.command_headers
+    }
+
+    /// Returns the sender protocol version from a `Start` request if it is supported.
+    pub fn sender_protocol_version(&self) -> Result<u16, MigratableError> {
+        assert_eq!(
+            self.command(),
+            Command::Start,
+            "sender_protocol_version() must only be called for Start requests",
+        );
+
+        // The protocol version is stored in the first two header bytes, the remaining bytes are ignored.
+        let sender_version = u16::from_le_bytes([self.command_headers[0], self.command_headers[1]]);
+        if !supported_protocol_versions().any(|version| version == sender_version) {
+            let supported_versions = supported_protocol_versions().join(", ");
+            return Err(MigratableError::MigrateReceive(anyhow!(
+                "Migration protocol version {sender_version} doesn't match supported versions: {supported_versions}"
+            )));
+        }
+
+        Ok(sender_version)
     }
 
     pub fn read_from(fd: &mut dyn Read) -> Result<Request, MigratableError> {
@@ -522,7 +543,9 @@ impl MemoryRangeTable {
 
 #[cfg(test)]
 mod unit_tests {
-    use crate::protocol::{Command, MemoryRange, MemoryRangeTable, Request};
+    use crate::protocol::{
+        CURRENT_PROTOCOL_VERSION, Command, MemoryRange, MemoryRangeTable, Request,
+    };
 
     #[test]
     fn test_start_request_ignores_residual_command_headers_bytes() {
@@ -536,6 +559,18 @@ mod unit_tests {
             u16::from_le_bytes([request.command_headers()[0], request.command_headers()[1]]),
             1
         );
+    }
+
+    #[test]
+    fn test_sender_protocol_version_rejects_unsupported_version() {
+        let request = Request {
+            command: Command::Start,
+            command_headers: [255, 0, 0, 0, 0, 0],
+            length: 0,
+        };
+
+        const { assert!(CURRENT_PROTOCOL_VERSION < 255) };
+        request.sender_protocol_version().unwrap_err();
     }
 
     #[test]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -937,7 +937,11 @@ impl Vmm {
         let state_name = state.variant_name();
         match state {
             Established => match req.command() {
-                Command::Start => Ok(Started),
+                Command::Start => {
+                    let migration_protocol_version = req.sender_protocol_version()?;
+                    debug!("Using migration protocol {migration_protocol_version}");
+                    Ok(Started)
+                }
                 c => invalid_command(state_name, c),
             },
             Started => match req.command() {
@@ -1420,6 +1424,7 @@ impl Vmm {
             Request::start(),
             MigratableError::MigrateSend(anyhow!("Error starting migration")),
         )?;
+        debug!("Using migration protocol {CURRENT_PROTOCOL_VERSION}");
 
         // Send config
         let vm_config = vm.get_config();


### PR DESCRIPTION
# Motivation

Live migration needs an explicit protocol version so Cloud Hypervisor can evolve the migration protocol without leaving compatibility behavior implicit.

This PR introduces a simple dedicated versioning for the migration protocol. We do not expect regular version bumps, based on our current backwards compatibility history.
The protocol starts at version `0` for compatibility with existing deployments. A zeroed `Start` command header is therefore treated as protocol `v0`.

Compatibility is intentionally limited to the current and immediately previous protocol version. If an operator wants to migrate across a larger version gap, they must migrate through an intermediate Cloud Hypervisor version first.

This keeps compatibility handling slim. The receiver only needs to handle the  current compatibility window instead of carrying long-lived backward  compatibility code for many older protocol versions.

# Protocol changes

The existing 6-byte `Start` command header (previously 6-zero-byte padding) now carries the sender's migration protocol version. The version is encoded as a little-endian `u16` in the first two bytes. The remaining four bytes are ignored.

The destination validates the sender version when handling `Start`. It accepts only the current and immediately previous protocol versions. Unsupported versions are rejected with `Error`, which aborts the migration.

Both sender and receiver log the selected migration protocol version.

`cloud-hypervisor --version` now prints the supported vm-migration protocol version range.

Future compatibility differences should be handled on the receiving side. When a compatibility-sensitive code path appears, the negotiated protocol version needs to be plumbed to that code path as part of the change that requires it.
