### PR TITLE
block: vhdx: use logical sector size for block transfers

### DIFF
--- a/block/src/formats/vhdx/internal/io.rs
+++ b/block/src/formats/vhdx/internal/io.rs
@@ -11,8 +11,6 @@ use thiserror::Error;
 use super::bat::{self, BatEntry, VhdxBatError};
 use super::metadata::{self, DiskSpec};
 
-const SECTOR_SIZE: u64 = 512;
-
 #[sorted]
 #[derive(Error, Debug)]
 pub enum VhdxIoError {
@@ -116,11 +114,8 @@ pub fn read(
             bat::PAYLOAD_BLOCK_FULLY_PRESENT => {
                 f.seek(SeekFrom::Start(sector.file_offset))
                     .map_err(VhdxIoError::ReadSectorBlock)?;
-                f.read_exact(
-                    &mut buf
-                        [read_count..(read_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
-                )
-                .map_err(VhdxIoError::ReadSectorBlock)?;
+                f.read_exact(&mut buf[read_count..(read_count + sector.free_bytes as usize)])
+                    .map_err(VhdxIoError::ReadSectorBlock)?;
             }
             bat::PAYLOAD_BLOCK_PARTIALLY_PRESENT => {
                 return Err(VhdxIoError::UnsupportedMode);
@@ -186,10 +181,8 @@ pub fn write(
 
                 f.seek(SeekFrom::Start(file_offset))
                     .map_err(VhdxIoError::ReadSectorBlock)?;
-                f.write_all(
-                    &buf[write_count..(write_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
-                )
-                .map_err(VhdxIoError::ReadSectorBlock)?;
+                f.write_all(&buf[write_count..(write_count + sector.free_bytes as usize)])
+                    .map_err(VhdxIoError::ReadSectorBlock)?;
             }
             bat::PAYLOAD_BLOCK_FULLY_PRESENT => {
                 if sector.file_offset < metadata::BLOCK_SIZE_MIN as u64 {
@@ -198,10 +191,8 @@ pub fn write(
 
                 f.seek(SeekFrom::Start(sector.file_offset))
                     .map_err(VhdxIoError::ReadSectorBlock)?;
-                f.write_all(
-                    &buf[write_count..(write_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
-                )
-                .map_err(VhdxIoError::ReadSectorBlock)?;
+                f.write_all(&buf[write_count..(write_count + sector.free_bytes as usize)])
+                    .map_err(VhdxIoError::ReadSectorBlock)?;
             }
             bat::PAYLOAD_BLOCK_PARTIALLY_PRESENT => {
                 return Err(VhdxIoError::UnsupportedMode);

--- a/block/src/formats/vhdx/internal/mod.rs
+++ b/block/src/formats/vhdx/internal/mod.rs
@@ -94,14 +94,32 @@ impl Vhdx {
     pub fn virtual_disk_size(&self) -> u64 {
         self.disk_spec.virtual_disk_size
     }
+
+    /// Translate the current offset and a transfer length in bytes to a
+    /// sector index and count. I/O is performed in whole logical sectors,
+    /// so both the offset and the length must be multiples of the logical
+    /// sector size.
+    fn sector_span(&self, len: usize) -> std::result::Result<(u64, u64), std::io::Error> {
+        let sector_size = self.disk_spec.logical_sector_size as u64;
+        if self.current_offset % sector_size != 0 || len as u64 % sector_size != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "Unaligned VHDx access of {len} bytes at offset {} (logical sector size is {sector_size})",
+                    self.current_offset
+                ),
+            ));
+        }
+
+        Ok((self.current_offset / sector_size, len as u64 / sector_size))
+    }
 }
 
 impl Read for Vhdx {
     /// Wrapper function to satisfy Read trait implementation for VHDx disk.
     /// Convert the offset to sector index and buffer length to sector count.
     fn read(&mut self, buf: &mut [u8]) -> std::result::Result<usize, std::io::Error> {
-        let sector_count = (buf.len() as u64).div_ceil(self.disk_spec.logical_sector_size as u64);
-        let sector_index = self.current_offset / self.disk_spec.logical_sector_size as u64;
+        let (sector_index, sector_count) = self.sector_span(buf.len())?;
 
         let result = io::read(
             &mut self.file,
@@ -131,8 +149,7 @@ impl Write for Vhdx {
     /// Wrapper function to satisfy Write trait implementation for VHDx disk.
     /// Convert the offset to sector index and buffer length to sector count.
     fn write(&mut self, buf: &[u8]) -> std::result::Result<usize, std::io::Error> {
-        let sector_count = (buf.len() as u64).div_ceil(self.disk_spec.logical_sector_size as u64);
-        let sector_index = self.current_offset / self.disk_spec.logical_sector_size as u64;
+        let (sector_index, sector_count) = self.sector_span(buf.len())?;
 
         if self.first_write {
             self.first_write = false;


### PR DESCRIPTION
**Wrong transfer length for VHDX images with 4K logical sectors**

`read` and `write` size each block transfer as `free_sectors * 512`, yet the loop cursor advances by `free_sectors * logical_sector_size`, so a 4096-byte-sector image moves only an eighth of every block and `read` can return more bytes than the destination buffer holds (a 512-byte read then panics in the caller on `&buf[..result]`). Switched the three sites to the already-computed `free_bytes`, which leaves 512-byte images byte-for-byte unchanged.

The byte-to-sector conversion in the `Read`/`Write` wrappers had the same assumption baked in: it rounded the sector count up and the offset down, so a sub-sector request made `io::read` slice past the end of the buffer and an unaligned offset silently transferred the wrong sector. Requests whose offset or length isn't a multiple of the logical sector size are now rejected with `InvalidInput`, which guarantees `sector_count * logical_sector_size == buf.len()` by the time `io::read`/`io::write` run.