### PR TITLE
vmm: Fix PCI segment ID validation

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -1717,12 +1717,12 @@ mod unit_tests {
                     "--serial",
                     "null",
                     "--console",
-                    "tty,pci_segment=1,pci_device_id=7",
+                    "tty,pci_segment=0,pci_device_id=7",
                 ],
                 r#"{
                     "payload": {"kernel": "/path/to/kernel"},
                     "serial": {"mode": "Null"},
-                    "console": {"mode": "Tty", "iommu": false, "pci_segment": 1, "pci_device_id": 7}
+                    "console": {"mode": "Tty", "iommu": false, "pci_segment": 0, "pci_device_id": 7}
                 }"#,
                 true,
             ),

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1365,17 +1365,23 @@ impl PciDeviceCommonConfig {
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        if let Some(platform_config) = vm_config.platform.as_ref() {
-            if self.pci_segment >= platform_config.num_pci_segments {
-                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
-            }
+        let num_pci_segments = vm_config
+            .platform
+            .as_ref()
+            .map_or(DEFAULT_NUM_PCI_SEGMENTS, |platform_config| {
+                platform_config.num_pci_segments
+            });
 
-            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
-                && iommu_segments.contains(&self.pci_segment)
-                && !self.iommu
-            {
-                return Err(ValidationError::OnIommuSegment(self.pci_segment));
-            }
+        if self.pci_segment >= num_pci_segments {
+            return Err(ValidationError::InvalidPciSegment(self.pci_segment));
+        }
+
+        if let Some(platform_config) = vm_config.platform.as_ref()
+            && let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
+            && iommu_segments.contains(&self.pci_segment)
+            && !self.iommu
+        {
+            return Err(ValidationError::OnIommuSegment(self.pci_segment));
         }
 
         if let Some(device_id) = self.pci_device_id {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2892,8 +2892,7 @@ mod unit_tests {
     #[test]
     fn test_vmm_vm_cold_add_user_device() {
         let mut vmm = create_dummy_vmm();
-        let user_device_config =
-            UserDeviceConfig::parse("socket=/path/to/socket,id=8,pci_segment=2").unwrap();
+        let user_device_config = UserDeviceConfig::parse("socket=/path/to/socket,id=8").unwrap();
 
         assert!(matches!(
             vmm.vm_add_user_device(user_device_config.clone()),


### PR DESCRIPTION
Support validating the PCI segment ID even when no platform configuration is
specified.

See: #8376

- **main: Fix test_valid_vm_config_serial_console**
- **vmm: Validate the PCI segment ID without platform configuration**
