### PR TITLE
hypervisor: kvm: Support pre-XSAVE x86 CPUs

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -876,6 +876,8 @@ impl vm::Vm for KvmVm {
             hyperv_synic: AtomicBool::new(false),
             #[cfg(target_arch = "x86_64")]
             xsave_size,
+            #[cfg(target_arch = "x86_64")]
+            has_xcrs: self.check_extension(Cap::Xcrs),
             #[cfg(feature = "sev_snp")]
             vm_fd: self.fd.clone(),
             #[cfg(feature = "sev_snp")]
@@ -1758,6 +1760,8 @@ pub struct KvmVcpu {
     hyperv_synic: AtomicBool,
     #[cfg(target_arch = "x86_64")]
     xsave_size: i32,
+    #[cfg(target_arch = "x86_64")]
+    has_xcrs: bool,
     #[cfg(feature = "sev_snp")]
     vm_fd: Arc<VmFd>,
     #[cfg(feature = "sev_snp")]
@@ -2853,7 +2857,11 @@ impl cpu::Vcpu for KvmVcpu {
         } else {
             self.get_xsave()?
         };
-        let xcrs = self.get_xcrs()?;
+        let xcrs: ExtendedControlRegisters = if self.has_xcrs {
+            self.get_xcrs()?
+        } else {
+            Default::default()
+        };
         let lapic_state = self.get_lapic()?;
         let fpu = self.get_fpu()?;
         let nested_state = self.nested_state()?;
@@ -3116,7 +3124,9 @@ impl cpu::Vcpu for KvmVcpu {
         } else {
             self.set_xsave(&state.xsave)?;
         }
-        self.set_xcrs(&state.xcrs)?;
+        if self.has_xcrs {
+            self.set_xcrs(&state.xcrs)?;
+        }
         self.set_lapic(&state.lapic_state)?;
         self.set_fpu(&state.fpu)?;
         if let Some(nested_state) = state.nested_state {

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -64,7 +64,6 @@ pub fn check_required_kvm_extensions(kvm: &Kvm) -> KvmResult<()> {
     check_extension!(Cap::UserMemory);
     check_extension!(Cap::UserNmi);
     check_extension!(Cap::VcpuEvents);
-    check_extension!(Cap::Xcrs);
     check_extension!(Cap::Xsave);
     Ok(())
 }


### PR DESCRIPTION
KVM will emulate XSAVE for us, so we need only to skip XCRS setting/retrieval if the respective CPU feature is not available.

Tested on Nehalem CPU by repeatedly saving and restoring guest workload involving as much CPU state as possible