### PR TITLE
Allow remapping of `MemoryZone`s to different host NUMA nodes

### DIFF
--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -381,6 +381,10 @@ migration process. Via the API or `ch-remote`, you may specify:
 - `memory_mode <precopy|postcopy>`: \
   Memory transfer mode. `postcopy` resumes the destination first and faults
   guest pages in on demand over a dedicated connection. Defaults to `precopy`.
+- `zone_updates <list of zone updates>`: \
+  A list of updates to apply to memory zones on the receiver side. For example,
+  this can be used to remap memory zones to another NUMA node. Each zone update
+  has the form `zone_id@host_numa_node`.
 
 ## Migrating VMs with VFIO Devices
 

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -426,7 +426,7 @@ impl<T: TryFrom<u64>> Parseable for IntegerList<T> {
 
 /// Types that can appear as the second element of a [`Tuple`] pair.
 ///
-/// Implemented for `u64`, `Vec<u8>`, `Vec<u64>`, and `Vec<usize>`.
+/// Implemented for `u32`, `u64`, `Vec<u8>`, `Vec<u64>`, and `Vec<usize>`.
 pub trait TupleValue {
     /// Parses the value portion of a `key@value` tuple element.
     fn parse_value(input: &str) -> Result<Self, TupleError>
@@ -437,6 +437,12 @@ pub trait TupleValue {
 impl TupleValue for u64 {
     fn parse_value(input: &str) -> Result<Self, TupleError> {
         input.parse::<u64>().map_err(TupleError::InvalidInteger)
+    }
+}
+
+impl TupleValue for u32 {
+    fn parse_value(input: &str) -> Result<Self, TupleError> {
+        input.parse::<u32>().map_err(TupleError::InvalidInteger)
     }
 }
 
@@ -1023,6 +1029,20 @@ mod unit_tests {
             matches!(e, TupleError::EmptyKey(ref s) if s == expected_value),
             "Expected \"{:?}\"; got \"{e:?}\"",
             TupleError::EmptyKey(expected_value.to_string()),
+        );
+    }
+
+    #[test]
+    fn test_tuple_parse_u32_value() {
+        use std::num::IntErrorKind;
+        let t = Tuple::<String, u32>::from_str("foo@42").unwrap();
+        assert_eq!(t, Tuple("foo".to_owned(), 42));
+        let t = Tuple::<String, u32>::from_str("foo@0").unwrap();
+        assert_eq!(t, Tuple("foo".to_owned(), 0));
+        let e = Tuple::<String, u32>::from_str("foo@-1").unwrap_err();
+        assert!(
+            matches!(e, TupleError::InvalidInteger(ref e) if *e.kind() == IntErrorKind::InvalidDigit),
+            "Expected \"InvalidInteger(ParseIntError(kind: InvalidDigit))\"; got \"{e:?}\"",
         );
     }
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -338,7 +338,8 @@ pub enum VmReceiveMigrationConfigError {
 impl VmReceiveMigrationData {
     pub const SYNTAX: &'static str = "VM receive migration parameters \
         \"<receiver_url>\" or \"receiver_url=<url>[,tls_dir=<path>][,memory_mode=precopy|postcopy]\
-        [,vfio_fds=<list_of_vfio_ids_with_their_associated_fd>][,iommufd_fd=<fd>]\"";
+        [,vfio_fds=<list_of_vfio_ids_with_their_associated_fd>][,iommufd_fd=<fd>]\
+        [,zone_updates=[<id@host_numa_node>]]\"";
 
     pub fn parse(migration: &str) -> Result<Self, VmReceiveMigrationConfigError> {
         let mut parser = OptionParser::new();
@@ -347,7 +348,8 @@ impl VmReceiveMigrationData {
             .add("tls_dir")
             .add("memory_mode")
             .add("vfio_fds")
-            .add("iommufd_fd");
+            .add("iommufd_fd")
+            .add("zone_updates");
         parser
             .parse(migration)
             .map_err(VmReceiveMigrationConfigError::ParseError)?;
@@ -380,13 +382,25 @@ impl VmReceiveMigrationData {
             .convert::<i32>("iommufd_fd")
             .map_err(VmReceiveMigrationConfigError::ParseError)?;
 
+        let zone_updates: Vec<VmMemoryZoneUpdateData> = parser
+            .convert::<TupleList<String, u32>>("zone_updates")
+            .map_err(VmReceiveMigrationConfigError::ParseError)?
+            .map_or(Vec::new(), |v| {
+                v.0.iter()
+                    .map(|Tuple(id, host_numa_node)| VmMemoryZoneUpdateData {
+                        id: id.clone(),
+                        host_numa_node: *host_numa_node,
+                    })
+                    .collect()
+            });
+
         let data = Self {
             receiver_url,
             tls_dir,
             memory_mode,
             vfio_fds,
             iommufd_fd,
-            zone_updates: vec![],
+            zone_updates,
         };
 
         data.validate()?;
@@ -423,6 +437,22 @@ impl VmReceiveMigrationData {
                     "invalid TLS configuration for receive-migration: {e}"
                 ))
             })?;
+        }
+
+        let unique_zones = self
+            .zone_updates
+            .iter()
+            .map(|update| update.id.as_str())
+            .collect::<HashSet<_>>();
+        if self.zone_updates.len() != unique_zones.len() {
+            return Err(VmReceiveMigrationConfigError::ValidationError(
+                "more than one update was defined for at least one memory zone".to_string(),
+            ));
+        }
+        if unique_zones.contains("") {
+            return Err(VmReceiveMigrationConfigError::ValidationError(
+                "Empty Id".to_string(),
+            ));
         }
 
         Ok(())
@@ -2193,6 +2223,21 @@ mod unit_tests {
         assert_eq!(fds[1].id, "vfio1");
         assert_eq!(fds[1].fd, Some(7));
         assert_eq!(data.iommufd_fd, Some(9));
+
+        // zone update tests
+        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,zone_updates=[]").unwrap_err();
+        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,zone_updates=[zone1 3]")
+            .unwrap_err();
+        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,zone_updates=[zone1@invalid]")
+            .unwrap_err();
+        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,zone_updates=[zone1@1,zone1@2]")
+            .unwrap_err();
+        // Mind the space before the second zone. If the whitespace isn't trimmed, we end up with
+        // two different ID
+        VmReceiveMigrationData::parse(
+            "receiver_url=unix:/tmp/sock,zone_updates=[zone1@1, zone1@2]",
+        )
+        .unwrap_err();
     }
 
     #[test]

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -47,7 +47,7 @@ use option_parser::{OptionParser, OptionParserError, Toggle, Tuple, TupleList};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vm_migration::MigratableError;
-use vm_migration::tls::{TlsEndpoint, validate_tls_dir};
+use vm_migration::tls::{TlsConfigError, TlsEndpoint, validate_tls_dir};
 use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(feature = "dbus_api")]
@@ -328,11 +328,47 @@ pub struct VmReceiveMigrationData {
 
 #[derive(Debug, Error)]
 pub enum VmReceiveMigrationConfigError {
+    /// Parsing of `VmReceiveMigrationData` failed
     #[error("Error parsing receive migration parameters")]
     ParseError(#[source] OptionParserError),
-
-    #[error("Error validating receive migration parameters: {0}")]
-    ValidationError(String),
+    /// Variant returned of validation of `receiver_url` failed.
+    #[error("Expected receiver_url in the form of either `tcp:<host>:<port>` or `unix:<path>:`")]
+    MalformedReceiverUrl(#[source] TcpAddressParseError),
+    /// TLS encryption cannot be used for UNIX sockets. It is therefore
+    /// forbidden to use TLS encryption with UNIX sockets.
+    #[error("UNIX sockets and TLS encryption cannot be used at the same time")]
+    TlsEncryptionUsedForUnixSocket,
+    /// The `receiver_url` does not contain one of the supported
+    /// prefixes. Supported prefixes are "tcp" and "unix".
+    #[error("Expected receiver_url to either use `tcp` or `unix` prefix")]
+    InvalidSocketPrefix,
+    /// The TLS configuration is invalid.
+    #[error("Invalid TLS configuration for receive-migration")]
+    InvalidTlsConfiguration(#[source] TlsConfigError),
+    /// Every VFIO device needs a replacement in vfio_fds and none was found for the respective
+    /// device
+    #[error(
+        "VFIO device '{0}' has no replacement in vfio_fds, its source path or fd is not usable on the destination"
+    )]
+    VfioDeviceNoReplacementFd(String),
+    /// The `vfio_fds` option was used without supplying `iommufd_fd`
+    #[error("Usage of `vfio_fds` requires `iommufd_fd` to be specified")]
+    VfioFdRequiresIommufdFd,
+    /// `iommufd_fd` was provided without also enabling the iommufd backend.
+    #[error("Platform `iommufd_fd=<fd>` requires `iommufd=on`")]
+    IommufdFdRequiresIommufd,
+    /// Identified duplicate fd replacements for the FD with the given ID.
+    #[error("Multiple replacements defined for fd with ID {0}")]
+    VfioFdMultipleReplacements(String),
+    /// Identified a fd replacements for a FD not present in the VmConfig.
+    #[error("Replacement ID {0} in vfio_fds id does not match any device in the received VmConfig")]
+    VfioFdReplacementWithoutTarget(String),
+    /// Multiple updates for the same memory zone were defined.
+    #[error("More than one update was defined for at least one memory zone")]
+    MultipleMemoryZoneUpdates,
+    /// An update with an empty memory zone ID was specified.
+    #[error("One or more memory zone updates contained an empty ID")]
+    MemoryZoneUpdatesEmptyId,
 }
 
 impl VmReceiveMigrationData {
@@ -410,33 +446,23 @@ impl VmReceiveMigrationData {
 
     pub fn validate(&self) -> Result<(), VmReceiveMigrationConfigError> {
         if let Some(addr) = self.receiver_url.strip_prefix("tcp:") {
-            tcp_address_to_server_name(addr).map_err(|e| {
-                VmReceiveMigrationConfigError::ValidationError(format!(
-                    "receiver_url must use tcp:<host>:<port> or unix:<path>: {e}."
-                ))
-            })?;
+            tcp_address_to_server_name(addr)
+                .map_err(VmReceiveMigrationConfigError::MalformedReceiverUrl)?;
         } else if self
             .receiver_url
             .strip_prefix("unix:")
             .is_some_and(|path| !path.is_empty())
         {
             if self.tls_dir.is_some() {
-                return Err(VmReceiveMigrationConfigError::ValidationError(
-                    "UNIX sockets and TLS encryption cannot be used at the same time.".to_string(),
-                ));
+                return Err(VmReceiveMigrationConfigError::TlsEncryptionUsedForUnixSocket);
             }
         } else {
-            return Err(VmReceiveMigrationConfigError::ValidationError(
-                "receiver_url must use tcp:<host>:<port> or unix:<path>.".to_string(),
-            ));
+            return Err(VmReceiveMigrationConfigError::InvalidSocketPrefix);
         }
 
         if let Some(tls_dir) = &self.tls_dir {
-            validate_tls_dir(tls_dir, TlsEndpoint::Server).map_err(|e| {
-                VmReceiveMigrationConfigError::ValidationError(format!(
-                    "invalid TLS configuration for receive-migration: {e}"
-                ))
-            })?;
+            validate_tls_dir(tls_dir, TlsEndpoint::Server)
+                .map_err(VmReceiveMigrationConfigError::InvalidTlsConfiguration)?;
         }
 
         let unique_zones = self
@@ -445,14 +471,10 @@ impl VmReceiveMigrationData {
             .map(|update| update.id.as_str())
             .collect::<HashSet<_>>();
         if self.zone_updates.len() != unique_zones.len() {
-            return Err(VmReceiveMigrationConfigError::ValidationError(
-                "more than one update was defined for at least one memory zone".to_string(),
-            ));
+            return Err(VmReceiveMigrationConfigError::MultipleMemoryZoneUpdates);
         }
         if unique_zones.contains("") {
-            return Err(VmReceiveMigrationConfigError::ValidationError(
-                "Empty Id".to_string(),
-            ));
+            return Err(VmReceiveMigrationConfigError::MemoryZoneUpdatesEmptyId);
         }
 
         Ok(())
@@ -476,10 +498,9 @@ impl VmReceiveMigrationData {
                 .as_deref()
                 .is_some_and(|id| substituted.contains(id))
             {
-                return Err(VmReceiveMigrationConfigError::ValidationError(format!(
-                    "VFIO device '{}' has no replacement in vfio_fds, its source path or fd is not usable on the destination",
-                    d.pci_common.id.as_deref().unwrap_or_default()
-                )));
+                return Err(VmReceiveMigrationConfigError::VfioDeviceNoReplacementFd(
+                    d.pci_common.id.as_deref().unwrap_or_default().to_owned(),
+                ));
             }
         }
 
@@ -489,23 +510,18 @@ impl VmReceiveMigrationData {
 
         // The supplied vfio_fds must be usable against the received VmConfig.
         if self.iommufd_fd.is_none() {
-            return Err(VmReceiveMigrationConfigError::ValidationError(
-                "vfio_fds requires iommufd_fd".to_string(),
-            ));
+            return Err(VmReceiveMigrationConfigError::VfioFdRequiresIommufdFd);
         }
         if !vm_config.platform.as_ref().is_some_and(|p| p.iommufd) {
-            return Err(VmReceiveMigrationConfigError::ValidationError(
-                "vfio_fds requires platform iommufd=on in the received VmConfig".to_string(),
-            ));
+            return Err(VmReceiveMigrationConfigError::IommufdFdRequiresIommufd);
         }
 
         let mut seen = HashSet::new();
         for v in vfio_fds {
             if !seen.insert(v.id.as_str()) {
-                return Err(VmReceiveMigrationConfigError::ValidationError(format!(
-                    "duplicate vfio_fds id '{}'",
-                    v.id
-                )));
+                return Err(VmReceiveMigrationConfigError::VfioFdMultipleReplacements(
+                    v.id.to_owned(),
+                ));
             }
         }
 
@@ -517,10 +533,9 @@ impl VmReceiveMigrationData {
             .collect();
         for v in vfio_fds {
             if !known_ids.contains(v.id.as_str()) {
-                return Err(VmReceiveMigrationConfigError::ValidationError(format!(
-                    "vfio_fds id '{}' does not match any device in the received VmConfig",
-                    v.id
-                )));
+                return Err(
+                    VmReceiveMigrationConfigError::VfioFdReplacementWithoutTarget(v.id.to_owned()),
+                );
             }
         }
 
@@ -2166,10 +2181,46 @@ mod unit_tests {
         ))
         .unwrap_err();
 
-        VmReceiveMigrationData::parse("receiver_url=file:///tmp/migration").unwrap_err();
-        VmReceiveMigrationData::parse("receiver_url=tcp:192.168.1.1").unwrap_err();
-        VmReceiveMigrationData::parse("receiver_url=tcp:[2001:db8::1]").unwrap_err();
-        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,tls_dir=/tmp").unwrap_err();
+        let e = VmReceiveMigrationData::parse("receiver_url=file:///tmp/migration").unwrap_err();
+        assert!(
+            matches!(e, VmReceiveMigrationConfigError::InvalidSocketPrefix),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            VmReceiveMigrationConfigError::InvalidSocketPrefix,
+        );
+        let e = VmReceiveMigrationData::parse("receiver_url=tcp:192.168.1.1").unwrap_err();
+        assert!(
+            matches!(
+                e,
+                VmReceiveMigrationConfigError::MalformedReceiverUrl(
+                    TcpAddressParseError::MissingPort
+                )
+            ),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            VmReceiveMigrationConfigError::MalformedReceiverUrl(TcpAddressParseError::MissingPort),
+        );
+        let e = VmReceiveMigrationData::parse("receiver_url=tcp:[2001:db8::1]").unwrap_err();
+        assert!(
+            matches!(
+                e,
+                VmReceiveMigrationConfigError::MalformedReceiverUrl(
+                    TcpAddressParseError::MissingPortSeparatorAfterBracketedHost
+                )
+            ),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            VmReceiveMigrationConfigError::MalformedReceiverUrl(
+                TcpAddressParseError::MissingPortSeparatorAfterBracketedHost
+            ),
+        );
+        let e =
+            VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,tls_dir=/tmp").unwrap_err();
+        assert!(
+            matches!(
+                e,
+                VmReceiveMigrationConfigError::TlsEncryptionUsedForUnixSocket
+            ),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            VmReceiveMigrationConfigError::TlsEncryptionUsedForUnixSocket,
+        );
 
         // memory_mode defaults to precopy when not specified.
         let data = VmReceiveMigrationData::parse("receiver_url=tcp:127.0.0.1:1234").unwrap();
@@ -2202,7 +2253,11 @@ mod unit_tests {
         );
 
         // Missing receiver_url in keyed form must fail.
-        VmReceiveMigrationData::parse("memory_mode=postcopy").unwrap_err();
+        let e = VmReceiveMigrationData::parse("memory_mode=postcopy").unwrap_err();
+        assert!(
+            matches!(e, VmReceiveMigrationConfigError::ParseError(_)),
+            "Expected \"ParseError\"; got \"{e:?}\"",
+        );
 
         // vfio_fds without iommufd_fd parses fine now, the pairing is checked
         // later against the received VmConfig by validate_vfio_fds.
@@ -2225,19 +2280,38 @@ mod unit_tests {
         assert_eq!(data.iommufd_fd, Some(9));
 
         // zone update tests
-        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,zone_updates=[]").unwrap_err();
-        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,zone_updates=[zone1 3]")
+        let e = VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,zone_updates=[]")
             .unwrap_err();
-        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,zone_updates=[zone1@invalid]")
+        assert!(
+            matches!(e, VmReceiveMigrationConfigError::ParseError(_)),
+            "Expected \"ParseError\"; got \"{e:?}\"",
+        );
+        let e = VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,zone_updates=[zone1 3]")
             .unwrap_err();
-        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,zone_updates=[zone1@1,zone1@2]")
-            .unwrap_err();
-        // Mind the space before the second zone. If the whitespace isn't trimmed, we end up with
-        // two different ID
-        VmReceiveMigrationData::parse(
+        assert!(
+            matches!(e, VmReceiveMigrationConfigError::ParseError(_)),
+            "Expected \"ParseError\"; got \"{e:?}\"",
+        );
+        let e = VmReceiveMigrationData::parse(
+            "receiver_url=unix:/tmp/sock,zone_updates=[zone1@1,zone1@2]",
+        )
+        .unwrap_err();
+        assert!(
+            matches!(e, VmReceiveMigrationConfigError::MultipleMemoryZoneUpdates),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            VmReceiveMigrationConfigError::MultipleMemoryZoneUpdates,
+        );
+        //Mind the space before the second zone. If the whitespace isn't trimmed, we end up with two
+        //different ID and the error does not trigger
+        let e = VmReceiveMigrationData::parse(
             "receiver_url=unix:/tmp/sock,zone_updates=[zone1@1, zone1@2]",
         )
         .unwrap_err();
+        assert!(
+            matches!(e, VmReceiveMigrationConfigError::MultipleMemoryZoneUpdates),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            VmReceiveMigrationConfigError::MultipleMemoryZoneUpdates,
+        );
     }
 
     #[test]

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -54,7 +54,9 @@ use vmm_sys_util::eventfd::EventFd;
 pub use self::dbus::start_dbus_thread;
 pub use self::http::{start_http_fd_thread, start_http_path_thread};
 use crate::Error as VmmError;
-use crate::config::{RestoreConfig, RestoredVfioConfig, deserialize_restored_fd};
+use crate::config::{
+    RestoreConfig, RestoredVfioConfig, VmMemoryZoneUpdateData, deserialize_restored_fd,
+};
 use crate::device_tree::DeviceTree;
 use crate::migration::transport::{
     MAX_MIGRATION_CONNECTIONS, TcpAddressParseError, tcp_address_to_server_name,
@@ -319,6 +321,9 @@ pub struct VmReceiveMigrationData {
     // FDs are not serialized and any deserialized value is invalid; see NetConfig::fds.
     #[serde(default, deserialize_with = "deserialize_restored_fd")]
     pub iommufd_fd: Option<i32>,
+    /// Optional memory zone update data
+    #[serde(default)]
+    pub zone_updates: Vec<VmMemoryZoneUpdateData>,
 }
 
 #[derive(Debug, Error)]
@@ -381,6 +386,7 @@ impl VmReceiveMigrationData {
             memory_mode,
             vfio_fds,
             iommufd_fd,
+            zone_updates: vec![],
         };
 
         data.validate()?;
@@ -2089,6 +2095,7 @@ mod unit_tests {
                 memory_mode: MigrationMode::Precopy,
                 vfio_fds: None,
                 iommufd_fd: None,
+                zone_updates: vec![],
             }
         );
 
@@ -2118,6 +2125,7 @@ mod unit_tests {
                 memory_mode: MigrationMode::Precopy,
                 vfio_fds: None,
                 iommufd_fd: None,
+                zone_updates: vec![],
             }
         );
 
@@ -2143,6 +2151,7 @@ mod unit_tests {
                 memory_mode: MigrationMode::Precopy,
                 vfio_fds: None,
                 iommufd_fd: None,
+                ..Default::default()
             }
         );
 
@@ -2158,6 +2167,7 @@ mod unit_tests {
                 memory_mode: MigrationMode::Postcopy,
                 vfio_fds: None,
                 iommufd_fd: None,
+                ..Default::default()
             }
         );
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1500,6 +1500,10 @@ components:
           $ref: "#/components/schemas/MemoryRestoreMode"
         resume:
           type: boolean
+        zone_updates:
+          type: array
+          items:
+            $ref: "#/components/schemas/VmMemoryZoneUpdateData"
 
     ReceiveMigrationData:
       required:
@@ -1516,6 +1520,10 @@ components:
             TLS is only supported with tcp:<host>:<port> receiver URLs.
         memory_mode:
           $ref: "#/components/schemas/MigrationMode"
+        zone_updates:
+          type: array
+          items:
+            $ref: "#/components/schemas/VmMemoryZoneUpdateData"
 
     MigrationMode:
       type: string
@@ -1525,6 +1533,18 @@ components:
         Memory transfer mode. Precopy transfers all guest memory before the
         destination resumes. Postcopy resumes the destination first and faults
         guest pages in on demand.
+
+    VmMemoryZoneUpdateData:
+      type: object
+      required: [id, host_numa_node]
+      properties:
+        id:
+          type: string
+          minLength: 1
+        host_numa_node:
+          type: integer
+          format: uint32
+          minimum: 0
 
     TimeoutStrategy:
       type: string

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -439,6 +439,12 @@ pub enum ValidationError {
     /// Invalid to set both 'mergeable' and 'shared' for memory
     #[error("Invalid to set both 'mergeable' and 'shared' for memory")]
     InvalidSharedMemoryWithMergeable,
+    /// More than one update was specified for one or more MemoryZone
+    #[error("Multiple updates for the same zone defined")]
+    MultipleMemoryZoneUpdates,
+    /// More than one update was specified that contains an empty memory zone ID
+    #[error("At least one memory zone update with an empty ID was defined")]
+    MemoryZoneUpdatesEmptyId,
 }
 
 type ValidationResult<T> = result::Result<T, ValidationError>;
@@ -2861,7 +2867,8 @@ impl RestoreConfig {
     pub const SYNTAX: &'static str = "Restore from a VM snapshot. \
         \nRestore parameters \"source_url=<source_url>,prefault=on|off,memory_restore_mode=copy|ondemand,\
         net_fds=<list_of_net_ids_with_their_associated_fds>,\
-        vfio_fds=<list_of_vfio_ids_with_their_associated_fd>,iommufd_fd=<fd>,resume=true|false\" \
+        vfio_fds=<list_of_vfio_ids_with_their_associated_fd>,iommufd_fd=<fd>,resume=true|false,\
+        zone_updates=<list_of_updates>\"
         \n`source_url` should be a valid URL (e.g file:///foo/bar or tcp://192.168.1.10/foo) \
         \n`prefault` controls eager prefaulting for the copy-based restore path (disabled by default) \
         \n`memory_restore_mode=copy` preserves the existing eager read-copy restore behavior, while `memory_restore_mode=ondemand` enables lazy demand paging and fails restore if userfaultfd support is unavailable \
@@ -2872,7 +2879,8 @@ impl RestoreConfig {
         sysfs path or host. Requires `iommufd_fd`.\
         \n`iommufd_fd` is a new iommufd file descriptor for the restored VM. \
         The one saved in the snapshot does not survive serialization.\
-        \n `resume` controls whether the VM will be directly resumed after restore ";
+        \n `resume` controls whether the VM will be directly resumed after restore \
+        \n `zone_updates` can be used to update NUMA memory zones. Expects a list of elements in the form `id@host_numa_node`";
 
     pub fn parse(restore: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2883,7 +2891,8 @@ impl RestoreConfig {
             .add("net_fds")
             .add("vfio_fds")
             .add("iommufd_fd")
-            .add("resume");
+            .add("resume")
+            .add("zone_updates");
         parser.parse(restore).map_err(Error::ParseRestore)?;
 
         let source_url = parser
@@ -2931,6 +2940,18 @@ impl RestoreConfig {
             .unwrap_or(Toggle(false))
             .0;
 
+        let zone_updates: Vec<VmMemoryZoneUpdateData> = parser
+            .convert::<TupleList<String, u32>>("zone_updates")
+            .map_err(Error::ParseRestore)?
+            .map_or(Vec::new(), |v| {
+                v.0.iter()
+                    .map(|Tuple(id, host_numa_node)| VmMemoryZoneUpdateData {
+                        id: id.clone(),
+                        host_numa_node: *host_numa_node,
+                    })
+                    .collect()
+            });
+
         Ok(RestoreConfig {
             source_url,
             prefault,
@@ -2939,7 +2960,7 @@ impl RestoreConfig {
             vfio_fds,
             iommufd_fd,
             resume,
-            zone_updates: vec![],
+            zone_updates,
         })
     }
 
@@ -2984,6 +3005,18 @@ impl RestoreConfig {
                     ));
                 }
             }
+        }
+
+        let unique_zones = self
+            .zone_updates
+            .iter()
+            .map(|update| update.id.as_str())
+            .collect::<HashSet<_>>();
+        if self.zone_updates.len() != unique_zones.len() {
+            return Err(ValidationError::MultipleMemoryZoneUpdates);
+        }
+        if unique_zones.contains("") {
+            return Err(ValidationError::MemoryZoneUpdatesEmptyId);
         }
 
         if !restored_net_with_fds.is_empty() {
@@ -5251,7 +5284,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             }
         );
         assert_eq!(
-            RestoreConfig::parse("source_url=/path/to/snapshot,resume=on")?,
+            RestoreConfig::parse("source_url=/path/to/snapshot,resume=on,zone_updates=[zone1@1]")?,
             RestoreConfig {
                 source_url: PathBuf::from("/path/to/snapshot"),
                 prefault: false,
@@ -5260,6 +5293,33 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 vfio_fds: None,
                 iommufd_fd: None,
                 resume: true,
+                zone_updates: vec![VmMemoryZoneUpdateData {
+                    host_numa_node: 1,
+                    id: "zone1".to_string(),
+                }],
+            }
+        );
+        assert_eq!(
+            RestoreConfig::parse(
+                "source_url=/path/to/snapshot,vfio_fds=[vfio0@5,vfio1@6],iommufd_fd=7"
+            )?,
+            RestoreConfig {
+                source_url: PathBuf::from("/path/to/snapshot"),
+                prefault: false,
+                memory_restore_mode: MemoryRestoreMode::Copy,
+                net_fds: None,
+                vfio_fds: Some(vec![
+                    RestoredVfioConfig {
+                        id: "vfio0".to_string(),
+                        fd: Some(5),
+                    },
+                    RestoredVfioConfig {
+                        id: "vfio1".to_string(),
+                        fd: Some(6),
+                    },
+                ]),
+                iommufd_fd: Some(7),
+                resume: false,
                 zone_updates: vec![],
             }
         );
@@ -5290,6 +5350,18 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         // Parsing should fail as source_url is a required field
         RestoreConfig::parse("prefault=off").unwrap_err();
         RestoreConfig::parse("source_url=/path/to/snapshot,memory_restore_mode=bogus").unwrap_err();
+        RestoreConfig::parse("source_url=/path/to/snapshot,resume=on,zone_updates=[@1]")
+            .unwrap_err();
+        RestoreConfig::parse("source_url=/path/to/snapshot,resume=on,zone_updates=[@]")
+            .unwrap_err();
+        RestoreConfig::parse("source_url=/path/to/snapshot,resume=on,zone_updates=[id1@]")
+            .unwrap_err();
+        RestoreConfig::parse("source_url=/path/to/snapshot,resume=on,zone_updates=[id1 1]")
+            .unwrap_err();
+        RestoreConfig::parse("source_url=/path/to/snapshot,resume=on,zone_updates=[[id1@1]]")
+            .unwrap_err();
+        RestoreConfig::parse("source_url=/path/to/snapshot,resume=on,zone_updates=id1@1")
+            .unwrap_err();
         Ok(())
     }
 
@@ -5308,6 +5380,17 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             .unwrap()
             .memory_restore_mode,
             MemoryRestoreMode::OnDemand
+        );
+        assert_eq!(
+            serde_json::from_str::<RestoreConfig>(
+                r#"{"source_url":"/path/to/snapshot","zone_updates":[{"id": "zone1", "host_numa_node": 1}]}"#
+            )
+            .unwrap()
+            .zone_updates,
+            vec![VmMemoryZoneUpdateData {
+                    host_numa_node: 1,
+                    id: "zone1".to_string(),
+                }],
         );
     }
 
@@ -5492,6 +5575,34 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             invalid_restore_mode.validate(&snapshot_vm_config),
             Err(ValidationError::InvalidRestorePrefaultWithOnDemand)
+        );
+
+        // It is invalid to submit more than one update for a single zone.
+        let mut invalid_config_zone_updates = valid_config.clone();
+        invalid_config_zone_updates.zone_updates = vec![
+            VmMemoryZoneUpdateData {
+                id: "id1".to_string(),
+                host_numa_node: 0,
+            },
+            VmMemoryZoneUpdateData {
+                id: "id1".to_string(),
+                host_numa_node: 20,
+            },
+        ];
+        assert_eq!(
+            invalid_config_zone_updates.validate(&snapshot_vm_config),
+            Err(ValidationError::MultipleMemoryZoneUpdates)
+        );
+
+        // It is invalid to submit an update without referring to a memory zone by specifying an ID.
+        let mut invalid_config_zone_updates = valid_config.clone();
+        invalid_config_zone_updates.zone_updates = vec![VmMemoryZoneUpdateData {
+            id: String::new(),
+            host_numa_node: 0,
+        }];
+        assert_eq!(
+            invalid_config_zone_updates.validate(&snapshot_vm_config),
+            Err(ValidationError::MemoryZoneUpdatesEmptyId)
         );
     }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2808,6 +2808,15 @@ impl FromStr for MemoryRestoreMode {
     }
 }
 
+#[derive(Clone, Deserialize, Serialize, Debug, Eq, PartialEq)]
+/// Data required for updating memory zone <-> host NUMA node mappings.
+pub struct VmMemoryZoneUpdateData {
+    /// Id of the MemoryZone to update
+    pub id: String,
+    /// Host NUMA node to relocate the MemoryZone to
+    pub host_numa_node: u32,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct RestoredVfioConfig {
     pub id: String,
@@ -2844,6 +2853,8 @@ pub struct RestoreConfig {
     pub iommufd_fd: Option<i32>,
     #[serde(default)]
     pub resume: bool,
+    #[serde(default)]
+    pub zone_updates: Vec<VmMemoryZoneUpdateData>,
 }
 
 impl RestoreConfig {
@@ -2928,6 +2939,7 @@ impl RestoreConfig {
             vfio_fds,
             iommufd_fd,
             resume,
+            zone_updates: vec![],
         })
     }
 
@@ -5196,6 +5208,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 vfio_fds: None,
                 iommufd_fd: None,
                 resume: false,
+                zone_updates: vec![],
             }
         );
         assert_eq!(
@@ -5221,6 +5234,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 vfio_fds: None,
                 iommufd_fd: None,
                 resume: false,
+                zone_updates: vec![],
             }
         );
         assert_eq!(
@@ -5233,6 +5247,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 vfio_fds: None,
                 iommufd_fd: None,
                 resume: false,
+                zone_updates: vec![],
             }
         );
         assert_eq!(
@@ -5245,6 +5260,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 vfio_fds: None,
                 iommufd_fd: None,
                 resume: true,
+                zone_updates: vec![],
             }
         );
         assert_eq!(
@@ -5268,6 +5284,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 ]),
                 iommufd_fd: Some(7),
                 resume: false,
+                zone_updates: vec![],
             }
         );
         // Parsing should fail as source_url is a required field
@@ -5382,6 +5399,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             vfio_fds: None,
             iommufd_fd: None,
             resume: false,
+            zone_updates: vec![],
         };
         valid_config.validate(&snapshot_vm_config).unwrap();
 
@@ -5449,6 +5467,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             vfio_fds: None,
             iommufd_fd: None,
             resume: false,
+            zone_updates: vec![],
         };
         snapshot_vm_config.net = Some(vec![NetConfig {
             pci_common: PciDeviceCommonConfig {
@@ -5468,6 +5487,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             vfio_fds: None,
             iommufd_fd: None,
             resume: false,
+            zone_updates: vec![],
         };
         assert_eq!(
             invalid_restore_mode.validate(&snapshot_vm_config),
@@ -5541,6 +5561,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             }]),
             iommufd_fd: Some(6),
             resume: false,
+            zone_updates: vec![],
         };
         valid_config.validate(&snapshot_vm_config).unwrap();
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{Read, Write, stdout};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
@@ -51,7 +51,7 @@ use crate::api::{
     ApiRequest, ApiResponse, MigrationMode, RequestHandler, TimeoutStrategy, VmInfoResponse,
     VmReceiveMigrationData, VmSendMigrationData, VmmPingResponse,
 };
-use crate::config::{MemoryRestoreMode, RestoreConfig, add_to_config};
+use crate::config::{MemoryRestoreMode, RestoreConfig, VmMemoryZoneUpdateData, add_to_config};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::coredump::GuestDebuggable;
 use crate::device_manager::DeviceManager;
@@ -233,6 +233,27 @@ pub enum Error {
     /// Cannot apply landlock based sandboxing
     #[error("Error applying landlock")]
     ApplyLandlock(#[source] LandlockError),
+}
+
+/// Errors associated with updating memory zones
+#[derive(Debug, Error)]
+pub enum MemoryZoneUpdateError {
+    /// Cannot apply update as the original configuration didn't specify any memory zones
+    #[error("No zones specified in original config")]
+    NoZones,
+    /// The memory zone is backed by a shared file and thus cannot be bound to a NUMA node.
+    #[error(
+        "Zone with ID \"{0}\" is a shared zone backed by a regular file and thus cannot be bound to a node"
+    )]
+    SharedZoneBackedByFile(String),
+    /// The original [`VmConfig`] did not contain the memory zone with the given
+    /// ID, thus the memory zone update is not compatible with the original configuration.
+    #[error("Zone ID \"{0}\" wasn't contained in original config")]
+    ZoneNotFound(String),
+    /// The update list contains multiple updates for the same memory zone ID. Any update is
+    /// rejected because no assumptions can be made about which update is the correct one.
+    #[error("Multiple updates were specified for memory zone with ID \"{0}\"")]
+    MultipleUpdates(String),
 }
 
 impl From<&VmConfig> for hypervisor::HypervisorVmConfig {
@@ -2241,6 +2262,52 @@ fn apply_vfio_fds_to_vm_config(
         .iommufd_fd = Some(iommufd_fd);
 }
 
+#[allow(unused)]
+fn update_memory_zones(
+    zone_updates: &[VmMemoryZoneUpdateData],
+    vm_config: &Arc<Mutex<VmConfig>>,
+) -> result::Result<(), MemoryZoneUpdateError> {
+    if !zone_updates.is_empty() {
+        let mut vm_config = vm_config.lock().unwrap();
+        // Clone zones so we can abort if we encounter an error without leaving the VmConfig in a
+        // inconsistent state.
+        let mut config_zones = vm_config
+            .memory
+            .zones
+            .clone()
+            .ok_or(MemoryZoneUpdateError::NoZones)?;
+
+        let mut seen_zone_ids = HashSet::new();
+        for zone_update in zone_updates {
+            // We currently only support to move MemoryZones to different host nodes.
+            if !seen_zone_ids.insert(zone_update.id.clone()) {
+                return Err(MemoryZoneUpdateError::MultipleUpdates(
+                    zone_update.id.clone(),
+                ));
+            }
+            let matched_zone = config_zones
+                .iter_mut()
+                .find(|z| z.id == zone_update.id)
+                .ok_or_else(|| MemoryZoneUpdateError::ZoneNotFound(zone_update.id.clone()))?;
+
+            if matched_zone.shared && matched_zone.file.is_some() {
+                error!(
+                    "Invalid to set host NUMA policy for a memory zone \
+                        backed by a regular file and mapped as 'shared' "
+                );
+                return Err(MemoryZoneUpdateError::SharedZoneBackedByFile(
+                    zone_update.id.clone(),
+                ));
+            }
+
+            matched_zone.host_numa_node = Some(zone_update.host_numa_node);
+        }
+        // Write back updated zones after all updates were successful
+        *(vm_config.memory.zones.as_mut().unwrap()) = config_zones;
+    }
+    Ok(())
+}
+
 impl RequestHandler for Vmm {
     fn vm_create(&mut self, config: Box<VmConfig>) -> result::Result<(), VmError> {
         match &self.vm {
@@ -3353,7 +3420,7 @@ mod unit_tests {
     use crate::vm_config::DebugConsoleConfig;
     use crate::vm_config::{
         CommonConsoleConfig, ConsoleConfig, ConsoleOutputMode, CoreScheduling, CpuFeatures,
-        CpusConfig, DeviceConfig, HotplugMethod, MemoryConfig, PayloadConfig,
+        CpusConfig, DeviceConfig, HotplugMethod, MemoryConfig, MemoryZoneConfig, PayloadConfig,
         PciDeviceCommonConfig, PlatformConfig, RngConfig, SerialConfig,
     };
 
@@ -4029,5 +4096,155 @@ mod unit_tests {
         let vm_config = vm_config_with_vfio_devices(&["vfio0"], true);
         let data = receive_data(Some(vec![vfio_fd("vfio0", 5)]), Some(6));
         data.validate_vfio_fds(&vm_config.lock().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_updates_memory_zones() {
+        const NEW_NUMA_NODE1: u32 = 3;
+        const NEW_NUMA_NODE2: u32 = 2;
+
+        let mut dummy_config = create_dummy_vm_config();
+        let memzone_updates = vec![
+            VmMemoryZoneUpdateData {
+                id: "zone1".to_string(),
+                host_numa_node: NEW_NUMA_NODE1,
+            },
+            VmMemoryZoneUpdateData {
+                id: "zone2".to_string(),
+                host_numa_node: NEW_NUMA_NODE2,
+            },
+        ];
+
+        // No zones configured in the original config -> Error
+        dummy_config.memory.zones = None;
+        let result = update_memory_zones(
+            &memzone_updates,
+            &Arc::new(Mutex::new(*dummy_config.clone())),
+        );
+        assert!(
+            matches!(result, Err(MemoryZoneUpdateError::NoZones)),
+            "Expected `Err(MemoryZoneUpdateError::NoZones)` but got {result:?}"
+        );
+
+        // More zone updates than originally specified zones -> Error
+        dummy_config.memory.zones = Some(vec![MemoryZoneConfig {
+            host_numa_node: Some(0),
+            id: "zone1".to_string(),
+            ..Default::default()
+        }]);
+        let result = update_memory_zones(
+            &memzone_updates,
+            &Arc::new(Mutex::new(*dummy_config.clone())),
+        );
+        assert!(
+            matches!(
+                result,
+                Err(MemoryZoneUpdateError::ZoneNotFound(ref id)) if id=="zone2"
+            ),
+            "Expected `Err(MemoryZoneUpdateError::ZoneNotFound(\"zone2\"))` but got {result:?}"
+        );
+
+        // The second zone update does not match -> Error
+        dummy_config.memory.zones = Some(vec![
+            MemoryZoneConfig {
+                host_numa_node: Some(0),
+                id: "zone1".to_string(),
+                ..Default::default()
+            },
+            MemoryZoneConfig {
+                host_numa_node: Some(1),
+                id: "zone3".to_string(),
+                ..Default::default()
+            },
+        ]);
+        let result = update_memory_zones(
+            &memzone_updates,
+            &Arc::new(Mutex::new(*dummy_config.clone())),
+        );
+        assert!(
+            matches!(
+                result,
+                Err(MemoryZoneUpdateError::ZoneNotFound(ref id)) if id=="zone2"
+            ),
+            "Expected `Err(MemoryZoneUpdateError::ZoneNotFound(\"zone2\"))` but got {result:?}"
+        );
+
+        // List contains two updates for the same memory Zone -> Error
+        dummy_config.memory.zones = Some(vec![
+            MemoryZoneConfig {
+                host_numa_node: Some(0),
+                id: "zone1".to_string(),
+                ..Default::default()
+            },
+            MemoryZoneConfig {
+                host_numa_node: Some(1),
+                id: "zone3".to_string(),
+                ..Default::default()
+            },
+        ]);
+
+        let memzone_updates = vec![
+            VmMemoryZoneUpdateData {
+                id: "zone1".to_string(),
+                host_numa_node: NEW_NUMA_NODE1,
+            },
+            VmMemoryZoneUpdateData {
+                id: "zone1".to_string(),
+                host_numa_node: NEW_NUMA_NODE2,
+            },
+        ];
+        let result = update_memory_zones(
+            &memzone_updates,
+            &Arc::new(Mutex::new(*dummy_config.clone())),
+        );
+        assert!(
+            matches!(
+                result,
+                Err(MemoryZoneUpdateError::MultipleUpdates(ref id)) if id=="zone1"
+            ),
+            "Expected `Err(MemoryZoneUpdateError::MultipleUpdates(\"zone1\"))` but got {result:?}"
+        );
+
+        // The update works. Result is okay and the update is written to the config
+        dummy_config.memory.zones = Some(vec![
+            MemoryZoneConfig {
+                host_numa_node: Some(0),
+                id: "zone1".to_string(),
+                ..Default::default()
+            },
+            MemoryZoneConfig {
+                host_numa_node: Some(1),
+                id: "zone2".to_string(),
+                ..Default::default()
+            },
+        ]);
+
+        let memzone_updates = vec![
+            VmMemoryZoneUpdateData {
+                id: "zone1".to_string(),
+                host_numa_node: NEW_NUMA_NODE1,
+            },
+            VmMemoryZoneUpdateData {
+                id: "zone2".to_string(),
+                host_numa_node: NEW_NUMA_NODE2,
+            },
+        ];
+        let dummy_config = Arc::new(Mutex::new(*dummy_config));
+        let result = update_memory_zones(&memzone_updates, &dummy_config.clone());
+        assert!(
+            matches!(result, Ok(()),),
+            "Result should have been Ok(()) but got {result:?}"
+        );
+        let result_zones = dummy_config.lock().unwrap().memory.zones.clone().unwrap();
+        assert_eq!(
+            result_zones[0].host_numa_node,
+            Some(NEW_NUMA_NODE1),
+            "Expected \"zone1\" to be updated to {NEW_NUMA_NODE1:?}"
+        );
+        assert_eq!(
+            result_zones[1].host_numa_node,
+            Some(NEW_NUMA_NODE2),
+            "Expected \"zone2\" to be updated to {NEW_NUMA_NODE2:?}"
+        );
     }
 }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1175,6 +1175,7 @@ impl Vmm {
         T: Read,
     {
         let mode = receive_data_migration.memory_mode;
+        let zone_updates = &receive_data_migration.zone_updates;
 
         // Read in config data along with memory manager data
         let mut data: Vec<u8> = Vec::new();
@@ -1218,6 +1219,10 @@ impl Vmm {
             &vm_migration_config.vm_config,
             &vm_migration_config.common_cpuid,
         )?;
+
+        update_memory_zones(zone_updates, &vm_migration_config.vm_config).map_err(|e| {
+            MigratableError::MigrateReceive(anyhow!("Error updating memory zones: {e:?}"))
+        })?;
 
         let config = vm_migration_config.vm_config.clone();
         self.vm_config = Some(vm_migration_config.vm_config);
@@ -2514,6 +2519,11 @@ impl RequestHandler for Vmm {
                         .expect("restore validated iommufd=on, so a platform exists")
                         .iommufd_fd = Some(iommufd_fd);
                 }
+
+                update_memory_zones(&restore_cfg.zone_updates, &vm_config).map_err(|e| {
+                    error!("VM Restore failed: {e:?}");
+                    VmError::ApplyMemoryZoneUpdate(e)
+                })?;
 
                 self.vm_restore(
                     source_url,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3079,9 +3079,10 @@ impl RequestHandler for Vmm {
             .map_err(MigratableError::MigrateReceive)?;
 
         info!(
-            "Receiving migration: receiver_url={},tls={}",
+            "Receiving migration: receiver_url={},tls={},zone_updates={:?}",
             receive_data_migration.receiver_url,
-            receive_data_migration.tls_dir.is_some()
+            receive_data_migration.tls_dir.is_some(),
+            receive_data_migration.zone_updates,
         );
 
         let mut listener = transport::receive_migration_listener(
@@ -3924,6 +3925,7 @@ mod unit_tests {
             memory_mode: MigrationMode::default(),
             vfio_fds,
             iommufd_fd,
+            zone_updates: vec![],
         }
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -120,7 +120,7 @@ use crate::vm_config::{
 };
 use crate::{
     CPU_MANAGER_SNAPSHOT_ID, DEVICE_MANAGER_SNAPSHOT_ID, GuestMemoryMmap,
-    MEMORY_MANAGER_SNAPSHOT_ID, PciDeviceInfo, acpi, cpu,
+    MEMORY_MANAGER_SNAPSHOT_ID, MemoryZoneUpdateError, PciDeviceInfo, acpi, cpu,
 };
 
 /// Errors associated with VM management
@@ -399,6 +399,10 @@ pub enum Error {
     #[cfg(feature = "fw_cfg")]
     #[error("Error using fw_cfg while disabled")]
     FwCfgDisabled,
+
+    /// Cannot apply NUMA memory zone updates
+    #[error("Error applying memory zone updates")]
+    ApplyMemoryZoneUpdate(#[source] MemoryZoneUpdateError),
 }
 pub type Result<T> = result::Result<T, Error>;
 


### PR DESCRIPTION
In customer environments, we observed migration failures between hosts with different but compatible NUMA topologies. For example, when migrating a VM from a host with four NUMA nodes, where memory zones were mapped to the last two nodes, to a host with only two NUMA nodes, the memory zones could not be recreated on the destination even though sufficient memory was available.

This patch series addresses the issue by providing Cloud Hypervisor with the information required to remap memory zones to compatible NUMA nodes on the destination host during migration.

For now, only remapping of existing NUMA node assignments is supported. Changes to the memory zones themselves, such as resizing, are not allowed.

This PR contains:

- Changes to allow passing information about `MemoryZone` remapping
- Changes to consume these information and remap `MemoryZone`s