### PR TITLE
scripts: auto-detect hypervisor with optional --hypervisor override

### DIFF
--- a/.github/workflows/mshv-integration.yaml
+++ b/.github/workflows/mshv-integration.yaml
@@ -76,7 +76,7 @@ jobs:
               fi
             done
 
-            sudo ./scripts/dev_cli.sh tests --hypervisor mshv --integration
+            sudo ./scripts/dev_cli.sh tests --integration
           EOF
 
       - name: Dump dmesg

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -78,7 +78,7 @@ scripts/dev_cli.sh build [--debug|--release] [--libc musl|gnu] \
 | `--debug`      | yes     | Build debug binaries.                    |
 | `--release`    |         | Build release binaries.                  |
 | `--libc`       | `gnu`   | C library to link against (`musl`/`gnu`).|
-| `--hypervisor` | `kvm`   | Hypervisor backend (`kvm`/`mshv`).       |
+| `--hypervisor` | auto    | Hypervisor backend (`kvm`/`mshv`). Auto-detected from the host device node when omitted. |
 | `--features`   |         | Additional cargo features.               |
 | `--volumes`    |         | Extra host volumes (`/a:/a#/b:/b`).      |
 | `--runtime`    | `docker`| Container runtime (`docker`/`podman`).   |
@@ -112,7 +112,7 @@ scripts/dev_cli.sh tests [<test type>] [--libc musl|gnu] \
 | Flag           | Default | Description                              |
 |----------------|---------|------------------------------------------|
 | `--libc`       | `gnu`   | C library to link against (`musl`/`gnu`).|
-| `--hypervisor` | `kvm`   | Hypervisor backend (`kvm`/`mshv`).       |
+| `--hypervisor` | auto    | Hypervisor backend (`kvm`/`mshv`). Auto-detected from the host device node when omitted. |
 | `--volumes`    |         | Extra host volumes (`/a:/a#/b:/b`).      |
 
 ### Argument passthrough
@@ -134,7 +134,7 @@ The test scripts accept the following common arguments via
 
 | Argument              | Description                                  |
 |-----------------------|----------------------------------------------|
-| `--hypervisor kvm\|mshv` | Select hypervisor (also passed by dev_cli.sh). |
+| `--hypervisor kvm\|mshv` | Override the hypervisor (auto-detected from the host device node when omitted; also passed by dev_cli.sh). |
 | `--test-filter <name>`| Run only tests matching the filter.           |
 | `--test-exclude <name>`| Exclude tests matching the pattern.          |
 | `--build-guest-kernel`| Build the guest kernel from source instead of downloading a prebuilt binary. |
@@ -207,6 +207,10 @@ interfaces can run.
 When the hypervisor is `mshv`, the feature flag `--features mshv` is
 passed to cargo. On x86_64 with KVM, the `tdx` feature is additionally
 enabled if needed (MSHV does not support TDX).
+
+The hypervisor backend is auto-detected from the host device node:
+`/dev/mshv` selects MSHV and `/dev/kvm` selects KVM. Pass
+`--hypervisor kvm|mshv` to override the detection explicitly.
 
 ## Integration tests
 
@@ -341,7 +345,7 @@ guest images and a prebuilt kernel.
 ### Confidential VMs
 
 ```shell
-scripts/dev_cli.sh tests --integration-cvm [--hypervisor mshv]
+scripts/dev_cli.sh tests --integration-cvm
 ```
 
 Runs `scripts/run_integration_tests_cvm.sh`. Builds with `--features

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -144,6 +144,29 @@ ok_or_die() {
     [[ $code -eq 0 ]] || die -c $code "$@"
 }
 
+# Auto-detect the host hypervisor device node and echo its path:
+# /dev/mshv for MSHV, /dev/kvm for KVM. Echoes nothing if neither is
+# present; callers are expected to validate the result.
+detect_hypervisor_device() {
+    if [ -e /dev/mshv ]; then
+        echo "/dev/mshv"
+    elif [ -e /dev/kvm ]; then
+        echo "/dev/kvm"
+    fi
+}
+
+# Resolve the hypervisor device node path. With an explicit hypervisor
+# name (kvm|mshv) in $1, map to its device node; with an empty $1,
+# auto-detect from the host. Echoes nothing for an unknown name or when
+# no device is found, letting the caller report the error.
+resolve_hypervisor_device() {
+    case "$1" in
+    kvm) echo "/dev/kvm" ;;
+    mshv) echo "/dev/mshv" ;;
+    "") detect_hypervisor_device ;;
+    esac
+}
+
 # Make sure the build/ dirs are available. Exit if we can't create them.
 # Upon returning from this call, the caller can be certain the build/ dirs exist.
 #
@@ -259,7 +282,7 @@ cmd_help() {
     echo "        --release             Build the release binaries."
     echo "        --libc                Select the C library Cloud Hypervisor will be built against. Default is gnu"
     echo "        --volumes             Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
-    echo "        --hypervisor          Underlying hypervisor. Options kvm, mshv"
+    echo "        --hypervisor          Underlying hypervisor. Options kvm, mshv. Auto-detected from the host device node when omitted."
     echo ""
     echo "    tests [<test type (see below)>] [--libc musl|gnu] [-- [<test scripts args>] [-- [<test binary args>]]] "
     echo "        Run the Cloud Hypervisor tests."
@@ -273,7 +296,7 @@ cmd_help() {
     echo "        --metrics                    Generate performance metrics"
     echo "        --coverage                   Generate code coverage information"
     echo "        --volumes                    Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
-    echo "        --hypervisor                 Underlying hypervisor. Options kvm, mshv"
+    echo "        --hypervisor                 Underlying hypervisor. Options kvm, mshv. Auto-detected from the host device node when omitted."
     echo "        --vm-type                    Type of VM to run. Options regular, confidential"
     echo "        --all                        Run all tests."
     echo ""
@@ -298,9 +321,8 @@ cmd_help() {
 cmd_build() {
     build="debug"
     libc="gnu"
-    hypervisor="kvm"
+    hypervisor=""
     features_build=()
-    exported_device="/dev/kvm"
     while [ $# -gt 0 ]; do
         case "$1" in
         "-h" | "--help") {
@@ -347,12 +369,9 @@ cmd_build() {
     ensure_latest_ctr
 
     process_volumes_args
-    if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
-        die "Hypervisor value must be kvm or mshv"
-    fi
-    if [[ "$hypervisor" = "mshv" ]]; then
-        exported_device="/dev/mshv"
-    fi
+    exported_device="$(resolve_hypervisor_device "$hypervisor")"
+    [ -n "$exported_device" ] ||
+        die "No hypervisor device found; pass --hypervisor kvm|mshv or ensure /dev/kvm or /dev/mshv exists"
     target="$(uname -m)-unknown-linux-${libc}"
 
     cargo_args=("$@")
@@ -371,7 +390,7 @@ cmd_build() {
         --user "$(id -u):$(id -g)" \
         --workdir "$CTR_CLH_ROOT_DIR" \
         --rm \
-        --volume $exported_device \
+        --volume "$exported_device" \
         --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
         ${exported_volumes:+$exported_volumes} \
         --env RUSTFLAGS="$rustflags" \
@@ -412,8 +431,7 @@ cmd_tests() {
     coverage=false
     libc="gnu"
     arg_vols=""
-    hypervisor="kvm"
-    exported_device="/dev/kvm"
+    hypervisor=""
     while [ $# -gt 0 ]; do
         case "$1" in
         "-h" | "--help") {
@@ -462,19 +480,17 @@ cmd_tests() {
         esac
         shift
     done
-    if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
-        die "Hypervisor value must be kvm or mshv"
+    exported_device="$(resolve_hypervisor_device "$hypervisor")"
+    [ -n "$exported_device" ] ||
+        die "No hypervisor device found; pass --hypervisor kvm|mshv or ensure /dev/kvm or /dev/mshv exists"
+    if [ ! -e "$exported_device" ]; then
+        die "$exported_device does not exist on the system"
     fi
-
-    if [[ "$hypervisor" = "mshv" ]]; then
-        exported_device="/dev/mshv"
+    # Forward an explicitly selected hypervisor to the test scripts; when
+    # omitted they auto-detect it from the same device node.
+    if [ -n "$hypervisor" ]; then
+        set -- '--hypervisor' "$hypervisor" "$@"
     fi
-
-    if [ ! -e "${exported_device}" ]; then
-        die "${exported_device} does not exist on the system"
-    fi
-
-    set -- '--hypervisor' "$hypervisor" "$@"
 
     ensure_build_dir
     ensure_latest_ctr
@@ -515,7 +531,7 @@ cmd_tests() {
         say "Running unit tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
-            --device $exported_device \
+            --device "$exported_device" \
             --device /dev/net/tun \
             --cap-add net_admin \
             "${common_env_args[@]}" \

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -3,9 +3,22 @@
 # shellcheck source=/dev/null
 set -x
 
-hypervisor="kvm"
 test_filter=""
 build_kernel=false
+
+# Auto-detect the underlying hypervisor based on the device node exposed
+# by the host kernel: /dev/mshv for MSHV, /dev/kvm for KVM.
+# shellcheck disable=SC2034
+detect_hypervisor() {
+    if [ -e /dev/mshv ]; then
+        hypervisor="mshv"
+    elif [ -e /dev/kvm ]; then
+        hypervisor="kvm"
+    else
+        echo "ERROR: no hypervisor device found (/dev/mshv or /dev/kvm)" >&2
+        exit 1
+    fi
+}
 
 # Download from a url with retries
 # Args:
@@ -98,7 +111,7 @@ cmd_help() {
     echo ""
     echo "Available arguments:"
     echo ""
-    echo "    --hypervisor  Underlying hypervisor. Options kvm, mshv"
+    echo "    --hypervisor  Underlying hypervisor. Options kvm, mshv. Auto-detected from the host device node when omitted."
     echo "    --test-filter Tests to run"
     echo "    --build-guest-kernel Build guest kernel from source instead of downloading pre-built"
     echo ""
@@ -140,8 +153,13 @@ process_common_args() {
         esac
         shift
     done
+    # Auto-detect the hypervisor when it was not provided explicitly.
+    if [ -z "$hypervisor" ]; then
+        detect_hypervisor
+    fi
     if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
-        die "Hypervisor value must be kvm or mshv"
+        echo "ERROR: hypervisor must be kvm or mshv" >&2
+        exit 1
     fi
     # shellcheck disable=SC2034
     test_binary_args=("$@")


### PR DESCRIPTION
## Summary

The `--hypervisor` flag previously defaulted to `kvm` and had to be set
explicitly to run against MSHV. This series makes the flag **optional**:
when it is omitted, the hypervisor backend is auto-detected from the host
device node — `/dev/mshv` selects MSHV and `/dev/kvm` selects KVM. An
explicit `--hypervisor kvm|mshv` still works and overrides the detection.

## Motivation

The hypervisor in use is fully determined by which device node the host
kernel exposes, so requiring the caller to repeat that information is
redundant and error-prone (e.g. passing `--hypervisor kvm` on an
MSHV-only host). Auto-detection removes that footgun while preserving the
explicit override for special cases.

## Changes

- **`scripts/test-util.sh`**: `process_common_args()` now treats
  `--hypervisor` as optional and falls back to a new `detect_hypervisor()`
  that probes `/dev/mshv` / `/dev/kvm`, erroring out when neither exists.
- **`scripts/dev_cli.sh`**: `build` and `tests` commands gain
  `detect_hypervisor_device()` / `resolve_hypervisor_device()` helpers
  that map an explicit name to its device node or auto-detect when the
  flag is omitted. The resolved device is validated before being mounted
  into the container, and an explicit `--hypervisor` is still forwarded to
  the test scripts.
- **`.github/workflows/mshv-integration.yaml`**: drop the explicit
  `--hypervisor mshv`; the runner exposes `/dev/mshv`, so auto-detection
  selects it.
- **`docs/testing.md`**: document `--hypervisor` as an optional override
  defaulting to auto-detection.

## Testing

- `bash -n` passes for both scripts.
- `shellcheck -x` is clean for both scripts.
- MSHV integration workflow exercises the auto-detection path on a
  `/dev/mshv` host.

## Backwards compatibility

Fully backwards compatible — existing invocations that pass
`--hypervisor kvm|mshv` continue to behave exactly as before.