### PR TITLE
pci: reevaluate #[allow] attributes

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -144,7 +144,7 @@ impl PciBus {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn register_mapping(
         &self,
         dev: Arc<dyn BusDeviceSync>,

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -194,7 +194,6 @@ pub trait PciProgrammingInterface {
 
 /// Types of PCI capabilities.
 #[derive(PartialEq, Eq, Copy, Clone)]
-#[allow(non_camel_case_types)]
 #[repr(u8)]
 pub enum PciCapabilityId {
     ListId = 0,
@@ -531,7 +530,7 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl PciConfiguration {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         vendor_id: u16,
         device_id: u16,

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -614,8 +614,6 @@ impl VfioCommon {
         }
     }
 
-    // The `allocator` argument is unused on `aarch64`
-    #[allow(unused_variables)]
     pub(crate) fn allocate_bars(
         &mut self,
         allocator: &mut SystemAllocator,
@@ -816,12 +814,9 @@ impl VfioCommon {
                 bar_id += 1;
             }
         }
-
         Ok(bars)
     }
 
-    // The `allocator` argument is unused on `aarch64`
-    #[allow(unused_variables)]
     pub(crate) fn free_bars(
         &mut self,
         allocator: &mut SystemAllocator,
@@ -1493,7 +1488,7 @@ pub struct VfioPciDevice {
 
 impl VfioPciDevice {
     /// Constructs a new Vfio Pci device for the given Vfio device
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         vm: Arc<dyn hypervisor::Vm>,
@@ -1790,7 +1785,6 @@ impl VfioPciDevice {
                     // Only needed if p2p_dma is enabled.
                     if !self.iommu_attached && self.p2p_dma {
                         // vfio_dma_map should be unsafe but isn't.
-                        #[allow(unused_unsafe)]
                         // SAFETY: MmapRegion invariants guarantee that
                         // user_memory_region.mapping.addr() points to
                         // user_memory_region.mapping.len() bytes of
@@ -2037,7 +2031,6 @@ iova 0x{:x}, size 0x{:x}: {}, ",
                     // Only needed if p2p_dma is enabled.
                     if !self.iommu_attached && self.p2p_dma {
                         // vfio_dma_map is unsound and ought to be marked as unsafe
-                        #[allow(unused_unsafe)]
                         // SAFETY: MmapRegion invariants guarantee that
                         // host_addr points to len bytes of
                         // valid memory that will only be unmapped with munmap().
@@ -2158,7 +2151,6 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M
         };
 
         // vfio_dma_map is unsound and ought to be marked as unsafe
-        #[allow(unused_unsafe)]
         // SAFETY: find_user_address and GuestMemory::get_slice() guarantee that
         // the returned pointer is valid for up to `usize_size` bytes.
         // `usize_size` is always equal to `size` due to the above `try_into()` call.

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -72,7 +72,7 @@ impl PciSubclass for PciVfioUserSubclass {
 }
 
 impl VfioUserPciDevice {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         vm: Arc<dyn hypervisor::Vm>,


### PR DESCRIPTION
Part of #8326. The `dead_code`/`unused` allows were already handled in #8323.

Removed stale suppressions whose lints no longer fire:
- `non_camel_case_types` on `PciCapabilityId`
- `unused_variables` on `VfioCommon::allocate_bars` / `free_bars`
- `unused_unsafe` (three sites in `vfio.rs`)

Converted the still-needed ones to `#[expect]` so they warn if they ever stop being necessary:
- `clippy::too_many_arguments` (3 sites)
- `clippy::needless_pass_by_value` (1 site)

Also dropped the now-inaccurate "unused on aarch64" comments above `allocate_bars`/`free_bars`. The `allocator` argument is read in the `IoRegion` match arm, which is compiled on all architectures. Verified clean on aarch64 with both kvm and mshv.