### PR TITLE
vm-migration: trim qualified paths

### DIFF
--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
+use std::collections::BTreeMap;
+use std::{io, result};
+
 use anyhow::anyhow;
 pub use context::{
     CompletedMigrationContext, DowntimeContext, MemoryMigrationContext, MigrationContextError,
@@ -23,7 +26,7 @@ pub enum UffdError {
     UnalignedRanges,
 
     #[error("Failed to create userfaultfd")]
-    Create(#[source] std::io::Error),
+    Create(#[source] io::Error),
 
     #[error("Cannot translate GPA {gpa:#x} to host address")]
     GpaTranslation {
@@ -37,20 +40,20 @@ pub enum UffdError {
         addr: u64,
         len: u64,
         #[source]
-        source: std::io::Error,
+        source: io::Error,
     },
 
     #[error("Region at {addr:#x}+{len:#x} missing COPY/WAKE support")]
     MissingIoctlSupport { addr: u64, len: u64 },
 
     #[error("Failed to spawn handler thread")]
-    SpawnThread(#[source] std::io::Error),
+    SpawnThread(#[source] io::Error),
 
     #[error("Handler terminated before startup completed")]
     HandlerStartup,
 
     #[error("Handler failed after startup")]
-    HandlerFailed(#[source] std::io::Error),
+    HandlerFailed(#[source] io::Error),
 }
 
 #[derive(Error, Debug)]
@@ -77,7 +80,7 @@ pub enum MigratableError {
     OnDemandRestore(#[source] UffdError),
 
     #[error("Socket error")]
-    MigrateSocket(#[source] std::io::Error),
+    MigrateSocket(#[source] io::Error),
 
     #[error("Failed to start migration for migratable component")]
     StartDirtyLog(#[source] anyhow::Error),
@@ -104,12 +107,12 @@ pub enum MigratableError {
 /// A Pausable component can be paused and resumed.
 pub trait Pausable {
     /// Pause the component.
-    fn pause(&mut self) -> std::result::Result<(), MigratableError> {
+    fn pause(&mut self) -> result::Result<(), MigratableError> {
         Ok(())
     }
 
     /// Resume the component.
-    fn resume(&mut self) -> std::result::Result<(), MigratableError> {
+    fn resume(&mut self) -> result::Result<(), MigratableError> {
         Ok(())
     }
 }
@@ -163,7 +166,7 @@ impl SnapshotData {
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct Snapshot {
     /// The Snapshottable component snapshots.
-    pub snapshots: std::collections::BTreeMap<String, Snapshot>,
+    pub snapshots: BTreeMap<String, Snapshot>,
 
     /// The Snapshottable component's snapshot data.
     /// A map of snapshot sections, indexed by the section ids.
@@ -226,7 +229,7 @@ pub trait Snapshottable: Pausable {
     }
 
     /// Take a component snapshot.
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         Ok(Snapshot::default())
     }
 }
@@ -247,7 +250,7 @@ pub trait Transportable: Pausable + Snapshottable {
         &self,
         _snapshot: &Snapshot,
         _destination_url: &str,
-    ) -> std::result::Result<(), MigratableError> {
+    ) -> result::Result<(), MigratableError> {
         Ok(())
     }
 
@@ -257,7 +260,7 @@ pub trait Transportable: Pausable + Snapshottable {
     ///
     /// * `source_url` - The source URL to fetch the snapshot from. This could be an HTTP
     ///   endpoint, a TCP address or a local file.
-    fn recv(&self, _source_url: &str) -> std::result::Result<Snapshot, MigratableError> {
+    fn recv(&self, _source_url: &str) -> result::Result<Snapshot, MigratableError> {
         Ok(Snapshot::default())
     }
 }
@@ -271,23 +274,23 @@ pub trait Transportable: Pausable + Snapshottable {
 /// Moreover a migratable component can be transported to a remote or local
 /// destination and thus must be Transportable.
 pub trait Migratable: Send + Pausable + Snapshottable + Transportable {
-    fn start_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
+    fn start_dirty_log(&mut self) -> result::Result<(), MigratableError> {
         Ok(())
     }
 
-    fn stop_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
+    fn stop_dirty_log(&mut self) -> result::Result<(), MigratableError> {
         Ok(())
     }
 
-    fn dirty_log(&mut self) -> std::result::Result<MemoryRangeTable, MigratableError> {
+    fn dirty_log(&mut self) -> result::Result<MemoryRangeTable, MigratableError> {
         Ok(MemoryRangeTable::default())
     }
 
-    fn start_migration(&mut self) -> std::result::Result<(), MigratableError> {
+    fn start_migration(&mut self) -> result::Result<(), MigratableError> {
         Ok(())
     }
 
-    fn complete_migration(&mut self) -> std::result::Result<(), MigratableError> {
+    fn complete_migration(&mut self) -> result::Result<(), MigratableError> {
         Ok(())
     }
 }

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -75,6 +75,7 @@
 //! ```
 
 use std::io::{Read, Write};
+use std::{mem, slice};
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -440,7 +441,7 @@ impl MemoryRangeTable {
         // `MemoryRange`s so the memory is valid for `length` bytes.
         // During the lifetime of the slice, neither the backing vector nor the pointed to memory are accessed.
         let data_slice_bytes =
-            unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr().cast(), length as usize) };
+            unsafe { slice::from_raw_parts_mut(data.as_mut_ptr().cast(), length as usize) };
 
         fd.read_exact(data_slice_bytes)
             .map_err(MigratableError::MigrateSocket)?;
@@ -449,13 +450,13 @@ impl MemoryRangeTable {
     }
 
     pub fn length(&self) -> u64 {
-        (std::mem::size_of::<MemoryRange>() * self.data.len()) as u64
+        (mem::size_of::<MemoryRange>() * self.data.len()) as u64
     }
 
     pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {
         // SAFETY: the slice is constructed with the correct arguments
         fd.write_all(unsafe {
-            std::slice::from_raw_parts(self.data.as_ptr().cast(), self.length() as usize)
+            slice::from_raw_parts(self.data.as_ptr().cast(), self.length() as usize)
         })
         .map_err(MigratableError::MigrateSocket)
     }


### PR DESCRIPTION
Part of #7670.

Import the std modules used in the crate instead of spelling the
fully-qualified paths at every use site:

- local `Result` alias case → `result::Result<_, MigratableError>` (kept the `result::` cue rather than collapsing to bare `Result`)
- `std::io::Error` → `io::Error`
- `std::collections::BTreeMap` → `BTreeMap`
- `std::mem::size_of` → `mem::size_of`
- `std::slice::from_raw_parts{,_mut}` → `slice::from_raw_parts{,_mut}`

Readability-only change; no functional impact. Follows the same approach as
the merged #8273 (tdx), #8344 (serial_buffer), #8345 (net_util) and #8349
(option_parser) cleanups.