### PR TITLE
net_util: trim qualified paths

### DIFF
--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
+use std::result;
+
 use log::{debug, error, info, warn};
 use thiserror::Error;
 use virtio_bindings::virtio_net::{
@@ -45,7 +47,7 @@ pub enum Error {
     QueueEnableNotification(#[source] virtio_queue::Error),
 }
 
-type Result<T> = std::result::Result<T, Error>;
+type Result<T> = result::Result<T, Error>;
 
 #[repr(C, packed)]
 #[derive(Debug, Clone, Copy, Default)]

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -15,7 +15,7 @@ use std::io::Error as IoError;
 use std::net::IpAddr;
 use std::os::raw::c_uint;
 use std::os::unix::io::{FromRawFd, RawFd};
-use std::{io, mem, net};
+use std::{io, mem, net, result};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -41,7 +41,7 @@ pub enum Error {
     CreateSocket(#[source] IoError),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
 
 #[repr(C, packed)]
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
@@ -102,7 +102,7 @@ fn create_unix_socket() -> Result<net::UdpSocket> {
 }
 
 fn vnet_hdr_len() -> usize {
-    std::mem::size_of::<virtio_net_hdr_v1>()
+    mem::size_of::<virtio_net_hdr_v1>()
 }
 
 pub fn register_listener(
@@ -110,7 +110,7 @@ pub fn register_listener(
     fd: RawFd,
     ev_type: epoll::Events,
     data: u64,
-) -> std::result::Result<(), io::Error> {
+) -> io::Result<()> {
     epoll::ctl(
         epoll_fd,
         epoll::ControlOptions::EPOLL_CTL_ADD,
@@ -124,7 +124,7 @@ pub fn unregister_listener(
     fd: RawFd,
     ev_type: epoll::Events,
     data: u64,
-) -> std::result::Result<(), io::Error> {
+) -> io::Result<()> {
     epoll::ctl(
         epoll_fd,
         epoll::ControlOptions::EPOLL_CTL_DEL,

--- a/net_util/src/mac.rs
+++ b/net_util/src/mac.rs
@@ -131,7 +131,7 @@ pub enum MacAddrParseError {
 impl FromStr for MacAddr {
     type Err = MacAddrParseError;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         MacAddr::parse_str(s).map_err(|_| MacAddrParseError::InvalidValue(s.to_owned()))
     }
 }

--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -4,7 +4,7 @@
 
 use std::net::IpAddr;
 use std::path::Path;
-use std::{fs, io};
+use std::{fs, io, num, result};
 
 use log::warn;
 use thiserror::Error;
@@ -14,7 +14,7 @@ use super::{MacAddr, Tap, TapError, vnet_hdr_len};
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Failed to convert an hexadecimal string into an integer")]
-    ConvertHexStringToInt(#[source] std::num::ParseIntError),
+    ConvertHexStringToInt(#[source] num::ParseIntError),
     #[error("Error related to the multiqueue support (no support TAP side)")]
     MultiQueueNoTapSupport,
     #[error("Error related to the multiqueue support (no support device side)")]
@@ -37,7 +37,7 @@ pub enum Error {
     TapEnable(#[source] TapError),
 }
 
-type Result<T> = std::result::Result<T, Error>;
+type Result<T> = result::Result<T, Error>;
 
 fn check_mq_support(if_name: &Option<&str>, queue_pairs: usize) -> Result<()> {
     if let Some(tap_name) = if_name {

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -4,6 +4,7 @@
 
 use std::io;
 use std::num::Wrapping;
+use std::ops::{Deref, DerefMut};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -125,10 +126,10 @@ impl TxVirtio {
                 };
 
                 if result < 0 {
-                    let e = std::io::Error::last_os_error();
+                    let e = io::Error::last_os_error();
 
                     /* EAGAIN */
-                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                    if e.kind() == io::ErrorKind::WouldBlock {
                         queue.go_to_previous_position();
                         retry_write = true;
                         break;
@@ -304,10 +305,10 @@ impl RxVirtio {
                     )
                 };
                 if result < 0 {
-                    let e = std::io::Error::last_os_error();
+                    let e = io::Error::last_os_error();
 
                     /* EAGAIN */
-                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                    if e.kind() == io::ErrorKind::WouldBlock {
                         exhausted_descs = false;
                         queue.go_to_previous_position();
                         break;
@@ -405,7 +406,7 @@ impl IovecBuffer {
 
 struct IovecBufferBorrowed<'a>(&'a mut Vec<libc::iovec>);
 
-impl std::ops::Deref for IovecBufferBorrowed<'_> {
+impl Deref for IovecBufferBorrowed<'_> {
     type Target = Vec<libc::iovec>;
 
     fn deref(&self) -> &Self::Target {
@@ -413,7 +414,7 @@ impl std::ops::Deref for IovecBufferBorrowed<'_> {
     }
 }
 
-impl std::ops::DerefMut for IovecBufferBorrowed<'_> {
+impl DerefMut for IovecBufferBorrowed<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -11,6 +11,7 @@ use std::io::{Error as IoError, Read, Result as IoResult, Write};
 use std::net::{IpAddr, Ipv6Addr};
 use std::os::raw::*;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::{mem, result, str};
 
 use libc::{__c_anonymous_ifr_ifru, IFNAMSIZ, ifreq};
 use thiserror::Error;
@@ -48,7 +49,7 @@ pub enum Error {
     InvalidNetmask,
 }
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
 
 /// Handle for a network tap interface.
 ///
@@ -69,7 +70,7 @@ impl PartialEq for Tap {
     }
 }
 
-impl std::clone::Clone for Tap {
+impl Clone for Tap {
     fn clone(&self) -> Self {
         Tap {
             tap_file: self.tap_file.try_clone().unwrap(),
@@ -342,9 +343,7 @@ impl Tap {
 
                 let ifreq = libc::in6_ifreq {
                     // SAFETY: addr can be safely transmuted to in6_addr
-                    ifr6_addr: unsafe {
-                        std::mem::transmute::<[u8; 16], libc::in6_addr>(addr.octets())
-                    },
+                    ifr6_addr: unsafe { mem::transmute::<[u8; 16], libc::in6_addr>(addr.octets()) },
                     ifr6_prefixlen: prefixlen as u32,
                     ifr6_ifindex: ifindex,
                 };
@@ -512,8 +511,7 @@ impl Tap {
     /// also always created from Rust strings, thus valid UTF-8.
     pub fn if_name_as_str(&self) -> &str {
         // Panicking here is fine, see function documentation.
-        std::str::from_utf8(self.if_name.as_bytes())
-            .expect("Tap interface name should be valid UTF-8")
+        str::from_utf8(self.if_name.as_bytes()).expect("Tap interface name should be valid UTF-8")
     }
 
     #[cfg(fuzzing)]


### PR DESCRIPTION
Part of #7670.

Import the std modules used across the crate instead of spelling the
fully-qualified paths at every use site. Examples:

- local `Result` alias: `std::result::Result<T, Error>` → `result::Result<T, Error>`
- `std::io::Error` / `std::io::ErrorKind` → `io::Error` / `io::ErrorKind`
- `std::mem::size_of` / `std::mem::transmute` → `mem::…`
- `std::num::ParseIntError` → `num::ParseIntError`
- `impl std::ops::Deref` / `std::clone::Clone` → `impl Deref` / `impl Clone`
- `std::str::from_utf8` → `str::from_utf8`
- the two `register_listener`/`unregister_listener` signatures returning a
  different error type → `io::Result<()>`

Readability-only change; no functional impact. Follows the same approach as
the merged #8273 (tdx) and #8152 (uffd) cleanups.
