### PR TITLE
devices: trim qualified paths

### DIFF
--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -5,8 +5,8 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
-use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+use std::{io, mem, thread};
 
 use acpi_tables::{Aml, AmlSink, aml};
 use log::{error, info, warn};
@@ -59,7 +59,7 @@ impl BusDevice for AcpiShutdownDevice {
             while !self.vcpus_kill_signalled.load(Ordering::SeqCst) {
                 // This is more effective than thread::yield_now() at
                 // avoiding a priority inversion with the VMM thread
-                thread::sleep(std::time::Duration::from_millis(1));
+                thread::sleep(Duration::from_millis(1));
             }
         }
         // The ACPI DSDT table specifies the S5 sleep state (shutdown) as value 5
@@ -76,7 +76,7 @@ impl BusDevice for AcpiShutdownDevice {
             while !self.vcpus_kill_signalled.load(Ordering::SeqCst) {
                 // This is more effective than thread::yield_now() at
                 // avoiding a priority inversion with the VMM thread
-                thread::sleep(std::time::Duration::from_millis(1));
+                thread::sleep(Duration::from_millis(1));
             }
         }
         None
@@ -105,10 +105,7 @@ impl AcpiGedDevice {
         }
     }
 
-    pub fn notify(
-        &mut self,
-        notification_type: AcpiNotificationFlags,
-    ) -> Result<(), std::io::Error> {
+    pub fn notify(&mut self, notification_type: AcpiNotificationFlags) -> io::Result<()> {
         self.notification_type |= notification_type;
         self.interrupt.trigger(0)
     }
@@ -238,7 +235,7 @@ impl Default for AcpiPmTimerDevice {
 
 impl BusDevice for AcpiPmTimerDevice {
     fn read(&mut self, _base: u64, _offset: u64, data: &mut [u8]) {
-        if data.len() != std::mem::size_of::<u32>() {
+        if data.len() != mem::size_of::<u32>() {
             warn!("Invalid sized read of PM timer: {}", data.len());
             return;
         }

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -155,7 +155,7 @@ impl Snapshottable for Gic {
         GIC_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         let vgic = self.vgic.as_ref().unwrap().clone();
         let state = vgic.lock().unwrap().state().unwrap();
         Snapshot::new_from_state(&state)
@@ -163,7 +163,7 @@ impl Snapshottable for Gic {
 }
 
 impl Pausable for Gic {
-    fn pause(&mut self) -> std::result::Result<(), MigratableError> {
+    fn pause(&mut self) -> result::Result<(), MigratableError> {
         // Flush tables to guest RAM
         let vgic = self.vgic.as_ref().unwrap().clone();
         vgic.lock().unwrap().save_data_tables().map_err(|e| {

--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -5,6 +5,8 @@
 
 use std::{io, result};
 
+#[cfg(target_arch = "aarch64")]
+use hypervisor::arch::aarch64::gic;
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -41,7 +43,7 @@ pub enum Error {
     #[cfg(target_arch = "aarch64")]
     /// Failed restoring GIC device.
     #[error("Failed restoring GIC device")]
-    RestoreGic(#[source] hypervisor::arch::aarch64::gic::Error),
+    RestoreGic(#[source] gic::Error),
     #[cfg(target_arch = "riscv64")]
     /// Failed creating AIA device.
     #[error("Failed creating AIA device")]

--- a/devices/src/ivshmem.rs
+++ b/devices/src/ivshmem.rs
@@ -5,9 +5,9 @@
 
 use std::any::Any;
 use std::path::PathBuf;
-use std::result;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
+use std::{io, result};
 
 use anyhow::anyhow;
 use log::{debug, error, warn};
@@ -220,7 +220,7 @@ impl PciDevice for IvshmemDevice {
         mmio32_allocator: &mut AddressAllocator,
         mmio64_allocator: &mut AddressAllocator,
         resources: Option<Vec<Resource>>,
-    ) -> std::result::Result<Vec<PciBarConfiguration>, PciDeviceError> {
+    ) -> result::Result<Vec<PciBarConfiguration>, PciDeviceError> {
         let mut bars = Vec::new();
         let mut bar0_addr = None;
         let mut bar2_addr = None;
@@ -301,7 +301,7 @@ impl PciDevice for IvshmemDevice {
         _allocator: &mut SystemAllocator,
         _mmio32_allocator: &mut AddressAllocator,
         _mmio64_allocator: &mut AddressAllocator,
-    ) -> std::result::Result<(), PciDeviceError> {
+    ) -> result::Result<(), PciDeviceError> {
         unimplemented!("Device hotplug  and remove are not supported for ivshmem");
     }
 
@@ -351,14 +351,14 @@ impl PciDevice for IvshmemDevice {
         None
     }
 
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> result::Result<(), std::io::Error> {
+    fn move_bar(&mut self, old_base: u64, new_base: u64) -> io::Result<()> {
         if new_base == self.data_bar_addr() {
             if let Some(old_mapping) = self.userspace_mapping.take() {
                 self.ivshmem_ops
                     .lock()
                     .unwrap()
                     .unmap_ram_region(old_mapping)
-                    .map_err(std::io::Error::other)?;
+                    .map_err(io::Error::other)?;
             }
             let (region, new_mapping) = self
                 .ivshmem_ops
@@ -369,7 +369,7 @@ impl PciDevice for IvshmemDevice {
                     self.region_size as usize,
                     self.backend_file.clone(),
                 )
-                .map_err(std::io::Error::other)?;
+                .map_err(io::Error::other)?;
             self.set_region(region, new_mapping);
         }
         for bar in self.bar_regions.iter_mut() {
@@ -403,7 +403,7 @@ impl Snapshottable for IvshmemDevice {
 
     // The snapshot/restore (also live migration) support only work for ivshmem-plain mode.
     // Additional work is needed for supporting ivshmem-doorbell.
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         let mut snapshot = Snapshot::new_from_state(&self.state())?;
 
         // Snapshot PciConfiguration

--- a/devices/src/legacy/cmos.rs
+++ b/devices/src/legacy/cmos.rs
@@ -7,6 +7,7 @@
 use std::cmp::min;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
+use std::time::Duration;
 use std::{mem, thread};
 
 // https://github.com/rust-lang/libc/issues/1848
@@ -84,7 +85,7 @@ impl BusDevice for Cmos {
                         while !vcpus_kill_signalled.load(Ordering::SeqCst) {
                             // This is more effective than thread::yield_now() at
                             // avoiding a priority inversion with the VMM thread
-                            thread::sleep(std::time::Duration::from_millis(1));
+                            thread::sleep(Duration::from_millis(1));
                         }
                     }
                 } else {

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -12,6 +12,8 @@
 /// No kernel requirement if above functionality is not required,
 /// only firmware must implement mechanism to interact with this fw_cfg device
 use std::{
+    cmp,
+    ffi::CString,
     fs::File,
     io::{ErrorKind, Read, Result, Seek, SeekFrom},
     mem::offset_of,
@@ -21,6 +23,8 @@ use std::{
 
 use acpi_tables::rsdp::Rsdp;
 use arch::RegionType;
+#[cfg(target_arch = "aarch64")]
+use arch::aarch64::arch_memory_regions;
 #[cfg(target_arch = "aarch64")]
 use arch::aarch64::layout::{
     MEM_32BIT_DEVICES_START, MEM_32BIT_RESERVED_START, RAM_64BIT_START, RAM_START as HIGH_RAM_START,
@@ -161,7 +165,7 @@ impl FwCfgContent {
             FwCfgContent::Slice(s) => s.len(),
             FwCfgContent::U32(n) => size_of_val(n),
         };
-        u32::try_from(ret).map_err(|_| std::io::ErrorKind::InvalidInput.into())
+        u32::try_from(ret).map_err(|_| ErrorKind::InvalidInput.into())
     }
     fn access(&self, offset: u32) -> FwCfgContentAccess<'_> {
         FwCfgContentAccess {
@@ -229,7 +233,7 @@ pub const FILE_NAME_SIZE: usize = 56;
 
 pub fn create_file_name(name: &str) -> [u8; FILE_NAME_SIZE] {
     let mut c_name = [0u8; FILE_NAME_SIZE];
-    let c_len = std::cmp::min(FILE_NAME_SIZE - 1, name.len());
+    let c_len = cmp::min(FILE_NAME_SIZE - 1, name.len());
     c_name[0..c_len].copy_from_slice(&name.as_bytes()[0..c_len]);
     c_name
 }
@@ -438,7 +442,7 @@ impl FwCfg {
         mem_size: Option<usize>,
         kernel: Option<File>,
         initramfs: Option<File>,
-        cmdline: Option<std::ffi::CString>,
+        cmdline: Option<CString>,
         fw_cfg_item_list: Option<Vec<FwCfgItem>>,
         #[cfg(target_arch = "x86_64")] kvm_sev_snp_enabled: bool,
     ) -> Result<()> {
@@ -483,7 +487,7 @@ impl FwCfg {
             (STAGE0_START_ADDRESS, STAGE0_SIZE, RegionType::Reserved),
         ];
         #[cfg(target_arch = "aarch64")]
-        let mut mem_regions = arch::aarch64::arch_memory_regions();
+        let mut mem_regions = arch_memory_regions();
         if mem_size < MEM_32BIT_DEVICES_START.0 as usize {
             mem_regions.push((
                 HIGH_RAM_START,
@@ -562,7 +566,7 @@ impl FwCfg {
         address: u64,
     ) -> Result<u32> {
         let content_size = content.size()?.saturating_sub(offset);
-        let op_size = std::cmp::min(content_size, len);
+        let op_size = cmp::min(content_size, len);
         let mut access = content.access(offset);
         let mut buf = vec![0u8; op_size as usize];
         access.read_exact(buf.as_mut_bytes())?;
@@ -687,7 +691,7 @@ impl FwCfg {
         Ok(())
     }
 
-    pub fn add_kernel_cmdline(&mut self, s: std::ffi::CString) {
+    pub fn add_kernel_cmdline(&mut self, s: CString) {
         let bytes = s.into_bytes_with_nul();
         self.known_items[FW_CFG_CMDLINE_SIZE as usize] = FwCfgContent::U32(bytes.len() as u32);
         self.known_items[FW_CFG_CMDLINE_DATA as usize] = FwCfgContent::Bytes(bytes);

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -314,7 +314,7 @@ impl Snapshottable for Gpio {
         self.id.clone()
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         Snapshot::new_from_state(&self.state())
     }
 }
@@ -338,7 +338,7 @@ mod unit_tests {
     }
 
     impl InterruptSourceGroup for TestInterrupt {
-        fn trigger(&self, _index: InterruptIndex) -> result::Result<(), std::io::Error> {
+        fn trigger(&self, _index: InterruptIndex) -> io::Result<()> {
             self.event_fd.write(1)
         }
 
@@ -348,11 +348,11 @@ mod unit_tests {
             _config: InterruptSourceConfig,
             _masked: bool,
             _set_gsi: bool,
-        ) -> result::Result<(), std::io::Error> {
+        ) -> io::Result<()> {
             Ok(())
         }
 
-        fn set_gsi(&self) -> result::Result<(), std::io::Error> {
+        fn set_gsi(&self) -> io::Result<()> {
             Ok(())
         }
 

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -7,6 +7,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
+use std::time::Duration;
 
 use log::{error, info};
 use vm_device::BusDevice;
@@ -53,7 +54,7 @@ impl BusDevice for I8042Device {
             while !self.vcpus_kill_signalled.load(Ordering::SeqCst) {
                 // This is more effective than thread::yield_now() at
                 // avoiding a priority inversion with the VMM thread
-                thread::sleep(std::time::Duration::from_millis(1));
+                thread::sleep(Duration::from_millis(1));
             }
         }
 

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -217,6 +217,8 @@ impl BusDevice for Rtc {
 
 #[cfg(test)]
 mod unit_tests {
+    use std::{fmt, ptr};
+
     use super::*;
     use crate::{
         read_be_u16, read_be_u32, read_le_i32, read_le_u16, read_le_u64, write_be_u16,
@@ -252,7 +254,7 @@ mod unit_tests {
                 tm_yday: 0,
                 tm_isdst: 0,
                 tm_gmtoff: 0,
-                tm_zone: std::ptr::null(),
+                tm_zone: ptr::null(),
             };
 
             // SAFETY: the parameters are valid.
@@ -273,8 +275,8 @@ mod unit_tests {
         }
     }
 
-    impl std::fmt::Display for LocalTime {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl fmt::Display for LocalTime {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(
                 f,
                 "{}-{:02}-{:02}T{:02}:{:02}:{:02}.{:09}",

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -177,7 +177,7 @@ impl Serial {
         Ok(())
     }
 
-    pub fn flush_output(&mut self) -> result::Result<(), io::Error> {
+    pub fn flush_output(&mut self) -> io::Result<()> {
         if let Some(out) = self.out.as_mut() {
             out.flush()?;
         }
@@ -229,7 +229,7 @@ impl Serial {
         Ok(())
     }
 
-    fn trigger_interrupt(&mut self) -> result::Result<(), io::Error> {
+    fn trigger_interrupt(&mut self) -> io::Result<()> {
         self.interrupt.trigger(0)
     }
 
@@ -330,7 +330,7 @@ impl Snapshottable for Serial {
         self.id.clone()
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         Snapshot::new_from_state(&self.state())
     }
 }
@@ -355,7 +355,7 @@ mod unit_tests {
     }
 
     impl InterruptSourceGroup for TestInterrupt {
-        fn trigger(&self, _index: InterruptIndex) -> result::Result<(), std::io::Error> {
+        fn trigger(&self, _index: InterruptIndex) -> io::Result<()> {
             self.event_fd.write(1)
         }
         fn update(
@@ -364,10 +364,10 @@ mod unit_tests {
             _config: InterruptSourceConfig,
             _masked: bool,
             _set_gsi: bool,
-        ) -> result::Result<(), std::io::Error> {
+        ) -> io::Result<()> {
             Ok(())
         }
-        fn set_gsi(&self) -> result::Result<(), std::io::Error> {
+        fn set_gsi(&self) -> io::Result<()> {
             Ok(())
         }
         fn notifier(&self, _index: InterruptIndex) -> Option<EventFd> {

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -17,6 +17,7 @@ use thiserror::Error;
 use vm_device::BusDevice;
 use vm_device::interrupt::InterruptSourceGroup;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vmm_sys_util::errno;
 
 use crate::{read_le_u32, write_le_u32};
 
@@ -84,7 +85,7 @@ pub struct Pl011 {
     read_trigger: u32,
     irq: Arc<dyn InterruptSourceGroup>,
     out: Option<Box<dyn io::Write + Send>>,
-    timestamp: std::time::Instant,
+    timestamp: Instant,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -217,7 +218,7 @@ impl Pl011 {
     }
 
     /// Queues raw bytes for the guest to read and signals the interrupt
-    pub fn queue_input_bytes(&mut self, c: &[u8]) -> vmm_sys_util::errno::Result<()> {
+    pub fn queue_input_bytes(&mut self, c: &[u8]) -> errno::Result<()> {
         self.read_fifo.extend(c);
         self.read_count += c.len() as u32;
         self.flags &= !PL011_FLAG_RXFE;
@@ -234,7 +235,7 @@ impl Pl011 {
         Ok(())
     }
 
-    pub fn flush_output(&mut self) -> result::Result<(), io::Error> {
+    pub fn flush_output(&mut self) -> io::Result<()> {
         if let Some(out) = self.out.as_mut() {
             out.flush()?;
         }
@@ -362,7 +363,7 @@ impl Pl011 {
         }
     }
 
-    fn trigger_interrupt(&mut self) -> result::Result<(), io::Error> {
+    fn trigger_interrupt(&mut self) -> io::Result<()> {
         self.irq.trigger(0)
     }
 }
@@ -443,7 +444,7 @@ impl Snapshottable for Pl011 {
         self.id.clone()
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         Snapshot::new_from_state(&self.state())
     }
 }
@@ -468,7 +469,7 @@ mod unit_tests {
     }
 
     impl InterruptSourceGroup for TestInterrupt {
-        fn trigger(&self, _index: InterruptIndex) -> result::Result<(), std::io::Error> {
+        fn trigger(&self, _index: InterruptIndex) -> io::Result<()> {
             self.event_fd.write(1)
         }
         fn update(
@@ -477,10 +478,10 @@ mod unit_tests {
             _config: InterruptSourceConfig,
             _masked: bool,
             _set_gsi: bool,
-        ) -> result::Result<(), std::io::Error> {
+        ) -> io::Result<()> {
             Ok(())
         }
-        fn set_gsi(&self) -> result::Result<(), std::io::Error> {
+        fn set_gsi(&self) -> io::Result<()> {
             Ok(())
         }
         fn notifier(&self, _index: InterruptIndex) -> Option<EventFd> {

--- a/devices/src/pvmemcontrol.rs
+++ b/devices/src/pvmemcontrol.rs
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::any::Any;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::{Arc, Barrier, RwLock};
-use std::{io, result};
+use std::{fmt, io, mem, ptr, result};
 
 use log::{debug, warn};
 use num_enum::TryFromPrimitive;
@@ -53,7 +54,7 @@ pub enum Error {
     #[error("Unknown function code: {0}")]
     UnknownFunctionCode(u64),
     #[error("Libc call fail")]
-    LibcFail(#[source] std::io::Error),
+    LibcFail(#[source] io::Error),
 }
 
 #[derive(Copy, Clone)]
@@ -107,8 +108,8 @@ struct PvmemcontrolTransport {
     command: PvmemcontrolTransportCommand,
 }
 
-const PVMEMCONTROL_DEVICE_MMIO_SIZE: u64 = std::mem::size_of::<PvmemcontrolTransport>() as u64;
-const PVMEMCONTROL_DEVICE_MMIO_ALIGN: u64 = std::mem::align_of::<PvmemcontrolTransport>() as u64;
+const PVMEMCONTROL_DEVICE_MMIO_SIZE: u64 = mem::size_of::<PvmemcontrolTransport>() as u64;
+const PVMEMCONTROL_DEVICE_MMIO_ALIGN: u64 = mem::align_of::<PvmemcontrolTransport>() as u64;
 
 impl PvmemcontrolTransport {
     fn ack() -> Self {
@@ -190,8 +191,8 @@ struct PvmemcontrolResp {
     arg1: Le64,
 }
 
-impl std::fmt::Debug for PvmemcontrolResp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for PvmemcontrolResp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let PvmemcontrolResp {
             ret_errno,
             ret_code,
@@ -292,7 +293,7 @@ impl PvmemcontrolDevice {
         let buf_phys_addr = GuestAddress(buf_phys_addr.into());
         if !guest_memory.memory().check_range(
             buf_phys_addr,
-            std::mem::size_of::<PvmemcontrolResp>().max(std::mem::size_of::<PvmemcontrolReq>()),
+            mem::size_of::<PvmemcontrolResp>().max(mem::size_of::<PvmemcontrolReq>()),
         ) {
             warn!("guest sent invalid phys addr {:#x}", buf_phys_addr.0);
             return PvmemcontrolDevice::new(
@@ -348,7 +349,7 @@ impl PvmemcontrolDevice {
         guest_memory: &GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>,
         command: PvmemcontrolTransportCommand,
     ) {
-        let state = std::mem::replace(&mut self.state, PvmemcontrolState::Broken);
+        let state = mem::replace(&mut self.state, PvmemcontrolState::Broken);
 
         *self = match command {
             PvmemcontrolTransportCommand::Reset => Self::reset(),
@@ -488,7 +489,7 @@ impl PvmemcontrolBusDevice {
         let name_ptr = if let Some(name) = &name {
             name.as_ptr()
         } else {
-            std::ptr::null()
+            ptr::null()
         };
         debug!("addr {addr:X} length {length} name {name:?}");
 
@@ -616,7 +617,7 @@ impl PvmemcontrolBusDevice {
     }
 
     fn handle_guest_write(&self, offset: u64, data: &[u8]) {
-        if offset as usize != std::mem::offset_of!(PvmemcontrolTransport, command) {
+        if offset as usize != mem::offset_of!(PvmemcontrolTransport, command) {
             if data.len() != 4 && data.len() != 8 {
                 warn!("guest write is not 4 or 8 bytes long");
                 return;
@@ -716,7 +717,7 @@ impl PciDevice for PvmemcontrolPciDevice {
         self.configuration.restore_bar_addr(params);
     }
 
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -770,7 +771,7 @@ impl PciDevice for PvmemcontrolPciDevice {
         Ok(())
     }
 
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> result::Result<(), io::Error> {
+    fn move_bar(&mut self, old_base: u64, new_base: u64) -> io::Result<()> {
         for bar in self.bar_regions.iter_mut() {
             if bar.addr() == old_base {
                 *bar = bar.set_address(new_base);
@@ -781,11 +782,11 @@ impl PciDevice for PvmemcontrolPciDevice {
 }
 
 impl Pausable for PvmemcontrolPciDevice {
-    fn pause(&mut self) -> std::result::Result<(), MigratableError> {
+    fn pause(&mut self) -> result::Result<(), MigratableError> {
         Ok(())
     }
 
-    fn resume(&mut self) -> std::result::Result<(), MigratableError> {
+    fn resume(&mut self) -> result::Result<(), MigratableError> {
         Ok(())
     }
 }
@@ -795,7 +796,7 @@ impl Snapshottable for PvmemcontrolPciDevice {
         self.id.clone()
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         let mut snapshot = Snapshot::new_from_state(&())?;
 
         // Snapshot PciConfiguration

--- a/devices/src/pvpanic.rs
+++ b/devices/src/pvpanic.rs
@@ -4,8 +4,8 @@
 //
 
 use std::any::Any;
-use std::result;
 use std::sync::{Arc, Barrier};
+use std::{io, result};
 
 use anyhow::anyhow;
 use event_monitor::event;
@@ -178,7 +178,7 @@ impl PciDevice for PvPanicDevice {
         mmio32_allocator: &mut AddressAllocator,
         _mmio64_allocator: &mut AddressAllocator,
         resources: Option<Vec<Resource>>,
-    ) -> std::result::Result<Vec<PciBarConfiguration>, PciDeviceError> {
+    ) -> result::Result<Vec<PciBarConfiguration>, PciDeviceError> {
         let mut bars = Vec::new();
         let region_type = PciBarRegionType::Memory32BitRegion;
         let bar_id = 0;
@@ -213,7 +213,7 @@ impl PciDevice for PvPanicDevice {
         _allocator: &mut SystemAllocator,
         mmio32_allocator: &mut AddressAllocator,
         _mmio64_allocator: &mut AddressAllocator,
-    ) -> std::result::Result<(), PciDeviceError> {
+    ) -> result::Result<(), PciDeviceError> {
         for bar in self.bar_regions.drain(..) {
             mmio32_allocator.free(GuestAddress(bar.addr()), bar.size());
         }
@@ -221,7 +221,7 @@ impl PciDevice for PvPanicDevice {
         Ok(())
     }
 
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> result::Result<(), std::io::Error> {
+    fn move_bar(&mut self, old_base: u64, new_base: u64) -> io::Result<()> {
         for bar in self.bar_regions.iter_mut() {
             if bar.addr() == old_base {
                 *bar = bar.set_address(new_base);
@@ -255,7 +255,7 @@ impl Snapshottable for PvPanicDevice {
         self.id.clone()
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         let mut snapshot = Snapshot::new_from_state(&self.state())?;
 
         // Snapshot PciConfiguration

--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -4,6 +4,7 @@
 //
 
 use std::cmp;
+use std::ops::Range;
 use std::path::Path;
 use std::sync::{Arc, Barrier};
 
@@ -252,7 +253,7 @@ fn complete_request(regs: &mut [u32; TPM_CRB_R_MAX], success: bool) {
     }
 }
 
-fn data_buffer_range(offset: u32, len: usize, buffer_len: usize) -> Option<std::ops::Range<usize>> {
+fn data_buffer_range(offset: u32, len: usize, buffer_len: usize) -> Option<Range<usize>> {
     let end_offset = offset.checked_add(len as u32)?;
     let buffer_end = CRB_DATA_BUFFER.checked_add(buffer_len as u32)?;
 


### PR DESCRIPTION
Part of #7670.

Import the modules used in the crate instead of spelling the
fully-qualified paths at every use site, leaving `devices` free of
`clippy::absolute_paths` warnings (including the feature-gated
`fw_cfg`, `ivshmem` and `pvmemcontrol` modules):

- std: `std::result::Result` → `result::Result`, `std::io::Error` → `io::Error`, `std::fmt::*` → `fmt::*`, `std::time::Duration`/`Instant`, `std::mem::*`, `std::ptr::null`, `std::cmp::min`, `std::ffi::CString`, `std::ops::Range`, `std::any::Any`
- collapse `Result<T, io::Error>` / `result::Result<T, io::Error>` → `io::Result<T>` (std's alias — same type, keeps the `io::` cue)
- arch-gated: `hypervisor::arch::aarch64::gic::Error` → `gic::Error` and `arch::aarch64::arch_memory_regions()` → `arch_memory_regions()`, with matching `#[cfg(target_arch = "aarch64")]` imports
- external: `vmm_sys_util::errno::Result` → `errno::Result`

Paths inside `macro_rules!` bodies are left fully qualified (the lint
exempts them, and trimming would impose imports on expansion sites).

Readability-only change; no functional impact. Follows the same approach
as the merged #8273, #8344, #8345, #8349, #8354 and #8355 cleanups, and
the open #8362 (pci).