### PR TITLE
virtio-devices: fix vhost-user restore deadlock for virtio-fs

### DIFF
--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -338,6 +338,17 @@ impl VhostUserHandle {
             && let Some(acked_protocol_features) =
                 VhostUserProtocolFeatures::from_bits(acked_protocol_features)
         {
+            // Query the back-end's available protocol features before setting
+            // them. This mirrors the boot-time negotiation sequence and is
+            // required for REPLY_ACK to work: a vhost-user back-end only enables
+            // sending acks once it has reported its protocol features through
+            // GET_PROTOCOL_FEATURES. Skipping this step leaves the back-end
+            // unable to ack later NEED_REPLY requests (e.g. SET_FEATURES),
+            // which would deadlock the restore path.
+            self.vu
+                .get_protocol_features()
+                .map_err(Error::VhostUserGetProtocolFeatures)?;
+
             self.vu
                 .set_protocol_features(acked_protocol_features)
                 .map_err(Error::VhostUserSetProtocolFeatures)?;


### PR DESCRIPTION
During live migration restore, the vhost-user frontend reapplies the acked protocol features by calling SET_PROTOCOL_FEATURES directly. The back-end, however, only starts honoring REPLY_ACK once it has reported its protocol features via GET_PROTOCOL_FEATURES, exactly as happens during boot-time negotiation.

Skipping that query left the back-end unable to ack subsequent NEED_REPLY requests (e.g. SET_FEATURES), deadlocking the restore path and hanging virtio-fs live migration on MSHV.

Issue a GET_PROTOCOL_FEATURES before SET_PROTOCOL_FEATURES so the restore sequence mirrors boot-time negotiation and REPLY_ACK works.

Assisted-by: Claude:Opus-4.8