### PR TITLE
pci: trim qualified paths

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -7,6 +7,7 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::ops::DerefMut;
+use std::result;
 use std::sync::{Arc, Barrier, Mutex};
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -53,7 +54,7 @@ pub enum PciRootError {
     #[error("Valid PCI device identifier but already used: {0}")]
     AlreadyInUsePciDeviceSlot(usize),
 }
-pub type Result<T> = std::result::Result<T, PciRootError>;
+pub type Result<T> = result::Result<T, PciRootError>;
 
 /// Emulates the PCI Root bridge device.
 pub struct PciRoot {
@@ -554,6 +555,7 @@ fn parse_io_config_address(config_address: u32) -> (usize, usize, usize, usize) 
 #[cfg(test)]
 mod unit_tests {
     use std::error::Error;
+    use std::io;
     use std::result::Result;
 
     use super::*;
@@ -570,7 +572,7 @@ mod unit_tests {
             _len: u64,
             _pci_dev: &mut dyn PciDevice,
             _region_type: PciBarRegionType,
-        ) -> Result<(), std::io::Error> {
+        ) -> Result<(), io::Error> {
             Ok(())
         }
     }

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
+use std::result;
 use std::sync::{Arc, Mutex};
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -528,7 +529,7 @@ pub enum Error {
     #[error("rom bar address {0} not a power of two")]
     RomBarSizeInvalid(u64),
 }
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
 
 impl PciConfiguration {
     #[allow(clippy::too_many_arguments)]
@@ -1145,7 +1146,7 @@ impl Snapshottable for PciConfiguration {
         String::from(PCI_CONFIGURATION_ID)
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         Snapshot::new_from_state(&self.state())
     }
 }

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -34,7 +34,7 @@ pub enum Error {
     #[error("Invalid resource: {0:?}")]
     InvalidResource(Resource),
 }
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct BarReprogrammingParams {

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -19,7 +19,7 @@ use std::fmt::{self, Debug, Display};
 use std::num::ParseIntError;
 use std::str::FromStr;
 
-use serde::de::Visitor;
+use serde::de::{self, Visitor};
 
 pub use self::bus::{
     NUM_DEVICE_IDS, PCI_ROOT_DEVICE_ID, PciBus, PciConfigIo, PciConfigMmio, PciRoot, PciRootError,
@@ -75,7 +75,7 @@ impl Visitor<'_> for PciBdfVisitor {
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
     where
-        E: serde::de::Error,
+        E: de::Error,
     {
         Ok(v.into())
     }
@@ -157,7 +157,7 @@ impl From<&PciBdf> for u16 {
 }
 
 impl Debug for PciBdf {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{:04x}:{:02x}:{:02x}.{:01x}",
@@ -170,7 +170,7 @@ impl Debug for PciBdf {
 }
 
 impl Display for PciBdf {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{:04x}:{:02x}:{:02x}.{:01x}",

--- a/pci/src/mmap.rs
+++ b/pci/src/mmap.rs
@@ -6,7 +6,7 @@
 
 use core::ffi::c_int;
 use core::ptr::null_mut;
-use std::io::{Error, ErrorKind};
+use std::io::{self, Error, ErrorKind};
 use std::os::fd::{AsRawFd as _, BorrowedFd};
 
 use libc::size_t;
@@ -55,7 +55,7 @@ impl MmapRegion {
         fd: BorrowedFd,
         offset1: u64,
         offset2: u64,
-    ) -> std::io::Result<Self> {
+    ) -> io::Result<Self> {
         const BAD_LENGTH: &str = "Offsets must fit in libc::off_t";
         const BAD_OFFSET: &str = "Mapping length must fit \
 in both isize and libc::size_t";

--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 
-use std::io;
 use std::sync::Arc;
+use std::{io, result};
 
 use byteorder::{ByteOrder, LittleEndian};
 use log::error;
@@ -290,7 +290,7 @@ impl Snapshottable for MsiConfig {
         String::from(MSI_CONFIG_ID)
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         Snapshot::new_from_state(&self.state())
     }
 }

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -11,7 +11,7 @@ use log::{debug, error};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vm_device::interrupt::{
-    InterruptIndex, InterruptSourceConfig, InterruptSourceGroup, MsiIrqSourceConfig,
+    self, InterruptIndex, InterruptSourceConfig, InterruptSourceGroup, MsiIrqSourceConfig,
 };
 use vm_memory::ByteValued;
 use vm_migration::{MigratableError, Pausable, Snapshot, Snapshottable};
@@ -96,9 +96,9 @@ macro_rules! impl_method {
 
 impl InterruptSourceGroup for MaybeMutInterruptSourceGroup {
     impl_method! {
-        fn trigger(&self, index: InterruptIndex) -> vm_device::interrupt::Result<()>;
+        fn trigger(&self, index: InterruptIndex) -> interrupt::Result<()>;
 
-        fn notifier(&self, index: InterruptIndex) -> Option<vmm_sys_util::eventfd::EventFd>;
+        fn notifier(&self, index: InterruptIndex) -> Option<EventFd>;
 
         fn update(
             &self,
@@ -106,9 +106,9 @@ impl InterruptSourceGroup for MaybeMutInterruptSourceGroup {
             config: InterruptSourceConfig,
             masked: bool,
             set_gsi: bool,
-        ) -> vm_device::interrupt::Result<()>;
+        ) -> interrupt::Result<()>;
 
-        fn set_gsi(&self) -> vm_device::interrupt::Result<()>;
+        fn set_gsi(&self) -> interrupt::Result<()>;
     }
 }
 
@@ -118,7 +118,7 @@ impl MaybeMutInterruptSourceGroup {
         index: InterruptIndex,
         eventfd: Option<EventFd>,
         vm: &dyn hypervisor::Vm,
-    ) -> std::io::Result<()> {
+    ) -> io::Result<()> {
         match self {
             Self::Immutable(_) => panic!(
                 "Attempted to set a notifier of an immutable source.  You must mark your device as needing a mutable source by having sets_irqfd() return true."
@@ -516,7 +516,7 @@ impl Snapshottable for MsixConfig {
         String::from(MSIX_CONFIG_ID)
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         Snapshot::new_from_state(&self.state())
     }
 }

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -5,11 +5,11 @@
 
 use std::any::Any;
 use std::collections::{BTreeMap, HashMap};
-use std::io;
 use std::os::fd::BorrowedFd;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::sync::{Arc, Barrier, Mutex};
+use std::{cmp, io, result};
 
 use anyhow::anyhow;
 use byteorder::{ByteOrder, LittleEndian};
@@ -34,6 +34,7 @@ use vm_memory::{Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestUsiz
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
+use crate::configuration::{COMMAND_REG, COMMAND_REG_MEMORY_SPACE_MASK};
 use crate::mmap::MmapRegion;
 use crate::msi::{MSI_CONFIG_ID, MsiConfigState};
 use crate::msix::{MaybeMutInterruptSourceGroup, MsixConfigState};
@@ -270,7 +271,7 @@ impl Interrupt {
 pub struct UserMemoryRegion {
     pub slot: u32,
     pub start: u64,
-    pub mapping: Arc<crate::mmap::MmapRegion>,
+    pub mapping: Arc<MmapRegion>,
 }
 
 #[derive(Clone)]
@@ -602,7 +603,7 @@ impl VfioCommon {
             let (pba_offset, pba_size) = msix_cap.pba_range();
             let msix_sz = align_page_size_up(table_size + pba_size);
             // Expand region to hold RW and trap region which both page size aligned
-            let size = std::cmp::max(region_size * 2, msix_sz * 2);
+            let size = cmp::max(region_size * 2, msix_sz * 2);
             // let table starts from the middle of the region
             msix_cap.table_set_offset((size / 2) as u32);
             msix_cap.pba_set_offset((size / 2 + pba_offset - table_offset) as u32);
@@ -774,7 +775,7 @@ impl VfioCommon {
                         .allocate(
                             restored_bar_addr,
                             region_size,
-                            Some(std::cmp::max(
+                            Some(cmp::max(
                                 // SAFETY: FFI call. Trivially safe.
                                 unsafe { sysconf(_SC_PAGESIZE) as GuestUsize },
                                 region_size,
@@ -1332,9 +1333,8 @@ impl VfioCommon {
         // Return pending BAR repgrogramming if MSE bit is set
         let mut ret_param = self.configuration.pending_bar_reprogram();
         if !ret_param.is_empty() {
-            if self.read_config_register(crate::configuration::COMMAND_REG)
-                & crate::configuration::COMMAND_REG_MEMORY_SPACE_MASK
-                == crate::configuration::COMMAND_REG_MEMORY_SPACE_MASK
+            if self.read_config_register(COMMAND_REG) & COMMAND_REG_MEMORY_SPACE_MASK
+                == COMMAND_REG_MEMORY_SPACE_MASK
             {
                 info!("BAR reprogramming parameter is returned: {ret_param:x?}");
                 self.configuration.clear_pending_bar_reprogram();
@@ -1450,7 +1450,7 @@ impl Snapshottable for VfioCommon {
         String::from(VFIO_COMMON_ID)
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         let mut vfio_common_snapshot = Snapshot::new_from_state(&self.state())?;
 
         // Snapshot PciConfiguration
@@ -1759,7 +1759,7 @@ impl VfioPciDevice {
                                 "Could not mmap sparse area (offset = 0x{:x}, size = 0x{:x}): {}",
                                 mmap_offset,
                                 mmap_len,
-                                std::io::Error::last_os_error()
+                                io::Error::last_os_error()
                             );
                             return Err(VfioPciError::MmapArea);
                         }
@@ -2081,7 +2081,7 @@ impl Snapshottable for VfioPciDevice {
         self.id.clone()
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         let mut vfio_pci_dev_snapshot = Snapshot::default();
 
         // Snapshot VfioCommon
@@ -2123,7 +2123,7 @@ impl<M: GuestAddressSpace> VfioDmaMapping<M> {
 }
 
 impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M> {
-    fn map(&self, iova: u64, gpa: u64, size: u64) -> std::result::Result<(), io::Error> {
+    fn map(&self, iova: u64, gpa: u64, size: u64) -> result::Result<(), io::Error> {
         let Ok(usize_size): Result<usize, _> = size.try_into() else {
             return Err(io::Error::other(format!("size {size} overflows usize")));
         };
@@ -2170,7 +2170,7 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M
         })
     }
 
-    fn unmap(&self, iova: u64, size: u64) -> std::result::Result<(), io::Error> {
+    fn unmap(&self, iova: u64, size: u64) -> result::Result<(), io::Error> {
         self.vfio_ops
             .vfio_dma_unmap(iova, size as usize)
             .map_err(|e| {

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -7,6 +7,7 @@ use std::any::Any;
 use std::os::fd::AsFd;
 use std::os::unix::prelude::AsRawFd;
 use std::sync::{Arc, Barrier, Mutex};
+use std::{io, result};
 
 use hypervisor::HypervisorVmError;
 use log::{error, info};
@@ -57,7 +58,7 @@ pub enum VfioUserPciDeviceError {
     #[error("Failed to create VfioCommon")]
     CreateVfioCommon(#[source] VfioPciError),
     #[error("Other OS error")]
-    Other(#[source] std::io::Error),
+    Other(#[source] io::Error),
 }
 
 #[derive(Copy, Clone)]
@@ -429,7 +430,7 @@ impl PciDevice for VfioUserPciDevice {
         self.common.write_bar(base, offset, data)
     }
 
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> Result<(), std::io::Error> {
+    fn move_bar(&mut self, old_base: u64, new_base: u64) -> Result<(), io::Error> {
         info!("Moving BAR 0x{old_base:x} -> 0x{new_base:x}");
         for mmio_region in self.common.mmio_regions.iter_mut() {
             if mmio_region.start.raw_value() == old_base {
@@ -448,7 +449,7 @@ impl PciDevice for VfioUserPciDevice {
                             false,
                         )
                     }
-                    .map_err(std::io::Error::other)?;
+                    .map_err(io::Error::other)?;
 
                     // Update the user memory region with the correct start address.
                     if new_base > old_base {
@@ -469,7 +470,7 @@ impl PciDevice for VfioUserPciDevice {
                             false,
                         )
                     }
-                    .map_err(std::io::Error::other)?;
+                    .map_err(io::Error::other)?;
                 }
                 info!("Moved bar 0x{old_base:x} -> 0x{new_base:x}");
             }
@@ -516,7 +517,7 @@ impl Snapshottable for VfioUserPciDevice {
         self.id.clone()
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         let mut vfio_pci_dev_snapshot = Snapshot::default();
 
         // Snapshot VfioCommon
@@ -540,47 +541,45 @@ impl<M: GuestAddressSpace> VfioUserDmaMapping<M> {
 }
 
 impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioUserDmaMapping<M> {
-    fn map(&self, iova: u64, gpa: u64, size: u64) -> std::result::Result<(), std::io::Error> {
+    fn map(&self, iova: u64, gpa: u64, size: u64) -> result::Result<(), io::Error> {
         let mem = self.memory.memory();
         let guest_addr = GuestAddress(gpa);
         let Some(region) = mem.find_region(guest_addr) else {
-            return Err(std::io::Error::other(format!(
-                "Region not found for 0x{gpa:x}"
-            )));
+            return Err(io::Error::other(format!("Region not found for 0x{gpa:x}")));
         };
 
         // Check that the range fits in the region.
         let region_offset = guest_addr
             .checked_offset_from(region.start_addr())
-            .ok_or_else(|| std::io::Error::other(format!("gpa 0x{gpa:x} below region start")))?;
+            .ok_or_else(|| io::Error::other(format!("gpa 0x{gpa:x} below region start")))?;
         let region_remaining = (region.len())
             .checked_sub(region_offset)
-            .ok_or_else(|| std::io::Error::other(format!("gpa 0x{gpa:x} past region end")))?;
+            .ok_or_else(|| io::Error::other(format!("gpa 0x{gpa:x} past region end")))?;
         if size > region_remaining {
-            return Err(std::io::Error::other(format!(
+            return Err(io::Error::other(format!(
                 "DMA map (gpa 0x{gpa:x}, size 0x{size:x}) extends past region end"
             )));
         }
 
         let file_offset = region.file_offset().ok_or_else(|| {
-            std::io::Error::other(format!("region for gpa 0x{gpa:x} has no backing file"))
+            io::Error::other(format!("region for gpa 0x{gpa:x} has no backing file"))
         })?;
         let offset = region_offset
             .checked_add(file_offset.start())
-            .ok_or_else(|| std::io::Error::other("offset overflow in DMA map"))?;
+            .ok_or_else(|| io::Error::other("offset overflow in DMA map"))?;
 
         self.client
             .lock()
             .unwrap()
             .dma_map(offset, iova, size, file_offset.file().as_raw_fd())
-            .map_err(|e| std::io::Error::other(format!("Error mapping region: {e}")))
+            .map_err(|e| io::Error::other(format!("Error mapping region: {e}")))
     }
 
-    fn unmap(&self, iova: u64, size: u64) -> std::result::Result<(), std::io::Error> {
+    fn unmap(&self, iova: u64, size: u64) -> result::Result<(), io::Error> {
         self.client
             .lock()
             .unwrap()
             .dma_unmap(iova, size)
-            .map_err(|e| std::io::Error::other(format!("Error unmapping region: {e}")))
+            .map_err(|e| io::Error::other(format!("Error unmapping region: {e}")))
     }
 }


### PR DESCRIPTION
Part of #7670.

Import the modules used in the crate instead of spelling the
fully-qualified paths at every use site, leaving `pci` free of
`clippy::absolute_paths` warnings:

- std: `std::result::Result` → `result::Result`, `std::io::Error`/`io::Result`, `std::fmt::Formatter`/`fmt::Result`, `std::cmp::max`
- crate-internal: `crate::configuration::{COMMAND_REG, COMMAND_REG_MEMORY_SPACE_MASK}`, `crate::mmap::MmapRegion`
- external: `serde::de::Error`, `vm_device::interrupt::Result`, `vmm_sys_util::eventfd::EventFd`

Readability-only change; no functional impact. Follows the same approach as
the merged #8273 (tdx), #8344 (serial_buffer), #8345 (net_util), #8349
(option_parser), #8354 (api_client) and #8355 (vm-migration) cleanups, and
takes the whole crate to absolute_paths-clean.