### PR TITLE
arm64: correct the guest clock across snapshot/restore and migration

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7981,19 +7981,43 @@ mod ivshmem {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_hotplug_virtiomem() {
-        snapshot_restore_common::_test_snapshot_restore(true, false);
+        snapshot_restore_common::_test_snapshot_restore(
+            snapshot_restore_common::SnapshotRestoreTest {
+                use_hotplug: true,
+                ..Default::default()
+            },
+        );
     }
 
     #[test]
     #[cfg(not(feature = "mshv"))] // See issue #7437
     fn test_snapshot_restore_basic() {
-        snapshot_restore_common::_test_snapshot_restore(false, false);
+        snapshot_restore_common::_test_snapshot_restore(
+            snapshot_restore_common::SnapshotRestoreTest::default(),
+        );
     }
 
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_with_resume() {
-        snapshot_restore_common::_test_snapshot_restore(false, true);
+        snapshot_restore_common::_test_snapshot_restore(
+            snapshot_restore_common::SnapshotRestoreTest {
+                use_resume_option: true,
+                ..Default::default()
+            },
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "mshv"))]
+    fn test_snapshot_check_guest_time() {
+        snapshot_restore_common::_test_snapshot_restore(
+            snapshot_restore_common::SnapshotRestoreTest {
+                use_resume_option: true,
+                check_clock: true,
+                ..Default::default()
+            },
+        );
     }
 
     #[test]
@@ -8039,6 +8063,12 @@ mod snapshot_restore_common {
     use std::process::Command;
 
     use crate::*;
+
+    // Off-host interval simulated between snapshot and restore, and the maximum
+    // guest-vs-host clock skew tolerated afterwards. The interval must exceed the
+    // tolerance so a guest that fails to advance on restore is caught.
+    const CLOCK_DOWNTIME_SECS: u64 = 30;
+    const CLOCK_SKEW_TOLERANCE_SECS: i64 = 15;
 
     pub(crate) fn snapshot_and_check_events(
         api_socket: &str,
@@ -8089,7 +8119,20 @@ mod snapshot_restore_common {
         ));
     }
 
-    pub(crate) fn _test_snapshot_restore(use_hotplug: bool, use_resume_option: bool) {
+    /// Easy disambiguation between snapshot/restore variants.
+    #[derive(Clone, Copy, Default)]
+    pub(crate) struct SnapshotRestoreTest {
+        pub use_hotplug: bool,
+        pub use_resume_option: bool,
+        pub check_clock: bool,
+    }
+
+    pub(crate) fn _test_snapshot_restore(cfg: SnapshotRestoreTest) {
+        let SnapshotRestoreTest {
+            use_hotplug,
+            use_resume_option,
+            check_clock,
+        } = cfg;
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
@@ -8115,6 +8158,15 @@ mod snapshot_restore_common {
         let socket = temp_vsock_path(&guest.tmp_dir);
         let event_path = temp_event_monitor_path(&guest.tmp_dir);
 
+        // x86_64: force kvm-clock — the restore catch-up moves kvmclock (KVM_SET_CLOCK),
+        // not the tsc clocksource, so a tsc guest wouldn't catch up. aarch64 ignores this
+        // (CNTVCT is advanced directly).
+        let boot_cmdline = if check_clock && cfg!(target_arch = "x86_64") {
+            format!("{DIRECT_KERNEL_BOOT_CMDLINE} clocksource=kvm-clock")
+        } else {
+            DIRECT_KERNEL_BOOT_CMDLINE.to_string()
+        };
+
         let mut child = GuestCommand::new(&guest)
             .args(["--api-socket", &api_socket_source])
             .args(["--event-monitor", format!("path={event_path}").as_str()])
@@ -8133,7 +8185,7 @@ mod snapshot_restore_common {
             ])
             .args(["--net", net_params.as_str()])
             .args(["--vsock", format!("cid=3,socket={socket}").as_str()])
-            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .args(["--cmdline", &boot_cmdline])
             .capture_output()
             .spawn()
             .unwrap();
@@ -8238,6 +8290,12 @@ mod snapshot_restore_common {
             .arg(socket.as_str())
             .output()
             .unwrap();
+
+        // Simulate an off-host interval between snapshot and restore so the guest
+        // clock must visibly catch up on restore (asserted after resume below).
+        if check_clock {
+            thread::sleep(Duration::from_secs(CLOCK_DOWNTIME_SECS));
+        }
 
         let api_socket_restored = format!("{}.2", temp_api_path(&guest.tmp_dir));
         let event_path_restored = format!("{}.2", temp_event_monitor_path(&guest.tmp_dir));
@@ -8373,6 +8431,31 @@ mod snapshot_restore_common {
             }
 
             guest.check_devices_common(Some(&socket), Some(&console_text), None);
+
+            if check_clock {
+                // Across the off-host interval the restored guest's wall clock
+                // must catch up to real time: x86_64 via kvmclock
+                // (KVM_CLOCK_REALTIME), aarch64 via the CNTVCT advance. The test
+                // network is isolated, so the guest cannot NTP-correct itself --
+                // any catch-up is the restore path's doing.
+                let host_secs = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs() as i64;
+                let guest_secs = guest
+                    .ssh_command("date -u +%s")
+                    .unwrap()
+                    .trim()
+                    .parse::<i64>()
+                    .unwrap();
+                let skew = (host_secs - guest_secs).abs();
+                assert!(
+                    skew <= CLOCK_SKEW_TOLERANCE_SECS,
+                    "guest clock is {skew}s from host after restore \
+                     (host={host_secs}, guest={guest_secs}); the \
+                     {CLOCK_DOWNTIME_SECS}s off-host interval was not applied"
+                );
+            }
         });
         // Shutdown the target VM and check console output
         kill_child(&mut child);

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8020,6 +8020,66 @@ mod ivshmem {
         );
     }
 
+    // aarch64 same-host pause/resume must keep the guest clock correct: the
+    // architected counter free-runs across the pause, so the resume clock path
+    // must not perturb it. The test network is isolated, so the guest cannot
+    // NTP-correct itself -- any drift would be the pause path's doing. x86_64
+    // has its own kvmclock path and is covered separately.
+    #[test]
+    #[cfg(all(not(feature = "mshv"), target_arch = "aarch64"))]
+    fn test_pause_resume_guest_time() {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+        let api_socket = temp_api_path(&guest.tmp_dir);
+        let kernel_path = direct_kernel_boot_path();
+
+        let mut child = GuestCommand::new(&guest)
+            .args(["--api-socket", &api_socket])
+            .args(["--cpus", "boot=2"])
+            .args(["--memory", "size=1G"])
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .default_disks()
+            .args(["--net", guest.default_net_string().as_str()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+
+            // Pause for an off-host interval, then resume on the same host.
+            assert!(remote_command(&api_socket, "pause", None));
+            thread::sleep(Duration::from_secs(
+                snapshot_restore_common::CLOCK_DOWNTIME_SECS,
+            ));
+            assert!(remote_command(&api_socket, "resume", None));
+
+            // The counter advanced across the pause, so the guest wall clock must
+            // still match the host.
+            let host_secs = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64;
+            let guest_secs = guest
+                .ssh_command("date -u +%s")
+                .unwrap()
+                .trim()
+                .parse::<i64>()
+                .unwrap();
+            let skew = (host_secs - guest_secs).abs();
+            assert!(
+                skew <= snapshot_restore_common::CLOCK_SKEW_TOLERANCE_SECS,
+                "guest clock is {skew}s from host after pause/resume \
+                 (host={host_secs}, guest={guest_secs})"
+            );
+        });
+
+        kill_child(&mut child);
+        let output = child.wait_with_output().unwrap();
+        handle_child_output(r, &output);
+    }
+
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_uffd() {
@@ -8067,8 +8127,8 @@ mod snapshot_restore_common {
     // Off-host interval simulated between snapshot and restore, and the maximum
     // guest-vs-host clock skew tolerated afterwards. The interval must exceed the
     // tolerance so a guest that fails to advance on restore is caught.
-    const CLOCK_DOWNTIME_SECS: u64 = 30;
-    const CLOCK_SKEW_TOLERANCE_SECS: i64 = 15;
+    pub(crate) const CLOCK_DOWNTIME_SECS: u64 = 30;
+    pub(crate) const CLOCK_SKEW_TOLERANCE_SECS: i64 = 15;
 
     pub(crate) fn snapshot_and_check_events(
         api_socket: &str,

--- a/hypervisor/src/arch/aarch64/mod.rs
+++ b/hypervisor/src/arch/aarch64/mod.rs
@@ -7,6 +7,23 @@ pub mod regs;
 
 use serde::{Deserialize, Serialize};
 
+/// Reads the architected counter frequency (`CNTFRQ_EL0`, Hz) from the host: KVM
+/// does not expose it through ONE_REG and the guest counter runs at host frequency.
+pub fn get_cntfrq() -> u64 {
+    use std::arch::asm;
+    let cntfrq: u64;
+    // SAFETY: `mrs cntfrq_el0` only reads a read-only system register and
+    // touches no memory (nomem, nostack, preserves_flags).
+    unsafe {
+        asm!(
+            "mrs {}, cntfrq_el0",
+            out(reg) cntfrq,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+    cntfrq
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ExtendedReg {
     pub id: u64,

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -516,6 +516,11 @@ pub trait Vcpu: Send + Sync {
     #[cfg(all(target_arch = "aarch64", feature = "kvm"))]
     fn get_cntvct(&self) -> Result<u64>;
     ///
+    /// Sets the guest virtual counter (`CNTVCT_EL0`).
+    ///
+    #[cfg(all(target_arch = "aarch64", feature = "kvm"))]
+    fn set_cntvct(&self, val: u64) -> Result<()>;
+    ///
     /// Gets the value of a non-core register on RISC-V 64-bit
     ///
     #[cfg(target_arch = "riscv64")]

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -511,6 +511,11 @@ pub trait Vcpu: Send + Sync {
     #[cfg(target_arch = "aarch64")]
     fn get_sys_reg(&self, sys_reg: u32) -> Result<u64>;
     ///
+    /// Gets the guest virtual counter (`CNTVCT_EL0`) via `KVM_REG_ARM_TIMER_CNT`.
+    ///
+    #[cfg(all(target_arch = "aarch64", feature = "kvm"))]
+    fn get_cntvct(&self) -> Result<u64>;
+    ///
     /// Gets the value of a non-core register on RISC-V 64-bit
     ///
     #[cfg(target_arch = "riscv64")]

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -78,7 +78,7 @@ use x86_64::check_required_kvm_extensions;
 pub use x86_64::{CpuId, ExtendedControlRegisters, MsrEntries, VcpuKvmState};
 
 #[cfg(target_arch = "x86_64")]
-use crate::ClockData;
+use crate::{ClockData, ClockState};
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{
     CpuIdEntry, FpuState, LapicState, MTRR_MSR_INDICES, MsrEntry, NUM_IOAPIC_PINS,
@@ -1262,6 +1262,18 @@ impl vm::Vm for KvmVm {
         self.fd
             .set_clock(&data)
             .map_err(|e| vm::HypervisorVmError::SetClock(e.into()))
+    }
+
+    /// Capture kvmclock (filling realtime) for snapshot/migration.
+    #[cfg(target_arch = "x86_64")]
+    fn snapshot_clock(&self) -> vm::Result<Option<ClockState>> {
+        Ok(Some(self.get_clock()?.with_realtime_filled()))
+    }
+
+    /// Restore kvmclock before the vCPUs resume.
+    #[cfg(target_arch = "x86_64")]
+    fn restore_clock(&self, state: &ClockState) -> vm::Result<()> {
+        self.set_clock(state)
     }
 
     /// Create a device that is used for passthrough

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -81,13 +81,13 @@ pub use x86_64::{CpuId, ExtendedControlRegisters, MsrEntries, VcpuKvmState};
 
 #[cfg(target_arch = "x86_64")]
 use crate::ClockData;
-#[cfg(any(target_arch = "x86_64", all(target_arch = "aarch64", feature = "kvm")))]
-use crate::ClockState;
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{
     CpuIdEntry, FpuState, LapicState, MTRR_MSR_INDICES, MsrEntry, NUM_IOAPIC_PINS,
     SpecialRegisters, XsaveState,
 };
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+use crate::{ClockRestoreMode, ClockState};
 use crate::{
     CpuState, HypervisorType, HypervisorVmConfig, InterruptSourceConfig, IoEventAddress,
     IrqRoutingEntry, MpState, StandardRegisters, USER_MEMORY_REGION_GUEST_MEMFD,
@@ -167,6 +167,9 @@ const KVM_REG_ARM_TIMER_CNT: u64 = KVM_REG_ARM64
     | ((14_u64 << KVM_REG_ARM64_SYSREG_CRN_SHIFT) & KVM_REG_ARM64_SYSREG_CRN_MASK as u64)
     | ((3_u64 << KVM_REG_ARM64_SYSREG_CRM_SHIFT) & KVM_REG_ARM64_SYSREG_CRM_MASK as u64)
     | (2_u64 & KVM_REG_ARM64_SYSREG_OP2_MASK as u64);
+
+#[cfg(target_arch = "aarch64")]
+const NANOS_PER_SECOND: u128 = 1_000_000_000;
 
 #[cfg(target_arch = "x86_64")]
 ioctl_io_nr!(KVM_NMI, kvm_bindings::KVMIO, 0x9a);
@@ -1315,8 +1318,58 @@ impl vm::Vm for KvmVm {
 
     /// Restore kvmclock before the vCPUs resume.
     #[cfg(target_arch = "x86_64")]
-    fn restore_clock(&self, state: &ClockState) -> vm::Result<()> {
+    fn restore_clock(
+        &self,
+        _vcpus: &[&dyn cpu::Vcpu],
+        state: &ClockState,
+        _mode: ClockRestoreMode,
+    ) -> vm::Result<()> {
         self.set_clock(state)
+    }
+
+    /// Advance the guest virtual counter to current wall time before the vCPUs
+    /// resume. A no-op for a `SameHostResume` (the counter free-ran across the
+    /// pause); on `SnapshotRestore`/migration-receive it must catch up.
+    #[cfg(target_arch = "aarch64")]
+    fn restore_clock(
+        &self,
+        vcpus: &[&dyn cpu::Vcpu],
+        saved: &ClockState,
+        mode: ClockRestoreMode,
+    ) -> vm::Result<()> {
+        if mode == ClockRestoreMode::SameHostResume {
+            return Ok(());
+        }
+        // KVM does not rescale the counter frequency across hosts (unlike x86
+        // TSC), so a differing destination frequency would scale the elapsed
+        // ticks incorrectly. Reject rather than corrupt the guest clock.
+        let host_cntfrq = get_cntfrq();
+        if host_cntfrq != saved.cntfrq {
+            return Err(vm::HypervisorVmError::CntfrqMismatch {
+                saved: saved.cntfrq,
+                host: host_cntfrq,
+            });
+        }
+        let now_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| vm::HypervisorVmError::RestoreTimerState(e.into()))?
+            .as_nanos() as u64;
+        let elapsed_ns = now_ns.saturating_sub(saved.host_realtime_ns);
+        let elapsed_ticks = (elapsed_ns as u128 * saved.cntfrq as u128 / NANOS_PER_SECOND) as u64;
+        let target = saved.cntvct.wrapping_add(elapsed_ticks);
+        // Linux >= 6.4 (KVM_CAP_COUNTER_OFFSET) tracks the vtimer offset VM-wide, so one
+        // write advances every vCPU; older kernels track it per-vCPU, so program each.
+        // Restore is the snapshot-boot hot path, so skip the redundant writes when we can.
+        let targets = if self.check_extension(Cap::CounterOffset) {
+            &vcpus[..1]
+        } else {
+            vcpus
+        };
+        for vcpu in targets {
+            vcpu.set_cntvct(target)
+                .map_err(|e| vm::HypervisorVmError::RestoreTimerState(e.into()))?;
+        }
+        Ok(())
     }
 
     /// Create a device that is used for passthrough
@@ -2787,6 +2840,17 @@ impl cpu::Vcpu for KvmVcpu {
             .get_one_reg(KVM_REG_ARM_TIMER_CNT, &mut bytes)
             .map_err(|e| cpu::HypervisorCpuError::GetSysRegister(e.into()))?;
         Ok(u64::from_le_bytes(bytes))
+    }
+
+    ///
+    /// Sets the guest virtual counter via `KVM_REG_ARM_TIMER_CNT`.
+    ///
+    #[cfg(target_arch = "aarch64")]
+    fn set_cntvct(&self, val: u64) -> cpu::Result<()> {
+        self.fd
+            .set_one_reg(KVM_REG_ARM_TIMER_CNT, &val.to_le_bytes())
+            .map_err(|e| cpu::HypervisorCpuError::SetSysRegister(e.into()))?;
+        Ok(())
     }
 
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -27,6 +27,8 @@ use std::sync::Mutex;
 #[cfg(target_arch = "x86_64")]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
+#[cfg(target_arch = "aarch64")]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(target_arch = "x86_64")]
 use anyhow::Context;
@@ -78,7 +80,9 @@ use x86_64::check_required_kvm_extensions;
 pub use x86_64::{CpuId, ExtendedControlRegisters, MsrEntries, VcpuKvmState};
 
 #[cfg(target_arch = "x86_64")]
-use crate::{ClockData, ClockState};
+use crate::ClockData;
+#[cfg(any(target_arch = "x86_64", all(target_arch = "aarch64", feature = "kvm")))]
+use crate::ClockState;
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{
     CpuIdEntry, FpuState, LapicState, MTRR_MSR_INDICES, MsrEntry, NUM_IOAPIC_PINS,
@@ -119,9 +123,11 @@ pub use kvm_bindings::{
 #[cfg(target_arch = "aarch64")]
 use kvm_bindings::{
     KVM_GUESTDBG_USE_HW, KVM_NR_SPSR, KVM_REG_ARM_COPROC_MASK, KVM_REG_ARM_CORE, KVM_REG_ARM64,
-    KVM_REG_ARM64_SYSREG, KVM_REG_ARM64_SYSREG_CRM_MASK, KVM_REG_ARM64_SYSREG_CRN_MASK,
-    KVM_REG_ARM64_SYSREG_OP0_MASK, KVM_REG_ARM64_SYSREG_OP1_MASK, KVM_REG_ARM64_SYSREG_OP2_MASK,
-    KVM_REG_SIZE_U32, KVM_REG_SIZE_U64, KVM_REG_SIZE_U128, kvm_regs, user_pt_regs,
+    KVM_REG_ARM64_SYSREG, KVM_REG_ARM64_SYSREG_CRM_MASK, KVM_REG_ARM64_SYSREG_CRM_SHIFT,
+    KVM_REG_ARM64_SYSREG_CRN_MASK, KVM_REG_ARM64_SYSREG_CRN_SHIFT, KVM_REG_ARM64_SYSREG_OP0_MASK,
+    KVM_REG_ARM64_SYSREG_OP0_SHIFT, KVM_REG_ARM64_SYSREG_OP1_MASK, KVM_REG_ARM64_SYSREG_OP1_SHIFT,
+    KVM_REG_ARM64_SYSREG_OP2_MASK, KVM_REG_SIZE_U32, KVM_REG_SIZE_U64, KVM_REG_SIZE_U128, kvm_regs,
+    user_pt_regs,
 };
 #[cfg(target_arch = "riscv64")]
 use kvm_bindings::{KVM_REG_RISCV_CORE, KVM_REG_RISCV_TIMER, kvm_riscv_core};
@@ -141,9 +147,26 @@ use vmm_sys_util::{ioctl::ioctl_with_val, ioctl_iowr_nr};
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use crate::RegList;
 #[cfg(target_arch = "aarch64")]
-use crate::arch::aarch64::regs;
+use crate::TimerState;
+#[cfg(target_arch = "aarch64")]
+use crate::arch::aarch64::{get_cntfrq, regs};
 #[cfg(target_arch = "x86_64")]
 use crate::kvm::x86_64::XsaveStateError;
+
+// `KVM_REG_ARM_TIMER_CNT`, the timer-counter firmware register the kernel defines
+// as `ARM64_SYS_REG(3, 3, 14, 3, 2)`. kvm-bindings exposes no constant for it, so
+// build the id the way the kernel's `ARM64_SYS_REG` macro would. The kernel pins
+// the EL0 virtual-timer reg encodings by value (CVAL/CNT were historically
+// swapped), so CNT must be exactly op0=3, op1=3, crn=14, crm=3, op2=2.
+#[cfg(target_arch = "aarch64")]
+const KVM_REG_ARM_TIMER_CNT: u64 = KVM_REG_ARM64
+    | KVM_REG_SIZE_U64
+    | KVM_REG_ARM64_SYSREG as u64
+    | ((3_u64 << KVM_REG_ARM64_SYSREG_OP0_SHIFT) & KVM_REG_ARM64_SYSREG_OP0_MASK as u64)
+    | ((3_u64 << KVM_REG_ARM64_SYSREG_OP1_SHIFT) & KVM_REG_ARM64_SYSREG_OP1_MASK as u64)
+    | ((14_u64 << KVM_REG_ARM64_SYSREG_CRN_SHIFT) & KVM_REG_ARM64_SYSREG_CRN_MASK as u64)
+    | ((3_u64 << KVM_REG_ARM64_SYSREG_CRM_SHIFT) & KVM_REG_ARM64_SYSREG_CRM_MASK as u64)
+    | (2_u64 & KVM_REG_ARM64_SYSREG_OP2_MASK as u64);
 
 #[cfg(target_arch = "x86_64")]
 ioctl_io_nr!(KVM_NMI, kvm_bindings::KVMIO, 0x9a);
@@ -1266,8 +1289,28 @@ impl vm::Vm for KvmVm {
 
     /// Capture kvmclock (filling realtime) for snapshot/migration.
     #[cfg(target_arch = "x86_64")]
-    fn snapshot_clock(&self) -> vm::Result<Option<ClockState>> {
+    fn snapshot_clock(&self, _boot_vcpu: &dyn cpu::Vcpu) -> vm::Result<Option<ClockState>> {
         Ok(Some(self.get_clock()?.with_realtime_filled()))
+    }
+
+    /// Capture the guest virtual counter and host wall clock for
+    /// snapshot/migration. The vCPUs must be paused.
+    #[cfg(target_arch = "aarch64")]
+    fn snapshot_clock(&self, boot_vcpu: &dyn cpu::Vcpu) -> vm::Result<Option<ClockState>> {
+        // cntvct and the host wall clock must be sampled back-to-back; cntfrq is
+        // static, so read it last.
+        let cntvct = boot_vcpu
+            .get_cntvct()
+            .map_err(|e| vm::HypervisorVmError::CaptureTimerState(e.into()))?;
+        let host_realtime_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| vm::HypervisorVmError::CaptureTimerState(e.into()))?
+            .as_nanos() as u64;
+        Ok(Some(TimerState {
+            cntvct,
+            host_realtime_ns,
+            cntfrq: get_cntfrq(),
+        }))
     }
 
     /// Restore kvmclock before the vCPUs resume.
@@ -2730,6 +2773,18 @@ impl cpu::Vcpu for KvmVcpu {
         let mut bytes = [0_u8; 8];
         self.fd
             .get_one_reg(id, &mut bytes)
+            .map_err(|e| cpu::HypervisorCpuError::GetSysRegister(e.into()))?;
+        Ok(u64::from_le_bytes(bytes))
+    }
+
+    ///
+    /// Gets the guest virtual counter via `KVM_REG_ARM_TIMER_CNT`.
+    ///
+    #[cfg(target_arch = "aarch64")]
+    fn get_cntvct(&self) -> cpu::Result<u64> {
+        let mut bytes = [0_u8; 8];
+        self.fd
+            .get_one_reg(KVM_REG_ARM_TIMER_CNT, &mut bytes)
             .map_err(|e| cpu::HypervisorCpuError::GetSysRegister(e.into()))?;
         Ok(u64::from_le_bytes(bytes))
     }

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -226,9 +226,28 @@ impl ClockData {
 }
 
 /// Guest clock state preserved across pause/resume and snapshot/restore
-/// (`ClockData` on x86).
+/// (`ClockData` on x86, `TimerState` on aarch64+kvm.
+/// The platform where it has not guest clock, `Option<ClockState>` will be None.
 #[cfg(target_arch = "x86_64")]
 pub type ClockState = ClockData;
+#[cfg(all(target_arch = "aarch64", feature = "kvm"))]
+pub type ClockState = TimerState;
+#[cfg(not(any(target_arch = "x86_64", all(target_arch = "aarch64", feature = "kvm"))))]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub enum ClockState {}
+
+/// Guest timer state captured on aarch64 for snapshot/migration: the guest
+/// virtual counter (`CNTVCT_EL0`) plus the host wall clock and counter
+/// frequency needed to advance it to current wall time on restore. aarch64 has
+/// no `KVM_SET_CLOCK`/`KVM_CLOCK_REALTIME`, so the VMM records these and does the
+/// advance itself.
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[cfg(all(target_arch = "aarch64", feature = "kvm"))]
+pub struct TimerState {
+    pub cntvct: u64,
+    pub host_realtime_ns: u64,
+    pub cntfrq: u64,
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct HypervisorVmConfig {

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -249,6 +249,17 @@ pub struct TimerState {
     pub cntfrq: u64,
 }
 
+/// How the guest clock is re-established when the vCPUs resume: a same-host
+/// pause/resume left it running, whereas a snapshot restore / migration-receive
+/// means the guest was off-host and the clock must catch up to wall time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockRestoreMode {
+    /// Same-host pause -> resume; the clock kept running, nothing to advance.
+    SameHostResume,
+    /// Restored from a snapshot or migrated in; advance to current wall time.
+    SnapshotRestore,
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct HypervisorVmConfig {
     #[cfg(feature = "tdx")]

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -49,6 +49,8 @@ mod cpu;
 mod device;
 
 use std::sync::Arc;
+#[cfg(target_arch = "x86_64")]
+use std::time::SystemTime;
 
 use anyhow::anyhow;
 use concat_idents::concat_idents;
@@ -196,7 +198,7 @@ impl ClockData {
         }
     }
 
-    pub fn set_realtime(&mut self, realtime: std::time::SystemTime) {
+    pub fn set_realtime(&mut self, realtime: SystemTime) {
         match self {
             #[cfg(feature = "kvm")]
             ClockData::Kvm(s) => {
@@ -211,7 +213,22 @@ impl ClockData {
             }
         }
     }
+
+    /// Returns the clock with `CLOCK_REALTIME` filled from the host wall clock
+    /// when absent, so a later restore can advance the guest to current wall
+    /// time. No-op for backends without a realtime field (e.g. MSHV).
+    pub fn with_realtime_filled(mut self) -> Self {
+        if !self.has_realtime() {
+            self.set_realtime(SystemTime::now());
+        }
+        self
+    }
 }
+
+/// Guest clock state preserved across pause/resume and snapshot/restore
+/// (`ClockData` on x86).
+#[cfg(target_arch = "x86_64")]
+pub type ClockState = ClockData;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct HypervisorVmConfig {

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1324,6 +1324,11 @@ impl cpu::Vcpu for MshvVcpu {
         Ok(res)
     }
 
+    #[cfg(all(target_arch = "aarch64", feature = "kvm"))]
+    fn get_cntvct(&self) -> cpu::Result<u64> {
+        unimplemented!()
+    }
+
     #[cfg(target_arch = "aarch64")]
     fn get_reg_list(&self, _reg_list: &mut crate::RegList) -> cpu::Result<()> {
         unimplemented!()
@@ -2202,7 +2207,7 @@ impl vm::Vm for MshvVm {
 
     /// Capture the partition reference time for snapshot/migration.
     #[cfg(target_arch = "x86_64")]
-    fn snapshot_clock(&self) -> vm::Result<Option<ClockState>> {
+    fn snapshot_clock(&self, _boot_vcpu: &dyn cpu::Vcpu) -> vm::Result<Option<ClockState>> {
         Ok(Some(self.get_clock()?.with_realtime_filled()))
     }
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -77,14 +77,14 @@ pub use {
     mshv_bindings::mshv_device_attr as DeviceAttr, mshv_ioctls, mshv_ioctls::DeviceFd,
 };
 
-#[cfg(target_arch = "x86_64")]
-use crate::{ClockData, ClockState};
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::{Vgic, VgicConfig};
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::regs;
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{CpuIdEntry, FpuState, MsrEntry};
+#[cfg(target_arch = "x86_64")]
+use crate::{ClockData, ClockRestoreMode, ClockState};
 use crate::{CpuState, IoEventAddress, IrqRoutingEntry, MpState};
 
 pub const PAGE_SHIFT: usize = 12;
@@ -1329,6 +1329,11 @@ impl cpu::Vcpu for MshvVcpu {
         unimplemented!()
     }
 
+    #[cfg(all(target_arch = "aarch64", feature = "kvm"))]
+    fn set_cntvct(&self, _val: u64) -> cpu::Result<()> {
+        unimplemented!()
+    }
+
     #[cfg(target_arch = "aarch64")]
     fn get_reg_list(&self, _reg_list: &mut crate::RegList) -> cpu::Result<()> {
         unimplemented!()
@@ -2213,7 +2218,12 @@ impl vm::Vm for MshvVm {
 
     /// Restore the partition reference time before the vCPUs resume.
     #[cfg(target_arch = "x86_64")]
-    fn restore_clock(&self, state: &ClockState) -> vm::Result<()> {
+    fn restore_clock(
+        &self,
+        _vcpus: &[&dyn cpu::Vcpu],
+        state: &ClockState,
+        _mode: ClockRestoreMode,
+    ) -> vm::Result<()> {
         self.set_clock(state)
     }
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -78,7 +78,7 @@ pub use {
 };
 
 #[cfg(target_arch = "x86_64")]
-use crate::ClockData;
+use crate::{ClockData, ClockState};
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::{Vgic, VgicConfig};
 #[cfg(target_arch = "aarch64")]
@@ -2198,6 +2198,18 @@ impl vm::Vm for MshvVm {
                 data.ref_time,
             )
             .map_err(|e| vm::HypervisorVmError::SetClock(e.into()))
+    }
+
+    /// Capture the partition reference time for snapshot/migration.
+    #[cfg(target_arch = "x86_64")]
+    fn snapshot_clock(&self) -> vm::Result<Option<ClockState>> {
+        Ok(Some(self.get_clock()?.with_realtime_filled()))
+    }
+
+    /// Restore the partition reference time before the vCPUs resume.
+    #[cfg(target_arch = "x86_64")]
+    fn restore_clock(&self, state: &ClockState) -> vm::Result<()> {
+        self.set_clock(state)
     }
 
     /// Downcast to the underlying MshvVm type

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(target_arch = "x86_64")]
-use crate::ClockData;
+use crate::{ClockData, ClockState};
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::{Vgic, VgicConfig};
 #[cfg(target_arch = "riscv64")]
@@ -384,6 +384,17 @@ pub trait Vm: Send + Sync + Any {
     /// Set guest clock.
     #[cfg(target_arch = "x86_64")]
     fn set_clock(&self, data: &ClockData) -> Result<()>;
+    /// Capture the guest clock for snapshot/migration while the VM is paused.
+    /// `Ok(None)` means this backend has no clock to preserve.
+    #[cfg(target_arch = "x86_64")]
+    fn snapshot_clock(&self) -> Result<Option<ClockState>> {
+        Ok(None)
+    }
+    /// Re-establish the guest clock before the vCPUs resume.
+    #[cfg(target_arch = "x86_64")]
+    fn restore_clock(&self, _state: &ClockState) -> Result<()> {
+        Ok(())
+    }
     /// Create a device that is used for passthrough
     fn create_passthrough_device(&self) -> Result<vfio_ioctls::VfioDeviceFd>;
     /// Start logging dirty pages

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -23,7 +23,8 @@ use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(target_arch = "x86_64")]
-use crate::{ClockData, ClockState};
+use crate::ClockData;
+use crate::ClockState;
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::{Vgic, VgicConfig};
 #[cfg(target_arch = "riscv64")]
@@ -139,6 +140,12 @@ pub enum HypervisorVmError {
     ///
     #[error("Failed to set clock")]
     SetClock(#[source] anyhow::Error),
+    ///
+    /// Capture guest timer state error (aarch64)
+    ///
+    #[cfg(all(target_arch = "aarch64", feature = "kvm"))]
+    #[error("Failed to capture the guest timer state")]
+    CaptureTimerState(#[source] anyhow::Error),
     ///
     /// Create passthrough device
     ///
@@ -385,9 +392,10 @@ pub trait Vm: Send + Sync + Any {
     #[cfg(target_arch = "x86_64")]
     fn set_clock(&self, data: &ClockData) -> Result<()>;
     /// Capture the guest clock for snapshot/migration while the VM is paused.
-    /// `Ok(None)` means this backend has no clock to preserve.
-    #[cfg(target_arch = "x86_64")]
-    fn snapshot_clock(&self) -> Result<Option<ClockState>> {
+    /// `Ok(None)` means this backend has no clock to preserve. `boot_vcpu` is the
+    /// boot vCPU, used by backends whose clock is per-vCPU state (e.g the aarch64
+    /// counter);
+    fn snapshot_clock(&self, _boot_vcpu: &dyn Vcpu) -> Result<Option<ClockState>> {
         Ok(None)
     }
     /// Re-establish the guest clock before the vCPUs resume.

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -24,7 +24,6 @@ use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(target_arch = "x86_64")]
 use crate::ClockData;
-use crate::ClockState;
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::{Vgic, VgicConfig};
 #[cfg(target_arch = "riscv64")]
@@ -32,7 +31,7 @@ use crate::arch::riscv64::aia::{Vaia, VaiaConfig};
 #[cfg(feature = "tdx")]
 use crate::arch::x86::CpuIdEntry;
 use crate::cpu::Vcpu;
-use crate::{IoEventAddress, IrqRoutingEntry};
+use crate::{ClockRestoreMode, ClockState, IoEventAddress, IrqRoutingEntry};
 
 ///
 /// I/O events data matches (32 or 64 bits).
@@ -146,6 +145,20 @@ pub enum HypervisorVmError {
     #[cfg(all(target_arch = "aarch64", feature = "kvm"))]
     #[error("Failed to capture the guest timer state")]
     CaptureTimerState(#[source] anyhow::Error),
+    ///
+    /// Restore guest timer state error (aarch64)
+    ///
+    #[cfg(all(target_arch = "aarch64", feature = "kvm"))]
+    #[error("Failed to restore the guest timer state")]
+    RestoreTimerState(#[source] anyhow::Error),
+    ///
+    /// Counter frequency mismatch on restore (aarch64)
+    ///
+    #[cfg(all(target_arch = "aarch64", feature = "kvm"))]
+    #[error(
+        "Saved counter frequency ({saved} Hz) != host ({host} Hz); refusing to advance guest counter"
+    )]
+    CntfrqMismatch { saved: u64, host: u64 },
     ///
     /// Create passthrough device
     ///
@@ -398,9 +411,17 @@ pub trait Vm: Send + Sync + Any {
     fn snapshot_clock(&self, _boot_vcpu: &dyn Vcpu) -> Result<Option<ClockState>> {
         Ok(None)
     }
-    /// Re-establish the guest clock before the vCPUs resume.
-    #[cfg(target_arch = "x86_64")]
-    fn restore_clock(&self, _state: &ClockState) -> Result<()> {
+    /// Re-establish the guest clock before the vCPUs resume. `mode` distinguishes a
+    /// same-host pause/resume (the clock kept running) from a restore/migration where
+    /// it must catch up to wall time; x86 ignores it (kvmclock is re-applied on every
+    /// resume). aarch64 writes the counter on all `vcpus` (older kernels track the
+    /// offset per-vCPU); x86 ignores `vcpus`.
+    fn restore_clock(
+        &self,
+        _vcpus: &[&dyn Vcpu],
+        _state: &ClockState,
+        _mode: ClockRestoreMode,
+    ) -> Result<()> {
         Ok(())
     }
     /// Create a device that is used for passthrough

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -499,6 +499,12 @@ pub struct Vcpu {
 }
 
 impl Vcpu {
+    /// Borrow the underlying hypervisor vCPU, for guest-clock capture/restore
+    /// because the aarch64 counter is per-vCPU state
+    pub fn hypervisor_vcpu(&self) -> &dyn hypervisor::Vcpu {
+        self.vcpu.as_ref()
+    }
+
     /// Constructs a new VCPU for `vm`.
     ///
     /// # Arguments
@@ -1689,6 +1695,11 @@ impl CpuManager {
             .iter()
             .map(|cpu| cpu.lock().unwrap().get_mpidr())
             .collect()
+    }
+
+    /// The boot vCPU (vCPU 0), or `None` before the vCPUs are created.
+    pub fn boot_vcpu(&self) -> Option<Arc<Mutex<Vcpu>>> {
+        self.vcpus.first().cloned()
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -625,7 +625,7 @@ pub struct VmmThreadHandle {
 
 /// Models the current ownership and associated state of the VM from the
 /// perspective of the VMM.
-#[cfg_attr(feature = "tdx", expect(clippy::large_enum_variant))]
+#[allow(clippy::large_enum_variant)]
 pub enum VmOwnership {
     Owned(Vm),
     None,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -513,6 +513,16 @@ pub fn physical_bits(hypervisor: &dyn hypervisor::Hypervisor, max_phys_bits: u8)
     cmp::min(host_phys_bits, max_phys_bits)
 }
 
+/// Guest clock baseline captured for snapshot/restore, plus how it must be
+/// re-established on the next resume. `mode` is runtime-only (`SnapshotRestore`
+/// after restore/migration-receive, `SameHostResume` for a live same-host capture)
+/// and is not serialized: it is re-derived from "was this VM built from a snapshot".
+#[derive(Clone, Copy)]
+struct SavedClock {
+    mode: hypervisor::ClockRestoreMode,
+    state: hypervisor::ClockState,
+}
+
 pub struct Vm {
     #[cfg(feature = "tdx")]
     kernel: Option<File>,
@@ -526,7 +536,7 @@ pub struct Vm {
     #[cfg_attr(any(not(feature = "kvm"), target_arch = "aarch64"), allow(dead_code))]
     // The hypervisor abstracted virtual machine.
     vm: Arc<dyn hypervisor::Vm>,
-    saved_clock: Option<hypervisor::ClockState>,
+    saved_clock: Option<SavedClock>,
     #[cfg(not(target_arch = "riscv64"))]
     numa_nodes: NumaNodes,
     #[cfg_attr(any(not(feature = "kvm"), target_arch = "aarch64"), allow(dead_code))]
@@ -681,7 +691,12 @@ impl Vm {
 
         let saved_clock = if let Some(snapshot) = snapshot.as_ref() {
             let vm_snapshot = get_vm_snapshot(snapshot).map_err(Error::Restore)?;
-            vm_snapshot.clock
+            // Restored or migrated in: the guest clock must catch up to wall time
+            // on resume (the counter was reset to the saved value).
+            vm_snapshot.clock.map(|state| SavedClock {
+                mode: hypervisor::ClockRestoreMode::SnapshotRestore,
+                state,
+            })
         } else {
             None
         };
@@ -3199,6 +3214,37 @@ impl Vm {
             .nmi()
             .map_err(Error::ErrorNmi);
     }
+
+    /// Capture the guest clock for a same-host resume (mode `SameHostResume`).
+    /// `None` if the VM is not booted or the backend has no guest clock.
+    fn capture_guest_clock(&self) -> std::result::Result<Option<SavedClock>, MigratableError> {
+        let Some(boot_vcpu) = self.cpu_manager.lock().unwrap().boot_vcpu() else {
+            return Ok(None);
+        };
+        let boot_vcpu = boot_vcpu.lock().unwrap();
+        Ok(self
+            .vm
+            .snapshot_clock(boot_vcpu.hypervisor_vcpu())
+            .map_err(|e| MigratableError::Pause(anyhow!("Could not capture guest clock: {e}")))?
+            .map(|state| SavedClock {
+                mode: hypervisor::ClockRestoreMode::SameHostResume,
+                state,
+            }))
+    }
+
+    /// Re-establish the guest clock before the vCPUs resume. No-op if none captured.
+    fn restore_guest_clock(&self) -> std::result::Result<(), MigratableError> {
+        let Some(saved) = &self.saved_clock else {
+            return Ok(());
+        };
+        let vcpus = self.cpu_manager.lock().unwrap().vcpus();
+        let guards: Vec<_> = vcpus.iter().map(|v| v.lock().unwrap()).collect();
+        let hv_vcpus: Vec<&dyn hypervisor::Vcpu> =
+            guards.iter().map(|g| g.hypervisor_vcpu()).collect();
+        self.vm
+            .restore_clock(&hv_vcpus, &saved.state, saved.mode)
+            .map_err(|e| MigratableError::Resume(anyhow!("Could not restore guest clock: {e}")))
+    }
 }
 
 impl Pausable for Vm {
@@ -3217,15 +3263,9 @@ impl Pausable for Vm {
 
         self.cpu_manager.lock().unwrap().pause()?;
 
-        // Capture the guest clock once the vCPUs are paused: aarch64 reads the
-        // boot vCPU's virtual counter, which requires the vCPU to be quiesced.
-        if let Some(boot_vcpu) = self.cpu_manager.lock().unwrap().boot_vcpu() {
-            let boot_vcpu = boot_vcpu.lock().unwrap();
-            self.saved_clock = self
-                .vm
-                .snapshot_clock(boot_vcpu.hypervisor_vcpu())
-                .map_err(|e| MigratableError::Pause(anyhow!("Could not capture guest clock: {e}")))?;
-        }
+        // Capture the guest clock now that the vCPUs are quiesced.
+        self.saved_clock = self.capture_guest_clock()?;
+
         self.device_manager.lock().unwrap().pause()?;
 
         self.vm
@@ -3247,16 +3287,8 @@ impl Pausable for Vm {
             .valid_transition(new_state)
             .map_err(|e| MigratableError::Resume(anyhow!("Invalid transition: {e:?}")))?;
 
-        // Restore the guest clock BEFORE the vCPUs start running, so they see the
-        // corrected time from the first instruction after resume.
-        #[cfg(target_arch = "x86_64")]
-        {
-            if let Some(state) = &self.saved_clock {
-                self.vm.restore_clock(state).map_err(|e| {
-                    MigratableError::Resume(anyhow!("Could not restore guest clock: {e}"))
-                })?;
-            }
-        }
+        // Restore the guest clock before the vCPUs start running.
+        self.restore_guest_clock()?;
 
         if current_state == VmState::Paused {
             self.vm
@@ -3276,7 +3308,7 @@ impl Pausable for Vm {
 
 #[derive(Serialize, Deserialize)]
 pub struct VmSnapshot {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clock: Option<hypervisor::ClockState>,
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     pub common_cpuid: Vec<hypervisor::arch::x86::CpuIdEntry>,
@@ -3338,7 +3370,7 @@ impl Snapshottable for Vm {
         };
 
         let vm_snapshot_state = VmSnapshot {
-            clock: self.saved_clock,
+            clock: self.saved_clock.map(|saved| saved.state),
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             common_cpuid,
         };

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -529,7 +529,7 @@ pub struct Vm {
     // The hypervisor abstracted virtual machine.
     vm: Arc<dyn hypervisor::Vm>,
     #[cfg(target_arch = "x86_64")]
-    saved_clock: Option<hypervisor::ClockData>,
+    saved_clock: Option<hypervisor::ClockState>,
     #[cfg(not(target_arch = "riscv64"))]
     numa_nodes: NumaNodes,
     #[cfg_attr(any(not(feature = "kvm"), target_arch = "aarch64"), allow(dead_code))]
@@ -3216,14 +3216,10 @@ impl Pausable for Vm {
 
         #[cfg(target_arch = "x86_64")]
         {
-            let mut clock = self
+            self.saved_clock = self
                 .vm
-                .get_clock()
-                .map_err(|e| MigratableError::Pause(anyhow!("Could not get VM clock: {e}")))?;
-            if !clock.has_realtime() {
-                clock.set_realtime(std::time::SystemTime::now());
-            }
-            self.saved_clock = Some(clock);
+                .snapshot_clock()
+                .map_err(|e| MigratableError::Pause(anyhow!("Could not capture guest clock: {e}")))?;
         }
 
         // Before pausing the vCPUs activate any pending virtio devices that might
@@ -3254,14 +3250,14 @@ impl Pausable for Vm {
             .valid_transition(new_state)
             .map_err(|e| MigratableError::Resume(anyhow!("Invalid transition: {e:?}")))?;
 
-        // Restore KVM clock BEFORE vCPUs start running, so they see correct
-        // TSC/kvmclock from the first instruction after resume.
+        // Restore the guest clock BEFORE the vCPUs start running, so they see the
+        // corrected time from the first instruction after resume.
         #[cfg(target_arch = "x86_64")]
         {
-            if let Some(clock) = &self.saved_clock {
-                self.vm
-                    .set_clock(clock)
-                    .map_err(|e| MigratableError::Resume(anyhow!("Could not set VM clock: {e}")))?;
+            if let Some(state) = &self.saved_clock {
+                self.vm.restore_clock(state).map_err(|e| {
+                    MigratableError::Resume(anyhow!("Could not restore guest clock: {e}"))
+                })?;
             }
         }
 
@@ -3284,7 +3280,7 @@ impl Pausable for Vm {
 #[derive(Serialize, Deserialize)]
 pub struct VmSnapshot {
     #[cfg(target_arch = "x86_64")]
-    pub clock: Option<hypervisor::ClockData>,
+    pub clock: Option<hypervisor::ClockState>,
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     pub common_cpuid: Vec<hypervisor::arch::x86::CpuIdEntry>,
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -100,11 +100,9 @@ use crate::landlock::LandlockError;
 use crate::memory_manager::{
     Error as MemoryManagerError, MemoryManager, MemoryManagerSnapshotData,
 };
-#[cfg(target_arch = "x86_64")]
-use crate::migration::get_vm_snapshot;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::migration::url_to_file;
-use crate::migration::{SNAPSHOT_CONFIG_FILE, SNAPSHOT_STATE_FILE, url_to_path};
+use crate::migration::{SNAPSHOT_CONFIG_FILE, SNAPSHOT_STATE_FILE, get_vm_snapshot, url_to_path};
 #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
 use crate::sev::MeasuredBootInfo;
 #[cfg(feature = "fw_cfg")]
@@ -528,7 +526,6 @@ pub struct Vm {
     #[cfg_attr(any(not(feature = "kvm"), target_arch = "aarch64"), allow(dead_code))]
     // The hypervisor abstracted virtual machine.
     vm: Arc<dyn hypervisor::Vm>,
-    #[cfg(target_arch = "x86_64")]
     saved_clock: Option<hypervisor::ClockState>,
     #[cfg(not(target_arch = "riscv64"))]
     numa_nodes: NumaNodes,
@@ -682,7 +679,6 @@ impl Vm {
             .transpose()
             .map_err(Error::InitramfsFile)?;
 
-        #[cfg(target_arch = "x86_64")]
         let saved_clock = if let Some(snapshot) = snapshot.as_ref() {
             let vm_snapshot = get_vm_snapshot(snapshot).map_err(Error::Restore)?;
             vm_snapshot.clock
@@ -707,7 +703,6 @@ impl Vm {
             cpu_manager,
             memory_manager,
             vm,
-            #[cfg(target_arch = "x86_64")]
             saved_clock,
             #[cfg(not(target_arch = "riscv64"))]
             numa_nodes,
@@ -3214,14 +3209,6 @@ impl Pausable for Vm {
             .valid_transition(new_state)
             .map_err(|e| MigratableError::Pause(anyhow!("Invalid transition: {e:?}")))?;
 
-        #[cfg(target_arch = "x86_64")]
-        {
-            self.saved_clock = self
-                .vm
-                .snapshot_clock()
-                .map_err(|e| MigratableError::Pause(anyhow!("Could not capture guest clock: {e}")))?;
-        }
-
         // Before pausing the vCPUs activate any pending virtio devices that might
         // need activation between starting the pause (or e.g. a migration it's part of)
         self.activate_virtio_devices().map_err(|e| {
@@ -3229,6 +3216,16 @@ impl Pausable for Vm {
         })?;
 
         self.cpu_manager.lock().unwrap().pause()?;
+
+        // Capture the guest clock once the vCPUs are paused: aarch64 reads the
+        // boot vCPU's virtual counter, which requires the vCPU to be quiesced.
+        if let Some(boot_vcpu) = self.cpu_manager.lock().unwrap().boot_vcpu() {
+            let boot_vcpu = boot_vcpu.lock().unwrap();
+            self.saved_clock = self
+                .vm
+                .snapshot_clock(boot_vcpu.hypervisor_vcpu())
+                .map_err(|e| MigratableError::Pause(anyhow!("Could not capture guest clock: {e}")))?;
+        }
         self.device_manager.lock().unwrap().pause()?;
 
         self.vm
@@ -3279,7 +3276,7 @@ impl Pausable for Vm {
 
 #[derive(Serialize, Deserialize)]
 pub struct VmSnapshot {
-    #[cfg(target_arch = "x86_64")]
+    #[serde(default)]
     pub clock: Option<hypervisor::ClockState>,
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     pub common_cpuid: Vec<hypervisor::arch::x86::CpuIdEntry>,
@@ -3341,7 +3338,6 @@ impl Snapshottable for Vm {
         };
 
         let vm_snapshot_state = VmSnapshot {
-            #[cfg(target_arch = "x86_64")]
             clock: self.saved_clock,
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             common_cpuid,


### PR DESCRIPTION
On x86, a snapshot-restored or migrated guest catches its CLOCK_REALTIME back up to real time via the kvmclock path (KVM_SET_CLOCK + KVM_CLOCK_REALTIME). 

ARM64 has no such helper. Cloud Hypervisor just round-trips CNTVCT_EL0 which results in old time(behind real time by the entire downtime) at resume in a cold-restored or migrated guest resumes. 

This series mirrors the x86 fix for arm64/KVM using KVM_REG_ARM_TIMER_CNT ONEREG inteface. At snapshot time, it records the guest counter together with the host wall clock and counter frequency; at restore/migration-receive, before the vCPUs run, it advances CNTVCT by the wall-clock time that elapsed while the VM was down. arm64 has no kernel-side helper, so the VMM does the arithmetic itself.

  - KVM/arm64 only — x86 is unchanged and MSHV is unaffected.
  - an unreadable host clock or a cross-host CNTFRQ mismatch will fail now rather than resuming with a wrong clock.

 Tested with 
 1. new test_snapshot_check_guest_time (boot → snapshot → wait → restore → assert the guest's UTC caught up) on x86 and ARM64
 2. Manual with snapshot/restore on an arm64/KVM host.

 We also considered the VM-wide counter-offset ioctl (KVM_CAP_COUNTER_OFFSET; available > Linux 6.4) as an alternative but advancing CNTVCT through the ONE_REG is the better fit here. It reuses the exact path snapshot/restore already uses for the guest counter restore writes CNTVCT via SET_ONE_REG, so the correction is just writing the advanced value through the same mechanism, instead of bolting on a second, capability-gated API. 
 
Let us know if there is any other angle which favors the KVM_CAP_COUNTER_OFFSET

 ## v1 → v2 summary 

  - Backend-agnostic clock abstraction on the hypervisor Vm trait (snapshot_clock()/restore_clock() + ClockState) so the VMM drives save/restore uniformly and arch/backend details stay behind the hypervisor layer  (Suggested-by Sebastien Boeuf.)
   - aarch64 multi-vCPU correctness gate the counter write on KVM_CAP_COUNTER_OFFSET — Linux ≥6.4 tracks the vtimer offset VM-wide (one boot-vCPU write), older kernels per-vCPU (write all). v1 wrote vcpu0 only.
   
   - Added a pause/resume integration test for ARM64
  
  
## Testing
| Feature behavior | x86_64 | aarch64 |
  | --- | :---: | :---: |
  | Snapshot → restore: clock catches up to wall time (intra-host) | ✅ integration test + manual | ✅ integration test + manual  |
  | Snapshot → restore: clock catches up to wall time (inter-host) | X | ✅ manual |
  | Same-host pause → resume: no backward jump | ✅ manual | ✅ manual |
  | Multi-vCPU consistency after restore | ✅ manual | ✅ manual |



