### PR TITLE
vmm: allow madvise in the event-monitor seccomp filter

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -1024,6 +1024,7 @@ fn event_monitor_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendE
         (libc::SYS_futex, vec![]),
         (libc::SYS_landlock_create_ruleset, vec![]),
         (libc::SYS_landlock_restrict_self, vec![]),
+        (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
         (libc::SYS_munmap, vec![]),
         (libc::SYS_prctl, vec![]),


### PR DESCRIPTION
Fix racy seccomp kill on shutdown. When a VM shuts down the event-monitor thread's recv() loop ends and the thread exits. glibc's thread teardown then runs __malloc_arena_thread_freeres, which trims the per-thread malloc arena with madvise(MADV_DONTNEED).

Add madvise to the allowed calls to match other threads. The crash is intermittent because it only fires when that thread's arena accumulated trimmable memory by shutdown.