### PR TITLE
Implement limited virtiofs DAX support

### DIFF
--- a/docs/fs.md
+++ b/docs/fs.md
@@ -91,8 +91,3 @@ mount -t virtiofs myfs mount_dir/
 
 The `tag` needs to be consistent with what has been provided through the
 Cloud Hypervisor command line, which happens to be `myfs` in this example.
-
-## DAX feature
-
-Given the DAX feature is not stable yet from a daemon standpoint, it is not
-available in Cloud Hypervisor.

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -45,7 +45,7 @@ pub use self::block::{Block, BlockState};
 pub use self::console::{Console, ConsoleResizer, Endpoint};
 pub use self::device::{
     ActivationContext, DmaRemapping, VirtioCommon, VirtioDevice, VirtioInterrupt,
-    VirtioInterruptType, VirtioSharedMemoryList,
+    VirtioInterruptType, VirtioSharedMemory, VirtioSharedMemoryList,
 };
 pub use self::epoll_helper::{
     EPOLL_HELPER_EVENT_LAST, EpollHelper, EpollHelperError, EpollHelperHandler,

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::os::unix::io::AsRawFd;
 use std::result;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier, Mutex};
@@ -10,7 +11,9 @@ use log::{error, info};
 use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use serde_with::{Bytes, serde_as};
-use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
+use vhost::vhost_user::message::{
+    VhostUserMMap, VhostUserMMapFlags, VhostUserProtocolFeatures, VhostUserVirtioFeatures,
+};
 use vhost::vhost_user::{FrontendReqHandler, VhostUserFrontend, VhostUserFrontendReqHandler};
 use vm_device::UserspaceMapping;
 use vm_memory::{ByteValued, GuestMemoryAtomic};
@@ -23,8 +26,8 @@ use super::{DEFAULT_VIRTIO_FEATURES, Error, Result};
 use crate::seccomp_filters::Thread;
 use crate::vhost_user::{VhostUserCommon, VhostUserState};
 use crate::{
-    ActivateResult, GuestMemoryMmap, GuestRegionMmap, MmapRegion, VIRTIO_F_ACCESS_PLATFORM,
-    VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioSharedMemoryList,
+    ActivateResult, GuestMemoryMmap, GuestRegionMmap, VIRTIO_F_ACCESS_PLATFORM, VirtioCommon,
+    VirtioDevice, VirtioDeviceType, VirtioSharedMemoryList,
 };
 
 const NUM_QUEUE_OFFSET: usize = 1;
@@ -32,8 +35,71 @@ const DEFAULT_QUEUE_NUMBER: usize = 2;
 
 pub type State = VhostUserState<VirtioFsConfig>;
 
-struct BackendReqHandler {}
-impl VhostUserFrontendReqHandler for BackendReqHandler {}
+struct BackendReqHandler {
+    mmap_cache_addr: u64,
+    cache_size: u64,
+}
+
+impl VhostUserFrontendReqHandler for BackendReqHandler {
+    fn shmem_map(&self, request: &VhostUserMMap, fd: &dyn AsRawFd) -> std::io::Result<u64> {
+        self.validate_request(request)?;
+
+        let prot = if request.flags & VhostUserMMapFlags::WRITABLE.bits() != 0 {
+            libc::PROT_READ | libc::PROT_WRITE
+        } else {
+            libc::PROT_READ
+        };
+        let addr = self.mmap_cache_addr + request.shm_offset;
+        // SAFETY: The destination range is bounded to the DAX window.
+        let ret = unsafe {
+            libc::mmap(
+                addr as *mut libc::c_void,
+                request.len as usize,
+                prot,
+                libc::MAP_SHARED | libc::MAP_FIXED,
+                fd.as_raw_fd(),
+                request.fd_offset as libc::off_t,
+            )
+        };
+        if ret == libc::MAP_FAILED {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(0)
+    }
+
+    fn shmem_unmap(&self, request: &VhostUserMMap) -> std::io::Result<u64> {
+        self.validate_request(request)?;
+
+        let addr = self.mmap_cache_addr + request.shm_offset;
+        // SAFETY: The range is bounded to the DAX window, which is checked above. Replacing it with
+        // an anonymous mapping punches a hole back into the window.
+        let ret = unsafe {
+            libc::mmap(
+                addr as *mut libc::c_void,
+                request.len as usize,
+                libc::PROT_NONE,
+                libc::MAP_ANONYMOUS | libc::MAP_PRIVATE | libc::MAP_FIXED,
+                -1,
+                0,
+            )
+        };
+        if ret == libc::MAP_FAILED {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(0)
+    }
+}
+
+impl BackendReqHandler {
+    fn validate_request(&self, request: &VhostUserMMap) -> std::io::Result<()> {
+        match request.shm_offset.checked_add(request.len) {
+            Some(end) if request.shm_offset < self.cache_size && end <= self.cache_size => Ok(()),
+            _ => Err(std::io::Error::from_raw_os_error(libc::EINVAL)),
+        }
+    }
+}
 
 pub const VIRTIO_FS_TAG_LEN: usize = 36;
 #[serde_as]
@@ -63,7 +129,7 @@ pub struct Fs {
     config: VirtioFsConfig,
     // Hold ownership of the memory that is allocated for the device
     // which will be automatically dropped when the device is dropped
-    cache: Option<(VirtioSharedMemoryList, MmapRegion)>,
+    cache: Option<VirtioSharedMemoryList>,
     seccomp_action: SeccompAction,
     guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     exit_evt: EventFd,
@@ -79,7 +145,7 @@ impl Fs {
         tag: &str,
         req_num_queues: usize,
         queue_size: u16,
-        cache: Option<(VirtioSharedMemoryList, MmapRegion)>,
+        cache: Option<VirtioSharedMemoryList>,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
         access_platform_enabled: bool,
@@ -123,12 +189,17 @@ impl Fs {
             // Filling device and vring features VMM supports.
             let avail_features = DEFAULT_VIRTIO_FEATURES;
 
-            let avail_protocol_features = VhostUserProtocolFeatures::MQ
+            let mut avail_protocol_features = VhostUserProtocolFeatures::MQ
                 | VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS
                 | VhostUserProtocolFeatures::REPLY_ACK
                 | VhostUserProtocolFeatures::INFLIGHT_SHMFD
                 | VhostUserProtocolFeatures::LOG_SHMFD
                 | VhostUserProtocolFeatures::DEVICE_STATE;
+            if cache.is_some() {
+                avail_protocol_features |= VhostUserProtocolFeatures::BACKEND_REQ
+                    | VhostUserProtocolFeatures::BACKEND_SEND_FD
+                    | VhostUserProtocolFeatures::SHMEM;
+            }
 
             let (acked_features, acked_protocol_features) =
                 vu.negotiate_features_vhost_user(avail_features, avail_protocol_features)?;
@@ -252,7 +323,36 @@ impl VirtioDevice for Fs {
             .activate(&queues, interrupt_cb.clone())?;
         self.guest_memory = Some(mem.clone());
 
-        let backend_req_handler: Option<FrontendReqHandler<BackendReqHandler>> = None;
+        let has_backend_req = self.vu_common.acked_protocol_features
+            & VhostUserProtocolFeatures::BACKEND_REQ.bits()
+            != 0;
+        let backend_req_handler = if has_backend_req {
+            self.cache
+                .as_ref()
+                .map(|cache| {
+                    let mut handler = FrontendReqHandler::new(Arc::new(BackendReqHandler {
+                        mmap_cache_addr: cache.mapping.as_ptr() as u64,
+                        cache_size: cache.mapping.size() as u64,
+                    }))
+                    .map_err(|e| {
+                        crate::ActivateError::VhostUserFsSetup(Error::FrontendReqHandlerCreation(e))
+                    })?;
+
+                    if self.vu_common.acked_protocol_features
+                        & VhostUserProtocolFeatures::REPLY_ACK.bits()
+                        != 0
+                    {
+                        handler.set_reply_ack_flag(true);
+                    }
+
+                    Ok(handler)
+                })
+                // Return inner Err early, keep Option of `Ok` value.
+                .transpose()?
+        } else {
+            None
+        };
+
         // Run a dedicated thread for handling potential reconnections with
         // the backend.
         let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds()?;
@@ -293,7 +393,7 @@ impl VirtioDevice for Fs {
     }
 
     fn get_shm_regions(&self) -> Option<VirtioSharedMemoryList> {
-        self.cache.as_ref().map(|cache| cache.0.clone())
+        self.cache.clone()
     }
 
     fn set_shm_regions(
@@ -301,7 +401,7 @@ impl VirtioDevice for Fs {
         shm_regions: VirtioSharedMemoryList,
     ) -> std::result::Result<(), crate::Error> {
         if let Some(cache) = self.cache.as_mut() {
-            cache.0 = shm_regions;
+            *cache = shm_regions;
             Ok(())
         } else {
             Err(crate::Error::SetShmRegionsNotSupported)
@@ -319,9 +419,9 @@ impl VirtioDevice for Fs {
         let mut mappings = Vec::new();
         if let Some(cache) = self.cache.as_ref() {
             mappings.push(UserspaceMapping {
-                mem_slot: cache.0.mem_slot,
-                addr: cache.0.addr,
-                mapping: cache.0.mapping.clone(),
+                mem_slot: cache.mem_slot,
+                addr: cache.addr,
+                mapping: cache.mapping.clone(),
                 mergeable: false,
             });
         }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2069,6 +2069,8 @@ impl FsConfig {
             .add("queue_size")
             .add("num_queues")
             .add("socket")
+            .add("dax")
+            .add("shm_size")
             .add_all(PciDeviceCommonConfig::OPTIONS);
         parser.parse(fs).map_err(Error::ParseFileSystem)?;
 
@@ -2086,6 +2088,11 @@ impl FsConfig {
             .convert("num_queues")
             .map_err(Error::ParseFileSystem)?
             .unwrap_or_else(default_fsconfig_num_queues);
+        let dax = parser
+            .convert("dax")
+            .map_err(Error::ParseFileSystem)?
+            .unwrap_or(false);
+        let shm_size = parser.convert("shm_size").map_err(Error::ParseFileSystem)?;
 
         let pci_common = PciDeviceCommonConfig::parse(fs)?;
 
@@ -2095,6 +2102,8 @@ impl FsConfig {
             socket,
             num_queues,
             queue_size,
+            dax,
+            shm_size,
         })
     }
 
@@ -4380,6 +4389,8 @@ mod unit_tests {
             tag: "mytag".to_owned(),
             num_queues: 1,
             queue_size: 1024,
+            dax: false,
+            shm_size: None,
         }
     }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -89,6 +89,7 @@ use virtio_devices::transport::{VirtioPciDevice, VirtioPciDeviceActivator, Virti
 use virtio_devices::vhost_user::VhostUserConfig;
 use virtio_devices::{
     AccessPlatformMapping, Block, Endpoint, IommuMapping, VdpaDmaMapping, VirtioMemMappingSource,
+    VirtioSharedMemory, VirtioSharedMemoryList,
 };
 use vm_allocator::{AddressAllocator, InterruptAllocError, SystemAllocator};
 use vm_device::dma_mapping::ExternalDmaMapping;
@@ -321,6 +322,14 @@ pub enum DeviceManagerError {
     /// Cannot find a memory range for virtio-fs
     #[error("Cannot find a memory range for virtio-fs")]
     FsRangeAllocation,
+
+    /// The virtio-fs DAX cache is enabled but no shm_size was provided
+    #[error("the virtio-fs DAX cache is enabled but no shm_size was provided")]
+    FsMissingCacheSize,
+
+    /// The virtio-fs DAX cache size is not 2MiB aligned
+    #[error("the virtio-fs DAX cache size is not 2MiB aligned")]
+    FsCacheSizeNotAligned,
 
     /// Error creating serial output file
     #[error("Error creating serial output file")]
@@ -3255,6 +3264,64 @@ impl DeviceManager {
         let mut node = device_node!(id);
 
         if let Some(fs_socket) = fs_cfg.socket.to_str() {
+            let cache = if fs_cfg.dax {
+                let cache_size = fs_cfg
+                    .shm_size
+                    .ok_or(DeviceManagerError::FsMissingCacheSize)?;
+                // The DAX window must be 2MiB aligned in order to support hugepages.
+                if cache_size % 0x0020_0000 != 0 {
+                    return Err(DeviceManagerError::FsCacheSizeNotAligned);
+                }
+
+                // The memory needs to be 2MiB aligned in order to support hugepages.
+                let cache_base = self.pci_segments[fs_cfg.pci_common.pci_segment as usize]
+                    .mem64_allocator
+                    .lock()
+                    .unwrap()
+                    .allocate(None, cache_size as GuestUsize, Some(0x0020_0000))
+                    .ok_or(DeviceManagerError::FsRangeAllocation)?
+                    .raw_value();
+
+                // Reserve the DAX window as an anonymous, inaccessible mapping. The backend maps
+                // files into it on demand through the request channel.
+                let mmap_region = MmapRegion::build(
+                    None,
+                    cache_size as usize,
+                    libc::PROT_NONE,
+                    MAP_NORESERVE | libc::MAP_ANONYMOUS | MAP_PRIVATE,
+                )
+                .map_err(DeviceManagerError::NewMmapRegion)?;
+                let host_addr = mmap_region.as_ptr();
+
+                // SAFETY: host_addr points to cache_size bytes of mmap-allocated memory.
+                let mem_slot = unsafe {
+                    self.memory_manager
+                        .lock()
+                        .unwrap()
+                        .create_userspace_mapping(
+                            cache_base,
+                            cache_size as usize,
+                            host_addr,
+                            false,
+                            false,
+                            false,
+                        )
+                        .map_err(DeviceManagerError::MemoryManager)
+                }?;
+
+                Some(VirtioSharedMemoryList {
+                    mem_slot,
+                    addr: GuestAddress(cache_base),
+                    mapping: Arc::new(mmap_region),
+                    region_list: vec![VirtioSharedMemory {
+                        offset: 0,
+                        len: cache_size,
+                    }],
+                })
+            } else {
+                None
+            };
+
             let virtio_fs_device = Arc::new(Mutex::new(
                 virtio_devices::vhost_user::Fs::new(
                     id.clone(),
@@ -3262,7 +3329,7 @@ impl DeviceManager {
                     &fs_cfg.tag,
                     fs_cfg.num_queues,
                     fs_cfg.queue_size,
-                    None,
+                    cache,
                     self.seccomp_action.clone(),
                     self.exit_evt
                         .try_clone()

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -551,6 +551,8 @@ pub struct FsConfig {
     pub num_queues: usize,
     #[serde(default = "default_fsconfig_queue_size")]
     pub queue_size: u16,
+    pub dax: bool,
+    pub shm_size: Option<u64>,
 }
 
 pub fn default_fsconfig_num_queues() -> usize {


### PR DESCRIPTION
We needed support for this to optimize a VFS served over virtiofs to guests running in cloud hypervisor. The implementation is based on the discussion in #5591.

I've tested against a local fork of virtiofsd that implements and forwards the correct map/unmap calls from the filesystem implementation, and it seems to work well with the exception of hot plugging.
