### PR TITLE
[RFC] Modify `fw_cfg` to allow for boot order hints

### DIFF
--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -116,7 +116,9 @@ pub enum FwCfgContent {
     Bytes(Vec<u8>),
     Slice(&'static [u8]),
     File(u64, File),
+    U64(u64),
     U32(u32),
+    U16(u16),
 }
 
 struct FwCfgContentAccess<'a> {
@@ -139,7 +141,15 @@ impl Read for FwCfgContentAccess<'_> {
                 Some(mut s) => s.read(buf),
                 None => Err(ErrorKind::UnexpectedEof)?,
             },
+            FwCfgContent::U64(n) => match n.to_le_bytes().get(self.offset as usize..) {
+                Some(mut s) => s.read(buf),
+                None => Err(ErrorKind::UnexpectedEof)?,
+            },
             FwCfgContent::U32(n) => match n.to_le_bytes().get(self.offset as usize..) {
+                Some(mut s) => s.read(buf),
+                None => Err(ErrorKind::UnexpectedEof)?,
+            },
+            FwCfgContent::U16(n) => match n.to_le_bytes().get(self.offset as usize..) {
                 Some(mut s) => s.read(buf),
                 None => Err(ErrorKind::UnexpectedEof)?,
             },
@@ -159,7 +169,9 @@ impl FwCfgContent {
             FwCfgContent::Bytes(v) => v.len(),
             FwCfgContent::File(offset, f) => (f.metadata()?.len() - offset) as usize,
             FwCfgContent::Slice(s) => s.len(),
+            FwCfgContent::U64(n) => size_of_val(n),
             FwCfgContent::U32(n) => size_of_val(n),
+            FwCfgContent::U16(n) => size_of_val(n),
         };
         u32::try_from(ret).map_err(|_| std::io::ErrorKind::InvalidInput.into())
     }
@@ -736,7 +748,15 @@ impl FwCfg {
             FwCfgContent::File(o, f) => {
                 f.read_exact_at(data, o + offset as u64).ok()?;
             }
+            FwCfgContent::U64(n) => {
+                let bytes = n.to_le_bytes();
+                data.copy_from_slice(&bytes[start..end]);
+            }
             FwCfgContent::U32(n) => {
+                let bytes = n.to_le_bytes();
+                data.copy_from_slice(&bytes[start..end]);
+            }
+            FwCfgContent::U16(n) => {
                 let bytes = n.to_le_bytes();
                 data.copy_from_slice(&bytes[start..end]);
             }

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -79,12 +79,27 @@ pub const PORT_FW_CFG_WIDTH: u64 = 0x10;
 
 const FW_CFG_SIGNATURE: u16 = 0x00;
 const FW_CFG_ID: u16 = 0x01;
+const FW_CFG_UUID: u16 = 0x02;
+const FW_CFG_RAM_SIZE: u16 = 0x03;
+const FW_CFG_NOGRAPHIC: u16 = 0x04;
+const FW_CFG_NB_CPUS: u16 = 0x05;
+const FW_CFG_MACHINE_ID: u16 = 0x06;
+const FW_CFG_KERNEL_ADDR: u16 = 0x07;
 const FW_CFG_KERNEL_SIZE: u16 = 0x08;
+const FW_CFG_KERNEL_CMDLINE: u16 = 0x09;
+const FW_CFG_INITRD_ADDR: u16 = 0x0a;
 const FW_CFG_INITRD_SIZE: u16 = 0x0b;
+const FW_CFG_BOOT_DEVICE: u16 = 0x0c;
+const FW_CFG_NUMA: u16 = 0x0d;
+const FW_CFG_BOOT_MENU: u16 = 0x0e;
+const FW_CFG_MAX_CPUS: u16 = 0x0f;
+const FW_CFG_KERNEL_ENTRY: u16 = 0x10;
 const FW_CFG_KERNEL_DATA: u16 = 0x11;
 const FW_CFG_INITRD_DATA: u16 = 0x12;
+const FW_CFG_CMDLINE_ADDR: u16 = 0x13;
 const FW_CFG_CMDLINE_SIZE: u16 = 0x14;
 const FW_CFG_CMDLINE_DATA: u16 = 0x15;
+const FW_CFG_SETUP_ADDR: u16 = 0x16;
 const FW_CFG_SETUP_SIZE: u16 = 0x17;
 const FW_CFG_SETUP_DATA: u16 = 0x18;
 const FW_CFG_FILE_DIR: u16 = 0x19;
@@ -430,10 +445,34 @@ impl FwCfg {
     pub fn new(memory: GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>) -> FwCfg {
         const DEFAULT_ITEM: FwCfgContent = FwCfgContent::Slice(&[]);
         let mut known_items = [DEFAULT_ITEM; FW_CFG_KNOWN_ITEMS];
+        let file_buf = Vec::from(FwCfgFilesHeader { count_be: 0 }.as_mut_bytes());
+
         known_items[FW_CFG_SIGNATURE as usize] = FwCfgContent::Slice(&FW_CFG_DMA_SIGNATURE);
         known_items[FW_CFG_ID as usize] = FwCfgContent::Slice(&FW_CFG_FEATURE);
-        let file_buf = Vec::from(FwCfgFilesHeader { count_be: 0 }.as_mut_bytes());
-        known_items[FW_CFG_FILE_DIR as usize] = FwCfgContent::Bytes(file_buf);
+        known_items[FW_CFG_UUID as usize] = FwCfgContent::Bytes(Default::default()); /* TODO? */
+        known_items[FW_CFG_RAM_SIZE as usize] = FwCfgContent::U64(0); /* TODO? */
+        known_items[FW_CFG_NOGRAPHIC as usize] = FwCfgContent::U16(0); /* TODO? */
+        known_items[FW_CFG_NB_CPUS as usize] = FwCfgContent::U16(0); /* TODO? */
+        known_items[FW_CFG_MACHINE_ID as usize] = FwCfgContent::U16(0); /* TODO? */
+        known_items[FW_CFG_KERNEL_ADDR as usize] = FwCfgContent::U32(0); /* TODO? */
+        known_items[FW_CFG_KERNEL_SIZE as usize] = FwCfgContent::U32(0); /* TODO? */
+        known_items[FW_CFG_KERNEL_CMDLINE as usize] = FwCfgContent::U32(0); /* TODO? */
+        known_items[FW_CFG_INITRD_ADDR as usize] = FwCfgContent::U32(0); /* TODO? */
+        known_items[FW_CFG_INITRD_SIZE as usize] = FwCfgContent::U32(0); /* TODO? */
+        known_items[FW_CFG_BOOT_DEVICE as usize] = FwCfgContent::U16(0); /* TODO? */
+        known_items[FW_CFG_NUMA as usize] = FwCfgContent::Bytes(Default::default()); /* TODO? */
+        known_items[FW_CFG_BOOT_MENU as usize] = FwCfgContent::U16(0); /* TODO? */
+        known_items[FW_CFG_MAX_CPUS as usize] = FwCfgContent::U16(255); /* TODO? */
+        known_items[FW_CFG_KERNEL_ENTRY as usize] = FwCfgContent::U32(0); /* TODO? */
+        known_items[FW_CFG_KERNEL_DATA as usize] = FwCfgContent::Bytes(Default::default()); /* TODO? */
+        known_items[FW_CFG_INITRD_DATA as usize] = FwCfgContent::Bytes(Default::default()); /* TODO? */
+        known_items[FW_CFG_CMDLINE_ADDR as usize] = FwCfgContent::U32(0); /* TODO? */
+        known_items[FW_CFG_CMDLINE_SIZE as usize] = FwCfgContent::U32(0); /* TODO? */
+        known_items[FW_CFG_CMDLINE_DATA as usize] = FwCfgContent::Bytes(Default::default()); /* TODO? */
+        known_items[FW_CFG_SETUP_ADDR as usize] = FwCfgContent::U32(0); /* TODO? */
+        known_items[FW_CFG_SETUP_SIZE as usize] = FwCfgContent::U32(0); /* TODO? */
+        known_items[FW_CFG_SETUP_DATA as usize] = FwCfgContent::Bytes(Default::default()); /* TODO? */
+        known_items[FW_CFG_FILE_DIR as usize] = FwCfgContent::Bytes(file_buf); /* TODO? */
 
         FwCfg {
             selector: 0,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1373,6 +1373,7 @@ impl PciDeviceCommonConfig {
 }
 
 impl DiskConfig {
+    #[cfg(not(feature = "fw_cfg"))]
     pub const SYNTAX: &'static str = "Disk parameters \
          \"path=<disk_image_path>,readonly=on|off,direct=on|off,iommu=on|off,\
          num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,\
@@ -1384,6 +1385,20 @@ impl DiskConfig {
          queue_affinity=<list_of_queue_indices_with_their_associated_cpuset>,\
          serial=<serial_number>,backing_files=on|off,sparse=on|off,\
          image_type=<raw,qcow2,vhd,vhdx>,lock_granularity=byte-range|full";
+
+    #[cfg(feature = "fw_cfg")]
+    pub const SYNTAX: &'static str = "Disk parameters \
+         \"path=<disk_image_path>,readonly=on|off,direct=on|off,iommu=on|off,\
+         num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,\
+         vhost_user=on|off,socket=<vhost_user_socket_path>,\
+         bw_size=<bytes>,bw_one_time_burst=<bytes>,bw_refill_time=<ms>,\
+         ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,\
+         id=<device_id>,pci_segment=<segment_id>,pci_device_id=<pci_slot>,\
+         rate_limit_group=<group_id>,\
+         queue_affinity=<list_of_queue_indices_with_their_associated_cpuset>,\
+         serial=<serial_number>,backing_files=on|off,sparse=on|off,\
+         image_type=<raw,qcow2,vhd,vhdx>,lock_granularity=byte-range|full,\
+         bootindex=<index>";
 
     pub fn parse(disk: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -1411,6 +1426,9 @@ impl DiskConfig {
             .add("image_type")
             .add("lock_granularity")
             .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
+
+        #[cfg(feature = "fw_cfg")]
+        parser.add("bootindex");
 
         parser.parse(disk).map_err(Error::ParseDisk)?;
 
@@ -1541,6 +1559,11 @@ impl DiskConfig {
 
         let pci_common = PciDeviceCommonConfig::parse(disk)?;
 
+        #[cfg(feature = "fw_cfg")]
+        let bootindex = parser
+            .convert::<u16>("bootindex")
+            .map_err(Error::ParseDisk)?;
+
         Ok(DiskConfig {
             pci_common,
             path,
@@ -1560,6 +1583,8 @@ impl DiskConfig {
             sparse,
             image_type,
             lock_granularity,
+            #[cfg(feature = "fw_cfg")]
+            bootindex,
         })
     }
 
@@ -4134,6 +4159,8 @@ mod unit_tests {
             sparse: true,
             image_type: ImageType::Unknown,
             lock_granularity: LockGranularityChoice::default(),
+            #[cfg(feature = "fw_cfg")]
+            bootindex: Default::default(),
         }
     }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1148,6 +1148,9 @@ pub struct DeviceManager {
     #[cfg(feature = "ivshmem")]
     // ivshmem device
     ivshmem_device: Option<Arc<Mutex<devices::IvshmemDevice>>>,
+
+    #[cfg(feature = "fw_cfg")]
+    boot_order: HashMap<u16, String>,
 }
 
 /// Create per-PCI-segment MMIO allocators over the range `[start, end]`.
@@ -1438,6 +1441,8 @@ impl DeviceManager {
             #[cfg(feature = "ivshmem")]
             ivshmem_device: None,
             _acpi_cpu_hotplug_controller: acpi_cpu_hotplug_controller,
+            #[cfg(feature = "fw_cfg")]
+            boot_order: HashMap::new(),
         };
 
         let device_manager = Arc::new(Mutex::new(device_manager));
@@ -2879,6 +2884,11 @@ impl DeviceManager {
             .lock()
             .unwrap()
             .insert(id.clone(), device_node!(id, migratable_device));
+
+        #[cfg(feature = "fw_cfg")]
+        if let Some(bootindex) = disk_cfg.bootindex {
+            self.boot_order.insert(bootindex, id.clone());
+        }
 
         Ok(MetaVirtioDevice {
             virtio_device,
@@ -4434,11 +4444,31 @@ impl DeviceManager {
         }
 
         // Update the device tree with correct resource information.
+        #[cfg(feature = "fw_cfg")]
+        let node_id = node.id.clone();
+
         node.resources = new_resources;
         node.migratable = Some(Arc::clone(&virtio_pci_device) as Arc<Mutex<dyn Migratable>>);
         node.pci_bdf = Some(pci_device_bdf);
         node.pci_device_handle = Some(PciDeviceHandle::Virtio(virtio_pci_device));
-        self.device_tree.lock().unwrap().insert(id, node);
+        self.device_tree.lock().unwrap().insert(id.clone(), node);
+
+        #[cfg(feature = "fw_cfg")]
+        {
+            // Find the virtio device in the boot item list
+            let boot_entry = self
+                .boot_order
+                .iter()
+                .find(|(_k, v)| *v == virtio_device_id);
+
+            // Update the device ID in the boot item list
+            if let Some((k, _)) = boot_entry {
+                self.boot_order.insert(
+                    *k,
+                    self.device_tree.lock().unwrap().fw_cfg_path_by_id(&node_id),
+                );
+            }
+        }
 
         Ok(pci_device_bdf)
     }
@@ -5362,6 +5392,19 @@ impl DeviceManager {
             debug!("Drop VfioOps given no active VFIO devices.");
             self.vfio_ops = None;
         }
+    }
+
+    /// Returns a list of devices to boot from in the order expected
+    #[cfg(feature = "fw_cfg")]
+    pub fn get_bootitems(&self) -> Vec<String> {
+        let mut result: Vec<String> = Vec::new();
+        let mut keys: Vec<u16> = self.boot_order.clone().into_keys().collect();
+        keys.sort();
+
+        for k in &keys {
+            result.push(self.boot_order.get(k).unwrap().clone());
+        }
+        result
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -117,6 +117,8 @@ use crate::interrupt::{LegacyUserspaceInterruptManager, MsiInterruptManager};
 use crate::memory_manager::{Error as MemoryManagerError, MEMORY_MANAGER_ACPI_SIZE, MemoryManager};
 use crate::pci_segment::PciSegment;
 use crate::serial_manager::{Error as SerialManagerError, SerialManager};
+#[cfg(feature = "fw_cfg")]
+use crate::vm_config::FwCfgConfig;
 #[cfg(feature = "ivshmem")]
 use crate::vm_config::IvshmemConfig;
 use crate::vm_config::{
@@ -1569,6 +1571,18 @@ impl DeviceManager {
             let mut ivshmem = self.config.lock().unwrap().ivshmem.clone();
             if let Some(ivshmem) = &mut ivshmem {
                 self.ivshmem_device = self.add_ivshmem_device(ivshmem, snapshot)?;
+            }
+        }
+
+        #[cfg(feature = "fw_cfg")]
+        {
+            // if we have a boot order but no fw_cfg device, we must create on
+            let mut vm_config = self.config.lock().unwrap();
+            if !self.boot_order.is_empty()
+                && vm_config.payload.is_some()
+                && vm_config.payload.as_mut().unwrap().fw_cfg_config.is_none()
+            {
+                vm_config.payload.as_mut().unwrap().fw_cfg_config = Some(FwCfgConfig::default());
             }
         }
 

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -7,10 +7,26 @@ use std::sync::{Arc, Mutex};
 
 use pci::PciBdf;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "fw_cfg")]
+use thiserror::Error;
 use vm_device::Resource;
 use vm_migration::Migratable;
 
 use crate::device_manager::PciDeviceHandle;
+
+#[cfg(feature = "fw_cfg")]
+#[derive(Debug, Error)]
+pub enum DeviceNodePathError {
+    /// Device is not attached to a bus.
+    #[error("Can't create a open firmware device path from a device not attached to a bus")]
+    NoBusDevice,
+    /// Device is not bootable.
+    #[error("Can't create a open firmware device path for a non-bootable device")]
+    DeviceNotBootable,
+    /// Device is not a PCI device.
+    #[error("Currently only PCI devices are supported!")]
+    NoPciDevice,
+}
 
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Serialize, Deserialize)]
@@ -36,6 +52,36 @@ impl DeviceNode {
             migratable,
             pci_bdf: None,
             pci_device_handle: None,
+        }
+    }
+
+    /// Returns the open firmware device path
+    ///
+    /// The open firmware path is used by Qemu in it's `fw_cfg` device to pass boot order hints
+    /// to EDK2/OVMF. [0]
+    ///
+    /// [0] https://github.com/tianocore/edk2/blob/2816ff0ab0d6505bf580aa8eec02cc2b89f04230/OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.c#L1222
+    #[cfg(feature = "fw_cfg")]
+    pub fn openfw_device_path(&self) -> Result<String, DeviceNodePathError> {
+        if let Some(handle) = &self.pci_device_handle {
+            if let PciDeviceHandle::Virtio(virtio_handle) = handle {
+                let virtio_device = virtio_handle.lock().unwrap();
+                let device_type = virtio_device.virtio_device().lock().unwrap().device_type();
+                if let Some(bdf) = self.pci_bdf {
+                    match device_type {
+                        0x2 /* VirtioBlk */ => {
+                            Ok(format!("/pci@i0cf8/scsi@{:x}/disk@0,0", bdf.device()))
+                        }
+                        _ => Err(DeviceNodePathError::DeviceNotBootable),
+                    }
+                } else {
+                    unreachable!("PCI devices should have a bdf!")
+                }
+            } else {
+                Err(DeviceNodePathError::NoPciDevice)
+            }
+        } else {
+            Err(DeviceNodePathError::NoBusDevice)
         }
     }
 }
@@ -102,6 +148,11 @@ impl DeviceTree {
         } else {
             None
         }
+    }
+
+    #[cfg(feature = "fw_cfg")]
+    pub fn fw_cfg_path_by_id(&self, id: &str) -> String {
+        self.get(id).unwrap().openfw_device_path().unwrap()
     }
 }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -38,7 +38,7 @@ use devices::AcpiNotificationFlags;
 #[cfg(target_arch = "aarch64")]
 use devices::interrupt_controller;
 #[cfg(feature = "fw_cfg")]
-use devices::legacy::fw_cfg::FwCfgItem;
+use devices::legacy::fw_cfg::{FwCfgContent, FwCfgItem};
 use event_monitor::event;
 #[cfg(all(target_arch = "aarch64", feature = "guest_debug"))]
 use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
@@ -1218,8 +1218,8 @@ impl Vm {
             initramfs_option = initramfs;
         }
         let mut fw_cfg_item_list_option: Option<Vec<FwCfgItem>> = None;
+        let mut fw_cfg_item_list = vec![];
         if let Some(fw_cfg_items) = &fw_cfg_config.items {
-            let mut fw_cfg_item_list = vec![];
             for fw_cfg_item in fw_cfg_items.item_list.clone() {
                 let content = match (fw_cfg_item.string, fw_cfg_item.file) {
                     (Some(string_val), None) => {
@@ -1238,6 +1238,28 @@ impl Vm {
                     content,
                 });
             }
+        }
+        // Create bootorder entry in fw_cfg
+        {
+            let mut content: Vec<u8> = Vec::new();
+            let bootitems = device_manager.lock().unwrap().get_bootitems();
+            for (index, boot_item) in bootitems.iter().enumerate() {
+                let cstring = std::ffi::CString::new(boot_item.as_str()).unwrap();
+                if index == (bootitems.len() - 1) {
+                    content.extend_from_slice(cstring.as_bytes_with_nul());
+                } else {
+                    content.extend_from_slice(cstring.as_bytes());
+                    content.extend_from_slice(std::ffi::CString::new("\n").unwrap().as_bytes());
+                }
+            }
+            let bootorder_item = FwCfgItem {
+                name: "bootorder".to_string(),
+                content: FwCfgContent::Bytes(content),
+            };
+            fw_cfg_item_list.push(bootorder_item);
+        }
+
+        if !fw_cfg_item_list.is_empty() {
             fw_cfg_item_list_option = Some(fw_cfg_item_list);
         }
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -956,9 +956,9 @@ impl Default for FwCfgConfig {
     fn default() -> Self {
         FwCfgConfig {
             e820: true,
-            kernel: true,
-            cmdline: true,
-            initramfs: true,
+            kernel: false,
+            cmdline: false,
+            initramfs: false,
             acpi_tables: true,
             items: None,
         }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -391,6 +391,9 @@ pub struct DiskConfig {
     pub image_type: ImageType,
     #[serde(default)]
     pub lock_granularity: LockGranularityChoice,
+    #[cfg(feature = "fw_cfg")]
+    #[serde(default)]
+    pub bootindex: Option<u16>,
 }
 
 impl ApplyLandlock for DiskConfig {


### PR DESCRIPTION
As discussed during the Community Call on April 30th, We from Cyberus would like to add support for firmware-controlled boot ordering in Cloud Hypervisor, similar to [Qemu's bootindex](https://www.qemu.org/docs/master/system/bootindex.html) mechanism. As back then some design concerns were raised, I would like to discuss some design details in before with you that mainly concern the CLI and API.

## Why would we need something like Qemu's bootindex?
Our motivation is a use case where a VM may become temporarily unbootable due to guest configuration issues. In such situations, users may want to attach and boot a rescue or live image without modifying guest-visible device topology.

Today this can only be achieved indirectly, for example by changing PCI BDF ordering so the rescue medium appears earlier in the firmware boot order. However, changing guest-visible device addresses is undesirable and may itself introduce compatibility or stability issues.

QEMU addresses this problem by exposing boot order hints through `fw_cfg`, which OVMF can consume during boot selection. I would therefore like to explore adding similar functionality to Cloud Hypervisor.

## Proposed Design
The design implemented in this RFC PR follows that of Qemu. We make `bootorder` part of the device configs and collect these indices when populating the `fw_cfg` device.
Currently, these changes rather implement a proof of concept instead of a complete solution, e.g I'm going to add some tests once we decided the design and also add support for network devices. Together with [patches that enable the `fw_cfg` device driver in OVMF](https://github.com/scholzp/edk2/tree/activate_fw_cfg), these changes are enough to allow to influence the boot order.

I described an alternative design in https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8192

It would be nice if also either @Talador12 or @AlexOrozco1256 could take a look on these changes to prevent me from breaking anything on their side.

The CI is not expected to succeed, as this is a PoC that shows the design.