### PR TITLE
logger: cache local timezone before seccomp

### DIFF
--- a/cloud-hypervisor/src/logger.rs
+++ b/cloud-hypervisor/src/logger.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use std::sync::Mutex;
 use std::time::Instant;
 
+use jiff::tz::TimeZone;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -185,6 +186,9 @@ pub struct Logger {
     start: Instant,
     pid: u32,
     tokens: Vec<Token>,
+    // Saving the timezone when Logger is constructed avoids potential seccomp violations when the
+    // internal libc timezone cache expires as the affected thread is unpredictable.
+    local_tz: TimeZone,
 }
 
 impl Logger {
@@ -194,6 +198,7 @@ impl Logger {
             start: Instant::now(),
             pid: std::process::id(),
             tokens: parse_format(format)?,
+            local_tz: TimeZone::try_system().unwrap_or(TimeZone::UTC),
         })
     }
 }
@@ -232,7 +237,9 @@ impl log::Log for Logger {
                     write!(&mut *out, "{}", zoned.strftime("%m%d %H:%M:%S%.6f"))
                 }
                 Token::LocalGlog => {
-                    let zoned = zoned_local.get_or_insert_with(jiff::Zoned::now);
+                    let zoned = zoned_local.get_or_insert_with(|| {
+                        jiff::Timestamp::now().to_zoned(self.local_tz.clone())
+                    });
                     write!(&mut *out, "{}", zoned.strftime("%m%d %H:%M:%S%.6f"))
                 }
                 Token::Pid => write!(&mut *out, "{}", self.pid),
@@ -255,7 +262,9 @@ impl log::Log for Logger {
                         Zone::Utc => zoned_utc.get_or_insert_with(|| {
                             jiff::Timestamp::now().to_zoned(jiff::tz::TimeZone::UTC)
                         }),
-                        Zone::Local => zoned_local.get_or_insert_with(jiff::Zoned::now),
+                        Zone::Local => zoned_local.get_or_insert_with(|| {
+                            jiff::Timestamp::now().to_zoned(self.local_tz.clone())
+                        }),
                     };
                     write_time_field(&mut *out, *field, zoned)
                 }


### PR DESCRIPTION
We saw some seccomp violations when the tz cache was dropped. manually cache it before enforcing seccomp so that can't happen