### PR TITLE
ci: Move metrics and rate-limiter workers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -716,7 +716,7 @@ jobs:
     needs: [preflight, dco, quality, build]
     if: >-
       github.event_name == 'merge_group' && needs.preflight.outputs.full == 'true' && needs.dco.result == 'success' && needs.quality.result == 'success' && needs.build.result == 'success'
-    runs-on: bare-metal-9950x
+    runs-on: garm-jammy-16
     env:
       AUTH_DOWNLOAD_TOKEN: ${{ secrets.AUTH_DOWNLOAD_TOKEN }}
     steps:
@@ -724,6 +724,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Install Docker
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ca-certificates curl gnupg
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          sudo chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt install -y docker-ce docker-ce-cli
       - name: Run rate-limiter integration tests
         timeout-minutes: 20
         run: scripts/dev_cli.sh tests --integration-rate-limiter

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -713,9 +713,6 @@ jobs:
         run: scripts/dev_cli.sh tests --integration-windows --libc musl
   integration-rate-limiter:
     name: integration-rate-limiter
-    needs: [preflight, dco, quality, build]
-    if: >-
-      github.event_name == 'merge_group' && needs.preflight.outputs.full == 'true' && needs.dco.result == 'success' && needs.quality.result == 'success' && needs.build.result == 'success'
     runs-on: garm-jammy-16
     env:
       AUTH_DOWNLOAD_TOKEN: ${{ secrets.AUTH_DOWNLOAD_TOKEN }}

--- a/.github/workflows/integration-metrics.yaml
+++ b/.github/workflows/integration-metrics.yaml
@@ -1,15 +1,10 @@
 name: Cloud Hypervisor Tests (Metrics)
-on:
-  push:
-    branches:
-      - main
+on: pull_request
 
 jobs:
   build:
     name: Tests (Metrics)
     runs-on: garm-jammy-16
-    env:
-      METRICS_PUBLISH_KEY: ${{ secrets.METRICS_PUBLISH_KEY }}
     steps:
       - name: Code checkout
         uses: actions/checkout@v6
@@ -27,5 +22,3 @@ jobs:
       - name: Run metrics tests
         timeout-minutes: 60
         run: scripts/dev_cli.sh tests --metrics -- --test-exclude micro_ -- --report-file /root/workloads/metrics.json
-      - name: Upload metrics report
-        run: 'curl -X PUT https://ch-metrics.azurewebsites.net/api/publishmetrics -H "x-functions-key: $METRICS_PUBLISH_KEY" -T ~/workloads/metrics.json'

--- a/.github/workflows/integration-metrics.yaml
+++ b/.github/workflows/integration-metrics.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Tests (Metrics)
-    runs-on: bare-metal-9950x
+    runs-on: garm-jammy-16
     env:
       METRICS_PUBLISH_KEY: ${{ secrets.METRICS_PUBLISH_KEY }}
     steps:
@@ -15,6 +15,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Install Docker
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ca-certificates curl gnupg
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          sudo chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt install -y docker-ce docker-ce-cli
       - name: Run metrics tests
         timeout-minutes: 60
         run: scripts/dev_cli.sh tests --metrics -- --test-exclude micro_ -- --report-file /root/workloads/metrics.json

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -11843,7 +11843,7 @@ mod rate_limiter {
             } else {
                 parse_fio_output_iops(&output, &fio_ops, num_queues).unwrap()
             };
-            assert!(check_rate_limit(measured_rate, limit_rate, 0.1));
+            assert!(check_rate_limit(measured_rate, limit_rate, 0.2));
         });
 
         let _ = child.kill();
@@ -11855,7 +11855,7 @@ mod rate_limiter {
         let fio_ops = FioOps::RandRW;
 
         let bw_size = if bandwidth {
-            104857600_u64 // bytes
+            10485760_u64 // bytes
         } else {
             1000_u64 // I/O
         };

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -51,7 +51,7 @@ cargo build --features mshv --all --release --target "$BUILD_TARGET"
 export RUST_BACKTRACE=1
 export RUSTFLAGS="$RUSTFLAGS"
 
-time cargo nextest run -p cloud-hypervisor --no-tests=pass $test_features --test-threads=1 "rate_limiter::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run -p cloud-hypervisor --no-tests=pass --no-fail-fast $test_features --test-threads=1 "rate_limiter::$test_filter" -- ${test_binary_args[*]}
 RES=$?
 
 exit $RES


### PR DESCRIPTION
Since the underline bare-metal system is retired, we are moving the
metrics and rate-limiter workers to use Azure VMs.

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7752
