### PR TITLE
vmm: defer PCI device visibility to fix hotplug race condition

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -13,12 +13,9 @@ use std::sync::{Arc, Barrier, Mutex};
 use byteorder::{ByteOrder, LittleEndian};
 use log::warn;
 use thiserror::Error;
-use vm_device::{Bus, BusDevice, BusDeviceSync};
+use vm_device::BusDevice;
 
-use crate::PciBarConfiguration;
-use crate::configuration::{
-    PciBarRegionType, PciBridgeSubclass, PciClassCode, PciConfiguration, PciHeaderType,
-};
+use crate::configuration::{PciBridgeSubclass, PciClassCode, PciConfiguration, PciHeaderType};
 use crate::device::{BarReprogrammingParams, DeviceRelocation, Error as PciDeviceError, PciDevice};
 
 /// Denotes the PCI device ID of a bus' root bridge device.
@@ -38,12 +35,6 @@ pub enum PciRootError {
     /// Could not allocate an IRQ number.
     #[error("Could not allocate an IRQ number")]
     AllocateIrq,
-    /// Could not add a device to the port io bus.
-    #[error("Could not add a device to the port io bus")]
-    PioInsert(#[source] vm_device::BusError),
-    /// Could not add a device to the mmio bus.
-    #[error("Could not add a device to the mmio bus")]
-    MmioInsert(#[source] vm_device::BusError),
     /// Could not find an available device slot on the PCI bus.
     #[error("Could not find an available device slot on the PCI bus")]
     NoPciDeviceSlotAvailable,
@@ -143,31 +134,6 @@ impl PciBus {
             device_reloc,
             device_ids,
         }
-    }
-
-    #[expect(clippy::needless_pass_by_value)]
-    pub fn register_mapping(
-        &self,
-        dev: Arc<dyn BusDeviceSync>,
-        io_bus: &Bus,
-        mmio_bus: &Bus,
-        bars: Vec<PciBarConfiguration>,
-    ) -> Result<()> {
-        for bar in bars {
-            match bar.region_type() {
-                PciBarRegionType::IoRegion => {
-                    io_bus
-                        .insert(dev.clone(), bar.addr(), bar.size())
-                        .map_err(PciRootError::PioInsert)?;
-                }
-                PciBarRegionType::Memory32BitRegion | PciBarRegionType::Memory64BitRegion => {
-                    mmio_bus
-                        .insert(dev.clone(), bar.addr(), bar.size())
-                        .map_err(PciRootError::MmioInsert)?;
-                }
-            }
-        }
-        Ok(())
     }
 
     pub fn add_device(&mut self, device_id: u8, device: Arc<Mutex<dyn PciDevice>>) -> Result<()> {
@@ -559,6 +525,7 @@ mod unit_tests {
     use std::result::Result;
 
     use super::*;
+    use crate::configuration::PciBarRegionType;
 
     #[derive(Debug)]
     /// Helper struct that mocks the implementation of DeviceRelocation

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -74,8 +74,8 @@ use libc::{
 };
 use log::{debug, error, info, warn};
 use pci::{
-    DeviceRelocation, MmioRegion, PciBarRegionType, PciBdf, PciDevice, VfioDmaMapping,
-    VfioPciDevice, VfioUserDmaMapping, VfioUserPciDevice, VfioUserPciDeviceError,
+    DeviceRelocation, MmioRegion, PciBarConfiguration, PciBarRegionType, PciBdf, PciDevice,
+    VfioDmaMapping, VfioPciDevice, VfioUserDmaMapping, VfioUserPciDevice, VfioUserPciDeviceError,
 };
 use rate_limiter::group::RateLimiterGroup;
 use seccompiler::SeccompAction;
@@ -305,6 +305,14 @@ pub enum DeviceManagerError {
     /// Cannot add PCI device
     #[error("Cannot add PCI device")]
     AddPciDevice(#[source] pci::PciRootError),
+
+    /// Could not add a device to the port io bus
+    #[error("Could not add a device to the port io bus")]
+    PioInsert(#[source] vm_device::BusError),
+
+    /// Could not add a device to the mmio bus
+    #[error("Could not add a device to the mmio bus")]
+    MmioInsert(#[source] vm_device::BusError),
 
     /// Cannot open persistent memory file
     #[error("Cannot open persistent memory file")]
@@ -4120,25 +4128,16 @@ impl DeviceManager {
             )
             .map_err(DeviceManagerError::AllocateBars)?;
 
-        let mut pci_bus = self.pci_segments[segment_id as usize]
+        self.pci_segments[segment_id as usize]
             .pci_bus
             .lock()
-            .unwrap();
-
-        pci_bus
+            .unwrap()
             .add_device(bdf.device(), pci_device)
             .map_err(DeviceManagerError::AddPciDevice)?;
 
         self.bus_devices.push(Arc::clone(&bus_device));
 
-        pci_bus
-            .register_mapping(
-                bus_device,
-                self.address_manager.io_bus.as_ref(),
-                self.address_manager.mmio_bus.as_ref(),
-                bars.clone(),
-            )
-            .map_err(DeviceManagerError::AddPciDevice)?;
+        self.register_bar_mapping(bus_device, &bars)?;
 
         let mut new_resources = Vec::new();
         for bar in bars {
@@ -4152,6 +4151,31 @@ impl DeviceManager {
         }
 
         Ok(new_resources)
+    }
+
+    #[expect(clippy::needless_pass_by_value)]
+    fn register_bar_mapping(
+        &mut self,
+        bus_device: Arc<dyn BusDeviceSync>,
+        bars: &[PciBarConfiguration],
+    ) -> DeviceManagerResult<()> {
+        for bar in bars {
+            match bar.region_type() {
+                PciBarRegionType::IoRegion => {
+                    self.address_manager
+                        .io_bus
+                        .insert(bus_device.clone(), bar.addr(), bar.size())
+                        .map_err(DeviceManagerError::PioInsert)?;
+                }
+                PciBarRegionType::Memory32BitRegion | PciBarRegionType::Memory64BitRegion => {
+                    self.address_manager
+                        .mmio_bus
+                        .insert(bus_device.clone(), bar.addr(), bar.size())
+                        .map_err(DeviceManagerError::MmioInsert)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     fn add_vfio_devices(

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3653,13 +3653,8 @@ impl DeviceManager {
         let pvmemcontrol_pci_device = Arc::new(Mutex::new(pvmemcontrol_pci_device));
         let pvmemcontrol_bus_device = Arc::new(pvmemcontrol_bus_device);
 
-        let new_resources = self.add_pci_device(
-            pvmemcontrol_bus_device.clone(),
-            pvmemcontrol_pci_device.clone(),
-            pci_segment_id,
-            pci_device_bdf,
-            resources,
-        )?;
+        let (bars, new_resources) =
+            self.allocate_pci_bars(pvmemcontrol_pci_device.clone(), pci_segment_id, resources)?;
 
         let mut node = device_node!(id, pvmemcontrol_pci_device);
 
@@ -3668,6 +3663,14 @@ impl DeviceManager {
         node.pci_device_handle = None;
 
         self.device_tree.lock().unwrap().insert(id, node);
+
+        self.commit_pci_device(
+            pvmemcontrol_bus_device.clone(),
+            pvmemcontrol_pci_device.clone(),
+            pci_segment_id,
+            pci_device_bdf,
+            bars,
+        )?;
 
         Ok((pvmemcontrol_bus_device, pvmemcontrol_pci_device))
     }
@@ -4066,13 +4069,8 @@ impl DeviceManager {
 
         let vfio_pci_device = Arc::new(Mutex::new(vfio_pci_device));
 
-        let new_resources = self.add_pci_device(
-            vfio_pci_device.clone(),
-            vfio_pci_device.clone(),
-            pci_segment_id,
-            pci_device_bdf,
-            resources,
-        )?;
+        let (bars, new_resources) =
+            self.allocate_pci_bars(vfio_pci_device.clone(), pci_segment_id, resources)?;
 
         vfio_pci_device
             .lock()
@@ -4089,7 +4087,7 @@ impl DeviceManager {
         // Update the device tree with correct resource information.
         node.resources = new_resources;
         node.pci_bdf = Some(pci_device_bdf);
-        node.pci_device_handle = Some(PciDeviceHandle::Vfio(vfio_pci_device));
+        node.pci_device_handle = Some(PciDeviceHandle::Vfio(vfio_pci_device.clone()));
 
         self.device_tree
             .lock()
@@ -4100,17 +4098,24 @@ impl DeviceManager {
         self.device_id_to_bdf
             .insert(vfio_name.clone(), pci_device_bdf);
 
+        self.commit_pci_device(
+            vfio_pci_device.clone(),
+            vfio_pci_device,
+            pci_segment_id,
+            pci_device_bdf,
+            bars,
+        )?;
+
         Ok((pci_device_bdf, vfio_name))
     }
 
-    fn add_pci_device(
+    #[expect(clippy::needless_pass_by_value)]
+    fn allocate_pci_bars(
         &mut self,
-        bus_device: Arc<dyn BusDeviceSync>,
         pci_device: Arc<Mutex<dyn PciDevice>>,
         segment_id: u16,
-        bdf: PciBdf,
         resources: Option<Vec<Resource>>,
-    ) -> DeviceManagerResult<Vec<Resource>> {
+    ) -> DeviceManagerResult<(Vec<PciBarConfiguration>, Vec<Resource>)> {
         let bars = pci_device
             .lock()
             .unwrap()
@@ -4128,19 +4133,8 @@ impl DeviceManager {
             )
             .map_err(DeviceManagerError::AllocateBars)?;
 
-        self.pci_segments[segment_id as usize]
-            .pci_bus
-            .lock()
-            .unwrap()
-            .add_device(bdf.device(), pci_device)
-            .map_err(DeviceManagerError::AddPciDevice)?;
-
-        self.bus_devices.push(Arc::clone(&bus_device));
-
-        self.register_bar_mapping(bus_device, &bars)?;
-
         let mut new_resources = Vec::new();
-        for bar in bars {
+        for bar in &bars {
             new_resources.push(Resource::PciBar {
                 index: bar.idx(),
                 base: bar.addr(),
@@ -4150,7 +4144,30 @@ impl DeviceManager {
             });
         }
 
-        Ok(new_resources)
+        Ok((bars, new_resources))
+    }
+
+    #[expect(clippy::needless_pass_by_value)]
+    fn commit_pci_device(
+        &mut self,
+        bus_device: Arc<dyn BusDeviceSync>,
+        pci_device: Arc<Mutex<dyn PciDevice>>,
+        segment_id: u16,
+        bdf: PciBdf,
+        bars: Vec<PciBarConfiguration>,
+    ) -> DeviceManagerResult<()> {
+        self.bus_devices.push(Arc::clone(&bus_device));
+
+        self.register_bar_mapping(bus_device, &bars)?;
+
+        self.pci_segments[segment_id as usize]
+            .pci_bus
+            .lock()
+            .unwrap()
+            .add_device(bdf.device(), pci_device)
+            .map_err(DeviceManagerError::AddPciDevice)?;
+
+        Ok(())
     }
 
     #[expect(clippy::needless_pass_by_value)]
@@ -4276,15 +4293,10 @@ impl DeviceManager {
 
         let vfio_user_pci_device = Arc::new(Mutex::new(vfio_user_pci_device));
 
-        let new_resources = self.add_pci_device(
-            vfio_user_pci_device.clone(),
-            vfio_user_pci_device.clone(),
-            pci_segment_id,
-            pci_device_bdf,
-            resources,
-        )?;
+        let (bars, new_resources) =
+            self.allocate_pci_bars(vfio_user_pci_device.clone(), pci_segment_id, resources)?;
 
-        // Note it is required to call 'add_pci_device()' in advance to have the list of
+        // Note it is required to call 'allocate_pci_bars()' in advance to have the list of
         // mmio regions provisioned correctly
         vfio_user_pci_device
             .lock()
@@ -4297,7 +4309,7 @@ impl DeviceManager {
         // Update the device tree with correct resource information.
         node.resources = new_resources;
         node.pci_bdf = Some(pci_device_bdf);
-        node.pci_device_handle = Some(PciDeviceHandle::VfioUser(vfio_user_pci_device));
+        node.pci_device_handle = Some(PciDeviceHandle::VfioUser(vfio_user_pci_device.clone()));
 
         self.device_tree
             .lock()
@@ -4307,6 +4319,14 @@ impl DeviceManager {
         // Track device ID → guest BDF mapping for Generic Initiator resolution
         self.device_id_to_bdf
             .insert(vfio_user_name.clone(), pci_device_bdf);
+
+        self.commit_pci_device(
+            vfio_user_pci_device.clone(),
+            vfio_user_pci_device,
+            pci_segment_id,
+            pci_device_bdf,
+            bars,
+        )?;
 
         Ok((pci_device_bdf, vfio_user_name))
     }
@@ -4442,13 +4462,8 @@ impl DeviceManager {
             .map_err(DeviceManagerError::VirtioDevice)?,
         ));
 
-        let new_resources = self.add_pci_device(
-            virtio_pci_device.clone(),
-            virtio_pci_device.clone(),
-            pci_segment_id,
-            pci_device_bdf,
-            resources,
-        )?;
+        let (bars, new_resources) =
+            self.allocate_pci_bars(virtio_pci_device.clone(), pci_segment_id, resources)?;
 
         let bar_addr = virtio_pci_device.lock().unwrap().config_bar_addr();
         for (event, addr) in virtio_pci_device.lock().unwrap().ioeventfds(bar_addr) {
@@ -4463,8 +4478,16 @@ impl DeviceManager {
         node.resources = new_resources;
         node.migratable = Some(Arc::clone(&virtio_pci_device) as Arc<Mutex<dyn Migratable>>);
         node.pci_bdf = Some(pci_device_bdf);
-        node.pci_device_handle = Some(PciDeviceHandle::Virtio(virtio_pci_device));
+        node.pci_device_handle = Some(PciDeviceHandle::Virtio(virtio_pci_device.clone()));
         self.device_tree.lock().unwrap().insert(id, node);
+
+        self.commit_pci_device(
+            virtio_pci_device.clone(),
+            virtio_pci_device,
+            pci_segment_id,
+            pci_device_bdf,
+            bars,
+        )?;
 
         Ok(pci_device_bdf)
     }
@@ -4488,13 +4511,8 @@ impl DeviceManager {
 
         let pvpanic_device = Arc::new(Mutex::new(pvpanic_device));
 
-        let new_resources = self.add_pci_device(
-            pvpanic_device.clone(),
-            pvpanic_device.clone(),
-            pci_segment_id,
-            pci_device_bdf,
-            resources,
-        )?;
+        let (bars, new_resources) =
+            self.allocate_pci_bars(pvpanic_device.clone(), pci_segment_id, resources)?;
 
         let mut node = device_node!(id, pvpanic_device);
 
@@ -4503,6 +4521,14 @@ impl DeviceManager {
         node.pci_device_handle = None;
 
         self.device_tree.lock().unwrap().insert(id, node);
+
+        self.commit_pci_device(
+            pvpanic_device.clone(),
+            pvpanic_device.clone(),
+            pci_segment_id,
+            pci_device_bdf,
+            bars,
+        )?;
 
         Ok(Some(pvpanic_device))
     }
@@ -4543,13 +4569,8 @@ impl DeviceManager {
             )
             .map_err(DeviceManagerError::IvshmemCreate)?,
         ));
-        let new_resources = self.add_pci_device(
-            ivshmem_device.clone(),
-            ivshmem_device.clone(),
-            pci_segment_id,
-            pci_device_bdf,
-            resources,
-        )?;
+        let (bars, new_resources) =
+            self.allocate_pci_bars(ivshmem_device.clone(), pci_segment_id, resources)?;
 
         let start_addr = ivshmem_device.lock().unwrap().data_bar_addr();
         let (region, mapping) = ivshmem_ops
@@ -4564,6 +4585,14 @@ impl DeviceManager {
         node.pci_bdf = Some(pci_device_bdf);
         node.pci_device_handle = None;
         self.device_tree.lock().unwrap().insert(id, node);
+
+        self.commit_pci_device(
+            ivshmem_device.clone(),
+            ivshmem_device.clone(),
+            pci_segment_id,
+            pci_device_bdf,
+            bars,
+        )?;
 
         Ok(Some(ivshmem_device))
     }


### PR DESCRIPTION
  ## Summary

  Fix a race condition during PCI device hotplug where the guest can discover a partially-initialized device, causing BAR reprogramming failures.

  ## Problem
  
  When PCI devices are hotplugged, the Linux guest kernel scans **all** PCI slots upon each hotplug notification — not just the slot that triggered it. A device that has been added to the PCI bus but whose `device_tree` entry and ioeventfds have not yet been registered can be discovered and probed by the guest prematurely.

  The previous `add_pci_device()` made the device visible on the PCI bus (via `pci_bus.add_device()`) **before** completing device-specific setup. The following timeline illustrates the race:

```
  // disk2 hotplug — normal
  
  Jun 04 04:38:35 h1027 containerd[2140]: {"msg":""cloud-hypervisor: 10.382729s:  INFO:vmm/src/api/mod.rs:475 -- API request event: AddDisk DiskConfig { path: Some(\"/dev/rbd3\"), ... }"", ...}
  Jun 04 04:38:35 h1027 containerd[2140]: {"msg":""cloud-hypervisor: 10.383702s:  INFO:vmm/src/device_manager.rs:2379 -- Using asynchronous RAW disk file (io_uring)"", ...}
  Jun 04 04:38:35 h1027 containerd[2140]: {"msg":""cloud-hypervisor: 10.387161s:  INFO:pci/src/configuration.rs:977 -- Detected BAR reprogramming: (BAR 4) 0xe7f00000->0xc0000000"", ...}
  Jun 04 04:38:35 h1027 containerd[2140]: {"msg":""cloud-hypervisor: 10.391038s:  INFO:virtio-devices/src/transport/pci_device.rs:1222 -- _virtio-pci-_disk2: Needs activation; writing to activate event fd"", ...}

  // disk3 hotplug — while vcpu3 device scan is still in progress

  Jun 04 04:38:35 h1027 containerd[2140]: {"msg":""cloud-hypervisor: 10.399767s:  INFO:vmm/src/api/mod.rs:475 -- API request event: AddDisk DiskConfig { path: Some(\"/dev/rbd6\"), ... }"", ...}
  Jun 04 04:38:35 h1027 containerd[2140]: {"msg":""cloud-hypervisor: 10.400550s:  INFO:vmm/src/device_manager.rs:2379 -- Using asynchronous RAW disk file (io_uring)"", ...}

  // vcpu3's scan reaches disk3's slot — on bus but device_tree not yet registered

  Jun 04 04:38:35 h1027 containerd[2140]: {"msg":""cloud-hypervisor: 10.403578s:  INFO:pci/src/configuration.rs:977 -- Detected BAR reprogramming: (BAR 4) 0xe7f00000->0xc0080000"", ...}
  Jun 04 04:38:35 h1027 containerd[2140]: {"msg":""cloud-hypervisor: 10.403598s:  ERROR:pci/src/bus.rs:270 -- Failed moving device BAR: Couldn't find device _virtio-pci-_disk3 from device tree: 0xe7f00000->0xc0080000(0x80000)"", ...}

// subsequent fallout

  Jun 04 04:38:35 h1027 containerd[2140]: {"msg":""cloud-hypervisor: 10.417011s:  ERROR:virtio-devices/src/transport/pci_device.rs:1196 -- Unexpected write to notification BAR: offset = 0x6000"", ...}

```

  The root cause is that `pci_bus.add_device()` made disk3 discoverable on the bus before its `device_tree` entry was registered, so when vcpu3 scanned all slots and attempted BAR reprogramming on disk3, the VMM could not find the device in the device tree to complete the BAR move.

  ## Solution

  **Commit 1** refactors `PciBus::register_mapping()` into `DeviceManager::register_bar_mapping()`, since it operates on `mmio_bus`/`io_bus` which are external to `PciBus`. The corresponding error variants are moved from `PciRootError` to `DeviceManagerError`.
  
  **Commit 2** splits `add_pci_device()` into two phases:

  - `allocate_pci_bars()` — reserves BAR address space only, without making the device visible to the guest.
  - `commit_pci_device()` — pushes the device into `bus_devices`, registers BAR mappings on the VMM buses, and finally adds the device to the PCI bus. At this point, the device is discoverable by guest.

  All six callers now follow the pattern:
  
  allocate_pci_bars() → device-specific setup → commit_pci_device()

  This ensures ioeventfds, device_tree entries, and MMIO mappings are fully in place before the device becomes discoverable by the guest, closing the race window.
