### PR TITLE
ch-remote: Make snapshot and restore config arguments required 

### DIFF
--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -1127,6 +1127,7 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
             .arg(
                 Arg::new("restore_config")
                     .index(1)
+                    .required(true)
                     .help(RestoreConfig::SYNTAX),
             ),
         Command::new("resume").about("Resume the VM"),
@@ -1144,6 +1145,7 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
             .arg(
                 Arg::new("snapshot_config")
                     .index(1)
+                    .required(true)
                     .help("<destination_url>"),
             ),
     ]

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -1247,7 +1247,7 @@ fn main() {
                 let body = body.as_ref().map_or("", |body| body.as_str());
 
                 // Retrieve the list of error messages back.
-                let lines: Vec<&str> = match serde_json::from_str(body) {
+                let lines: Vec<String> = match serde_json::from_str(body) {
                     Ok(json) => json,
                     Err(e) => {
                         return Some(format!(
@@ -1259,7 +1259,8 @@ fn main() {
 
                 let error_status = format!("Server responded with {status_code:?}");
                 // Prepend the error status line to the lines iter.
-                let lines = std::iter::once(error_status.as_str()).chain(lines);
+                let lines =
+                    std::iter::once(error_status.as_str()).chain(lines.iter().map(|s| s.as_str()));
                 let error_msg_multiline = lines
                     .enumerate()
                     .map(|(index, error_msg)| (index + level, error_msg))
@@ -1320,5 +1321,18 @@ mod unit_tests {
         for command in commands {
             assert_args_sorted(|| command.get_arguments());
         }
+    }
+
+    #[test]
+    fn test_error_deserialization() {
+        let body = r#"["Error from API","The VM could not be snapshotted","Cannot send VM snapshot","Failed to send migratable component snapshot","Destination is not a directory: \"/tmp/ch.dump\""]"#;
+        let lines: Result<Vec<String>, _> = serde_json::from_str(body);
+        assert!(lines.is_ok());
+        let lines = lines.unwrap();
+        assert_eq!(lines.len(), 5);
+        assert_eq!(
+            lines[4],
+            r#"Destination is not a directory: "/tmp/ch.dump""#
+        );
     }
 }


### PR DESCRIPTION
The snapshot and restore commands in ch-remote had optional snapshot_config and restore_config arguments, but the implementation was unconditionally unwrapping them.

This change marks these arguments as required to handle the missing argument validation and report a proper error message instead of letting the application panic.