### PR TITLE
api_client: trim qualified paths

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -3,24 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::os::unix::io::RawFd;
+use std::{num, str};
 
 use thiserror::Error;
+use vmm_sys_util::errno;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Error writing to or reading from HTTP socket")]
-    Socket(#[source] std::io::Error),
+    Socket(#[source] io::Error),
     #[error("Error sending file descriptors")]
-    SocketSendFds(#[source] vmm_sys_util::errno::Error),
+    SocketSendFds(#[source] errno::Error),
     #[error("Error parsing HTTP status code")]
-    StatusCodeParsing(#[source] std::num::ParseIntError),
+    StatusCodeParsing(#[source] num::ParseIntError),
     #[error("HTTP output is missing protocol statement")]
     MissingProtocol,
     #[error("Error parsing HTTP Content-Length field")]
-    ContentLengthParsing(#[source] std::num::ParseIntError),
+    ContentLengthParsing(#[source] num::ParseIntError),
     #[error("Server responded with error {0:?}: {1:?}")]
     ServerResponse(
         StatusCode,
@@ -100,7 +102,7 @@ fn parse_http_response(socket: &mut dyn Read) -> Result<Option<String>, Error> {
         if count == 0 {
             break;
         }
-        res.push_str(std::str::from_utf8(&bytes[0..count]).unwrap());
+        res.push_str(str::from_utf8(&bytes[0..count]).unwrap());
 
         // End of headers
         if let Some(o) = res.find("\r\n\r\n") {


### PR DESCRIPTION
Part of #7670.

Import the std modules used in the crate instead of spelling the
fully-qualified paths at every use site:

- `std::io::Error` → `io::Error` (`use std::io::{self, ..}`)
- `std::num::ParseIntError` → `num::ParseIntError`
- `std::str::from_utf8` → `str::from_utf8`
- `vmm_sys_util::errno::Error` → `errno::Error`

Readability-only change; no functional impact. Follows the same approach as
the merged #8273 (tdx), #8344 (serial_buffer), #8345 (net_util) and #8349
(option_parser) cleanups.