### PR TITLE
README: update guest kernel version to ch-6.16.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ To build the kernel:
 
 ```shell
 # Clone the Cloud Hypervisor Linux branch
-$ git clone --depth 1 https://github.com/cloud-hypervisor/linux.git -b ch-6.12.8 linux-cloud-hypervisor
+$ git clone --depth 1 https://github.com/cloud-hypervisor/linux.git -b ch-6.16.9 linux-cloud-hypervisor
 $ pushd linux-cloud-hypervisor
 $ make ch_defconfig
 # Do native build of the x86-64 kernel


### PR DESCRIPTION
The guest kernel build instructions in the README referenced the ch-6.12.8 branch, which was inconsistent with the version used by the test scripts (scripts/test-util.sh uses ch-6.16.9). Update the README to point at ch-6.16.9 so documentation and CI stay in sync.