### PR TITLE
virtio-devices: block: make shutdown join the worker

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -1167,6 +1167,10 @@ impl VirtioDevice for Block {
         event!("virtio-device", "reset", "id", &self.id);
     }
 
+    fn shutdown(&mut self) {
+        self.common.wait_for_epoll_threads();
+    }
+
     fn counters(&self) -> Option<HashMap<&'static str, Wrapping<u64>>> {
         let mut counters = HashMap::new();
 


### PR DESCRIPTION
eject_device calls shutdown, but Block doesn't implement it, so the worker thread was never joined. Drop for Block does not help either, VirtioPciDevice keeps an Arc<Mutex<Block>> past eject, so Drop never runs. The async worker keeps completing in-flight I/O into the guest RAM that backed it when issued.

Implement shutdown() to call wait_for_epoll_threads(), which drops the WorkerThreads handle and ensures that worker's io completes.