### PR TITLE
vmm: device_manager: verify pci_segment_id before using it as index

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -686,6 +686,10 @@ pub enum DeviceManagerError {
         specified: ImageType,
         detected: ImageType,
     },
+
+    /// Invalid PCI segment id
+    #[error("Invalid PCI segment id: {0}")]
+    InvalidPciSegment(u16),
 }
 
 pub type DeviceManagerResult<T> = result::Result<T, DeviceManagerError>;
@@ -4667,8 +4671,12 @@ impl DeviceManager {
 
             (pci_segment_id, pci_device_bdf, resources)
         } else {
-            let pci_device_bdf =
-                self.pci_segments[pci_segment_id as usize].allocate_device_id(pci_device_id)?;
+            let pci_segment = self
+                .pci_segments
+                .get(pci_segment_id as usize)
+                .ok_or_else(|| DeviceManagerError::InvalidPciSegment(pci_segment_id))?;
+
+            let pci_device_bdf = pci_segment.allocate_device_id(pci_device_id)?;
 
             (pci_segment_id, pci_device_bdf, None)
         })


### PR DESCRIPTION
Currently, if there is no platform configuration provided it is possible to crash the hypervisor by attaching a device to a nonexistent PCI segment:

ch-remote ... add-device path=... pci_segment=1 pci_device_id=6 id=...

This results in an out-of-bounds access to pci_segments and a consequent crash:

thread 'vmm' (88165) panicked at vmm/src/device_manager.rs:4596:17: index out of bounds: the len is 1 but the index is 1

There is already some check that is done in
PciDeviceCommonConfig::validate(), but it is performed only when a platform configuration has been provided. Theoretically, the fix could be implemented there instead of the device manager, but that would break the existing logic of numerous tests that verify whether a configuration in question has been created according to the provided pattern ignoring the fact that the generated configuration is in fact erroneous. For example, an attempt to launch a vmm with the setting "tty,pci_segment=1,pci_device_id=7" from
test_valid_vm_config_serial_console() results in the same crash as mentioned above.

Perform a check before accessing the array.