### PR TITLE
Introduce typed barrier between deserialized and active FDs

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -4,7 +4,7 @@
 //
 
 use std::io::{Read, Write};
-use std::os::unix::io::RawFd;
+use std::os::fd::{AsRawFd, OwnedFd};
 
 use thiserror::Error;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
@@ -142,7 +142,7 @@ pub fn simple_api_full_command_with_fds_and_response<T: Read + Write + ScmSocket
     method: &str,
     full_command: &str,
     request_body: Option<&str>,
-    request_fds: &[RawFd],
+    request_fds: &[OwnedFd],
 ) -> Result<Option<String>, Error> {
     socket
         .send_with_fds(
@@ -150,7 +150,10 @@ pub fn simple_api_full_command_with_fds_and_response<T: Read + Write + ScmSocket
                 "{method} /api/v1/{full_command} HTTP/1.1\r\nHost: localhost\r\nAccept: */*\r\n"
             )
             .as_bytes()],
-            request_fds,
+            &request_fds
+                .iter()
+                .map(AsRawFd::as_raw_fd)
+                .collect::<Vec<_>>(),
         )
         .map_err(Error::SocketSendFds)?;
 
@@ -178,7 +181,7 @@ pub fn simple_api_full_command_with_fds<T: Read + Write + ScmSocket>(
     method: &str,
     full_command: &str,
     request_body: Option<&str>,
-    request_fds: &[RawFd],
+    request_fds: &[OwnedFd],
 ) -> Result<(), Error> {
     let response = simple_api_full_command_with_fds_and_response(
         socket,
@@ -218,7 +221,7 @@ pub fn simple_api_command_with_fds<T: Read + Write + ScmSocket>(
     method: &str,
     c: &str,
     request_body: Option<&str>,
-    request_fds: &[RawFd],
+    request_fds: &[OwnedFd],
 ) -> Result<(), Error> {
     // Create the full VM command. For VMM commands, use
     // simple_api_full_command().

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -9,6 +9,7 @@ mod test_util;
 
 use std::io::Read;
 use std::marker::PhantomData;
+use std::os::fd::OwnedFd;
 use std::os::unix::net::UnixStream;
 use std::process;
 
@@ -23,6 +24,7 @@ use log::error;
 use option_parser::{ByteSized, ByteSizedParseError};
 use thiserror::Error;
 use vmm::config::RestoreConfig;
+use vmm::deserialization_barrier::ExportScmRights;
 use vmm::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, NetConfig, PmemConfig,
     UserDeviceConfig, VdpaConfig, VsockConfig,
@@ -882,14 +884,10 @@ fn add_pmem_config(config: &str) -> Result<String, Error> {
     Ok(pmem_config)
 }
 
-fn add_net_config(config: &str) -> Result<(String, Vec<i32>), Error> {
-    let mut net_config = NetConfig::parse(config).map_err(Error::AddNetConfig)?;
+fn add_net_config(config: &str) -> Result<(String, Vec<OwnedFd>), Error> {
+    let net_config = NetConfig::parse(config).map_err(Error::AddNetConfig)?;
 
-    // NetConfig is modified on purpose here by taking the list of file
-    // descriptors out. Keeping the list and send it to the server side
-    // process would not make any sense since the file descriptor may be
-    // represented with different values.
-    let fds = net_config.fds.take().unwrap_or_default();
+    let (net_config, fds) = net_config.export_fd_list();
     let net_config = serde_json::to_string(&net_config).unwrap();
 
     Ok((net_config, fds))
@@ -917,17 +915,10 @@ fn snapshot_config(url: &str) -> String {
     serde_json::to_string(&snapshot_config).unwrap()
 }
 
-fn restore_config(config: &str) -> Result<(String, Vec<i32>), Error> {
-    let mut restore_config = RestoreConfig::parse(config).map_err(Error::Restore)?;
-    // RestoreConfig is modified on purpose to take out the file descriptors.
-    // These fds are passed to the server side process via SCM_RIGHTS
-    let fds = match &mut restore_config.net_fds {
-        Some(net_fds) => net_fds
-            .iter_mut()
-            .flat_map(|net| net.fds.take().unwrap_or_default())
-            .collect(),
-        None => Vec::new(),
-    };
+fn restore_config(config: &str) -> Result<(String, Vec<OwnedFd>), Error> {
+    let restore_config = RestoreConfig::parse(config).map_err(Error::Restore)?;
+
+    let (restore_config, fds) = restore_config.export_fd_list();
     let restore_config = serde_json::to_string(&restore_config).unwrap();
 
     Ok((restore_config, fds))

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -925,15 +925,17 @@ fn main() {
 
 #[cfg(test)]
 mod unit_tests {
+    use std::collections::HashMap;
     use std::path::PathBuf;
 
     use vmm::config::VmParams;
+    use vmm::deserialization_barrier::UpdateFds;
     #[cfg(target_arch = "x86_64")]
     use vmm::vm_config::DebugConsoleConfig;
     use vmm::vm_config::{
         CommonConsoleConfig, ConsoleConfig, ConsoleOutputMode, CoreScheduling, CpuFeatures,
         CpusConfig, HotplugMethod, MemoryConfig, PayloadConfig, PciDeviceCommonConfig, RngConfig,
-        SerialConfig, VmConfig,
+        SerialConfig, VmConfig, VmConfigInnerDeserialized,
     };
 
     use crate::test_util::assert_args_sorted;
@@ -954,7 +956,8 @@ mod unit_tests {
         equal: bool,
     ) -> (VmConfig, VmConfig) {
         let cli_vm_config = get_vm_config_from_vec(cli);
-        let openapi_vm_config: VmConfig = serde_json::from_str(openapi).unwrap();
+        let openapi_vm_config: VmConfigInnerDeserialized = serde_json::from_str(openapi).unwrap();
+        let openapi_vm_config = openapi_vm_config.update_fds(HashMap::new()).unwrap();
 
         if equal {
             assert_eq!(cli_vm_config, openapi_vm_config);
@@ -1056,7 +1059,6 @@ mod unit_tests {
             pci_segments: None,
             platform: None,
             tpm: None,
-            preserved_fds: None,
             landlock_enable: false,
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -204,7 +204,6 @@ impl RequestHandler for StubApiRequestHandler {
                 pci_segments: None,
                 platform: None,
                 tpm: None,
-                preserved_fds: None,
                 landlock_enable: false,
                 landlock_rules: None,
                 #[cfg(feature = "ivshmem")]

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -9,6 +9,7 @@ use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io::{Error as IoError, Read, Result as IoResult, Write};
 use std::net::{IpAddr, Ipv6Addr};
+use std::os::fd::OwnedFd;
 use std::os::raw::*;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
@@ -231,21 +232,20 @@ impl Tap {
         Self::open_named("vmtap%d", num_queue_pairs, None)
     }
 
-    pub fn from_tap_fd(fd: RawFd, num_queue_pairs: usize) -> Result<Tap> {
+    pub fn from_tap_fd(fd: OwnedFd, num_queue_pairs: usize) -> Result<Tap> {
         // Ensure that the file is opened non-blocking, this is particularly
         // needed when opened via the shell for macvtap.
         // SAFETY: FFI call
         let ret = unsafe {
-            let mut flags = libc::fcntl(fd, libc::F_GETFL);
+            let mut flags = libc::fcntl(fd.as_raw_fd(), libc::F_GETFL);
             flags |= libc::O_NONBLOCK;
-            libc::fcntl(fd, libc::F_SETFL, flags)
+            libc::fcntl(fd.as_raw_fd(), libc::F_SETFL, flags)
         };
         if ret < 0 {
             return Err(Error::ConfigureTap(IoError::last_os_error()));
         }
 
-        // SAFETY: fd is a tap fd
-        let tap_file = unsafe { File::from_raw_fd(fd) };
+        let tap_file = fd.into();
         let mut ifreq: libc::ifreq = ifreq {
             ifr_name: [0; IFNAMSIZ],
             ifr_ifru: __c_anonymous_ifr_ifru { ifru_flags: 0 },
@@ -713,7 +713,8 @@ mod unit_tests {
         let _tap_ip_guard = TAP_IP_LOCK.lock().unwrap();
 
         let orig_tap = Tap::new(1).unwrap();
-        let fd = orig_tap.as_raw_fd();
+        // SAFETY: The fd is taken from an existing tap device, so it must be valid.
+        let fd = unsafe { OwnedFd::from_raw_fd(orig_tap.as_raw_fd()) };
         let _new_tap = Tap::from_tap_fd(fd, 1).unwrap();
     }
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -9,7 +9,8 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::num::Wrapping;
 use std::ops::Deref;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::fd::BorrowedFd;
+use std::os::unix::io::AsRawFd;
 use std::result;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Barrier};
@@ -579,7 +580,7 @@ impl Net {
     #[allow(clippy::too_many_arguments)]
     pub fn from_tap_fds(
         id: String,
-        fds: &[RawFd],
+        fds: &[BorrowedFd],
         guest_mac: Option<MacAddr>,
         mtu: Option<u16>,
         access_platform_enabled: bool,
@@ -596,12 +597,8 @@ impl Net {
         let num_queue_pairs = fds.len();
 
         for fd in fds.iter() {
-            // Duplicate so that it can survive reboots
-            // SAFETY: FFI call to dup. Trivially safe.
-            let fd = unsafe { libc::dup(*fd) };
-            if fd < 0 {
-                return Err(Error::DuplicateTapFd(std::io::Error::last_os_error()));
-            }
+            let fd = fd.try_clone_to_owned().map_err(Error::DuplicateTapFd)?;
+
             let tap = Tap::from_tap_fd(fd, num_queue_pairs).map_err(Error::TapError)?;
             taps.push(tap);
         }

--- a/vmm/src/api/dbus/mod.rs
+++ b/vmm/src/api/dbus/mod.rs
@@ -26,8 +26,11 @@ use crate::api::{
     VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeZone,
     VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot, VmmPing, VmmShutdown,
 };
+use crate::config::RestoreConfigDeserialized;
+use crate::deserialization_barrier::IngestScmRights;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
-use crate::{Error as VmmError, NetConfig, Result as VmmResult, VmConfig};
+use crate::vm_config::{NetConfigDeserialized, VmConfigInnerDeserialized};
+use crate::{Error as VmmError, Result as VmmResult};
 
 pub type DBusApiShutdownChannels = (oneshot::Sender<()>, oneshot::Receiver<()>);
 
@@ -154,11 +157,13 @@ impl DBusApi {
     }
 
     async fn vm_add_net(&self, net_config: String) -> Result<Optional<String>> {
-        let mut net_config: NetConfig = serde_json::from_str(&net_config).map_err(api_error)?;
+        let mut net_config: NetConfigDeserialized =
+            serde_json::from_str(&net_config).map_err(api_error)?;
         if net_config.fds.is_some() {
             warn!("Ignoring FDs sent via the D-Bus request body");
             net_config.fds = None;
         }
+        let net_config = net_config.ingest_scm_rights(Vec::new()).unwrap();
         self.vm_action(&VmAddNet, net_config).await
     }
 
@@ -213,7 +218,8 @@ impl DBusApi {
         let api_sender = self.clone_api_sender().await;
         let api_notifier = self.clone_api_notifier()?;
 
-        let mut vm_config: Box<VmConfig> = serde_json::from_str(&vm_config).map_err(api_error)?;
+        let mut vm_config: VmConfigInnerDeserialized =
+            serde_json::from_str(&vm_config).map_err(api_error)?;
 
         if let Some(ref mut nets) = vm_config.net {
             if nets.iter().any(|net| net.fds.is_some()) {
@@ -223,6 +229,7 @@ impl DBusApi {
                 net.fds = None;
             }
         }
+        let vm_config = Box::new(vm_config.ingest_scm_rights(Vec::new()).unwrap());
 
         blocking::unblock(move || VmCreate.send(api_notifier, api_sender, vm_config))
             .await
@@ -277,7 +284,13 @@ impl DBusApi {
     }
 
     async fn vm_restore(&self, restore_config: String) -> Result<()> {
-        let restore_config = serde_json::from_str(&restore_config).map_err(api_error)?;
+        let mut restore_config: RestoreConfigDeserialized =
+            serde_json::from_str(&restore_config).map_err(api_error)?;
+        if restore_config.net_fds.is_some() {
+            warn!("Ignoring FDs sent via the D-Bus request body");
+            restore_config.net_fds = None;
+        }
+        let restore_config = restore_config.ingest_scm_rights(Vec::new()).unwrap();
         self.vm_action(&VmRestore, restore_config).await.map(|_| ())
     }
 

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -42,220 +42,18 @@ use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::api::VmCoredump;
-use crate::api::http::http_endpoint::fds_helper::{attach_fds_to_cfg, attach_fds_to_cfgs};
 use crate::api::http::{EndpointHandler, HttpError, error_response};
 use crate::api::{
-    AddDisk, ApiAction, ApiError, ApiRequest, NetConfig, VmAddDevice, VmAddFs,
-    VmAddGenericVhostUser, VmAddNet, VmAddPmem, VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot,
-    VmConfig, VmCounters, VmDelete, VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration,
-    VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration,
-    VmShutdown, VmSnapshot,
+    AddDisk, ApiAction, ApiError, ApiRequest, VmAddDevice, VmAddFs, VmAddGenericVhostUser,
+    VmAddNet, VmAddPmem, VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmCounters, VmDelete,
+    VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize,
+    VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
-use crate::config::RestoreConfig;
+use crate::config::RestoreConfigDeserialized;
 use crate::cpu::Error as CpuError;
+use crate::deserialization_barrier::IngestScmRights;
 use crate::vm::Error as VmError;
-
-/// Helper module for attaching externally opened FDs to config objects.
-///
-/// # Difference between [`ConfigWithFDs`] and [`ConfigWithVariableFDs`]
-///
-/// The base trait [`ConfigWithFDs`] type must be implemented by all config
-/// types that want to take ownership of externally provided FDs.
-///
-/// In the case of restore operations, e.g., after a live-migration, config
-/// objects will know the amount of FDs they need. In this case, they must
-/// also implement [`ConfigWithVariableFDs`]. In other scenarios, such as
-/// hot device attach, the base type is sufficient and the type will take
-/// over all available FDs.
-///
-/// In any case, the management software (e.g., libvirt) is responsible for
-/// providing the exact amount of FDs.
-mod fds_helper {
-    use std::fs::File;
-    use std::os::fd::{IntoRawFd, RawFd};
-
-    use log::{debug, error, warn};
-
-    use crate::api::http::HttpError;
-
-    /// Abstraction over configuration types received via the HTTP API that
-    /// have associated externally opened FDs.
-    pub trait ConfigWithFDs {
-        /// Returns the ID of the device.
-        ///
-        /// Used for logging.
-        fn id(&self) -> Option<&str>;
-
-        /// Returns any FDs provided in the HTTP body.
-        ///
-        /// They will always be invalid and are used for user-facing logging.
-        fn fds_from_http_body(&self) -> Option<&[RawFd]>;
-
-        /// Assigns the provided file descriptors (`fds`) to this configuration
-        /// object.
-        ///
-        /// After calling this method, the configuration will behave as if it
-        /// had originally been created with these FDs. Next, the configuration
-        /// can be used to properly configure the corresponding device.
-        ///
-        /// # Arguments
-        /// - `fds`: Either a non-empty Vector with corresponding FDs or `None`
-        ///   indicating that no valid FDs were supplied.
-        fn set_fds(&mut self, fds: Option<Vec<RawFd>>);
-    }
-
-    /// Extension of [`ConfigWithFDs`] for config objects that know how many
-    /// FDs they want (e.g., a restore configuration that is aware of the
-    /// previous state).
-    pub trait ConfigWithVariableFDs: ConfigWithFDs {
-        /// Returns how many FDs this type wants to have from the pool of
-        /// available FDs.
-        fn expected_num_fds(&self) -> usize;
-    }
-
-    mod config_with_fds_impls {
-        use std::os::fd::RawFd;
-
-        use super::{ConfigWithFDs, ConfigWithVariableFDs};
-        use crate::config::RestoredNetConfig;
-        use crate::vm_config::NetConfig;
-
-        impl ConfigWithFDs for NetConfig {
-            fn id(&self) -> Option<&str> {
-                self.pci_common.id.as_deref()
-            }
-
-            fn fds_from_http_body(&self) -> Option<&[RawFd]> {
-                self.fds.as_deref()
-            }
-
-            fn set_fds(&mut self, fds: Option<Vec<RawFd>>) {
-                self.fds = fds;
-            }
-        }
-
-        impl ConfigWithFDs for RestoredNetConfig {
-            fn id(&self) -> Option<&str> {
-                Some(self.id.as_str())
-            }
-
-            fn fds_from_http_body(&self) -> Option<&[RawFd]> {
-                self.fds.as_deref()
-            }
-
-            fn set_fds(&mut self, fds: Option<Vec<RawFd>>) {
-                self.fds = fds;
-            }
-        }
-
-        impl ConfigWithVariableFDs for RestoredNetConfig {
-            fn expected_num_fds(&self) -> usize {
-                self.num_fds
-            }
-        }
-    }
-
-    fn attach_fds_to_cfg_inner<T: ConfigWithFDs>(
-        fds: &mut Vec<RawFd>,
-        fds_amount: usize,
-        cfg: &mut T,
-    ) {
-        if cfg.fds_from_http_body().is_some() {
-            // Only FDs transmitted via an SCM_RIGHTS UNIX Domain Socket message
-            // are valid. Any provided over the HTTP API are set to `-1` in our
-            // specialized serializer callbacks.
-            warn!(
-                "FD numbers were present in HTTP request body for device {:?} but will be ignored",
-                cfg.id()
-            );
-
-            // Reset old value in any case; if there are FDs, they are invalid.
-            cfg.set_fds(None);
-        }
-
-        if fds_amount > 0 {
-            let new_fds = fds.drain(..fds_amount).collect::<Vec<_>>();
-            debug!(
-                "Attaching network FDs received via UNIX domain socket to device: id={:?}, fds={new_fds:?}",
-                cfg.id()
-            );
-            cfg.set_fds(Some(new_fds));
-        }
-    }
-
-    /// Applies FDs to configs for their corresponding devices, as part of the special
-    /// handling for devices backed by externally provided FDs.
-    ///
-    /// The FDs (via `files`) must be provided in the exact order matching the
-    /// config struct they belong to.
-    ///
-    /// See [module description] for more info.
-    ///
-    /// # Arguments
-    /// - `device_fds`: Ordered list of all FDs from the request.
-    /// - `cfgs`: List of network configurations where each network can have up to `n` FDs.
-    ///
-    /// [module description]: self
-    pub fn attach_fds_to_cfgs<T: ConfigWithVariableFDs>(
-        device_fds: Vec<File>,
-        cfgs: &mut [&mut T],
-    ) -> Result<(), HttpError> {
-        let expected_fds: usize = cfgs.iter().map(|cfg| cfg.expected_num_fds()).sum();
-
-        if device_fds.len() != expected_fds {
-            error!(
-                "Number of expected FDs: {}, received: {}",
-                expected_fds,
-                device_fds.len()
-            );
-            return Err(HttpError::BadRequest);
-        }
-
-        // We are only interested in the raw FDs. After this operation, we are
-        // responsible for manually closing the FDs eventually.
-        let mut fds = device_fds
-            .into_iter()
-            .map(|f| f.into_raw_fd())
-            .collect::<Vec<_>>();
-
-        // For each config: We drain the FDs vector by the amount of FDs the config expects.
-        for cfg in cfgs {
-            attach_fds_to_cfg_inner(&mut fds, cfg.expected_num_fds(), *cfg);
-        }
-
-        // We checked that `fds.len() == expected_fds`; so if we panic here, we
-        // have a hard programming error
-        assert!(fds.is_empty());
-
-        Ok(())
-    }
-
-    /// Applies FDs to the config for the corresponding device, as part of the special
-    /// handling for devices backed by externally provided FDs.
-    ///
-    /// See [module description] for more info.
-    ///
-    /// # Arguments
-    /// - `device_fds`: Ordered list of all FDs from the request.
-    /// - `cfg`: The config object that wants to take ownership of all available FDs.
-    ///
-    /// [module description]: self
-    pub fn attach_fds_to_cfg<T: ConfigWithFDs>(
-        device_fds: Vec<File>,
-        cfg: &mut T,
-    ) -> Result<(), HttpError> {
-        // We are only interested in the raw FDs.
-        let mut fds = device_fds
-            .into_iter()
-            .map(|f| f.into_raw_fd())
-            .collect::<Vec<_>>();
-
-        let len = fds.len();
-        attach_fds_to_cfg_inner(&mut fds, len, cfg);
-
-        Ok(())
-    }
-}
+use crate::vm_config::{NetConfigDeserialized, VmConfigInnerDeserialized};
 
 // /api/v1/vm.create handler
 pub struct VmCreate {}
@@ -272,28 +70,21 @@ impl EndpointHandler for VmCreate {
                 match &req.body {
                     Some(body) => {
                         // Deserialize into a VmConfig
-                        let mut vm_config: Box<VmConfig> = match serde_json::from_slice(body.raw())
-                            .map_err(HttpError::SerdeJsonDeserialize)
-                        {
-                            Ok(config) => config,
-                            Err(e) => return error_response(e, StatusCode::BadRequest),
-                        };
+                        let vm_config: VmConfigInnerDeserialized =
+                            match serde_json::from_slice(body.raw())
+                                .map_err(HttpError::SerdeJsonDeserialize)
+                            {
+                                Ok(config) => config,
+                                Err(e) => return error_response(e, StatusCode::BadRequest),
+                            };
 
-                        if let Some(ref mut nets) = vm_config.net {
-                            let mut cfgs = nets.iter_mut().collect::<Vec<&mut _>>();
-                            let cfgs = cfgs.as_mut_slice();
-
-                            // For the VmCreate call, we do not accept FDs from the socket currently.
-                            // This call sets all FDs to null while doing the same logging as
-                            // similar code paths.
-                            for cfg in cfgs {
-                                if let Err(e) = attach_fds_to_cfg(vec![], *cfg)
-                                    .map_err(|e| error_response(e, StatusCode::InternalServerError))
-                                {
-                                    return e;
-                                }
+                        // SCM_RIGHTS is not supported yet.
+                        let vm_config = match vm_config.ingest_scm_rights(Vec::new()) {
+                            Ok(vm_config) => Box::new(vm_config),
+                            Err(e) => {
+                                return error_response(e.into(), StatusCode::BadRequest);
                             }
-                        }
+                        };
 
                         match crate::api::VmCreate
                             .send(api_notifier, api_sender, vm_config)
@@ -446,8 +237,8 @@ impl PutHandler for VmAddNet {
         files: Vec<File>,
     ) -> std::result::Result<Option<Body>, HttpError> {
         if let Some(body) = body {
-            let mut net_cfg: NetConfig = serde_json::from_slice(body.raw())?;
-            attach_fds_to_cfg(files, &mut net_cfg)?;
+            let net_cfg: NetConfigDeserialized = serde_json::from_slice(body.raw())?;
+            let net_cfg = net_cfg.ingest_scm_rights(files)?;
 
             self.send(api_notifier, api_sender, net_cfg)
                 .map_err(HttpError::ApiError)
@@ -498,13 +289,9 @@ impl PutHandler for VmRestore {
         files: Vec<File>,
     ) -> std::result::Result<Option<Body>, HttpError> {
         if let Some(body) = body {
-            let mut restore_cfg: RestoreConfig = serde_json::from_slice(body.raw())?;
+            let restore_cfg: RestoreConfigDeserialized = serde_json::from_slice(body.raw())?;
 
-            if let Some(cfgs) = restore_cfg.net_fds.as_mut() {
-                let mut cfgs = cfgs.iter_mut().collect::<Vec<&mut _>>();
-                let cfgs = cfgs.as_mut_slice();
-                attach_fds_to_cfgs(files, cfgs)?;
-            }
+            let restore_cfg = restore_cfg.ingest_scm_rights(files)?;
 
             self.send(api_notifier, api_sender, restore_cfg)
                 .map_err(HttpError::ApiError)
@@ -629,117 +416,5 @@ impl EndpointHandler for VmmShutdown {
             }
             _ => error_response(HttpError::BadRequest, StatusCode::BadRequest),
         }
-    }
-}
-
-#[cfg(test)]
-mod external_fds_tests {
-    use super::*;
-    use crate::api::http::http_endpoint::fds_helper::{ConfigWithFDs, ConfigWithVariableFDs};
-
-    struct DummyNewDeviceCfg {
-        http_fds: Option<Vec<i32>>,
-    }
-
-    impl ConfigWithFDs for DummyNewDeviceCfg {
-        fn id(&self) -> Option<&str> {
-            Some("dummy")
-        }
-
-        fn fds_from_http_body(&self) -> Option<&[i32]> {
-            self.http_fds.as_deref()
-        }
-
-        fn set_fds(&mut self, fds: Option<Vec<i32>>) {
-            self.http_fds = fds;
-        }
-    }
-
-    struct DummyRestoreDeviceCfg {
-        http_fds: Option<Vec<i32>>,
-        num_fds: usize,
-    }
-
-    impl ConfigWithFDs for DummyRestoreDeviceCfg {
-        fn id(&self) -> Option<&str> {
-            Some("dummy")
-        }
-
-        fn fds_from_http_body(&self) -> Option<&[i32]> {
-            self.http_fds.as_deref()
-        }
-
-        fn set_fds(&mut self, fds: Option<Vec<i32>>) {
-            self.http_fds = fds;
-        }
-    }
-
-    impl ConfigWithVariableFDs for DummyRestoreDeviceCfg {
-        fn expected_num_fds(&self) -> usize {
-            self.num_fds
-        }
-    }
-
-    #[test]
-    fn test_fds_provided_via_http_api_are_reset() {
-        let mut config = DummyNewDeviceCfg {
-            http_fds: Some(vec![1, 2, 3]),
-        };
-
-        attach_fds_to_cfg(vec![], &mut config).unwrap();
-        assert_eq!(config.http_fds, None);
-    }
-
-    #[test]
-    fn test_new_device_cfg_takes_all_fds() {
-        let path = "/dev/null";
-
-        let new_fds = vec![
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-        ];
-        let mut config = DummyNewDeviceCfg {
-            http_fds: Some(vec![1, 2, 3]),
-        };
-
-        attach_fds_to_cfg(new_fds, &mut config).unwrap();
-        assert_eq!(config.http_fds.unwrap().len(), 3);
-    }
-
-    #[test]
-    fn test_restore_cfgs_take_only_their_fds() {
-        let path = "/dev/null";
-        let new_fds = vec![
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-        ];
-        let mut config1 = DummyRestoreDeviceCfg {
-            http_fds: None,
-            num_fds: 3,
-        };
-        let mut config2 = DummyRestoreDeviceCfg {
-            http_fds: None,
-            num_fds: 1,
-        };
-        let mut config3 = DummyRestoreDeviceCfg {
-            http_fds: None,
-            num_fds: 0,
-        };
-        let mut config4 = DummyRestoreDeviceCfg {
-            http_fds: None,
-            num_fds: 2,
-        };
-        let mut configs = [&mut config1, &mut config2, &mut config3, &mut config4];
-
-        attach_fds_to_cfgs(new_fds, &mut configs).unwrap();
-        assert_eq!(config1.http_fds.unwrap().len(), 3);
-        assert_eq!(config2.http_fds.unwrap().len(), 1);
-        assert!(config3.http_fds.is_none());
-        assert_eq!(config4.http_fds.unwrap().len(), 2);
     }
 }

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -32,6 +32,7 @@ use crate::api::{
     VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk,
     VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
+use crate::deserialization_barrier::IngestScmRightsError;
 use crate::landlock::Landlock;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::{Error as VmmError, Result};
@@ -66,6 +67,10 @@ pub enum HttpError {
     /// Error from internal API
     #[error("Error from API")]
     ApiError(#[source] ApiError),
+
+    /// Error from SCM_RIGHTS file descriptor handling
+    #[error("Failed to apply file descriptors")]
+    FileDescriptorError(#[from] IngestScmRightsError),
 }
 
 const HTTP_ROOT: &str = "/api/v1";

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -213,7 +213,7 @@ pub enum ApiError {
 }
 pub type ApiResult<T> = Result<T, ApiError>;
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Serialize)]
 pub struct VmInfoResponse {
     pub config: Box<VmConfig>,
     pub state: VmState,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 #[cfg(feature = "ivshmem")]
 use std::fs;
+use std::os::fd::{OwnedFd, RawFd};
 use std::path::PathBuf;
 use std::result;
 use std::str::FromStr;
@@ -14,7 +15,7 @@ use std::sync::LazyLock;
 use arch::CpuProfile;
 use block::ImageType;
 use clap::ArgMatches;
-use log::{debug, warn};
+use log::warn;
 use option_parser::{
     ByteSized, IntegerList, OptionParser, OptionParserError, StringList, Toggle, Tuple,
 };
@@ -27,6 +28,10 @@ use virtio_devices::block::MINIMUM_BLOCK_QUEUE_SIZE;
 use virtio_devices::vhost_user::VIRTIO_FS_TAG_LEN;
 use virtio_devices::{RateLimiterConfig, TokenBucketConfig};
 
+use crate::deserialization_barrier::{
+    Active, Deserialized, ExportScmRights, ExtractFdMap, ExtractFdMapError, Fd, FdIdent, FdMap,
+    FdMarker, FromRawError, IngestScmRights, IngestScmRightsError,
+};
 use crate::landlock::LandlockAccess;
 use crate::vm_config::*;
 
@@ -219,6 +224,9 @@ pub enum Error {
     ParseFwCfgItem(#[source] OptionParserError),
     #[error("Error parsing common PCI device config")]
     ParsePciDeviceCommonConfig(#[source] OptionParserError),
+    /// Error from file descriptor handling
+    #[error("Failed to parse file descriptors")]
+    FdError(#[from] FromRawError),
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -273,9 +281,6 @@ pub enum ValidationError {
     /// The input queue number for virtio_net must match the number of input fds
     #[error("Number of queues ({0}) to virtio_net does not match the number of FDs ({1})")]
     VnetQueueFdMismatch(usize /* num of queues */, usize /* FD num */),
-    /// Using reserved fd
-    #[error("Reserved fd number (<= 2): {0}")]
-    VnetReservedFd(i32),
     /// Hardware checksum offload is disabled.
     #[error("\"offload_tso\" and \"offload_ufo\" depend on \"offload_csum\"")]
     NoHardwareChecksumOffload,
@@ -371,12 +376,6 @@ pub enum ValidationError {
     #[cfg(all(feature = "sev_snp", feature = "igvm"))]
     #[error("SEV-SNP requires an IGVM payload (--payload igvm=<path>)")]
     SevSnpRequiresIgvm,
-    /// Restore expects all net ids that have fds
-    #[error("Net id {0} is associated with FDs and is required")]
-    RestoreMissingRequiredNetId(String),
-    /// Number of FDs passed during Restore are incorrect to the NetConfig
-    #[error("Number of Net FDs passed for '{0}' during Restore: {1}. Expected: {2}")]
-    RestoreNetFdCountMismatch(String, usize, usize),
     /// Prefault cannot be combined with on-demand restore
     #[error("'prefault' cannot be combined with 'memory_restore_mode=ondemand'")]
     InvalidRestorePrefaultWithOnDemand,
@@ -444,6 +443,34 @@ fn validate_pci_device_id(device_id: u8) -> ValidationResult<()> {
         return Err(ValidationError::ReservedPciDeviceId(device_id));
     }
 
+    Ok(())
+}
+
+/// Checks that there are no duplicates or values below 3.
+fn fd_sanity_check<I>(input: I) -> result::Result<(), OptionParserError>
+where
+    I: IntoIterator<Item = u64>,
+{
+    let mut raw_fds: Vec<_> = input.into_iter().collect();
+
+    raw_fds.sort();
+
+    raw_fds.windows(2).try_for_each(|window| {
+        if window[0] == window[1] {
+            Err(OptionParserError::InvalidValue(format!(
+                "Duplicate file descriptors provided: {}",
+                window[0]
+            )))
+        } else {
+            Ok(())
+        }
+    })?;
+
+    if raw_fds.iter().any(|fd| *fd <= 2) {
+        return Err(OptionParserError::InvalidValue(
+            "File descriptor with index lower than 3 provided".to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -1707,8 +1734,7 @@ impl NetConfig {
             .unwrap_or_default();
         let fds = parser
             .convert::<IntegerList>("fd")
-            .map_err(Error::ParseNetwork)?
-            .map(|v| v.0.iter().map(|e| *e as i32).collect());
+            .map_err(Error::ParseNetwork)?;
         let bw_size = parser
             .convert("bw_size")
             .map_err(Error::ParseNetwork)?
@@ -1762,6 +1788,23 @@ impl NetConfig {
 
         let pci_common = PciDeviceCommonConfig::parse(net)?;
 
+        let fds = if let Some(fds) = fds {
+            fd_sanity_check(fds.0.clone()).map_err(Error::ParseNetwork)?;
+
+            Some(
+                fds.0
+                    .iter()
+                    .map(|e| {
+                        // SAFETY: We checked for duplicates and rely on the
+                        // user/caller to provide correct file descriptors.
+                        unsafe { Fd::new_from_raw(*e as RawFd) }
+                    })
+                    .collect::<std::result::Result<_, _>>()?,
+            )
+        } else {
+            None
+        };
+
         let config = NetConfig {
             pci_common,
             tap,
@@ -1798,12 +1841,6 @@ impl NetConfig {
                     self.num_queues,
                     actual_queues,
                 ));
-            }
-
-            for &fd in fds {
-                if fd <= 2 {
-                    return Err(ValidationError::VnetReservedFd(fd));
-                }
             }
         }
 
@@ -2657,38 +2694,76 @@ impl NumaConfig {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
-pub struct RestoredNetConfig {
+#[serde(bound(deserialize = "crate::deserialization_barrier::Fd<S>: Deserialize<'de>",))]
+pub struct RestoredNetConfig<S>
+where
+    S: FdMarker,
+{
     pub id: String,
     #[serde(default)]
     pub num_fds: usize,
-    // Special deserialize handling:
-    // A serialize-deserialize cycle typically happens across processes.
-    // Therefore, we don't serialize FDs, and whatever value is here after
-    // deserialization is invalid.
-    //
-    // Valid FDs are transmitted via a different channel (SCM_RIGHTS message)
-    // and will be populated into this struct on the destination VMM eventually.
-    #[serde(default, deserialize_with = "deserialize_restorednetconfig_fds")]
-    pub fds: Option<Vec<i32>>,
+
+    pub fds: Option<Vec<Fd<S>>>,
 }
 
-fn deserialize_restorednetconfig_fds<'de, D>(
-    d: D,
-) -> std::result::Result<Option<Vec<i32>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let invalid_fds: Option<Vec<i32>> = Option::deserialize(d)?;
-    if let Some(invalid_fds) = invalid_fds {
-        // If the live-migration path is used properly, new FDs are passed as
-        // SCM_RIGHTS message. So, we don't get them from the serialized JSON
-        // anyway.
-        debug!(
-            "FDs in 'RestoredNetConfig' won't be deserialized as they are most likely invalid now. Deserializing them as -1."
-        );
-        Ok(Some(vec![-1; invalid_fds.len()]))
-    } else {
-        Ok(None)
+impl ExtractFdMap for RestoredNetConfig<Active> {
+    fn extract_fd_map_inner(
+        &mut self,
+        fd_map: &mut FdMap,
+    ) -> std::result::Result<(), ExtractFdMapError> {
+        let Some(fds) = self.fds.take() else {
+            return Ok(());
+        };
+        if fds.is_empty() {
+            return Ok(());
+        }
+        let fd_device = FdIdent::new_net(self.id.clone());
+        if fd_map.insert(fd_device, fds).is_some() {
+            return Err(ExtractFdMapError::IdCollision(format!(
+                "{:?}",
+                FdIdent::new_net(self.id.clone())
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl ExportScmRights for RestoredNetConfig<Active> {
+    type Inactive = RestoredNetConfig<Deserialized>;
+
+    fn export_fd_list_inner(self, fds: &mut Vec<OwnedFd>) -> Self::Inactive {
+        let inactive_fds = self.fds.map(|active_fds| {
+            active_fds
+                .into_iter()
+                .map(|fd| fd.export_fd_list_inner(fds))
+                .collect()
+        });
+        RestoredNetConfig {
+            id: self.id,
+            num_fds: self.num_fds,
+            fds: inactive_fds,
+        }
+    }
+}
+
+impl IngestScmRights for RestoredNetConfig<Deserialized> {
+    type Activated = RestoredNetConfig<Active>;
+
+    fn ingest_scm_rights_inner(
+        self,
+        fds: &mut Vec<Fd<Active>>,
+    ) -> std::result::Result<Self::Activated, IngestScmRightsError> {
+        if fds.len() < self.num_fds {
+            return Err(IngestScmRightsError::TooLittleFds);
+        }
+        let fds: Vec<Fd<Active>> = fds.drain(..self.num_fds).collect();
+
+        let fds = if fds.is_empty() { None } else { Some(fds) };
+        Ok(RestoredNetConfig {
+            id: self.id,
+            num_fds: self.num_fds,
+            fds,
+        })
     }
 }
 
@@ -2719,17 +2794,77 @@ impl FromStr for MemoryRestoreMode {
     }
 }
 
+pub type RestoreConfig = RestoreConfigInner<Active>;
+pub type RestoreConfigDeserialized = RestoreConfigInner<Deserialized>;
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
-pub struct RestoreConfig {
+#[serde(bound(deserialize = "RestoredNetConfig<S>: Deserialize<'de>",))]
+pub struct RestoreConfigInner<S>
+where
+    S: FdMarker,
+{
     pub source_url: PathBuf,
     #[serde(default)]
     pub prefault: bool,
     #[serde(default)]
     pub memory_restore_mode: MemoryRestoreMode,
     #[serde(default)]
-    pub net_fds: Option<Vec<RestoredNetConfig>>,
+    pub net_fds: Option<Vec<RestoredNetConfig<S>>>,
     #[serde(default)]
     pub resume: bool,
+}
+
+impl ExportScmRights for RestoreConfig {
+    type Inactive = RestoreConfigInner<Deserialized>;
+
+    fn export_fd_list_inner(self, fds: &mut Vec<OwnedFd>) -> Self::Inactive {
+        let net_fds = self.net_fds.map(|restored_net_configs| {
+            restored_net_configs
+                .into_iter()
+                .map(|restored_net_config| restored_net_config.export_fd_list_inner(fds))
+                .collect()
+        });
+        RestoreConfigInner {
+            source_url: self.source_url,
+            prefault: self.prefault,
+            memory_restore_mode: self.memory_restore_mode,
+            net_fds,
+            resume: self.resume,
+        }
+    }
+}
+
+impl IngestScmRights for RestoreConfigDeserialized {
+    type Activated = RestoreConfig;
+
+    fn ingest_scm_rights_inner(
+        self,
+        fds: &mut Vec<Fd<Active>>,
+    ) -> std::result::Result<Self::Activated, IngestScmRightsError> {
+        let net_fds = if let Some(restored_net_configs) = self.net_fds {
+            if restored_net_configs.is_empty() && fds.is_empty() {
+                None
+            } else {
+                let mut net_fds = Vec::with_capacity(restored_net_configs.len());
+
+                for restored_net_config in restored_net_configs {
+                    net_fds.push(restored_net_config.ingest_scm_rights_inner(fds)?);
+                }
+
+                Some(net_fds)
+            }
+        } else {
+            None
+        };
+
+        Ok(RestoreConfig {
+            source_url: self.source_url,
+            prefault: self.prefault,
+            memory_restore_mode: self.memory_restore_mode,
+            net_fds,
+            resume: self.resume,
+        })
+    }
 }
 
 impl RestoreConfig {
@@ -2768,21 +2903,38 @@ impl RestoreConfig {
             .unwrap_or_default();
         let net_fds = parser
             .convert::<Tuple<String, Vec<u64>>>("net_fds")
-            .map_err(Error::ParseRestore)?
-            .map(|v| {
-                v.0.iter()
-                    .map(|(id, fds)| RestoredNetConfig {
-                        id: id.clone(),
-                        num_fds: fds.len(),
-                        fds: Some(fds.iter().map(|e| *e as i32).collect()),
-                    })
-                    .collect()
-            });
+            .map_err(Error::ParseRestore)?;
         let resume = parser
             .convert::<Toggle>("resume")
             .map_err(Error::ParseRestore)?
             .unwrap_or(Toggle(false))
             .0;
+
+        let net_fds = if let Some(fds) = net_fds {
+            let mut result = Vec::with_capacity(fds.0.len());
+            fd_sanity_check(fds.0.iter().flat_map(|(_, fds)| fds).copied())
+                .map_err(Error::ParseRestore)?;
+
+            for (id, fds) in fds.0 {
+                let restored_net_config = RestoredNetConfig {
+                    id: id.clone(),
+                    num_fds: fds.len(),
+                    fds: Some(
+                        fds.iter()
+                            .map(|e| {
+                                // SAFETY: We checked for duplicates and rely on the
+                                // user/caller to provide correct file descriptors.
+                                unsafe { Fd::new_from_raw(*e as RawFd) }
+                            })
+                            .collect::<std::result::Result<_, _>>()?,
+                    ),
+                };
+                result.push(restored_net_config);
+            }
+            Some(result)
+        } else {
+            None
+        };
 
         Ok(RestoreConfig {
             source_url,
@@ -2793,53 +2945,29 @@ impl RestoreConfig {
         })
     }
 
-    // Ensure all net devices from 'VmConfig' backed by FDs have a
-    // corresponding 'RestoreNetConfig' with a matched 'id' and expected
-    // number of FDs.
-    pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
+    pub fn validate(&self, _vm_config: &VmConfig) -> ValidationResult<()> {
         if self.memory_restore_mode == MemoryRestoreMode::OnDemand && self.prefault {
             return Err(ValidationError::InvalidRestorePrefaultWithOnDemand);
         }
 
-        let mut restored_net_with_fds = HashMap::new();
-        for n in self.net_fds.iter().flatten() {
-            assert_eq!(
-                n.num_fds,
-                n.fds.as_ref().map_or(0, |f| f.len()),
-                "Invalid 'RestoredNetConfig' with conflicted fields."
-            );
-            if restored_net_with_fds.insert(n.id.clone(), n).is_some() {
-                return Err(ValidationError::IdentifierNotUnique(n.id.clone()));
-            }
-        }
+        Ok(())
+    }
+}
 
-        for net_fds in vm_config.net.iter().flatten() {
-            if let Some(expected_fds) = &net_fds.fds {
-                let expected_id = net_fds
-                    .pci_common
-                    .id
-                    .as_ref()
-                    .expect("Invalid 'NetConfig' with empty 'id' for VM restore.");
-                if let Some(r) = restored_net_with_fds.remove(expected_id) {
-                    if r.num_fds != expected_fds.len() {
-                        return Err(ValidationError::RestoreNetFdCountMismatch(
-                            expected_id.clone(),
-                            r.num_fds,
-                            expected_fds.len(),
-                        ));
-                    }
-                } else {
-                    return Err(ValidationError::RestoreMissingRequiredNetId(
-                        expected_id.clone(),
-                    ));
-                }
-            }
-        }
+impl ExtractFdMap for RestoreConfig {
+    fn extract_fd_map_inner(
+        &mut self,
+        fd_map: &mut FdMap,
+    ) -> result::Result<(), ExtractFdMapError> {
+        let Some(net_fds) = self.net_fds.take() else {
+            return Ok(());
+        };
 
-        if !restored_net_with_fds.is_empty() {
-            warn!("Ignoring unused 'net_fds' for VM restore.");
-        }
-
+        net_fds
+            .into_iter()
+            .try_for_each(|mut restored_net_config| {
+                restored_net_config.extract_fd_map_inner(fd_map)
+            })?;
         Ok(())
     }
 }
@@ -3602,7 +3730,6 @@ impl VmConfig {
             pci_segments,
             platform,
             tpm,
-            preserved_fds: None,
             landlock_enable: vm_params.landlock_enable,
             landlock_rules,
             #[cfg(feature = "ivshmem")]
@@ -3683,19 +3810,6 @@ impl VmConfig {
         removed
     }
 
-    /// # Safety
-    /// To use this safely, the caller must guarantee that the input
-    /// fds are all valid.
-    pub unsafe fn add_preserved_fds(&mut self, fds: Vec<i32>) {
-        if fds.is_empty() {
-            return;
-        }
-
-        self.preserved_fds
-            .get_or_insert_with(HashSet::new)
-            .extend(fds);
-    }
-
     #[cfg(feature = "tdx")]
     pub fn is_tdx_enabled(&self) -> bool {
         self.platform.as_ref().is_some_and(|p| p.tdx)
@@ -3707,62 +3821,10 @@ impl VmConfig {
     }
 }
 
-impl Clone for VmConfig {
-    fn clone(&self) -> Self {
-        VmConfig {
-            cpus: self.cpus.clone(),
-            memory: self.memory.clone(),
-            payload: self.payload.clone(),
-            rate_limit_groups: self.rate_limit_groups.clone(),
-            disks: self.disks.clone(),
-            net: self.net.clone(),
-            rng: self.rng.clone(),
-            rtc: self.rtc.clone(),
-            balloon: self.balloon.clone(),
-            #[cfg(feature = "pvmemcontrol")]
-            pvmemcontrol: self.pvmemcontrol.clone(),
-            fs: self.fs.clone(),
-            generic_vhost_user: self.generic_vhost_user.clone(),
-            pmem: self.pmem.clone(),
-            serial: self.serial.clone(),
-            console: self.console.clone(),
-            #[cfg(target_arch = "x86_64")]
-            debug_console: self.debug_console.clone(),
-            devices: self.devices.clone(),
-            user_devices: self.user_devices.clone(),
-            vdpa: self.vdpa.clone(),
-            vsock: self.vsock.clone(),
-            numa: self.numa.clone(),
-            pci_segments: self.pci_segments.clone(),
-            platform: self.platform.clone(),
-            tpm: self.tpm.clone(),
-            preserved_fds: self
-                .preserved_fds
-                .as_ref()
-                // SAFETY: FFI call with valid FDs
-                .map(|fds| fds.iter().map(|fd| unsafe { libc::dup(*fd) }).collect()),
-            landlock_rules: self.landlock_rules.clone(),
-            #[cfg(feature = "ivshmem")]
-            ivshmem: self.ivshmem.clone(),
-            ..*self
-        }
-    }
-}
-
-impl Drop for VmConfig {
-    fn drop(&mut self) {
-        if let Some(mut fds) = self.preserved_fds.take() {
-            for fd in fds.drain() {
-                // SAFETY: FFI call with valid FDs
-                unsafe { libc::close(fd) };
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod unit_tests {
     use std::fs::File;
+    use std::os::fd::IntoRawFd;
     use std::os::unix::io::AsRawFd;
 
     use net_util::MacAddr;
@@ -4314,15 +4376,17 @@ mod unit_tests {
             }
         );
 
-        assert_eq!(
-            NetConfig::parse("mac=de:ad:be:ef:12:34,fd=[3,7],num_queues=4")?,
-            NetConfig {
-                host_mac: None,
-                fds: Some(vec![3, 7]),
-                num_queues: 4,
-                ..net_fixture()
-            }
-        );
+        {
+            let fd: OwnedFd = File::open("/dev/null").unwrap().into();
+            let fd_1 = fd.try_clone().unwrap().into_raw_fd();
+            let fd_2 = fd.try_clone().unwrap().into_raw_fd();
+
+            let net_config = NetConfig::parse(&format!(
+                "mac=de:ad:be:ef:12:34,fd=[{fd_1},{fd_2}],num_queues=4",
+            ))?;
+            assert_eq!(net_config.fds.as_ref().unwrap()[0].as_raw_fd(), fd_1);
+            assert_eq!(net_config.fds.as_ref().unwrap()[1].as_raw_fd(), fd_2);
+        }
 
         assert_eq!(
             NetConfig::parse("mac=de:ad:be:ef:12:34,mask=255.255.255.0")?,
@@ -4857,29 +4921,68 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 resume: false,
             }
         );
-        assert_eq!(
-            RestoreConfig::parse(
-                "source_url=/path/to/snapshot,prefault=off,net_fds=[net0@[3,4],net1@[5,6,7,8]]"
-            )?,
-            RestoreConfig {
-                source_url: PathBuf::from("/path/to/snapshot"),
-                prefault: false,
-                memory_restore_mode: MemoryRestoreMode::Copy,
-                net_fds: Some(vec![
-                    RestoredNetConfig {
-                        id: "net0".to_string(),
-                        num_fds: 2,
-                        fds: Some(vec![3, 4]),
-                    },
-                    RestoredNetConfig {
-                        id: "net1".to_string(),
-                        num_fds: 4,
-                        fds: Some(vec![5, 6, 7, 8]),
-                    }
-                ]),
-                resume: false,
-            }
-        );
+
+        {
+            let fd: OwnedFd = File::open("/dev/null").unwrap().into();
+            let fd_1 = fd.try_clone().unwrap().into_raw_fd();
+            let fd_2 = fd.try_clone().unwrap().into_raw_fd();
+            let fd_3 = fd.try_clone().unwrap().into_raw_fd();
+            let fd_4 = fd.try_clone().unwrap().into_raw_fd();
+            let fd_5 = fd.try_clone().unwrap().into_raw_fd();
+            let fd_6 = fd.try_clone().unwrap().into_raw_fd();
+
+            let restore_config = RestoreConfig::parse(&format!(
+                "source_url=/path/to/snapshot,prefault=off,net_fds=[net0@[{fd_1},{fd_2}],net1@[{fd_3},{fd_4},{fd_5},{fd_6}]]",
+            ))?;
+            assert_eq!(
+                restore_config.net_fds.as_ref().unwrap()[0]
+                    .fds
+                    .as_ref()
+                    .unwrap()[0]
+                    .as_raw_fd(),
+                fd_1
+            );
+            assert_eq!(
+                restore_config.net_fds.as_ref().unwrap()[0]
+                    .fds
+                    .as_ref()
+                    .unwrap()[1]
+                    .as_raw_fd(),
+                fd_2
+            );
+            assert_eq!(
+                restore_config.net_fds.as_ref().unwrap()[1]
+                    .fds
+                    .as_ref()
+                    .unwrap()[0]
+                    .as_raw_fd(),
+                fd_3
+            );
+            assert_eq!(
+                restore_config.net_fds.as_ref().unwrap()[1]
+                    .fds
+                    .as_ref()
+                    .unwrap()[1]
+                    .as_raw_fd(),
+                fd_4
+            );
+            assert_eq!(
+                restore_config.net_fds.as_ref().unwrap()[1]
+                    .fds
+                    .as_ref()
+                    .unwrap()[2]
+                    .as_raw_fd(),
+                fd_5
+            );
+            assert_eq!(
+                restore_config.net_fds.as_ref().unwrap()[1]
+                    .fds
+                    .as_ref()
+                    .unwrap()[3]
+                    .as_raw_fd(),
+                fd_6
+            );
+        }
         assert_eq!(
             RestoreConfig::parse("source_url=/path/to/snapshot,memory_restore_mode=ondemand")?,
             RestoreConfig {
@@ -4909,13 +5012,15 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
     #[test]
     fn test_restore_config_serde() {
         assert_eq!(
-            serde_json::from_str::<RestoreConfig>(r#"{"source_url":"/path/to/snapshot"}"#)
-                .unwrap()
-                .memory_restore_mode,
+            serde_json::from_str::<RestoreConfigDeserialized>(
+                r#"{"source_url":"/path/to/snapshot"}"#
+            )
+            .unwrap()
+            .memory_restore_mode,
             MemoryRestoreMode::Copy
         );
         assert_eq!(
-            serde_json::from_str::<RestoreConfig>(
+            serde_json::from_str::<RestoreConfigDeserialized>(
                 r#"{"source_url":"/path/to/snapshot","memory_restore_mode":"OnDemand"}"#
             )
             .unwrap()
@@ -4926,7 +5031,6 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
 
     #[test]
     fn test_restore_config_validation() {
-        // interested in only VmConfig.net, so set rest to default values
         let mut snapshot_vm_config = VmConfig {
             cpus: CpusConfig::default(),
             memory: MemoryConfig::default(),
@@ -4958,117 +5062,12 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             pci_segments: None,
             platform: None,
             tpm: None,
-            preserved_fds: None,
-            net: Some(vec![
-                NetConfig {
-                    pci_common: PciDeviceCommonConfig {
-                        id: Some("net0".to_owned()),
-                        ..Default::default()
-                    },
-                    num_queues: 2,
-                    fds: Some(vec![-1, -1, -1, -1]),
-                    ..net_fixture()
-                },
-                NetConfig {
-                    pci_common: PciDeviceCommonConfig {
-                        id: Some("net1".to_owned()),
-                        ..Default::default()
-                    },
-                    num_queues: 1,
-                    fds: Some(vec![-1, -1]),
-                    ..net_fixture()
-                },
-                NetConfig {
-                    pci_common: PciDeviceCommonConfig {
-                        id: Some("net2".to_owned()),
-                        ..Default::default()
-                    },
-                    fds: None,
-                    ..net_fixture()
-                },
-            ]),
+            net: None,
             landlock_enable: false,
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]
             ivshmem: None,
         };
-
-        let valid_config = RestoreConfig {
-            source_url: PathBuf::from("/path/to/snapshot"),
-            prefault: false,
-            memory_restore_mode: MemoryRestoreMode::Copy,
-            net_fds: Some(vec![
-                RestoredNetConfig {
-                    id: "net0".to_string(),
-                    num_fds: 4,
-                    fds: Some(vec![3, 4, 5, 6]),
-                },
-                RestoredNetConfig {
-                    id: "net1".to_string(),
-                    num_fds: 2,
-                    fds: Some(vec![7, 8]),
-                },
-            ]),
-            resume: false,
-        };
-        valid_config.validate(&snapshot_vm_config).unwrap();
-
-        let mut invalid_config = valid_config.clone();
-        invalid_config.net_fds = Some(vec![RestoredNetConfig {
-            id: "netx".to_string(),
-            num_fds: 4,
-            fds: Some(vec![3, 4, 5, 6]),
-        }]);
-        assert_eq!(
-            invalid_config.validate(&snapshot_vm_config),
-            Err(ValidationError::RestoreMissingRequiredNetId(
-                "net0".to_string()
-            ))
-        );
-
-        invalid_config.net_fds = Some(vec![
-            RestoredNetConfig {
-                id: "net0".to_string(),
-                num_fds: 4,
-                fds: Some(vec![3, 4, 5, 6]),
-            },
-            RestoredNetConfig {
-                id: "net0".to_string(),
-                num_fds: 4,
-                fds: Some(vec![3, 4, 5, 6]),
-            },
-        ]);
-        assert_eq!(
-            invalid_config.validate(&snapshot_vm_config),
-            Err(ValidationError::IdentifierNotUnique("net0".to_string()))
-        );
-
-        invalid_config.net_fds = Some(vec![RestoredNetConfig {
-            id: "net0".to_string(),
-            num_fds: 4,
-            fds: Some(vec![3, 4, 5, 6]),
-        }]);
-        assert_eq!(
-            invalid_config.validate(&snapshot_vm_config),
-            Err(ValidationError::RestoreMissingRequiredNetId(
-                "net1".to_string()
-            ))
-        );
-
-        invalid_config.net_fds = Some(vec![RestoredNetConfig {
-            id: "net0".to_string(),
-            num_fds: 2,
-            fds: Some(vec![3, 4]),
-        }]);
-        assert_eq!(
-            invalid_config.validate(&snapshot_vm_config),
-            Err(ValidationError::RestoreNetFdCountMismatch(
-                "net0".to_string(),
-                2,
-                4
-            ))
-        );
-
         let another_valid_config = RestoreConfig {
             source_url: PathBuf::from("/path/to/snapshot"),
             prefault: false,
@@ -5212,7 +5211,6 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             pci_segments: None,
             platform: None,
             tpm: None,
-            preserved_fds: None,
             landlock_enable: false,
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]
@@ -5437,16 +5435,6 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             invalid_config.validate(),
             Err(ValidationError::VhostUserRateLimiterNotSupported)
-        );
-
-        let mut invalid_config = valid_config.clone();
-        invalid_config.net = Some(vec![NetConfig {
-            fds: Some(vec![0]),
-            ..net_fixture()
-        }]);
-        assert_eq!(
-            invalid_config.validate(),
-            Err(ValidationError::VnetReservedFd(0))
         );
 
         let mut invalid_config = valid_config.clone();
@@ -6073,17 +6061,6 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             invalid_config.validate(),
             Err(ValidationError::InvalidDeviceExcludeMmapBar(6))
         );
-
-        let mut still_valid_config = valid_config.clone();
-        // SAFETY: Safe as the file was just opened
-        let fd1 = unsafe { libc::dup(File::open("/dev/null").unwrap().as_raw_fd()) };
-        // SAFETY: Safe as the file was just opened
-        let fd2 = unsafe { libc::dup(File::open("/dev/null").unwrap().as_raw_fd()) };
-        // SAFETY: safe as both FDs are valid
-        unsafe {
-            still_valid_config.add_preserved_fds(vec![fd1, fd2]);
-        }
-        let _still_valid_config = still_valid_config.clone();
 
         // Valid BDF test
         let mut still_valid_config = valid_config.clone();

--- a/vmm/src/deserialization_barrier/activation.rs
+++ b/vmm/src/deserialization_barrier/activation.rs
@@ -1,0 +1,106 @@
+// Copyright © 2026 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Traits for activating structs with file descriptors.
+
+use std::fs::File;
+
+use thiserror::Error;
+
+use crate::deserialization_barrier::{Active, Fd, FdIdent, FdMap};
+
+/// Errors that can occur in [`UpdateFds`].
+#[derive(Error, Debug, Eq, PartialEq)]
+pub enum FdUpdateError {
+    #[error("Less file descriptors provided than expected for: {0:?}")]
+    TooLittleFds(FdIdent),
+    #[error("More file descriptors provided than expected for: {0:?}")]
+    TooManyFds(FdIdent),
+    #[error("Device without id expected file descriptors")]
+    MissingId,
+    #[error("Missing file descriptors for device: {0:?}")]
+    MissingFds(FdIdent),
+    #[error("File descriptors for the following devices were unused: {0:?}")]
+    SuperfluousFds(Vec<FdIdent>),
+}
+
+/// Trait for updating all deserialized file descriptors to active.
+///
+/// # Usage
+///
+/// Users of the trait should only call [`UpdateFds::update_fds`].
+/// Implementors should use [`UpdateFds::update_fds_inner`] instead.
+pub trait UpdateFds {
+    /// The [`Active`][super::Active] version of the implementor of this trait.
+    type Activated;
+
+    /// Updates all file descriptors within the implementor.
+    fn update_fds(self, mut fd_map: FdMap) -> Result<Self::Activated, FdUpdateError>
+    where
+        Self: Sized,
+    {
+        let result = self.update_fds_inner(&mut fd_map)?;
+        if fd_map.is_empty() {
+            Ok(result)
+        } else {
+            Err(FdUpdateError::SuperfluousFds(
+                fd_map.keys().cloned().collect(),
+            ))
+        }
+    }
+
+    /// Updates all file descriptors within the implementor.
+    ///
+    /// Only used by implementors of the trait.
+    /// To use this trait, call [`UpdateFds::update_fds`].
+    /// Call this method instead of [`UpdateFds::update_fds`] when implementing [`UpdateFds::update_fds_inner`] for parent structs.
+    fn update_fds_inner(self, fd_map: &mut FdMap) -> Result<Self::Activated, FdUpdateError>;
+}
+
+/// Errors that can occur in [`IngestScmRights`].
+#[derive(Error, Debug, Eq, PartialEq)]
+pub enum IngestScmRightsError {
+    #[error("Less file descriptors provided than expected")]
+    TooLittleFds,
+    #[error("More file descriptors provided than expected")]
+    TooManyFds,
+    #[error("SCM_RIGHTS is not supported")]
+    Unsupported,
+}
+
+/// Trait for ingesting `SCM_RIGHTS` provided file descriptors.
+///
+/// # Usage
+///
+/// Users of the trait should only call [`IngestScmRights::ingest_scm_rights`].
+/// Implementors should use [`IngestScmRights::ingest_scm_rights_inner`] instead.
+pub trait IngestScmRights {
+    /// The [`Active`][super::Active] version of the implementor of this trait.
+    type Activated;
+
+    /// Ingests a `SCM_RIGHTS` provided file descriptor list, updating all file descriptors.
+    fn ingest_scm_rights(self, files: Vec<File>) -> Result<Self::Activated, IngestScmRightsError>
+    where
+        Self: Sized,
+    {
+        let mut files = files.into_iter().map(Into::into).collect();
+        let result = self.ingest_scm_rights_inner(&mut files)?;
+        if files.is_empty() {
+            Ok(result)
+        } else {
+            Err(IngestScmRightsError::TooManyFds)
+        }
+    }
+
+    /// Ingests a `SCM_RIGHTS` provided file descriptor list, updating all file descriptors.
+    ///
+    /// Only used by implementors of the trait.
+    /// To use this trait, call [`IngestScmRights::ingest_scm_rights`].
+    /// Call this method instead of [`IngestScmRights::ingest_scm_rights`] when implementing [`IngestScmRights::ingest_scm_rights_inner`] for parent structs.
+    fn ingest_scm_rights_inner(
+        self,
+        fds: &mut Vec<Fd<Active>>,
+    ) -> Result<Self::Activated, IngestScmRightsError>;
+}

--- a/vmm/src/deserialization_barrier/extraction.rs
+++ b/vmm/src/deserialization_barrier/extraction.rs
@@ -1,0 +1,72 @@
+// Copyright © 2026 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Traits for extracting file descriptors from structs.
+
+use std::collections::HashMap;
+use std::os::fd::OwnedFd;
+
+use thiserror::Error;
+
+use crate::deserialization_barrier::FdMap;
+
+/// Errors that can occur in [`ExtractFdMap`].
+#[derive(Error, Debug, Eq, PartialEq)]
+pub enum ExtractFdMapError {
+    #[error("Identifier collision for {0}")]
+    IdCollision(String),
+}
+
+/// Trait for extracting a [`FdMap`] from a file descriptor containing struct.
+///
+/// # Usage
+///
+/// Users of the trait should only call [`ExtractFdMap::extract_fd_map`].
+/// Implementors should use [`ExtractFdMap::extract_fd_map_inner`] instead.
+pub trait ExtractFdMap {
+    /// Extracts all file descriptors into an [`FdMap`].
+    ///
+    /// This takes ownership of the file descriptors and leaves the struct without file descriptors.
+    fn extract_fd_map(&mut self) -> Result<FdMap, ExtractFdMapError> {
+        let mut fd_map = HashMap::new();
+        self.extract_fd_map_inner(&mut fd_map)?;
+        Ok(fd_map)
+    }
+
+    /// Extracts all file descriptors into `fd_map`.
+    ///
+    /// Only used by implementors of the trait.
+    /// To use this trait, call [`ExtractFdMap::extract_fd_map`].
+    /// Call this method instead of [`ExtractFdMap::extract_fd_map`] when implementing [`ExtractFdMap::extract_fd_map_inner`] for parent structs.
+    fn extract_fd_map_inner(&mut self, fd_map: &mut FdMap) -> Result<(), ExtractFdMapError>;
+}
+
+/// Trait for exporting all file descriptors for use in `SCM_RIGHTS`.
+///
+/// # Usage
+///
+/// Users of the trait should only call [`ExportScmRights::fd_map`].
+/// Implementors should use [`ExportScmRights::fd_map_inner`] instead.
+pub trait ExportScmRights {
+    /// The [`Deserialized`][super::Deserialized] version of the implementor of this trait.
+    type Inactive;
+
+    /// Exports all file descriptors for use in `SCM_RIGHTS` and turns `Self` in its [`Deserialized`][super::Deserialized] version.
+    fn export_fd_list(self) -> (Self::Inactive, Vec<OwnedFd>)
+    where
+        Self: Sized,
+    {
+        let mut fd_list = Vec::new();
+        let inactive = self.export_fd_list_inner(&mut fd_list);
+        (inactive, fd_list)
+    }
+
+    /// Exports all file descriptors for use in `SCM_RIGHTS` and turns `Self` in its [`Deserialized`][super::Deserialized] version.
+    ///
+    /// Only used by implementors of the trait.
+    /// To use this trait, call [`ExportScmRights::export_fd_list`].
+    /// Call this method instead of [`ExportScmRights::export_fd_list`] when implementing [`ExportScmRights::export_fd_list_inner`] for parent structs.
+    fn export_fd_list_inner(self, fds: &mut Vec<OwnedFd>) -> Self::Inactive;
+}

--- a/vmm/src/deserialization_barrier/fd.rs
+++ b/vmm/src/deserialization_barrier/fd.rs
@@ -1,0 +1,297 @@
+// Copyright © 2026 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! A deserialization barrier compatible file descriptor.
+
+use std::fmt::Debug;
+use std::fs::File;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
+
+use crate::deserialization_barrier::{Active, Deserialized, ExportScmRights, Sealed};
+
+/// Marker Trait
+#[expect(private_bounds)]
+pub trait FdMarker: FdMarkerImpl + Sealed {}
+
+/// Contains the implementation details for [`FdMarker`].
+///
+/// Private helper trait to prevent access to private implementation details.
+trait FdMarkerImpl {
+    /// File descriptor type.
+    type Repr: Debug + AsRawFd;
+    /// Clones [`Self::Repr`].
+    ///
+    /// Helper to enable a [`Clone`] implementation for all `T: FdMarkerImpl`.
+    fn clone(inner: &Self::Repr) -> Self::Repr;
+}
+
+impl FdMarkerImpl for Deserialized {
+    type Repr = RawFd;
+
+    fn clone(inner: &Self::Repr) -> Self::Repr {
+        *inner
+    }
+}
+impl FdMarker for Deserialized {}
+
+impl FdMarkerImpl for Active {
+    type Repr = OwnedFd;
+
+    fn clone(inner: &Self::Repr) -> Self::Repr {
+        inner.try_clone().unwrap()
+    }
+}
+impl FdMarker for Active {}
+
+/// File descriptor with state information.
+///
+/// Depending on the generic parameter, the file descriptor can be:
+/// - [`Deserialized`], which means the file descriptor is invalid.
+/// - [`Active`], which means the file descriptor can be used like [`OwnedFd`].
+///
+/// The file descriptor will always de-/serialize to an invalid state.
+#[derive(Debug)]
+pub struct Fd<S>
+where
+    S: FdMarker,
+{
+    fd: <S as FdMarkerImpl>::Repr,
+}
+
+impl Fd<Deserialized> {
+    /// Creates a new [`Fd<Deserialized>`].
+    pub fn new_deserialized(raw_fd: RawFd) -> Self {
+        Self { fd: raw_fd }
+    }
+
+    /// Updates the file descriptor with an [`OwnedFd`], turning it [`Active`].
+    pub fn activate(self, owned_fd: OwnedFd) -> Fd<Active> {
+        Fd { fd: owned_fd }
+    }
+}
+
+/// Errors creating an [`Fd<Active>`] from a [`RawFd`].
+#[derive(Error, Debug)]
+pub enum FromRawError {
+    /// F_GETFD on the file descriptor returned an error.
+    #[error("Invalid file descriptor \"{raw_fd}\": {source}")]
+    InvalidFd {
+        raw_fd: RawFd,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl Fd<Active> {
+    /// Creates a new [`Fd<Active>`].
+    pub fn new_active(owned_fd: OwnedFd) -> Self {
+        Self { fd: owned_fd }
+    }
+
+    /// Converts the [`RawFd`] into [`Fd<Active>`].
+    ///
+    /// # Safety
+    ///
+    /// Requires the same safety guarantees as [`OwnedFd::from_raw_fd`].
+    ///
+    /// # Panics
+    ///
+    /// Has the same panic cases as [`OwnedFd::from_raw_fd`].
+    pub unsafe fn new_from_raw(raw_fd: RawFd) -> Result<Self, FromRawError> {
+        // SAFETY: F_GETFD handles invalid file descriptors.
+        let fcntl_result = unsafe { libc::fcntl(raw_fd, libc::F_GETFD) };
+        if fcntl_result == -1 {
+            return Err(FromRawError::InvalidFd {
+                raw_fd,
+                source: std::io::Error::last_os_error(),
+            });
+        }
+        // SAFETY: We checked that the user supplied a valid file descriptor.
+        let owned_fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        Ok(owned_fd.into())
+    }
+}
+
+impl Default for Fd<Deserialized> {
+    fn default() -> Self {
+        Self { fd: -1 }
+    }
+}
+
+impl<S> Clone for Fd<S>
+where
+    S: FdMarker,
+{
+    fn clone(&self) -> Self {
+        Self {
+            fd: <S as FdMarkerImpl>::clone(&self.fd),
+        }
+    }
+}
+
+// TODO(fd): remove the `Eq` and `PartialEq` implementation.
+// Neither makes sense for `OwnedFd` since there cannot be two `OwnedFd`s with the same underlying `RawFd`.
+// Blocked on removing both traits from `VmConfig` and friends.
+impl<S> Eq for Fd<S> where S: FdMarker {}
+
+impl<S> PartialEq for Fd<S>
+where
+    S: FdMarker,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.fd.as_raw_fd() == other.fd.as_raw_fd()
+    }
+}
+
+impl<S> Serialize for Fd<S>
+where
+    S: FdMarker,
+{
+    fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
+    where
+        Ser: Serializer,
+    {
+        // File descriptors cannot be used over the serialization barrier so all fds are
+        // serialized as invalid.
+        serializer.serialize_i32(-1)
+    }
+}
+
+impl<'de> Deserialize<'de> for Fd<Deserialized> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let fd = RawFd::deserialize(deserializer)?;
+        Ok(Self::new_deserialized(fd))
+    }
+}
+
+impl AsFd for Fd<Active> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
+    }
+}
+
+impl AsRawFd for Fd<Active> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd.as_raw_fd()
+    }
+}
+
+impl From<RawFd> for Fd<Deserialized> {
+    fn from(value: RawFd) -> Self {
+        Self::new_deserialized(value)
+    }
+}
+
+impl From<OwnedFd> for Fd<Active> {
+    fn from(value: OwnedFd) -> Self {
+        Self::new_active(value)
+    }
+}
+
+impl From<File> for Fd<Active> {
+    fn from(value: File) -> Self {
+        Self::new_active(value.into())
+    }
+}
+
+impl From<Fd<Active>> for OwnedFd {
+    fn from(value: Fd<Active>) -> Self {
+        value.fd
+    }
+}
+
+impl ExportScmRights for Fd<Active> {
+    type Inactive = Fd<Deserialized>;
+
+    fn export_fd_list_inner(self, fds: &mut Vec<OwnedFd>) -> Self::Inactive {
+        let fd = self.fd;
+        let raw_fd = fd.as_raw_fd();
+        fds.push(fd);
+        Fd { fd: raw_fd }
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::fs::File;
+    use std::os::fd::{AsRawFd, IntoRawFd, OwnedFd};
+
+    use crate::deserialization_barrier::{Active, Deserialized, ExportScmRights, Fd, FromRawError};
+
+    #[test]
+    fn de_ser_roundtrip() {
+        let file = File::open("/dev/null").unwrap();
+        let fd: Fd<Active> = file.into();
+        let serialized_fd = serde_json::to_string(&fd).unwrap();
+        assert_eq!(serialized_fd, "-1");
+        let deserialized_fd: Fd<Deserialized> = serde_json::from_str(&serialized_fd).unwrap();
+        assert_eq!(deserialized_fd.fd, -1);
+    }
+
+    #[test]
+    fn deserialize_placeholder() {
+        let serialized_fd = "123";
+        let deserialized_fd: Fd<Deserialized> = serde_json::from_str(serialized_fd).unwrap();
+        assert_eq!(deserialized_fd.fd, 123);
+    }
+
+    #[test]
+    fn scm_rights() {
+        let file = File::open("/dev/null").unwrap();
+        let fd: Fd<Active> = file.into();
+        let raw_fd = fd.as_raw_fd();
+        let (inactive_fd, fd_list): (Fd<Deserialized>, _) = fd.export_fd_list();
+        assert_eq!(fd_list.len(), 1);
+        assert_eq!(inactive_fd.fd, raw_fd);
+    }
+
+    #[test]
+    fn activate() {
+        let file = File::open("/dev/null").unwrap();
+        let fd: OwnedFd = file.into();
+        let raw_fd = fd.as_raw_fd();
+        let inactive_fd = Fd::new_deserialized(-1);
+        let activated_fd = inactive_fd.activate(fd);
+        assert_eq!(activated_fd.as_raw_fd(), raw_fd);
+    }
+
+    #[test]
+    fn new_from_raw() {
+        // Success case:
+        let file = File::open("/dev/null").unwrap();
+        let raw_fd = file.into_raw_fd();
+        // SAFETY: We got the RawFd from an OwnedFd.
+        let fd = unsafe { Fd::new_from_raw(raw_fd) }.unwrap();
+        assert_eq!(fd.as_raw_fd(), raw_fd);
+
+        // Failure case:
+        let raw_fd = -1;
+        // SAFETY: `new_from_raw` will handle the invalid raw fd.
+        let FromRawError::InvalidFd { raw_fd, source } =
+            unsafe { Fd::new_from_raw(raw_fd) }.unwrap_err();
+        assert_eq!(raw_fd, -1);
+        assert_eq!(source.raw_os_error().unwrap(), libc::EBADF);
+    }
+
+    #[test]
+    fn clone() {
+        let file = File::open("/dev/null").unwrap();
+        let fd: Fd<Active> = file.into();
+        let cloned_fd = fd.clone();
+        assert_ne!(cloned_fd.as_raw_fd(), fd.as_raw_fd());
+        assert_ne!(cloned_fd, fd);
+
+        let fd = Fd::new_deserialized(-1);
+        let cloned_fd = fd.clone();
+        assert_eq!(cloned_fd.fd, fd.fd);
+        assert_eq!(cloned_fd, fd);
+    }
+}

--- a/vmm/src/deserialization_barrier/fd_ident.rs
+++ b/vmm/src/deserialization_barrier/fd_ident.rs
@@ -1,0 +1,17 @@
+// Copyright © 2026 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// An identifier for any resource backed by a file descriptor.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
+pub enum FdIdent {
+    Net { id: String },
+}
+
+impl FdIdent {
+    /// Returns a new [`FdIdent`] for a network device.
+    pub fn new_net(id: String) -> Self {
+        Self::Net { id }
+    }
+}

--- a/vmm/src/deserialization_barrier/mod.rs
+++ b/vmm/src/deserialization_barrier/mod.rs
@@ -1,0 +1,40 @@
+// Copyright © 2026 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! A barrier to distinguish between the active and deserialized state for structs/enums.
+//!
+//! Some resources, most notably file descriptors, cannot be de-/serialized.
+//! The barrier allows a type-safe handling and transition of states while guaranteeing that any active struct does not contain invalid remnants from deserialization.
+
+mod activation;
+mod extraction;
+mod fd;
+pub mod fd_ident;
+
+use std::collections::HashMap;
+
+pub use activation::{FdUpdateError, IngestScmRights, IngestScmRightsError, UpdateFds};
+pub use extraction::{ExportScmRights, ExtractFdMap, ExtractFdMapError};
+pub use fd::{Fd, FdMarker, FromRawError};
+pub use fd_ident::FdIdent;
+use serde::Serialize;
+
+pub type FdMap = HashMap<FdIdent, Vec<Fd<Active>>>;
+
+trait Sealed {}
+
+/// Marker to indicate a struct has been deserialized and not yet activated.
+///
+/// See the [module description][crate::deserialization_barrier] for more information.
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Serialize)]
+pub struct Deserialized;
+/// Marker for active structs.
+///
+/// See the [module description][crate::deserialization_barrier] for more information.
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Serialize)]
+pub struct Active;
+
+impl Sealed for Deserialized {}
+impl Sealed for Active {}

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::{self, IsTerminal, Seek, SeekFrom, stdout};
 use std::num::Wrapping;
+use std::os::fd::AsFd;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 #[cfg(not(target_arch = "riscv64"))]
@@ -2986,7 +2987,7 @@ impl DeviceManager {
             } else if let Some(fds) = &net_cfg.fds {
                 let net = virtio_devices::Net::from_tap_fds(
                     id.clone(),
-                    fds,
+                    &fds.iter().map(AsFd::as_fd).collect::<Vec<_>>(),
                     Some(net_cfg.mac),
                     net_cfg.mtu,
                     self.force_access_platform | net_cfg.pci_common.iommu,
@@ -3002,11 +3003,6 @@ impl DeviceManager {
                     net_cfg.offload_csum,
                 )
                 .map_err(DeviceManagerError::CreateVirtioNet)?;
-
-                // SAFETY: 'fds' are valid because TAP devices are created successfully
-                unsafe {
-                    self.config.lock().unwrap().add_preserved_fds(fds.clone());
-                }
 
                 Arc::new(Mutex::new(net))
             } else {
@@ -4826,35 +4822,9 @@ impl DeviceManager {
                     .unwrap()
                     .device_type(),
             );
-            // When the device is added, we close all file descriptors
-            // opened externally for this device. This allows management
-            // software to properly clean up resources, e.g., libvirt can clean
-            // up tap devices.
-            //
-            // TODO: once we allow externally opened FDs for other devices as well,
-            // we should create a descriptive abstraction/function for this
-            // functionality.
             match device_type {
-                VirtioDeviceType::Net => {
-                    let mut config = self.config.lock().unwrap();
-                    let nets = config.net.as_deref_mut().unwrap();
-                    let net_dev_cfg = nets
-                        .iter_mut()
-                        .find(|net| net.pci_common.id.as_deref() == Some(id))
-                        // unwrap: the device could not have been removed without an ID
-                        .unwrap();
-                    let fds = net_dev_cfg.fds.take().unwrap_or(Vec::new());
-
-                    debug!("Closing preserved FDs from virtio-net device: id={id}, fds={fds:?}");
-                    for fd in fds {
-                        config.preserved_fds.as_mut().unwrap().remove(&fd);
-                        // SAFETY: We are closing the only remaining instance of this FD.
-                        unsafe {
-                            libc::close(fd);
-                        }
-                    }
-                }
-                VirtioDeviceType::Block
+                VirtioDeviceType::Net
+                | VirtioDeviceType::Block
                 | VirtioDeviceType::Pmem
                 | VirtioDeviceType::Fs
                 | VirtioDeviceType::Vsock => {}

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -75,6 +75,7 @@ pub mod console_devices;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 mod coredump;
 pub mod cpu;
+pub mod deserialization_barrier;
 pub mod device_manager;
 pub mod device_tree;
 #[cfg(feature = "guest_debug")]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -22,6 +22,7 @@ use api::http::HttpApiHandle;
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 use arch::x86_64::MAX_SUPPORTED_CPUS_LEGACY;
 use console_devices::{ConsoleInfo, pre_create_console_devices};
+use deserialization_barrier::{Active, Deserialized, FdMarker, UpdateFds};
 use event_monitor::event;
 use landlock::LandlockError;
 use libc::{EFD_NONBLOCK, SIGINT, SIGTERM, TCSANOW, tcsetattr, termios};
@@ -52,6 +53,7 @@ use crate::api::{
 use crate::config::{MemoryRestoreMode, RestoreConfig, add_to_config};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::coredump::GuestDebuggable;
+use crate::deserialization_barrier::{ExtractFdMap, FdMap, FdUpdateError};
 use crate::landlock::Landlock;
 use crate::memory_manager::MemoryManager;
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
@@ -64,7 +66,7 @@ use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::vm::{Error as VmError, Vm, VmState};
 use crate::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, NetConfig, PmemConfig,
-    UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
+    UserDeviceConfig, VdpaConfig, VmConfig, VmConfigInner, VsockConfig,
 };
 
 mod acpi;
@@ -586,12 +588,41 @@ where
     Ok((value, duration))
 }
 
+type VmMigrationConfig = VmMigrationConfigInner<Active>;
+type VmMigrationConfigDeserialized = VmMigrationConfigInner<Deserialized>;
+
 #[derive(Clone, Deserialize, Serialize)]
-struct VmMigrationConfig {
-    vm_config: Arc<Mutex<VmConfig>>,
+#[serde(bound(deserialize = "VmConfigInner<S>: Deserialize<'de>",))]
+struct VmMigrationConfigInner<S>
+where
+    S: FdMarker,
+{
+    vm_config: Arc<Mutex<VmConfigInner<S>>>,
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     common_cpuid: Vec<hypervisor::arch::x86::CpuIdEntry>,
     memory_manager_data: MemoryManagerSnapshotData,
+}
+
+impl UpdateFds for VmMigrationConfigDeserialized {
+    type Activated = VmMigrationConfig;
+
+    fn update_fds_inner(
+        self,
+        fd_map: &mut FdMap,
+    ) -> result::Result<Self::Activated, FdUpdateError> {
+        let active_vm_config = self
+            .vm_config
+            .lock()
+            .unwrap()
+            .clone()
+            .update_fds_inner(fd_map)?;
+        Ok(VmMigrationConfig {
+            vm_config: Arc::new(Mutex::new(active_vm_config)),
+            #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+            common_cpuid: self.common_cpuid,
+            memory_manager_data: self.memory_manager_data,
+        })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1040,9 +1071,16 @@ impl Vmm {
             .read_exact(&mut data)
             .map_err(MigratableError::MigrateSocket)?;
 
-        let vm_migration_config: VmMigrationConfig =
-            serde_json::from_slice(&data).map_err(|e| {
+        let vm_migration_config: VmMigrationConfigDeserialized = serde_json::from_slice(&data)
+            .map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error deserialising config: {e}"))
+            })?;
+
+        //TODO(fd): We currently don't support migrations for VM that use fds for net devs.
+        let vm_migration_config = vm_migration_config
+            .update_fds(HashMap::new())
+            .map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Error activating config: {e}"))
             })?;
 
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
@@ -1945,21 +1983,32 @@ impl RequestHandler for Vmm {
         }
     }
 
-    fn vm_restore(&mut self, restore_cfg: RestoreConfig) -> result::Result<(), VmError> {
+    fn vm_restore(&mut self, mut restore_cfg: RestoreConfig) -> result::Result<(), VmError> {
         if self.vm.is_some() || self.vm_config.is_some() {
             return Err(VmError::VmAlreadyCreated);
         }
 
-        let source_url = restore_cfg.source_url.as_path().to_str();
+        let source_url = restore_cfg
+            .source_url
+            .as_path()
+            .to_str()
+            .map(ToOwned::to_owned);
         if source_url.is_none() {
             return Err(VmError::InvalidRestoreSourceUrl);
         }
         // Safe to unwrap as we checked it was Some(&str).
         let source_url = source_url.unwrap();
+        let vm_config_deserialized = recv_vm_config(&source_url).map_err(VmError::Restore)?;
 
-        let vm_config = Arc::new(Mutex::new(
-            recv_vm_config(source_url).map_err(VmError::Restore)?,
-        ));
+        let vm_config_activated = vm_config_deserialized
+            .update_fds(
+                restore_cfg
+                    .extract_fd_map()
+                    .map_err(VmError::ExtractFdMap)?,
+            )
+            .map_err(VmError::FdUpdate)?;
+
+        let vm_config = Arc::new(Mutex::new(vm_config_activated));
         restore_cfg
             .validate(&vm_config.lock().unwrap().clone())
             .map_err(VmError::ConfigValidation)?;
@@ -1981,7 +2030,7 @@ impl RequestHandler for Vmm {
         }
 
         self.vm_restore(
-            source_url,
+            &source_url,
             vm_config,
             restore_cfg.prefault,
             restore_cfg.memory_restore_mode,
@@ -2788,7 +2837,6 @@ mod unit_tests {
             pci_segments: None,
             platform: None,
             tpm: None,
-            preserved_fds: None,
             landlock_enable: false,
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]

--- a/vmm/src/migration.rs
+++ b/vmm/src/migration.rs
@@ -12,7 +12,7 @@ use vm_migration::{MigratableError, Snapshot};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::coredump::GuestDebuggableError;
 use crate::vm::VmSnapshot;
-use crate::vm_config::VmConfig;
+use crate::vm_config::VmConfigInnerDeserialized;
 
 pub const SNAPSHOT_STATE_FILE: &str = "state.json";
 pub const SNAPSHOT_CONFIG_FILE: &str = "config.json";
@@ -46,7 +46,9 @@ pub fn url_to_file(url: &str) -> std::result::Result<PathBuf, GuestDebuggableErr
     Ok(file)
 }
 
-pub fn recv_vm_config(source_url: &str) -> std::result::Result<VmConfig, MigratableError> {
+pub fn recv_vm_config(
+    source_url: &str,
+) -> std::result::Result<VmConfigInnerDeserialized, MigratableError> {
     let mut vm_config_path = url_to_path(source_url)?;
 
     vm_config_path.push(SNAPSHOT_CONFIG_FILE);

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -90,6 +90,7 @@ use crate::console_devices::{ConsoleDeviceError, ConsoleInfo};
 use crate::coredump::{
     CpuElf64Writable, DumpState, Elf64Writable, GuestDebuggable, GuestDebuggableError, NoteDescType,
 };
+use crate::deserialization_barrier::{ExtractFdMapError, FdUpdateError};
 use crate::device_manager::{DeviceManager, DeviceManagerError};
 use crate::device_tree::DeviceTree;
 #[cfg(feature = "guest_debug")]
@@ -361,6 +362,12 @@ pub enum Error {
 
     #[error("Error locking disk images: Another instance likely holds a lock")]
     LockingError(#[source] DeviceManagerError),
+
+    #[error("Error updating file descriptors: {0}")]
+    FdUpdate(#[source] FdUpdateError),
+
+    #[error("Error creating file descriptor map: {0}")]
+    ExtractFdMap(#[source] ExtractFdMapError),
 
     #[cfg(feature = "fw_cfg")]
     #[error("Fw Cfg missing kernel")]

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-use std::collections::HashSet;
 use std::net::IpAddr;
+use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
 #[cfg(feature = "fw_cfg")]
 use std::str::FromStr;
@@ -12,13 +12,17 @@ use std::{fs, result};
 use arch::CpuProfile;
 use block::ImageType;
 pub use block::fcntl::LockGranularityChoice;
-use log::{debug, warn};
+use log::warn;
 use net_util::MacAddr;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use virtio_devices::RateLimiterConfig;
 
 use crate::Landlock;
+use crate::deserialization_barrier::{
+    Active, Deserialized, ExportScmRights, Fd, FdIdent, FdMap, FdMarker, FdUpdateError,
+    IngestScmRights, IngestScmRightsError, UpdateFds,
+};
 use crate::landlock::LandlockError;
 
 pub type LandlockResult<T> = result::Result<T, LandlockError>;
@@ -412,8 +416,15 @@ pub fn default_diskconfig_sparse() -> bool {
     true
 }
 
+pub type NetConfig = NetConfigInner<Active>;
+pub type NetConfigDeserialized = NetConfigInner<Deserialized>;
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct NetConfig {
+#[serde(bound(deserialize = "Fd<S>: Deserialize<'de>",))]
+pub struct NetConfigInner<S>
+where
+    S: FdMarker,
+{
     #[serde(flatten)]
     pub pci_common: PciDeviceCommonConfig,
     #[serde(default = "default_netconfig_tap")]
@@ -435,14 +446,8 @@ pub struct NetConfig {
     pub vhost_socket: Option<String>,
     #[serde(default)]
     pub vhost_mode: VhostMode,
-    // Special deserialize handling:
-    // Therefore, we don't serialize FDs, and whatever value is here after
-    // deserialization is invalid.
-    //
-    // Valid FDs are transmitted via a different channel (SCM_RIGHTS message)
-    // and will be populated into this struct on the destination VMM eventually.
-    #[serde(default, deserialize_with = "deserialize_netconfig_fds")]
-    pub fds: Option<Vec<i32>>,
+    #[serde(default)]
+    pub fds: Option<Vec<Fd<S>>>,
     #[serde(default)]
     pub rate_limiter_config: Option<RateLimiterConfig>,
     #[serde(default = "default_netconfig_true")]
@@ -451,6 +456,152 @@ pub struct NetConfig {
     pub offload_ufo: bool,
     #[serde(default = "default_netconfig_true")]
     pub offload_csum: bool,
+}
+
+impl ExportScmRights for NetConfig {
+    type Inactive = NetConfigInner<Deserialized>;
+
+    fn export_fd_list_inner(self, fds: &mut Vec<OwnedFd>) -> Self::Inactive {
+        let inactive_fds = self.fds.map(|active_fds| {
+            active_fds
+                .into_iter()
+                .map(|fd| fd.export_fd_list_inner(fds))
+                .collect()
+        });
+        NetConfigInner {
+            pci_common: self.pci_common,
+            tap: self.tap,
+            ip: self.ip,
+            mask: self.mask,
+            mac: self.mac,
+            host_mac: self.host_mac,
+            mtu: self.mtu,
+            num_queues: self.num_queues,
+            queue_size: self.queue_size,
+            vhost_user: self.vhost_user,
+            vhost_socket: self.vhost_socket,
+            vhost_mode: self.vhost_mode,
+            fds: inactive_fds,
+            rate_limiter_config: self.rate_limiter_config,
+            offload_tso: self.offload_tso,
+            offload_ufo: self.offload_ufo,
+            offload_csum: self.offload_csum,
+        }
+    }
+}
+
+impl UpdateFds for NetConfigDeserialized {
+    type Activated = NetConfig;
+
+    fn update_fds_inner(self, fd_map: &mut FdMap) -> Result<Self::Activated, FdUpdateError> {
+        let fds = 'block: {
+            let Some(id) = &self.pci_common.id else {
+                if let Some(self_fds) = self.fds
+                    && !self_fds.is_empty()
+                {
+                    return Err(FdUpdateError::MissingId);
+                }
+                break 'block None;
+            };
+            let fd_ident = FdIdent::new_net(id.clone());
+
+            let fds = fd_map.remove(&fd_ident);
+            match (self.fds, fds) {
+                (Some(self_fds), Some(fds)) => {
+                    if self_fds.len() > fds.len() {
+                        return Err(FdUpdateError::TooLittleFds(fd_ident));
+                    }
+
+                    if self_fds.len() < fds.len() {
+                        return Err(FdUpdateError::TooManyFds(fd_ident));
+                    }
+
+                    Some(fds)
+                }
+                (Some(self_fds), None) => {
+                    if self_fds.is_empty() {
+                        None
+                    } else {
+                        return Err(FdUpdateError::MissingFds(fd_ident));
+                    }
+                }
+                (None, Some(fds)) => {
+                    if fds.is_empty() {
+                        None
+                    } else {
+                        return Err(FdUpdateError::SuperfluousFds(vec![FdIdent::new_net(
+                            id.clone(),
+                        )]));
+                    }
+                }
+                (None, None) => None,
+            }
+        };
+        Ok(NetConfig {
+            pci_common: self.pci_common,
+            tap: self.tap,
+            ip: self.ip,
+            mask: self.mask,
+            mac: self.mac,
+            host_mac: self.host_mac,
+            mtu: self.mtu,
+            num_queues: self.num_queues,
+            queue_size: self.queue_size,
+            vhost_user: self.vhost_user,
+            vhost_socket: self.vhost_socket,
+            vhost_mode: self.vhost_mode,
+            fds,
+            rate_limiter_config: self.rate_limiter_config,
+            offload_tso: self.offload_tso,
+            offload_ufo: self.offload_ufo,
+            offload_csum: self.offload_csum,
+        })
+    }
+}
+
+impl IngestScmRights for NetConfigDeserialized {
+    type Activated = NetConfig;
+
+    fn ingest_scm_rights_inner(
+        self,
+        fds: &mut Vec<Fd<Active>>,
+    ) -> Result<Self::Activated, IngestScmRightsError> {
+        if let Some(self_fds) = self.fds {
+            if self_fds.len() > fds.len() {
+                return Err(IngestScmRightsError::TooLittleFds);
+            }
+
+            if self_fds.len() < fds.len() {
+                return Err(IngestScmRightsError::TooManyFds);
+            }
+        }
+
+        let fds = if fds.is_empty() {
+            None
+        } else {
+            Some(std::mem::take(fds))
+        };
+
+        Ok(NetConfig {
+            pci_common: self.pci_common,
+            tap: self.tap,
+            ip: self.ip,
+            mask: self.mask,
+            mac: self.mac,
+            host_mac: self.host_mac,
+            mtu: self.mtu,
+            num_queues: self.num_queues,
+            queue_size: self.queue_size,
+            vhost_user: self.vhost_user,
+            vhost_socket: self.vhost_socket,
+            vhost_mode: self.vhost_mode,
+            fds,
+            rate_limiter_config: self.rate_limiter_config,
+            offload_tso: self.offload_tso,
+            offload_ufo: self.offload_ufo,
+            offload_csum: self.offload_csum,
+        })
+    }
 }
 
 pub fn default_netconfig_true() -> bool {
@@ -475,21 +626,6 @@ pub const DEFAULT_NET_QUEUE_SIZE: u16 = 256;
 
 pub fn default_netconfig_queue_size() -> u16 {
     DEFAULT_NET_QUEUE_SIZE
-}
-
-fn deserialize_netconfig_fds<'de, D>(d: D) -> Result<Option<Vec<i32>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let invalid_fds: Option<Vec<i32>> = Option::deserialize(d)?;
-    if let Some(invalid_fds) = invalid_fds {
-        debug!(
-            "FDs in 'NetConfig' won't be deserialized as they are most likely invalid now. Deserializing them as -1."
-        );
-        Ok(Some(vec![-1; invalid_fds.len()]))
-    } else {
-        Ok(None)
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -1081,8 +1217,15 @@ impl ApplyLandlock for LandlockConfig {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct VmConfig {
+pub type VmConfig = VmConfigInner<Active>;
+pub type VmConfigInnerDeserialized = VmConfigInner<Deserialized>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(bound(deserialize = "crate::deserialization_barrier::Fd<S>: Deserialize<'de>",))]
+pub struct VmConfigInner<S>
+where
+    S: FdMarker,
+{
     #[serde(default)]
     pub cpus: CpusConfig,
     #[serde(default)]
@@ -1090,7 +1233,7 @@ pub struct VmConfig {
     pub payload: Option<PayloadConfig>,
     pub rate_limit_groups: Option<Box<[RateLimiterGroupConfig]>>,
     pub disks: Option<Vec<DiskConfig>>,
-    pub net: Option<Vec<NetConfig>>,
+    pub net: Option<Vec<NetConfigInner<S>>>,
     #[serde(default)]
     pub rng: RngConfig,
     pub balloon: Option<BalloonConfig>,
@@ -1126,16 +1269,6 @@ pub struct VmConfig {
     pub pci_segments: Option<Box<[PciSegmentConfig]>>,
     pub platform: Option<PlatformConfig>,
     pub tpm: Option<TpmConfig>,
-    // Preserved FDs are the ones that share the same life-time as its holding
-    // VmConfig instance, such as FDs for creating TAP devices.
-    // Preserved FDs will stay open as long as the holding VmConfig instance is
-    // valid, and will be closed when the holding VmConfig instance is destroyed.
-    //
-    // This is populated as devices are added at runtime. Removing them again
-    // causes the FDs to be closed early. This allows management software to
-    // gracefully clean up resources (e.g., libvirt closes tap devices).
-    #[serde(skip)]
-    pub preserved_fds: Option<HashSet<i32>>,
     #[serde(default)]
     pub landlock_enable: bool,
     pub landlock_rules: Option<Box<[LandlockConfig]>>,
@@ -1252,5 +1385,695 @@ impl VmConfig {
         } else {
             self.cpus.max_vcpus
         }
+    }
+}
+
+impl UpdateFds for VmConfigInnerDeserialized {
+    type Activated = VmConfig;
+
+    fn update_fds_inner(self, fd_map: &mut FdMap) -> Result<Self::Activated, FdUpdateError> {
+        let net = {
+            if let Some(net) = self.net {
+                let mut net_configs = Vec::with_capacity(net.len());
+                for net_config in net {
+                    net_configs.push(net_config.update_fds_inner(fd_map)?);
+                }
+                Some(net_configs)
+            } else {
+                None
+            }
+        };
+
+        Ok(VmConfig {
+            cpus: self.cpus,
+            memory: self.memory,
+            payload: self.payload,
+            rate_limit_groups: self.rate_limit_groups,
+            disks: self.disks,
+            net,
+            rng: self.rng,
+            balloon: self.balloon,
+            generic_vhost_user: self.generic_vhost_user,
+            fs: self.fs,
+            pmem: self.pmem,
+            serial: self.serial,
+            console: self.console,
+            #[cfg(target_arch = "x86_64")]
+            debug_console: self.debug_console,
+            devices: self.devices,
+            user_devices: self.user_devices,
+            vdpa: self.vdpa,
+            vsock: self.vsock,
+            #[cfg(feature = "pvmemcontrol")]
+            pvmemcontrol: self.pvmemcontrol,
+            pvpanic: self.pvpanic,
+            iommu: self.iommu,
+            numa: self.numa,
+            watchdog: self.watchdog,
+            rtc: self.rtc,
+            #[cfg(feature = "guest_debug")]
+            gdb: self.gdb,
+            pci_segments: self.pci_segments,
+            platform: self.platform,
+            tpm: self.tpm,
+            landlock_enable: self.landlock_enable,
+            landlock_rules: self.landlock_rules,
+            #[cfg(feature = "ivshmem")]
+            ivshmem: self.ivshmem,
+        })
+    }
+}
+
+impl IngestScmRights for VmConfigInnerDeserialized {
+    type Activated = VmConfig;
+
+    fn ingest_scm_rights_inner(
+        self,
+        fds: &mut Vec<Fd<Active>>,
+    ) -> Result<Self::Activated, IngestScmRightsError> {
+        if fds.is_empty() {
+            let net = if let Some(nets) = self.net {
+                let mut result = Vec::new();
+                for net in nets {
+                    result.push(net.ingest_scm_rights_inner(fds)?);
+                }
+                if result.is_empty() {
+                    None
+                } else {
+                    Some(result)
+                }
+            } else {
+                None
+            };
+            Ok(VmConfig {
+                cpus: self.cpus,
+                memory: self.memory,
+                payload: self.payload,
+                rate_limit_groups: self.rate_limit_groups,
+                disks: self.disks,
+                net,
+                rng: self.rng,
+                balloon: self.balloon,
+                generic_vhost_user: self.generic_vhost_user,
+                fs: self.fs,
+                pmem: self.pmem,
+                serial: self.serial,
+                console: self.console,
+                #[cfg(target_arch = "x86_64")]
+                debug_console: self.debug_console,
+                devices: self.devices,
+                user_devices: self.user_devices,
+                vdpa: self.vdpa,
+                vsock: self.vsock,
+                #[cfg(feature = "pvmemcontrol")]
+                pvmemcontrol: self.pvmemcontrol,
+                pvpanic: self.pvpanic,
+                iommu: self.iommu,
+                numa: self.numa,
+                watchdog: self.watchdog,
+                rtc: self.rtc,
+                #[cfg(feature = "guest_debug")]
+                gdb: self.gdb,
+                pci_segments: self.pci_segments,
+                platform: self.platform,
+                tpm: self.tpm,
+                landlock_enable: self.landlock_enable,
+                landlock_rules: self.landlock_rules,
+                #[cfg(feature = "ivshmem")]
+                ivshmem: self.ivshmem,
+            })
+        } else {
+            Err(IngestScmRightsError::Unsupported)
+        }
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::collections::HashMap;
+    use std::fs::File;
+    use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+
+    use net_util::MacAddr;
+
+    use crate::config::{RestoreConfigInner, RestoredNetConfig};
+    use crate::deserialization_barrier::{
+        Active, ExportScmRights, ExtractFdMap, ExtractFdMapError, Fd, FdIdent, FdMap, FdMarker,
+        FdUpdateError, IngestScmRights, IngestScmRightsError, UpdateFds,
+    };
+    use crate::vm_config::{NetConfigInner, PciDeviceCommonConfig, VhostMode, VmConfigInner};
+
+    fn net_fixture<S>(fds: Option<Vec<Fd<S>>>, id: Option<&str>) -> NetConfigInner<S>
+    where
+        S: FdMarker,
+    {
+        NetConfigInner {
+            pci_common: PciDeviceCommonConfig {
+                id: id.map(|id| id.to_owned()),
+                ..Default::default()
+            },
+            tap: None,
+            ip: None,
+            mask: None,
+            mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
+            host_mac: Some(MacAddr::parse_str("12:34:de:ad:be:ef").unwrap()),
+            mtu: None,
+            num_queues: 2,
+            queue_size: 256,
+            vhost_user: false,
+            vhost_socket: None,
+            vhost_mode: VhostMode::Client,
+            fds,
+            rate_limiter_config: None,
+            offload_tso: true,
+            offload_ufo: true,
+            offload_csum: true,
+        }
+    }
+
+    fn restore_config_fixture<S>(
+        net_fds: Option<Vec<RestoredNetConfig<S>>>,
+    ) -> RestoreConfigInner<S>
+    where
+        S: FdMarker,
+    {
+        RestoreConfigInner {
+            source_url: Default::default(),
+            prefault: false,
+            memory_restore_mode: Default::default(),
+            net_fds,
+            resume: false,
+        }
+    }
+
+    fn vm_config_fixture<S>(net: Option<Vec<NetConfigInner<S>>>) -> VmConfigInner<S>
+    where
+        S: FdMarker,
+    {
+        VmConfigInner {
+            cpus: Default::default(),
+            memory: Default::default(),
+            payload: None,
+            rate_limit_groups: None,
+            disks: None,
+            net,
+            rng: Default::default(),
+            balloon: None,
+            generic_vhost_user: None,
+            fs: None,
+            pmem: None,
+            serial: Default::default(),
+            console: Default::default(),
+            #[cfg(target_arch = "x86_64")]
+            debug_console: Default::default(),
+            devices: None,
+            user_devices: None,
+            vdpa: None,
+            vsock: None,
+            #[cfg(feature = "pvmemcontrol")]
+            pvmemcontrol: Default::default(),
+            pvpanic: false,
+            iommu: false,
+            numa: None,
+            watchdog: false,
+            rtc: None,
+            #[cfg(feature = "guest_debug")]
+            gdb: Default::default(),
+            pci_segments: None,
+            platform: None,
+            tpm: None,
+            landlock_enable: false,
+            landlock_rules: None,
+            #[cfg(feature = "ivshmem")]
+            ivshmem: Default::default(),
+        }
+    }
+
+    fn restored_net_config_fixture<S>(fds: Option<Vec<Fd<S>>>) -> RestoredNetConfig<S>
+    where
+        S: FdMarker,
+    {
+        let num_fds = fds.as_ref().map(Vec::len).unwrap_or_default();
+        RestoredNetConfig {
+            id: "test".to_string(),
+            num_fds,
+            fds,
+        }
+    }
+
+    #[test]
+    fn export_scm_rights_netconfig() {
+        let config = net_fixture(None, None);
+        assert!(config.export_fd_list().1.is_empty());
+
+        let config = net_fixture(Some(Vec::new()), None);
+        assert!(config.export_fd_list().1.is_empty());
+
+        let fd: OwnedFd = File::open("/dev/null").unwrap().into();
+        let raw_fd = fd.as_raw_fd();
+        let config = net_fixture(Some(vec![fd.into()]), None);
+        let (config_deactivated, fd_list) = config.export_fd_list();
+        assert_eq!(fd_list.len(), 1);
+        assert_eq!(fd_list[0].as_raw_fd(), raw_fd);
+        assert_eq!(
+            config_deactivated.fds,
+            Some(vec![Fd::new_deserialized(raw_fd)])
+        );
+    }
+
+    #[test]
+    fn export_scm_rights_restore_config() {
+        let config = restore_config_fixture(None);
+        assert!(config.export_fd_list().1.is_empty());
+
+        let config = restore_config_fixture(Some(Vec::new()));
+        assert!(config.export_fd_list().1.is_empty());
+
+        let fd: OwnedFd = File::open("/dev/null").unwrap().into();
+        let raw_fd = fd.as_raw_fd();
+        let config = restore_config_fixture(Some(vec![restored_net_config_fixture(Some(vec![
+            fd.into(),
+        ]))]));
+        let (config_deactivated, fd_list) = config.export_fd_list();
+        assert_eq!(fd_list.len(), 1);
+        assert_eq!(fd_list[0].as_raw_fd(), raw_fd);
+        assert_eq!(
+            config_deactivated.net_fds,
+            Some(vec![restored_net_config_fixture(Some(
+                vec![raw_fd.into(),]
+            ))])
+        );
+    }
+
+    #[test]
+    fn export_scm_rights_restored_net_config() {
+        let config = restored_net_config_fixture(None);
+        assert!(config.export_fd_list().1.is_empty());
+
+        let config = restored_net_config_fixture(Some(Vec::new()));
+        assert!(config.export_fd_list().1.is_empty());
+
+        let fd: OwnedFd = File::open("/dev/null").unwrap().into();
+        let raw_fd = fd.as_raw_fd();
+        let config = restored_net_config_fixture(Some(vec![fd.into()]));
+        let (config_deactivated, fd_list) = config.export_fd_list();
+        assert_eq!(fd_list.len(), 1);
+        assert_eq!(fd_list[0].as_raw_fd(), raw_fd);
+        assert_eq!(config_deactivated.fds, Some(vec![raw_fd.into(),]));
+    }
+
+    #[test]
+    fn extract_fd_map_restored_net_config() {
+        let mut config = restored_net_config_fixture(None);
+        assert!(config.extract_fd_map().unwrap().is_empty());
+
+        let mut config = restored_net_config_fixture(Some(Vec::new()));
+        assert!(config.extract_fd_map().unwrap().is_empty());
+
+        let fd: OwnedFd = File::open("/dev/null").unwrap().into();
+        let raw_fd = fd.as_raw_fd();
+        let mut config = restored_net_config_fixture(Some(vec![fd.into()]));
+        let fd_map = config.extract_fd_map().unwrap();
+        assert_eq!(fd_map.len(), 1);
+        assert_eq!(
+            fd_map
+                .get(&FdIdent::Net {
+                    id: config.id.clone()
+                })
+                .unwrap()[0]
+                .as_raw_fd(),
+            raw_fd
+        );
+        assert_eq!(config.fds, None);
+
+        let fd: OwnedFd = File::open("/dev/null").unwrap().into();
+        let mut config = restored_net_config_fixture(Some(vec![fd.into()]));
+        let net_id = FdIdent::Net {
+            id: config.id.clone(),
+        };
+        let mut fd_map = FdMap::new();
+        fd_map.insert(net_id.clone(), Vec::new());
+        assert_eq!(
+            config.extract_fd_map_inner(&mut fd_map),
+            Err(ExtractFdMapError::IdCollision(format!("{net_id:?}")))
+        );
+    }
+
+    #[test]
+    fn extract_fd_map_restore_config() {
+        let mut config = restore_config_fixture(None);
+        assert!(config.extract_fd_map().unwrap().is_empty());
+
+        let mut config = restore_config_fixture(Some(Vec::new()));
+        assert!(config.extract_fd_map().unwrap().is_empty());
+
+        let fd: OwnedFd = File::open("/dev/null").unwrap().into();
+        let raw_fd = fd.as_raw_fd();
+        let mut config =
+            restore_config_fixture(Some(vec![restored_net_config_fixture(Some(vec![
+                fd.into(),
+            ]))]));
+        let fd_map = config.extract_fd_map().unwrap();
+        assert_eq!(fd_map.len(), 1);
+        assert_eq!(
+            fd_map
+                .get(&FdIdent::Net {
+                    id: "test".to_owned()
+                })
+                .unwrap()[0]
+                .as_raw_fd(),
+            raw_fd
+        );
+        assert_eq!(config.net_fds, None);
+
+        let fd: OwnedFd = File::open("/dev/null").unwrap().into();
+        let mut config =
+            restore_config_fixture(Some(vec![restored_net_config_fixture(Some(vec![
+                fd.into(),
+            ]))]));
+        let net_id = FdIdent::Net {
+            id: "test".to_owned(),
+        };
+        let mut fd_map = FdMap::new();
+        fd_map.insert(net_id.clone(), Vec::new());
+        assert_eq!(
+            config.extract_fd_map_inner(&mut fd_map),
+            Err(ExtractFdMapError::IdCollision(format!("{net_id:?}")))
+        );
+    }
+
+    #[test]
+    fn ingest_scm_rights_netconfig() {
+        let fds = Vec::new();
+        let config = net_fixture(None, None);
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        assert_eq!(active_config, net_fixture(None, None));
+
+        let fds = Vec::new();
+        let config = net_fixture(Some(Vec::new()), None);
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        assert_eq!(active_config, net_fixture(None, None));
+
+        let fds = (0..5).map(|_| File::open("/dev/null").unwrap()).collect();
+        let config = net_fixture(Some(Vec::new()), None);
+        assert_eq!(
+            config.ingest_scm_rights(fds),
+            Err(IngestScmRightsError::TooManyFds)
+        );
+
+        let fds = Vec::new();
+        let config = net_fixture(
+            Some((0..5).map(|_| Fd::new_deserialized(-1)).collect()),
+            None,
+        );
+        assert_eq!(
+            config.ingest_scm_rights(fds),
+            Err(IngestScmRightsError::TooLittleFds)
+        );
+
+        let fds: Vec<File> = (0..5).map(|_| File::open("/dev/null").unwrap()).collect();
+        let raw_fds: Vec<RawFd> = fds.iter().map(|fd| fd.as_raw_fd()).collect();
+        let config = net_fixture(
+            Some(fds.iter().map(|_| Fd::new_deserialized(-1)).collect()),
+            None,
+        );
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        active_config
+            .fds
+            .as_ref()
+            .unwrap()
+            .iter()
+            .zip(raw_fds)
+            .for_each(|(fd, raw_fd)| assert_eq!(fd.as_raw_fd(), raw_fd));
+    }
+
+    #[test]
+    fn ingest_scm_rights_restore_config() {
+        let fds = Vec::new();
+        let config = restore_config_fixture(None);
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        assert_eq!(active_config, restore_config_fixture(None));
+
+        let fds = Vec::new();
+        let config = restore_config_fixture(Some(Vec::new()));
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        assert_eq!(active_config, restore_config_fixture(None));
+
+        let fds = (0..5).map(|_| File::open("/dev/null").unwrap()).collect();
+        let config = restore_config_fixture(Some(Vec::new()));
+        assert_eq!(
+            config.ingest_scm_rights(fds),
+            Err(IngestScmRightsError::TooManyFds)
+        );
+
+        let fds = Vec::new();
+        let config = restore_config_fixture(Some(
+            (0..5)
+                .map(|_| restored_net_config_fixture(Some(vec![Fd::new_deserialized(-1)])))
+                .collect(),
+        ));
+        assert_eq!(
+            config.ingest_scm_rights(fds),
+            Err(IngestScmRightsError::TooLittleFds)
+        );
+
+        let fds: Vec<File> = (0..5).map(|_| File::open("/dev/null").unwrap()).collect();
+        let raw_fds: Vec<RawFd> = fds.iter().map(|fd| fd.as_raw_fd()).collect();
+        let config = restore_config_fixture(Some(
+            fds.iter()
+                .map(|_| restored_net_config_fixture(Some(vec![Fd::new_deserialized(-1)])))
+                .collect(),
+        ));
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        active_config
+            .net_fds
+            .as_ref()
+            .unwrap()
+            .iter()
+            .zip(raw_fds)
+            .for_each(|(fd, raw_fd)| assert_eq!(fd.fds.as_ref().unwrap()[0].as_raw_fd(), raw_fd));
+    }
+
+    #[test]
+    fn ingest_scm_rights_restored_net_config() {
+        let fds = Vec::new();
+        let config = restored_net_config_fixture(None);
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        assert_eq!(active_config, restored_net_config_fixture(None));
+
+        let fds = Vec::new();
+        let config = restored_net_config_fixture(Some(Vec::new()));
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        assert_eq!(active_config, restored_net_config_fixture(None));
+
+        let fds = (0..5).map(|_| File::open("/dev/null").unwrap()).collect();
+        let config = restored_net_config_fixture(Some(Vec::new()));
+        assert_eq!(
+            config.ingest_scm_rights(fds),
+            Err(IngestScmRightsError::TooManyFds)
+        );
+
+        let fds = Vec::new();
+        let config =
+            restored_net_config_fixture(Some((0..5).map(|_| Fd::new_deserialized(-1)).collect()));
+        assert_eq!(
+            config.ingest_scm_rights(fds),
+            Err(IngestScmRightsError::TooLittleFds)
+        );
+
+        let fds: Vec<File> = (0..5).map(|_| File::open("/dev/null").unwrap()).collect();
+        let raw_fds: Vec<RawFd> = fds.iter().map(|fd| fd.as_raw_fd()).collect();
+        let config = restored_net_config_fixture(Some(
+            fds.iter().map(|_| Fd::new_deserialized(-1)).collect(),
+        ));
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        active_config
+            .fds
+            .as_ref()
+            .unwrap()
+            .iter()
+            .zip(raw_fds)
+            .for_each(|(fd, raw_fd)| assert_eq!(fd.as_raw_fd(), raw_fd));
+    }
+
+    #[test]
+    fn ingest_scm_rights_vm_config() {
+        let fds = Vec::new();
+        let config = vm_config_fixture(None);
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        assert_eq!(active_config, vm_config_fixture(None));
+
+        let fds = Vec::new();
+        let config = vm_config_fixture(Some(Vec::new()));
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        assert_eq!(active_config, vm_config_fixture(None));
+
+        let fds = Vec::new();
+        let config = vm_config_fixture(Some((0..5).map(|_| net_fixture(None, None)).collect()));
+        let active_config = config.ingest_scm_rights(fds).unwrap();
+        assert_eq!(
+            active_config,
+            vm_config_fixture(Some((0..5).map(|_| net_fixture(None, None)).collect()))
+        );
+
+        let fds = (0..5).map(|_| File::open("/dev/null").unwrap()).collect();
+        let config = vm_config_fixture(Some(Vec::new()));
+        assert_eq!(
+            config.ingest_scm_rights(fds),
+            Err(IngestScmRightsError::Unsupported)
+        );
+
+        let fds: Vec<File> = (0..5).map(|_| File::open("/dev/null").unwrap()).collect();
+        let config = vm_config_fixture(Some(fds.iter().map(|_| net_fixture(None, None)).collect()));
+        assert_eq!(
+            config.ingest_scm_rights(fds),
+            Err(IngestScmRightsError::Unsupported)
+        );
+
+        let fds: Vec<File> = (0..5).map(|_| File::open("/dev/null").unwrap()).collect();
+        let config = vm_config_fixture(Some(
+            fds.iter()
+                .map(|_| net_fixture(Some(vec![Fd::new_deserialized(-1)]), None))
+                .collect(),
+        ));
+        assert_eq!(
+            config.ingest_scm_rights(fds),
+            Err(IngestScmRightsError::Unsupported)
+        );
+    }
+
+    #[test]
+    fn update_fds_netconfig() {
+        let fd_ident = FdIdent::new_net("test".to_owned());
+
+        let fd_map = HashMap::new();
+        let config = net_fixture(None, Some("test"));
+        let active_config = config.update_fds(fd_map).unwrap();
+        assert_eq!(active_config, net_fixture(None, Some("test")));
+
+        let fd_map = HashMap::new();
+        let config = net_fixture(Some(Vec::new()), Some("test"));
+        let active_config = config.update_fds(fd_map).unwrap();
+        assert_eq!(active_config, net_fixture(None, Some("test")));
+
+        let fd_map = HashMap::new();
+        let config = net_fixture(None, None);
+        let active_config = config.update_fds(fd_map).unwrap();
+        assert_eq!(active_config, net_fixture(None, None));
+
+        let fd_map = HashMap::new();
+        let config = net_fixture(Some(Vec::new()), None);
+        let active_config = config.update_fds(fd_map).unwrap();
+        assert_eq!(active_config, net_fixture(None, None));
+
+        let fd_map = [(fd_ident.clone(), Vec::new())].into();
+        let config = net_fixture(None, Some("test"));
+        let active_config = config.update_fds(fd_map).unwrap();
+        assert_eq!(active_config, net_fixture(None, Some("test")));
+
+        let fd_map = HashMap::new();
+        let config = net_fixture(
+            Some((0..5).map(|_| Fd::new_deserialized(-1)).collect()),
+            Some("test"),
+        );
+        assert_eq!(
+            config.update_fds(fd_map),
+            Err(FdUpdateError::MissingFds(fd_ident.clone()))
+        );
+
+        let fd_map = HashMap::new();
+        let config = net_fixture(Some(vec![Fd::new_deserialized(-1); 5]), None);
+        assert_eq!(config.update_fds(fd_map), Err(FdUpdateError::MissingId));
+
+        let fds = vec![File::open("/dev/null").unwrap().into(); 5];
+        let fd_map = [(fd_ident.clone(), fds)].into();
+        let config = net_fixture(None, Some("test"));
+        assert_eq!(
+            config.update_fds(fd_map),
+            Err(FdUpdateError::SuperfluousFds(vec![fd_ident.clone()]))
+        );
+
+        let fds = vec![File::open("/dev/null").unwrap().into(); 5];
+        let fds_raw: Vec<_> = fds.iter().map(|fd: &Fd<Active>| fd.as_raw_fd()).collect();
+        let fd_map = [(fd_ident.clone(), fds)].into();
+        let config = net_fixture(Some(vec![Fd::new_deserialized(-1); 5]), Some("test"));
+        let config_active = config.update_fds(fd_map).unwrap();
+        config_active
+            .fds
+            .as_ref()
+            .unwrap()
+            .iter()
+            .zip(fds_raw)
+            .for_each(|(fd, fd_raw)| assert_eq!(fd.as_raw_fd(), fd_raw));
+
+        let fds = vec![File::open("/dev/null").unwrap().into(); 5];
+        let fd_map = [(fd_ident.clone(), fds)].into();
+        let config = net_fixture(None, None);
+        assert_eq!(
+            config.update_fds(fd_map),
+            Err(FdUpdateError::SuperfluousFds(vec![fd_ident.clone()]))
+        );
+
+        let fds = vec![File::open("/dev/null").unwrap().into(); 5];
+        let fd_map = [(fd_ident.clone(), fds)].into();
+        let config = net_fixture(Some(vec![Fd::new_deserialized(-1)]), Some("test"));
+        assert_eq!(
+            config.update_fds(fd_map),
+            Err(FdUpdateError::TooManyFds(fd_ident.clone()))
+        );
+
+        let fds = vec![File::open("/dev/null").unwrap().into(); 5];
+        let fd_map = [(fd_ident.clone(), fds)].into();
+        let config = net_fixture(Some(vec![Fd::new_deserialized(-1); 10]), Some("test"));
+        assert_eq!(
+            config.update_fds(fd_map),
+            Err(FdUpdateError::TooLittleFds(fd_ident.clone()))
+        );
+
+        let fd_map = [(fd_ident.clone(), Vec::new())].into();
+        let config = net_fixture(Some(vec![Fd::new_deserialized(-1); 10]), Some("test"));
+        assert_eq!(
+            config.update_fds(fd_map),
+            Err(FdUpdateError::TooLittleFds(fd_ident.clone()))
+        );
+    }
+
+    #[test]
+    fn update_fds_vm_config() {
+        let fd_map = HashMap::new();
+        let config = vm_config_fixture(Some(vec![net_fixture(Some(Vec::new()), Some("test"))]));
+        let active_config = config.update_fds(fd_map).unwrap();
+        assert_eq!(
+            active_config,
+            vm_config_fixture(Some(vec![net_fixture(None, Some("test"))]))
+        );
+
+        let fd_map = HashMap::new();
+        let config = vm_config_fixture(None);
+        let active_config = config.update_fds(fd_map).unwrap();
+        assert_eq!(active_config, vm_config_fixture(None));
+
+        let fds = vec![File::open("/dev/null").unwrap().into(); 5];
+        let fd_map = [(FdIdent::new_net("test".to_owned()), fds)].into();
+        let config = vm_config_fixture(Some(vec![net_fixture(None, Some("other"))]));
+        assert_eq!(
+            config.update_fds(fd_map),
+            Err(FdUpdateError::SuperfluousFds(vec![FdIdent::new_net(
+                "test".to_owned()
+            )]))
+        );
+
+        let fds = vec![File::open("/dev/null").unwrap().into(); 5];
+        let fd_map = [(FdIdent::new_net("test".to_owned()), fds)].into();
+        let config = vm_config_fixture(Some(vec![net_fixture(
+            Some(vec![Fd::new_deserialized(-1)]),
+            Some("other"),
+        )]));
+        assert_eq!(
+            config.update_fds(fd_map),
+            Err(FdUpdateError::MissingFds(FdIdent::new_net(
+                "other".to_owned()
+            )))
+        );
     }
 }


### PR DESCRIPTION
This PR makes progress toward first-class file descriptor support as outlined in #7704.

Currently, fd-backed devices are handled with `i32`/`RawFd` plumbing and device-specific serde logic, which scales poorly beyond the current virtio-net support. This PR introduces a typed deserialization barrier for file descriptors and moves the existing fd-backed config paths over to it.

Main changes:
- introduce typed fd states for deserialized placeholders vs active owned fds
- use `OwnedFd` for live file descriptors instead of passing raw integers
through config objects
- centralize fd activation/export logic for API provided fds and restore/migration fd replacement
- remove one-off fd serde handling from the net/restore paths in favor of the
barrier model
- remove `VmConfig::preserved_fds` since fds are now owned by the respective configs.
- keep current API, including:
    - `vm.add-net` and `vm.restore` activating fd-backed configs
    - `vm.create` still not accepting fd activation
    - D-Bus continuing to ignore body-provided fd placeholders for now

This improves type safety, makes fd ownership explicit, and provides a more
scalable foundation for extending fd-backed device support beyond networking.

I wasn't able to split the changes into smaller bits without introducing excessive temporary glue-code that made reviewing harder.