### PR TITLE
scripts: auto-detect hypervisor from device node

### DIFF
--- a/.github/workflows/mshv-integration.yaml
+++ b/.github/workflows/mshv-integration.yaml
@@ -76,7 +76,7 @@ jobs:
               fi
             done
 
-            sudo ./scripts/dev_cli.sh tests --hypervisor mshv --integration
+            sudo ./scripts/dev_cli.sh tests --integration
           EOF
 
       - name: Dump dmesg

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -69,7 +69,7 @@ scripts/dev_cli.sh [flags] <command> [<command args>]
 
 ```shell
 scripts/dev_cli.sh build [--debug|--release] [--libc musl|gnu] \
-    [--hypervisor kvm|mshv] [--features <features>] \
+    [--features <features>] \
     [--volumes /host:/ctr#...] [-- <cargo args>]
 ```
 
@@ -78,7 +78,6 @@ scripts/dev_cli.sh build [--debug|--release] [--libc musl|gnu] \
 | `--debug`      | yes     | Build debug binaries.                    |
 | `--release`    |         | Build release binaries.                  |
 | `--libc`       | `gnu`   | C library to link against (`musl`/`gnu`).|
-| `--hypervisor` | `kvm`   | Hypervisor backend (`kvm`/`mshv`).       |
 | `--features`   |         | Additional cargo features.               |
 | `--volumes`    |         | Extra host volumes (`/a:/a#/b:/b`).      |
 | `--runtime`    | `docker`| Container runtime (`docker`/`podman`).   |
@@ -89,7 +88,7 @@ Arguments after `--` are forwarded directly to `cargo build`.
 
 ```shell
 scripts/dev_cli.sh tests [<test type>] [--libc musl|gnu] \
-    [--hypervisor kvm|mshv] [--volumes /host:/ctr#...] \
+    [--volumes /host:/ctr#...] \
     [-- <script args> [-- <binary args>]]
 ```
 
@@ -112,7 +111,6 @@ scripts/dev_cli.sh tests [<test type>] [--libc musl|gnu] \
 | Flag           | Default | Description                              |
 |----------------|---------|------------------------------------------|
 | `--libc`       | `gnu`   | C library to link against (`musl`/`gnu`).|
-| `--hypervisor` | `kvm`   | Hypervisor backend (`kvm`/`mshv`).       |
 | `--volumes`    |         | Extra host volumes (`/a:/a#/b:/b`).      |
 
 ### Argument passthrough
@@ -134,7 +132,6 @@ The test scripts accept the following common arguments via
 
 | Argument              | Description                                  |
 |-----------------------|----------------------------------------------|
-| `--hypervisor kvm\|mshv` | Select hypervisor (also passed by dev_cli.sh). |
 | `--test-filter <name>`| Run only tests matching the filter.           |
 | `--test-exclude <name>`| Exclude tests matching the pattern.          |
 | `--build-guest-kernel`| Build the guest kernel from source instead of downloading a prebuilt binary. |
@@ -189,7 +186,7 @@ CH_CUSTOM_OVMF=/path/to/CLOUDHV.fd \
 ## Unit tests
 
 ```shell
-scripts/dev_cli.sh tests --unit [--libc musl|gnu] [--hypervisor kvm|mshv]
+scripts/dev_cli.sh tests --unit [--libc musl|gnu]
 ```
 
 Unit tests run `cargo test` on the entire workspace in release mode:
@@ -207,6 +204,10 @@ interfaces can run.
 When the hypervisor is `mshv`, the feature flag `--features mshv` is
 passed to cargo. On x86_64 with KVM, the `tdx` feature is additionally
 enabled if needed (MSHV does not support TDX).
+
+The hypervisor backend is detected automatically from the host device
+node: `/dev/mshv` selects MSHV and `/dev/kvm` selects KVM. There is no
+flag to select it.
 
 ## Integration tests
 
@@ -341,7 +342,7 @@ guest images and a prebuilt kernel.
 ### Confidential VMs
 
 ```shell
-scripts/dev_cli.sh tests --integration-cvm [--hypervisor mshv]
+scripts/dev_cli.sh tests --integration-cvm
 ```
 
 Runs `scripts/run_integration_tests_cvm.sh`. Builds with `--features

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -144,6 +144,17 @@ ok_or_die() {
     [[ $code -eq 0 ]] || die -c $code "$@"
 }
 
+# Auto-detect the host hypervisor device node and echo its path:
+# /dev/mshv for MSHV, /dev/kvm for KVM. Echoes nothing if neither is
+# present; callers are expected to validate the result.
+detect_hypervisor_device() {
+    if [ -e /dev/mshv ]; then
+        echo "/dev/mshv"
+    elif [ -e /dev/kvm ]; then
+        echo "/dev/kvm"
+    fi
+}
+
 # Make sure the build/ dirs are available. Exit if we can't create them.
 # Upon returning from this call, the caller can be certain the build/ dirs exist.
 #
@@ -259,7 +270,6 @@ cmd_help() {
     echo "        --release             Build the release binaries."
     echo "        --libc                Select the C library Cloud Hypervisor will be built against. Default is gnu"
     echo "        --volumes             Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
-    echo "        --hypervisor          Underlying hypervisor. Options kvm, mshv"
     echo ""
     echo "    tests [<test type (see below)>] [--libc musl|gnu] [-- [<test scripts args>] [-- [<test binary args>]]] "
     echo "        Run the Cloud Hypervisor tests."
@@ -273,7 +283,6 @@ cmd_help() {
     echo "        --metrics                    Generate performance metrics"
     echo "        --coverage                   Generate code coverage information"
     echo "        --volumes                    Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
-    echo "        --hypervisor                 Underlying hypervisor. Options kvm, mshv"
     echo "        --vm-type                    Type of VM to run. Options regular, confidential"
     echo "        --all                        Run all tests."
     echo ""
@@ -298,9 +307,7 @@ cmd_help() {
 cmd_build() {
     build="debug"
     libc="gnu"
-    hypervisor="kvm"
     features_build=()
-    exported_device="/dev/kvm"
     while [ $# -gt 0 ]; do
         case "$1" in
         "-h" | "--help") {
@@ -324,10 +331,6 @@ cmd_build() {
             shift
             arg_vols="$1"
             ;;
-        "--hypervisor")
-            shift
-            hypervisor="$1"
-            ;;
         "--features")
             shift
             features_build=(--features "$1")
@@ -347,12 +350,8 @@ cmd_build() {
     ensure_latest_ctr
 
     process_volumes_args
-    if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
-        die "Hypervisor value must be kvm or mshv"
-    fi
-    if [[ "$hypervisor" = "mshv" ]]; then
-        exported_device="/dev/mshv"
-    fi
+    exported_device="$(detect_hypervisor_device)"
+    [ -n "$exported_device" ] || die "No hypervisor device found (/dev/mshv or /dev/kvm)"
     target="$(uname -m)-unknown-linux-${libc}"
 
     cargo_args=("$@")
@@ -371,7 +370,7 @@ cmd_build() {
         --user "$(id -u):$(id -g)" \
         --workdir "$CTR_CLH_ROOT_DIR" \
         --rm \
-        --volume $exported_device \
+        --volume "$exported_device" \
         --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
         ${exported_volumes:+$exported_volumes} \
         --env RUSTFLAGS="$rustflags" \
@@ -412,8 +411,6 @@ cmd_tests() {
     coverage=false
     libc="gnu"
     arg_vols=""
-    hypervisor="kvm"
-    exported_device="/dev/kvm"
     while [ $# -gt 0 ]; do
         case "$1" in
         "-h" | "--help") {
@@ -438,10 +435,6 @@ cmd_tests() {
             shift
             arg_vols="$1"
             ;;
-        "--hypervisor")
-            shift
-            hypervisor="$1"
-            ;;
         "--all") {
             unit=true
             integration=true
@@ -462,19 +455,8 @@ cmd_tests() {
         esac
         shift
     done
-    if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
-        die "Hypervisor value must be kvm or mshv"
-    fi
-
-    if [[ "$hypervisor" = "mshv" ]]; then
-        exported_device="/dev/mshv"
-    fi
-
-    if [ ! -e "${exported_device}" ]; then
-        die "${exported_device} does not exist on the system"
-    fi
-
-    set -- '--hypervisor' "$hypervisor" "$@"
+    exported_device="$(detect_hypervisor_device)"
+    [ -n "$exported_device" ] || die "No hypervisor device found (/dev/mshv or /dev/kvm)"
 
     ensure_build_dir
     ensure_latest_ctr
@@ -515,7 +497,7 @@ cmd_tests() {
         say "Running unit tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
-            --device $exported_device \
+            --device "$exported_device" \
             --device /dev/net/tun \
             --cap-add net_admin \
             "${common_env_args[@]}" \

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -3,9 +3,22 @@
 # shellcheck source=/dev/null
 set -x
 
-hypervisor="kvm"
 test_filter=""
 build_kernel=false
+
+# Auto-detect the underlying hypervisor based on the device node exposed
+# by the host kernel: /dev/mshv for MSHV, /dev/kvm for KVM.
+# shellcheck disable=SC2034
+detect_hypervisor() {
+    if [ -e /dev/mshv ]; then
+        hypervisor="mshv"
+    elif [ -e /dev/kvm ]; then
+        hypervisor="kvm"
+    else
+        echo "ERROR: no hypervisor device found (/dev/mshv or /dev/kvm)" >&2
+        exit 1
+    fi
+}
 
 # Download from a url with retries
 # Args:
@@ -98,7 +111,6 @@ cmd_help() {
     echo ""
     echo "Available arguments:"
     echo ""
-    echo "    --hypervisor  Underlying hypervisor. Options kvm, mshv"
     echo "    --test-filter Tests to run"
     echo "    --build-guest-kernel Build guest kernel from source instead of downloading pre-built"
     echo ""
@@ -114,10 +126,6 @@ process_common_args() {
             cmd_help
             exit 1
         } ;;
-        "--hypervisor")
-            shift
-            hypervisor="$1"
-            ;;
         "--test-filter")
             shift
             test_filter="$1"
@@ -140,9 +148,7 @@ process_common_args() {
         esac
         shift
     done
-    if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
-        die "Hypervisor value must be kvm or mshv"
-    fi
+    detect_hypervisor
     # shellcheck disable=SC2034
     test_binary_args=("$@")
 }


### PR DESCRIPTION
## Summary

The `dev_cli.sh` and test scripts previously required the underlying
hypervisor backend to be selected manually via the `--hypervisor
kvm|mshv` argument. This argument also decided whether `/dev/kvm` or
`/dev/mshv` was exposed to the container.

This series removes that manual selection and detects the hypervisor
automatically from the host device node: `/dev/mshv` selects MSHV and
`/dev/kvm` selects KVM. There is no longer any flag to set it.

## Changes

The work is split into independent commits:

- **`scripts: auto-detect hypervisor in test-util.sh`** — adds a
  `detect_hypervisor` helper called from `process_common_args`, and
  removes the `--hypervisor` argument parsing, its validation, and the
  help text. All sourcing test scripts (unit and integration) pick up
  the detected backend automatically.
- **`scripts: auto-detect hypervisor in dev_cli.sh`** — adds a
  `detect_hypervisor_device` helper used by both `build` and `tests`,
  and drops the `--hypervisor` argument, its validation, the related
  help text, and the flag previously forwarded to the test scripts.
- **`github: drop --hypervisor from mshv integration workflow`** —
  removes `--hypervisor mshv` from the MSHV CI command, which would
  otherwise be rejected as an unknown argument. The MSHV runner exposes
  `/dev/mshv`, which is detected automatically.
- **`docs: drop --hypervisor from testing guide`** — removes the flag
  from all examples and tables and documents the auto-detection.

## Behaviour

- Detection prefers `/dev/mshv` over `/dev/kvm`.
- If neither device is present, the scripts exit with an error.
- No other test logic changes; scripts that consume `$hypervisor` keep
  working unchanged.

## Testing

- `bash -n` syntax check on `scripts/dev_cli.sh` and
  `scripts/test-util.sh`.
- `shellcheck` clean on the modified scripts.
- Verified no remaining `--hypervisor` references across `scripts/`,
  `docs/`, and `.github/`.