### PR TITLE
block: Accept any virtio-blk descriptor layout

### DIFF
--- a/block/src/io/request.rs
+++ b/block/src/io/request.rs
@@ -18,7 +18,8 @@ use std::time::Instant;
 use log::{error, warn};
 use smallvec::SmallVec;
 use virtio_bindings::virtio_blk::{
-    VIRTIO_BLK_T_DISCARD, VIRTIO_BLK_T_WRITE_ZEROES, VIRTIO_BLK_WRITE_ZEROES_FLAG_UNMAP,
+    VIRTIO_BLK_T_DISCARD, VIRTIO_BLK_T_FLUSH, VIRTIO_BLK_T_GET_ID, VIRTIO_BLK_T_IN,
+    VIRTIO_BLK_T_OUT, VIRTIO_BLK_T_WRITE_ZEROES, VIRTIO_BLK_WRITE_ZEROES_FLAG_UNMAP,
     virtio_blk_discard_write_zeroes,
 };
 use virtio_queue::DescriptorChain;
@@ -33,7 +34,7 @@ use vm_virtio::checked_descriptor::DescriptorChainExt;
 use crate::async_io::{
     AsyncIo, AsyncIoCompletion, AsyncIoOperation, GuestMemoryTarget, OwnedIoBuffer,
 };
-use crate::{Error, ExecuteError, request_type, sector};
+use crate::{Error, ExecuteError};
 
 const SECTOR_SHIFT: u8 = 9;
 pub const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;
@@ -62,6 +63,8 @@ pub enum RequestType {
 
 pub const DEFAULT_DESCRIPTOR_VEC_SIZE: usize = 32;
 
+type Iovec = SmallVec<[(GuestAddress, u32); DEFAULT_DESCRIPTOR_VEC_SIZE]>;
+
 pub struct ExecuteAsync {
     // `true` if the execution will complete asynchronously
     pub async_complete: bool,
@@ -84,91 +87,79 @@ impl Request {
         desc_chain: &mut DescriptorChain<GuestMemoryLoadGuard<vm_memory::GuestMemoryMmap<B>>>,
         access_platform: Option<&dyn AccessPlatform>,
     ) -> Result<Request, Error> {
-        let hdr_desc = desc_chain
+        let mut readable: Iovec = SmallVec::new();
+        let mut writable: Iovec = SmallVec::new();
+
+        while let Some(desc) = desc_chain
             .next_checked(access_platform)
             .map_err(|addr| Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(addr)))?
-            .ok_or_else(|| {
+        {
+            if desc.is_empty() {
+                continue;
+            }
+            if desc.is_write_only() {
+                writable.push((desc.addr(), desc.len()));
+            } else if writable.is_empty() {
+                readable.push((desc.addr(), desc.len()));
+            } else {
+                error!("Readable descriptor follows a writable one");
+                return Err(Error::UnexpectedReadOnlyDescriptor);
+            }
+        }
+
+        if readable.is_empty() {
+            return Err(if writable.is_empty() {
                 error!("Missing head descriptor");
                 Error::DescriptorChainTooShort
-            })?;
-
-        // The head contains the request type which MUST be readable.
-        if hdr_desc.is_write_only() {
-            return Err(Error::UnexpectedWriteOnlyDescriptor);
+            } else {
+                error!("Missing readable head descriptor");
+                Error::UnexpectedWriteOnlyDescriptor
+            });
         }
 
-        let hdr_desc_addr = hdr_desc.addr();
+        let mem = desc_chain.memory();
+        let mut hdr = [0u8; 16];
+        iovec_read_bytes(mem, &readable, 0, &mut hdr)?;
+        let req_type = match u32::from_le_bytes(hdr[0..4].try_into().unwrap()) {
+            VIRTIO_BLK_T_IN => RequestType::In,
+            VIRTIO_BLK_T_OUT => RequestType::Out,
+            VIRTIO_BLK_T_FLUSH => RequestType::Flush,
+            VIRTIO_BLK_T_GET_ID => RequestType::GetDeviceId,
+            VIRTIO_BLK_T_DISCARD => RequestType::Discard,
+            VIRTIO_BLK_T_WRITE_ZEROES => RequestType::WriteZeroes,
+            t => RequestType::Unsupported(t),
+        };
+        let req_sector = u64::from_le_bytes(hdr[8..16].try_into().unwrap());
 
-        let mut req = Request {
-            request_type: request_type(desc_chain.memory(), hdr_desc_addr)?,
-            sector: sector(desc_chain.memory(), hdr_desc_addr)?,
-            data_descriptors: SmallVec::with_capacity(DEFAULT_DESCRIPTOR_VEC_SIZE),
-            status_addr: GuestAddress(0),
-            writeback: true,
-            start: Instant::now(),
+        let writable_total: u64 = writable.iter().map(|(_, l)| *l as u64).sum();
+        if writable_total < 1 {
+            error!("Missing status descriptor: request type = {req_type:?}");
+            return Err(Error::DescriptorChainTooShort);
+        }
+        let (writable_data, writable_tail) = iovec_split(&writable, writable_total - 1)?;
+        let status_addr = writable_tail[0].0;
+
+        let data_descriptors = match req_type {
+            RequestType::In | RequestType::GetDeviceId => writable_data,
+            RequestType::Out | RequestType::Discard | RequestType::WriteZeroes => {
+                let data = iovec_split(&readable, 16)?.1;
+                if data.is_empty() {
+                    error!("Missing data descriptor: request type = {req_type:?}");
+                    return Err(Error::DescriptorChainTooShort);
+                }
+                data
+            }
+            RequestType::Flush | RequestType::Unsupported(_) => Iovec::new(),
         };
 
-        let status_desc;
-        let mut desc = desc_chain
-            .next_checked(access_platform)
-            .map_err(|addr| Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(addr)))?
-            .ok_or_else(|| {
-                error!("Only head descriptor present: request = {req:?}");
-                Error::DescriptorChainTooShort
-            })?;
-
-        if desc.has_next() {
-            req.data_descriptors.reserve_exact(1);
-            while desc.has_next() {
-                if desc.is_write_only() && req.request_type == RequestType::Out {
-                    return Err(Error::UnexpectedWriteOnlyDescriptor);
-                }
-                if desc.is_write_only() && req.request_type == RequestType::Discard {
-                    return Err(Error::UnexpectedWriteOnlyDescriptor);
-                }
-                if desc.is_write_only() && req.request_type == RequestType::WriteZeroes {
-                    return Err(Error::UnexpectedWriteOnlyDescriptor);
-                }
-                if !desc.is_write_only() && req.request_type == RequestType::In {
-                    return Err(Error::UnexpectedReadOnlyDescriptor);
-                }
-                if !desc.is_write_only() && req.request_type == RequestType::GetDeviceId {
-                    return Err(Error::UnexpectedReadOnlyDescriptor);
-                }
-
-                req.data_descriptors.push((desc.addr(), desc.len()));
-                desc = desc_chain
-                    .next_checked(access_platform)
-                    .map_err(|addr| {
-                        Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(addr))
-                    })?
-                    .ok_or_else(|| {
-                        error!("DescriptorChain corrupted: request = {req:?}");
-                        Error::DescriptorChainTooShort
-                    })?;
-            }
-            status_desc = desc;
-        } else {
-            status_desc = desc;
-            // Only flush requests are allowed to skip the data descriptor.
-            if req.request_type != RequestType::Flush {
-                error!("Need a data descriptor: request = {req:?}");
-                return Err(Error::DescriptorChainTooShort);
-            }
-        }
-
-        // The status MUST always be writable.
-        if !status_desc.is_write_only() {
-            return Err(Error::UnexpectedReadOnlyDescriptor);
-        }
-
-        if status_desc.is_empty() {
-            return Err(Error::DescriptorLengthTooSmall);
-        }
-
-        req.status_addr = status_desc.addr();
-
-        Ok(req)
+        Ok(Request {
+            request_type: req_type,
+            sector: req_sector,
+            data_descriptors,
+            status_addr,
+            writeback: true,
+            start: Instant::now(),
+        })
     }
 
     pub fn execute<T: Seek + Read + Write, B: Bitmap + 'static>(
@@ -650,4 +641,65 @@ impl Request {
         }
         Ok(())
     }
+}
+
+fn iovec_read_bytes<B: Bitmap + 'static>(
+    mem: &vm_memory::GuestMemoryMmap<B>,
+    iov: &[(GuestAddress, u32)],
+    offset: u64,
+    out: &mut [u8],
+) -> Result<(), Error> {
+    let total = out.len();
+    let mut skip = offset;
+    let mut filled = 0usize;
+    for &(addr, len) in iov {
+        let len = len as u64;
+        if skip >= len {
+            skip -= len;
+            continue;
+        }
+        let avail = (len - skip) as usize;
+        let take = avail.min(total - filled);
+        let src = addr
+            .checked_add(skip)
+            .ok_or(Error::CheckedOffset(addr, skip as usize))?;
+        mem.read_slice(&mut out[filled..filled + take], src)
+            .map_err(Error::GuestMemory)?;
+        filled += take;
+        skip = 0;
+        if filled == total {
+            return Ok(());
+        }
+    }
+    Err(Error::DescriptorLengthTooSmall)
+}
+
+fn iovec_split(iov: &[(GuestAddress, u32)], offset: u64) -> Result<(Iovec, Iovec), Error> {
+    let mut head: Iovec = SmallVec::new();
+    let mut tail: Iovec = SmallVec::new();
+    let mut consumed = 0u64;
+    for &(addr, len) in iov {
+        let len_u64 = len as u64;
+        if consumed >= offset {
+            tail.push((addr, len));
+            continue;
+        }
+        if consumed + len_u64 <= offset {
+            head.push((addr, len));
+            consumed += len_u64;
+            continue;
+        }
+        let take = (offset - consumed) as u32;
+        head.push((addr, take));
+        let rem_len = len - take;
+        let rem_addr = addr
+            .checked_add(take as u64)
+            .ok_or(Error::CheckedOffset(addr, take as usize))?;
+        tail.push((rem_addr, rem_len));
+        consumed = offset;
+    }
+    if consumed < offset {
+        return Err(Error::DescriptorLengthTooSmall);
+    }
+    Ok((head, tail))
 }

--- a/block/src/io/request.rs
+++ b/block/src/io/request.rs
@@ -703,3 +703,55 @@ fn iovec_split(iov: &[(GuestAddress, u32)], offset: u64) -> Result<(Iovec, Iovec
     }
     Ok((head, tail))
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
+
+    use super::{Error, iovec_read_bytes, iovec_split};
+
+    fn make_mem() -> GuestMemoryMmap<()> {
+        GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1_0000)]).unwrap()
+    }
+
+    #[test]
+    fn iovec_read_bytes_spans_descriptors() {
+        let mem = make_mem();
+        let a = GuestAddress(0x1000);
+        let b = GuestAddress(0x2000);
+        mem.write_slice(&[0xAA; 4], a).unwrap();
+        mem.write_slice(&[0xBB; 12], b).unwrap();
+        let iov = [(a, 4u32), (b, 12u32)];
+        let mut out = [0u8; 16];
+        iovec_read_bytes(&mem, &iov, 0, &mut out).unwrap();
+        assert_eq!(&out[..4], &[0xAA; 4]);
+        assert_eq!(&out[4..], &[0xBB; 12]);
+    }
+
+    #[test]
+    fn iovec_read_bytes_short_iov_errors() {
+        let mem = make_mem();
+        let iov = [(GuestAddress(0x1000), 8u32)];
+        let mut out = [0u8; 16];
+        assert!(matches!(
+            iovec_read_bytes(&mem, &iov, 0, &mut out),
+            Err(Error::DescriptorLengthTooSmall)
+        ));
+    }
+
+    #[test]
+    fn iovec_split_at_boundary() {
+        let iov = [(GuestAddress(0x1000), 8u32), (GuestAddress(0x2000), 16u32)];
+        let (head, tail) = iovec_split(&iov, 8).unwrap();
+        assert_eq!(head.as_slice(), &[(GuestAddress(0x1000), 8)]);
+        assert_eq!(tail.as_slice(), &[(GuestAddress(0x2000), 16)]);
+    }
+
+    #[test]
+    fn iovec_split_inside_descriptor() {
+        let iov = [(GuestAddress(0x1000), 20u32)];
+        let (head, tail) = iovec_split(&iov, 16).unwrap();
+        assert_eq!(head.as_slice(), &[(GuestAddress(0x1000), 16)]);
+        assert_eq!(tail.as_slice(), &[(GuestAddress(0x1010), 4)]);
+    }
+}

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -39,8 +39,7 @@ use serde::{Deserialize, Serialize};
 pub use sparse::{BLKDISCARD, BLKZEROOUT};
 use thiserror::Error;
 use virtio_bindings::virtio_blk::*;
-use vm_memory::bitmap::Bitmap;
-use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError};
+use vm_memory::{ByteValued, GuestAddress, GuestMemoryError};
 use vmm_sys_util::{aio, ioctl_io_nr, ioctl_ior_nr};
 
 use crate::async_io::AsyncIoError;
@@ -178,35 +177,6 @@ impl ExecuteError {
         };
         status as u8
     }
-}
-
-pub fn request_type<B: Bitmap + 'static>(
-    mem: &vm_memory::GuestMemoryMmap<B>,
-    desc_addr: GuestAddress,
-) -> result::Result<RequestType, Error> {
-    let type_ = mem.read_obj(desc_addr).map_err(Error::GuestMemory)?;
-    match type_ {
-        VIRTIO_BLK_T_IN => Ok(RequestType::In),
-        VIRTIO_BLK_T_OUT => Ok(RequestType::Out),
-        VIRTIO_BLK_T_FLUSH => Ok(RequestType::Flush),
-        VIRTIO_BLK_T_GET_ID => Ok(RequestType::GetDeviceId),
-        VIRTIO_BLK_T_DISCARD => Ok(RequestType::Discard),
-        VIRTIO_BLK_T_WRITE_ZEROES => Ok(RequestType::WriteZeroes),
-        t => Ok(RequestType::Unsupported(t)),
-    }
-}
-
-fn sector<B: Bitmap + 'static>(
-    mem: &vm_memory::GuestMemoryMmap<B>,
-    desc_addr: GuestAddress,
-) -> result::Result<u64, Error> {
-    const SECTOR_OFFSET: usize = 8;
-    let addr = match mem.checked_offset(desc_addr, SECTOR_OFFSET) {
-        Some(v) => v,
-        None => return Err(Error::CheckedOffset(desc_addr, SECTOR_OFFSET)),
-    };
-
-    mem.read_obj(addr).map_err(Error::GuestMemory)
 }
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]


### PR DESCRIPTION
The current request parser rejects descriptor chains that the virtio 1.x spec allows. Virtio 1.3 section 2.7.4.2 only mandates that any device writable descriptors come after any device readable ones. It does not tie the request type header, the data region, or the status byte to specific descriptor positions or boundaries.

The existing parser instead binds those logical fields to descriptor positions. The header must be one descriptor of at least 16 bytes, the data must occupy its own descriptors, and the status must be a separate writable descriptor at the end. As a result, three valid layouts are wrongly rejected:

- header split across multiple descriptors
- one readable descriptor carrying both the header and OUT data
- one writable descriptor carrying both IN data and the status byte

Fixed by rewriting `Request::parse` to accept any spec conformant layout. In practice no shipping guest driver uses them, so no user visible workload is affected. This is a spec conformance and compatibility fix.

Fixes: #8304