### PR TITLE
tests: add support for KVM SEV-SNP integration tests

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -2545,7 +2545,7 @@ pub(crate) fn _test_direct_kernel_boot_noacpi(guest: &Guest) {
         guest.wait_vm_boot().unwrap();
 
         assert_eq!(guest.get_cpu_count().unwrap_or_default(), 1);
-        assert!(guest.get_total_memory().unwrap_or_default() > 480_000);
+        guest.validate_memory(None);
     });
 
     kill_child(&mut child);
@@ -2648,10 +2648,16 @@ pub(crate) fn _test_memory_overhead(guest: &Guest, guest_memory_size_kb: u32) {
 
     guest.wait_vm_boot().unwrap();
 
+    let max_overhead = if on_kvm_sev_snp() {
+        MAXIMUM_VMM_OVERHEAD_KB_SEV_SNP
+    } else {
+        MAXIMUM_VMM_OVERHEAD_KB
+    };
+
     let r = std::panic::catch_unwind(|| {
         let overhead = get_vmm_overhead(child.id(), guest_memory_size_kb);
-        eprintln!("Guest memory overhead: {overhead} vs {MAXIMUM_VMM_OVERHEAD_KB}");
-        assert!(overhead <= MAXIMUM_VMM_OVERHEAD_KB);
+        eprintln!("Guest memory overhead: {overhead} vs {max_overhead}");
+        assert!(overhead <= max_overhead);
     });
 
     kill_child(&mut child);

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -23,6 +23,8 @@ use wait_timeout::ChildExt;
 const QCOW2_INCOMPATIBLE_FEATURES_OFFSET: u64 = 72;
 // 10MB is our maximum accepted overhead.
 pub(crate) const MAXIMUM_VMM_OVERHEAD_KB: u32 = 10 * 1024;
+// The KVM SEV-SNP build (igvm+sev_snp+fw_cfg) has a larger size
+pub(crate) const MAXIMUM_VMM_OVERHEAD_KB_SEV_SNP: u32 = 12 * 1024;
 
 // This enum exists to make it more convenient to
 // implement test for both D-Bus and REST APIs.

--- a/cloud-hypervisor/tests/integration_cvm.rs
+++ b/cloud-hypervisor/tests/integration_cvm.rs
@@ -98,6 +98,7 @@ mod common_cvm {
     }
 
     #[test]
+    #[cfg(not(feature = "kvm"))]
     fn test_pci_multiple_segments() {
         // Use 8 segments to test the multiple segment support since it's more than the default 6
         //  supported by Linux
@@ -208,18 +209,21 @@ mod common_cvm {
     }
 
     #[test]
+    #[cfg(not(feature = "kvm"))]
     fn test_dmi_uuid() {
         let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
         _test_dmi_uuid(&guest);
     }
 
     #[test]
+    #[cfg(not(feature = "kvm"))]
     fn test_dmi_oem_strings() {
         let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
         _test_dmi_oem_strings(&guest);
     }
 
     #[test]
+    #[cfg(not(feature = "kvm"))]
     fn test_dmi_system_and_chassis() {
         let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
         _test_dmi_system_and_chassis(&guest);
@@ -324,6 +328,7 @@ mod common_cvm {
     }
 
     #[test]
+    #[cfg(not(feature = "kvm"))]
     fn test_vdpa_block() {
         assert!(exec_host_command_status("lsmod | grep vdpa_sim_blk").success());
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -354,6 +354,33 @@ mshv,igvm,sev_snp` and requires IGVM files to be present at
 
 **Test group:** `common_cvm` (`nproc / 4` threads, retries 3).
 
+#### KVM SEV-SNP
+
+```shell
+scripts/dev_cli.sh tests --integration-cvm --hypervisor kvm
+```
+
+With `--hypervisor kvm` the script builds with `--features
+kvm,igvm,sev_snp,fw_cfg`. On KVM the IGVM is an Oak stage0 firmware image
+and the guest kernel is supplied separately (read by stage0 over fw_cfg);
+the harness selects this boot model when a guest kernel is present at
+`/igvm_files/bzImage`. When no `--test-filter`
+is given it runs the full `common_cvm` set.
+
+Prerequisites:
+
+- An AMD SEV-SNP-capable KVM host with `/dev/kvm` and `/dev/sev` present
+  and SNP enabled.
+- A KVM-bootable stage0 IGVM file at `/usr/share/cloud-hypervisor/cvm` and
+  a guest kernel at `/igvm_files/bzImage`.
+
+To scope the run to a single test explicitly:
+
+```shell
+scripts/dev_cli.sh tests --integration-cvm --hypervisor kvm \
+    -- --test-filter test_jammy_simple_launch
+```
+
 ## Performance metrics
 
 ```shell

--- a/fuzz/fuzz_targets/iommu.rs
+++ b/fuzz/fuzz_targets/iommu.rs
@@ -67,6 +67,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
         EventFd::new(EFD_NONBLOCK).unwrap(),
         ((MEM_SIZE - IOVA_SPACE_SIZE) as u64, (MEM_SIZE - 1) as u64),
         64,
+        false,
         None,
     )
     .unwrap();

--- a/fuzz/fuzz_targets/watchdog.rs
+++ b/fuzz/fuzz_targets/watchdog.rs
@@ -37,6 +37,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
 
     let mut watchdog = virtio_devices::Watchdog::new(
         "fuzzer_watchdog".to_owned(),
+        false,
         EventFd::new(EFD_NONBLOCK).unwrap(),
         SeccompAction::Allow,
         EventFd::new(EFD_NONBLOCK).unwrap(),

--- a/scripts/run_integration_tests_cvm.sh
+++ b/scripts/run_integration_tests_cvm.sh
@@ -12,8 +12,12 @@ mkdir -p "$WORKLOADS_DIR/junit"
 
 process_common_args "$@"
 
-test_features="--features mshv,igvm,sev_snp"
-build_features="mshv,igvm,sev_snp"
+if [ "$hypervisor" = "mshv" ]; then
+    build_features="mshv,igvm,sev_snp"
+else # kvm
+    build_features="kvm,igvm,sev_snp,fw_cfg"
+fi
+test_features="--features $build_features"
 
 JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
 JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1804,7 +1804,11 @@ impl Guest {
             .or_else(|| self.get_expected_memory())
             .unwrap_or_default();
 
-        assert!(self.get_total_memory().unwrap_or_default() > memory);
+        let total = self.get_total_memory().unwrap_or_default();
+        assert!(
+            total > memory,
+            "guest MemTotal {total} kB is not greater than expected {memory} kB"
+        );
     }
 }
 

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1411,6 +1411,14 @@ impl Guest {
             "cmdline": self.kernel_cmdline.as_deref().unwrap(),
             "host_data": generate_host_data(),
             });
+            // On the KVM direct-kernel path the kernel is supplied separately
+            // and read by stage0 over fw_cfg (see on_kvm_sev_snp).
+            if let Some(kernel) = sev_snp_direct_kernel() {
+                body["payload"]["kernel"] = serde_json::json!(kernel.to_str().unwrap());
+                body["payload"]["fw_cfg_config"] = serde_json::json!({
+                    "initramfs": false,
+                });
+            }
         } else {
             body["payload"] = serde_json::json!({
             "kernel": self.kernel_path.as_deref().unwrap(),
@@ -2027,6 +2035,19 @@ impl<'a> GuestCommand<'a> {
                 "--igvm",
                 igvm.to_str().expect("IGVM path is not valid UTF-8"),
             ]);
+            // On the KVM direct-kernel path the kernel is supplied separately
+            // (see on_kvm_sev_snp); pass it plus the guest cmdline so
+            // console/serial tests route output as in a regular direct boot.
+            if let Some(kernel) = sev_snp_direct_kernel() {
+                self.command.args([
+                    "--kernel",
+                    kernel.to_str().expect("kernel path is not valid UTF-8"),
+                ]);
+                if let Some(cmdline) = &self.guest.kernel_cmdline {
+                    self.command.args(["--cmdline", cmdline]);
+                }
+                self.command.args(["--fw-cfg-config", "initramfs=off"]);
+            }
             self.command
                 .args(["--host-data", generate_host_data().as_str()]);
             self.command.args([
@@ -2540,6 +2561,16 @@ impl Display for GuestVmType {
             GuestVmType::Confidential => write!(f, "confidential"),
         }
     }
+}
+
+fn sev_snp_direct_kernel() -> Option<PathBuf> {
+    let kernel_path = PathBuf::from("/igvm_files/bzImage");
+    kernel_path.exists().then_some(kernel_path)
+}
+
+// True on the KVM SEV-SNP direct-kernel path.
+pub fn on_kvm_sev_snp() -> bool {
+    sev_snp_direct_kernel().is_some()
 }
 
 // Get the direct igvm boot file path based on the console type

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -27,7 +27,8 @@ use vmm_sys_util::eventfd::EventFd;
 
 use super::{
     ActivateResult, EPOLL_HELPER_EVENT_LAST, EpollHelper, EpollHelperError, EpollHelperHandler,
-    Error as DeviceError, VIRTIO_F_VERSION_1, VirtioCommon, VirtioDevice, VirtioDeviceType,
+    Error as DeviceError, VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_VERSION_1, VirtioCommon, VirtioDevice,
+    VirtioDeviceType,
 };
 use crate::seccomp_filters::Thread;
 use crate::{DmaRemapping, GuestMemoryMmap, VirtioInterrupt, VirtioInterruptType};
@@ -1117,6 +1118,7 @@ impl Iommu {
         exit_evt: EventFd,
         msi_iova_space: (u64, u64),
         address_width_bits: u8,
+        access_platform_enabled: bool,
         state: Option<IommuState>,
     ) -> io::Result<(Self, Arc<IommuMapping>)> {
         let (mut avail_features, acked_features, endpoints, domains, paused) =
@@ -1164,6 +1166,10 @@ impl Iommu {
         } else {
             None
         };
+
+        if access_platform_enabled {
+            avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
+        }
 
         let mapping = Arc::new(IommuMapping {
             endpoints: Arc::new(RwLock::new(endpoints)),

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -27,8 +27,8 @@ use vmm_sys_util::eventfd::EventFd;
 
 use super::{
     ActivateError, ActivateResult, EPOLL_HELPER_EVENT_LAST, EpollHelper, EpollHelperError,
-    EpollHelperHandler, Error as DeviceError, VIRTIO_F_VERSION_1, VirtioCommon, VirtioDevice,
-    VirtioDeviceType,
+    EpollHelperHandler, Error as DeviceError, VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_VERSION_1,
+    VirtioCommon, VirtioDevice, VirtioDeviceType,
 };
 use crate::seccomp_filters::Thread;
 use crate::{GuestMemoryMmap, VirtioInterrupt, VirtioInterruptType};
@@ -208,6 +208,7 @@ impl Watchdog {
     /// Create a new virtio watchdog device that will reboot VM if the guest hangs
     pub fn new(
         id: String,
+        access_platform_enabled: bool,
         reset_evt: EventFd,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
@@ -226,7 +227,11 @@ impl Watchdog {
 
             (state.avail_features, state.acked_features, true)
         } else {
-            (1u64 << VIRTIO_F_VERSION_1, 0, false)
+            let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
+            if access_platform_enabled {
+                avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
+            }
+            (avail_features, 0, false)
         };
 
         let timer_fd = timerfd_create().map_err(|e| {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1673,6 +1673,7 @@ impl DeviceManager {
                     .map_err(DeviceManagerError::EventFd)?,
                 self.get_msi_iova_space(),
                 iommu_address_width_bits,
+                self.force_access_platform,
                 state_from_id(snapshot, iommu_id.as_str())
                     .map_err(DeviceManagerError::RestoreGetState)?,
             )
@@ -3728,6 +3729,7 @@ impl DeviceManager {
         let virtio_watchdog_device = Arc::new(Mutex::new(
             virtio_devices::Watchdog::new(
                 id.clone(),
+                self.force_access_platform,
                 self.reset_evt.try_clone().unwrap(),
                 self.seccomp_action.clone(),
                 self.exit_evt

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -12,6 +12,8 @@ use libc::{
     TIOCSPTLCK, TUNGETFEATURES, TUNGETIFF, TUNSETIFF, TUNSETOFFLOAD, TUNSETVNETHDRSZ,
 };
 use seccompiler::SeccompCmpOp::Eq;
+#[cfg(all(feature = "sev_snp", feature = "kvm"))]
+use seccompiler::SeccompCmpOp::MaskedEq;
 use seccompiler::{
     BackendError, BpfProgram, Error, SeccompAction, SeccompCmpArgLen as ArgLen,
     SeccompCondition as Cond, SeccompFilter, SeccompRule,
@@ -969,7 +971,19 @@ fn http_api_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError>
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
         (libc::SYS_munmap, vec![]),
+        #[cfg(all(feature = "sev_snp", feature = "kvm"))]
+        (
+            libc::SYS_openat,
+            or![and![Cond::new(
+                2, // openat() flags argument
+                ArgLen::Dword,
+                MaskedEq(libc::O_ACCMODE as u64),
+                libc::O_RDONLY as u64,
+            )?]],
+        ),
         (libc::SYS_prctl, vec![]),
+        #[cfg(all(feature = "sev_snp", feature = "kvm"))]
+        (libc::SYS_read, vec![]),
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_rt_sigprocmask, vec![]),

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -1242,6 +1242,11 @@ impl VmConfig {
             payload.apply_landlock(&mut landlock)?;
         }
 
+        #[cfg(feature = "sev_snp")]
+        if self.platform.as_ref().is_some_and(|p| p.sev_snp) {
+            landlock.add_rule_with_access(Path::new("/dev/sev"), "rw")?;
+        }
+
         if let Some(tpm_config) = &self.tpm {
             tpm_config.apply_landlock(&mut landlock)?;
         }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -939,6 +939,7 @@ pub struct PayloadConfig {
 #[cfg(feature = "fw_cfg")]
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(default)]
 pub struct FwCfgConfig {
     pub e820: bool,
     pub kernel: bool,


### PR DESCRIPTION
#### Summary
This PR enables the confidential-VM integration tests on the KVM SEV-SNP backend, which previously only ran on MSHV. 

The harness now understands KVM's boot model — a stage0 firmware image with the kernel passed separately over fw_cfg. This also fixes some VMM-side issues:
- virtio devices advertise VIRTIO_F_ACCESS_PLATFORM for confidential DMA
- landlock allows opening /dev/sev
- and seccomp no longer kills the HTTP API thread.

Some tests do not work on KVM yet and are kept MSHV-only.

#### Testing
```
scripts/dev_cli.sh tests --integration-cvm --hypervisor kvm
...
    Starting 39 tests across 5 binaries (230 tests skipped, including 227 tests via profile.cvm_kvm.default-filter)
        PASS [   8.216s] ( 1/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_block_qcow2_backing_raw_file
        PASS [  10.938s] ( 2/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_block_qcow2_backing_zstd_file
        PASS [  11.867s] ( 3/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_block_qcow2_backing_uncompressed_file
        PASS [  12.034s] ( 4/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_block_qcow2_zstd
        PASS [  13.448s] ( 5/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_block_qcow2_zlib
        PASS [  16.571s] ( 6/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_queue_affinity
        PASS [  17.155s] ( 7/39) cloud-hypervisor::integration_cvm common_cvm::test_counters
        PASS [  17.336s] ( 8/39) cloud-hypervisor::integration_cvm common_cvm::test_console_file
        PASS [  17.872s] ( 9/39) cloud-hypervisor::integration_cvm common_cvm::test_cpu_affinity
        PASS [  18.163s] (10/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_block_qcow2
        PASS [  18.225s] (11/39) cloud-hypervisor::integration_cvm common_cvm::test_memory_overhead
        PASS [  18.428s] (12/39) cloud-hypervisor::integration_cvm common_cvm::test_pci_bar_reprogramming
        PASS [  18.444s] (13/39) cloud-hypervisor::integration_cvm common_cvm::test_api_http_create_boot
        PASS [  18.831s] (14/39) cloud-hypervisor::integration_cvm common_cvm::test_landlock
        PASS [  18.911s] (15/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_net_ctrl_queue
        PASS [  18.923s] (16/39) cloud-hypervisor::integration_cvm common_cvm::test_split_irqchip
        PASS [  19.080s] (17/39) cloud-hypervisor::integration_cvm common_cvm::test_multi_cpu
        PASS [  19.097s] (18/39) cloud-hypervisor::integration_cvm common_cvm::test_direct_kernel_boot_noacpi
        PASS [  19.109s] (19/39) cloud-hypervisor::integration_cvm common_cvm::test_pci_msi
        PASS [  19.359s] (20/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_block_sync
        PASS [  19.405s] (21/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_block_aio
        PASS [  19.460s] (22/39) cloud-hypervisor::integration_cvm common_cvm::test_power_button
        PASS [  19.634s] (23/39) cloud-hypervisor::integration_cvm common_cvm::test_serial_off
        PASS [  20.113s] (24/39) cloud-hypervisor::integration_cvm common_cvm::test_direct_kernel_boot
        PASS [  20.376s] (25/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_console
        PASS [  20.627s] (26/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_block_io_uring
        PASS [  20.690s] (27/39) cloud-hypervisor::integration_cvm common_cvm::test_multiple_network_interfaces
        PASS [  21.304s] (28/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_block_dynamic_vhdx_expand
        PASS [  23.173s] (29/39) cloud-hypervisor::integration_cvm common_cvm::test_tap_from_fd
        PASS [  24.024s] (30/39) cloud-hypervisor::integration_cvm common_cvm::test_pvpanic
        PASS [  24.459s] (31/39) cloud-hypervisor::integration_cvm common_cvm::test_macvtap
        PASS [  24.758s] (32/39) cloud-hypervisor::integration_cvm common_cvm::test_api_http_shutdown
        PASS [  25.333s] (33/39) cloud-hypervisor::integration_cvm common_cvm::test_macvtap_hotplug
        PASS [  25.854s] (34/39) cloud-hypervisor::integration_cvm common_cvm::test_api_http_delete
        PASS [  27.226s] (35/39) cloud-hypervisor::integration_cvm common_cvm::test_net_hotplug
        PASS [  34.162s] (36/39) cloud-hypervisor::integration_cvm common_cvm::test_disk_hotplug
        PASS [  45.556s] (37/39) cloud-hypervisor::integration_cvm common_cvm::test_virtio_vsock
  TRY 1 SLOW [> 60.000s] (───────) cloud-hypervisor::integration_cvm common_cvm::test_jammy_simple_launch
  TRY 1 SLOW [> 60.000s] (───────) cloud-hypervisor::integration_cvm common_cvm::test_watchdog
        PASS [ 100.411s] (38/39) cloud-hypervisor::integration_cvm common_cvm::test_watchdog
  TRY 1 SLOW [>120.000s] (───────) cloud-hypervisor::integration_cvm common_cvm::test_jammy_simple_launch
  TRY 1 SLOW [>180.000s] (───────) cloud-hypervisor::integration_cvm common_cvm::test_jammy_simple_launch
  TRY 1 SLOW [>240.000s] (───────) cloud-hypervisor::integration_cvm common_cvm::test_jammy_simple_launch
  TRY 1 SLOW [>300.000s] (───────) cloud-hypervisor::integration_cvm common_cvm::test_jammy_simple_launch
        PASS [ 324.996s] (39/39) cloud-hypervisor::integration_cvm common_cvm::test_jammy_simple_launch
────────────
     Summary [ 324.997s] 39 tests run: 39 passed (2 slow), 230 skipped

real	5m28.423s
user	6m19.957s
sys	3m8.177s
+ RES=0

```