### PR TITLE
vmm: memory_manager: free memslot in remove_userspace_mapping

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -2563,6 +2563,8 @@ impl MemoryManager {
             userspace_addr_ = userspace_addr as u64
         );
 
+        self.memory_slot_allocator().free_memory_slot(slot);
+
         Ok(())
     }
 


### PR DESCRIPTION
remove_userspace_mapping tears down the KVM mapping but never returns the slot id to the allocator's free list. Call `free_memory_slot` to avoid the leak.