### PR TITLE
reevaluate #[allow] attributes (vm-virtio, vm-device, virtio-devices, vmm)

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -493,7 +493,7 @@ pub struct Balloon {
 
 impl Balloon {
     // Create a new virtio-balloon.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         size: u64,

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -737,7 +737,7 @@ pub struct BlockState {
 
 impl Block {
     /// Create a new virtio block device that operates on the given file.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         disk_image: Box<dyn AsyncFullDiskFile>,

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -131,7 +131,7 @@ impl Endpoint {
 }
 
 impl ConsoleEpollHandler {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         input_queue: Queue,

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -746,7 +746,7 @@ pub struct Mem {
 
 impl Mem {
     // Create a new virtio-mem device.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         region: &Arc<GuestRegionMmap>,

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -416,7 +416,7 @@ pub struct NetState {
 
 impl Net {
     /// Create a new virtio network device with the given TAP interface.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_with_tap(
         id: String,
         taps: Vec<Tap>,
@@ -528,7 +528,7 @@ impl Net {
 
     /// Create a new virtio network device with the given IP address and
     /// netmask.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         if_name: Option<&str>,
@@ -576,7 +576,7 @@ impl Net {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn from_tap_fds(
         id: String,
         fds: &[RawFd],

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -282,7 +282,7 @@ pub struct PmemState {
 }
 
 impl Pmem {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         disk: File,

--- a/virtio-devices/src/thread_helper.rs
+++ b/virtio-devices/src/thread_helper.rs
@@ -16,7 +16,7 @@ use crate::epoll_helper::EpollHelperError;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::{ActivateError, VirtioInterrupt, mark_device_needs_reset};
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn spawn_virtio_thread<F>(
     name: &str,
     seccomp_action: &SeccompAction,

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -418,7 +418,7 @@ pub struct VirtioPciDevice {
 
 impl VirtioPciDevice {
     /// Constructs a new PCI transport for the given virtio device.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         memory: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -71,7 +71,7 @@ pub struct Fs {
 
 impl Fs {
     /// Create a new virtio-fs device.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         path: &str,

--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -59,7 +59,7 @@ pub struct GenericVhostUser {
 
 impl GenericVhostUser {
     /// Create a new generic vhost-user device.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         path: &str,

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -473,7 +473,7 @@ pub struct VhostUserCommon {
 }
 
 impl VhostUserCommon {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn activate<T: VhostUserFrontendReqHandler>(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -49,7 +49,7 @@ pub struct Net {
 
 impl Net {
     /// Create a new vhost-user-net device
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         mac_addr: MacAddr,

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -159,7 +159,7 @@ impl VhostUserHandle {
         Ok((acked_features, acked_protocol_features.bits()))
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn setup_vhost_user<S: VhostUserFrontendReqHandler>(
         &mut self,
         mem: &GuestMemoryMmap,
@@ -352,7 +352,7 @@ impl VhostUserHandle {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn reinitialize_vhost_user<S: VhostUserFrontendReqHandler>(
         &mut self,
         mem: &GuestMemoryMmap,

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -366,7 +366,7 @@ where
 {
     /// Create a new virtio-vsock device with the given VM CID and vsock
     /// backend.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         cid: u32,

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -205,7 +205,7 @@ pub mod unit_tests {
         pub evset: Option<epoll::Events>,
     }
     impl TestBackend {
-        #[allow(clippy::new_without_default)]
+        #[expect(clippy::new_without_default)]
         pub fn new() -> Self {
             Self {
                 evfd: EventFd::new(EFD_NONBLOCK).unwrap(),
@@ -270,7 +270,7 @@ pub mod unit_tests {
     }
 
     impl TestContext {
-        #[allow(clippy::new_without_default)]
+        #[expect(clippy::new_without_default)]
         pub fn new() -> Self {
             const CID: u32 = 52;
             const MEM_SIZE: usize = 1024 * 1024 * 128;

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 ///
 /// The device does not care where it exists in address space as each method is only given an offset
 /// into its allocated portion of address space.
-#[allow(unused_variables)]
+#[expect(unused_variables)]
 pub trait BusDevice: Send {
     /// Reads at `offset` from this device
     fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {}
@@ -28,7 +28,7 @@ pub trait BusDevice: Send {
     }
 }
 
-#[allow(unused_variables)]
+#[expect(unused_variables)]
 pub trait BusDeviceSync: Send + Sync {
     /// Reads at `offset` from this device
     fn read(&self, base: u64, offset: u64, data: &mut [u8]) {}
@@ -136,7 +136,6 @@ impl Bus {
         dev.upgrade().map(|d| (*range, d.clone()))
     }
 
-    #[allow(clippy::type_complexity)]
     fn resolve(&self, addr: u64) -> Option<(u64, u64, Arc<dyn BusDeviceSync>)> {
         if let Some((range, dev)) = self.first_before(addr) {
             let offset = addr - range.base;
@@ -150,7 +149,7 @@ impl Bus {
     /// Inserts a bus device into the bus.
     ///
     /// The bus will only hold a weak reference to the object.
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn insert(&self, device: Arc<dyn BusDeviceSync>, base: u64, len: u64) -> Result<()> {
         if len == 0 {
             return Err(Error::ZeroSizedRange);

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -164,7 +164,6 @@ pub trait InterruptSourceGroup: Send + Sync {
     /// An interrupt notifier allows for external components and processes
     /// to inject interrupts into a guest, by writing to the [`EventFd`] returned
     /// by this method.
-    #[allow(unused_variables)]
     fn notifier(&self, index: InterruptIndex) -> Option<EventFd>;
 
     /// Update the interrupt source group configuration.

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -34,7 +34,7 @@ pub enum PciBarType {
 }
 
 /// Enumeration for device resources.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Resource {
     /// IO Port address range.

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -23,7 +23,6 @@ pub const VIRTIO_MSI_NO_VECTOR: u16 = 0xffff;
 
 // Types taken from linux/virtio_ids.h
 #[derive(Copy, Clone, Debug)]
-#[allow(non_camel_case_types)]
 #[repr(C)]
 pub enum VirtioDeviceType {
     Net = 1,

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -98,7 +98,7 @@ const HTTP_ROOT: &str = "/api/v1";
 /// The error message contained in the response is supposed to be user-facing,
 /// thus insightful and helpful while balancing technical accuracy and
 /// simplicity.
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 pub fn error_response(error: HttpError) -> Response {
     let mut response = Response::new(Version::Http11, error.status_code());
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -603,7 +603,7 @@ pub trait RequestHandler {
 pub type ApiRequest =
     Box<dyn FnOnce(&mut dyn RequestHandler) -> Result<bool, VmmError> + Send + 'static>;
 
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 fn get_response<Action: ApiAction>(
     action: &Action,
     api_evt: EventFd,

--- a/vmm/src/clone3.rs
+++ b/vmm/src/clone3.rs
@@ -7,7 +7,6 @@ pub const CLONE_CLEAR_SIGHAND: u64 = 0x100000000;
 
 #[repr(C)]
 #[derive(Default)]
-#[allow(non_camel_case_types)]
 pub struct clone_args {
     pub flags: u64,
     pub pidfd: u64,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1046,7 +1046,7 @@ impl PlatformConfig {
 }
 
 impl MemoryConfig {
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn parse(memory: &str, memory_zones: Option<Vec<&str>>) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
@@ -4517,7 +4517,6 @@ mod unit_tests {
     }
 
     #[track_caller]
-    #[allow(clippy::too_many_arguments)]
     fn make_vhost_user_config(
         socket: &str,
         virtio_id: u64,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -842,8 +842,8 @@ impl VcpuState {
 }
 
 impl CpuManager {
-    #[allow(unused_variables)]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(unused_variables)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         config: &CpusConfig,
         vm: Arc<dyn hypervisor::Vm>,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1197,7 +1197,7 @@ fn use_64bit_bar_for_virtio_device(
 }
 
 impl DeviceManager {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         io_bus: Arc<Bus>,
         mmio_bus: Arc<Bus>,
@@ -1465,7 +1465,7 @@ impl DeviceManager {
         self.add_interrupt_controller(snapshot)
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn create_devices(
         &mut self,
         console_info: Option<ConsoleInfo>,
@@ -4305,7 +4305,7 @@ impl DeviceManager {
         Ok(vec![])
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn add_virtio_pci_device(
         &mut self,
         virtio_device: Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
@@ -4842,7 +4842,6 @@ impl DeviceManager {
             .pci_device_handle
             .as_ref()
             .ok_or(DeviceManagerError::MissingPciDevice)?;
-        #[allow(irrefutable_let_patterns)]
         if let PciDeviceHandle::Virtio(virtio_pci_device) = pci_device_handle {
             let device_type = VirtioDeviceType::from(
                 virtio_pci_device

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -273,7 +273,7 @@ pub fn extract_sev_features(igvm_file: &IgvmFile) -> u64 {
 /// NOTE: KVM and MSHV have different page type values and CPUID/VMSA handling.
 /// Hypervisor-specific code paths are gated by runtime type checks. A future
 /// refactor could split these into separate KVM/MSHV loader implementations.
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 pub fn load_igvm(
     igvm_file: IgvmFile,
     memory_manager: Arc<Mutex<MemoryManager>>,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -447,8 +447,7 @@ pub fn start_event_monitor_thread(
         .map_err(Error::EventMonitorThreadSpawn)
 }
 
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn start_vmm_thread(
     vmm_version: VmmVersionInfo,
     http_path: &Option<String>,
@@ -717,7 +716,7 @@ impl Vmm {
 
         for signal in signals.forever() {
             match signal {
-                #[allow(clippy::collapsible_match)]
+                #[expect(clippy::collapsible_match)]
                 SIGTERM | SIGINT => {
                     if exit_evt.write(1).is_err() {
                         // Resetting the terminal is usually done as the VMM exits

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1140,7 +1140,7 @@ impl MemoryManager {
     /// snapshot file followed by a `UFFDIO_COPY` to resolve the fault and
     /// wake the faulting thread. When no fault is pending, one prefault
     /// page is copied per loop iteration.
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn uffd_handler_loop(
         uffd_fd: OwnedFd,
         stop_event: EventFd,
@@ -1643,7 +1643,6 @@ impl MemoryManager {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         vm: Arc<dyn hypervisor::Vm>,
         config: &MemoryConfig,
@@ -1899,7 +1898,7 @@ impl MemoryManager {
         Ok(Arc::new(Mutex::new(memory_manager)))
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_from_snapshot(
         snapshot: &Snapshot,
         vm: Arc<dyn hypervisor::Vm>,
@@ -2042,7 +2041,7 @@ impl MemoryManager {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn create_ram_region_raw(
         backing_file: &Option<PathBuf>,
         file_offset: u64,
@@ -2179,7 +2178,7 @@ impl MemoryManager {
         Ok(region)
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn create_ram_region(
         backing_file: &Option<PathBuf>,
         file_offset: u64,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -560,8 +560,8 @@ impl Vm {
             .with_migrate_ma(0)
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::needless_pass_by_value)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_from_memory_manager(
         config: Arc<Mutex<VmConfig>>,
         memory_manager: Arc<Mutex<MemoryManager>>,
@@ -751,7 +751,7 @@ impl Vm {
     }
 
     /// Create and configure the CPU manager.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn create_cpu_manager(
         config: &Arc<Mutex<VmConfig>>,
         vm: Arc<dyn hypervisor::Vm>,
@@ -828,7 +828,7 @@ impl Vm {
     }
 
     /// Create and configure the device manager.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn create_device_manager(
         io_bus: Arc<Bus>,
         mmio_bus: Arc<Bus>,
@@ -881,7 +881,7 @@ impl Vm {
     /// - KVM (x86_64, aarch64, riscv64)
     /// - MSHV (x86_64, aarch64)
     /// - SEV-SNP (MSHV with confidential computing)
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn hypervisor_specific_init(
         vm: &Arc<dyn hypervisor::Vm>,
         memory_manager: &Arc<Mutex<MemoryManager>>,
@@ -995,7 +995,7 @@ impl Vm {
 
     /// Initialize SEV-SNP specific components.
     #[cfg(feature = "sev_snp")]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn init_sev_snp(
         vm: &Arc<dyn hypervisor::Vm>,
         memory_manager: &Arc<Mutex<MemoryManager>>,
@@ -1325,7 +1325,7 @@ impl Vm {
         Ok(numa_nodes)
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         vm_config: Arc<Mutex<VmConfig>>,
         exit_evt: EventFd,
@@ -1496,7 +1496,7 @@ impl Vm {
         Ok(cmdline)
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     fn load_firmware(
         mut firmware: &File,
@@ -1561,7 +1561,7 @@ impl Vm {
     }
 
     #[cfg(feature = "igvm")]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn load_igvm(
         igvm_file: IgvmFile,
         memory_manager: Arc<Mutex<MemoryManager>>,
@@ -1619,7 +1619,7 @@ impl Vm {
     ///
     /// For x86_64, the boot path is the same.
     #[cfg(target_arch = "x86_64")]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn load_kernel(
         mut kernel: File,
         cmdline: Option<Cmdline>,


### PR DESCRIPTION
Part of #8326. Continues from #8363 (pci).

Reevaluates the `#[allow]` attributes across four more crates, one commit per crate:

- **vm-virtio** - removed a stale `non_camel_case_types`.
- **vm-device** - removed stale suppressions, converted the rest to `#[expect]`.
- **virtio-devices** - converted the still-needed ones to `#[expect]`.
- **vmm** - removed stale ones, converted unconditional ones to `#[expect]`,
  and kept arch/feature-conditional ones as `#[allow]`.

Each attribute was classified by running clippy and either:
- deleting it if the lint no longer fires anywhere,
- converting to `#[expect]` if it fires unconditionally, or
- keeping it as `#[allow]` if it fires only under some configs.

Verified across kvm/mshv x  x86_64/aarch64 (and `vmm` additionally with
`--all-features` on x86_64), which caught lints that only fire under
specific feature/arch combinations.

Remaining crates (`devices`, `arch`, `hypervisor`) will follow in a
separate PR.