### PR TITLE
block: Remove use of raw libc::pread/pwrite & implement VHDx O_DIRECT support

### DIFF
--- a/block/src/aligned_buffer.rs
+++ b/block/src/aligned_buffer.rs
@@ -1,0 +1,277 @@
+// Copyright 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::alloc::{Layout, alloc_zeroed, dealloc};
+use std::os::unix::fs::FileExt;
+use std::{io, slice};
+
+/// RAII aligned heap buffer for O_DIRECT I/O.
+///
+/// Handles the alignment math for offset and length, allocating a buffer
+/// that satisfies O_DIRECT constraints. The caller's logical data lives
+/// at `as_slice()`/`as_mut_slice()` (accounting for head padding when the
+/// requested offset is not alignment-aligned). The full aligned region is
+/// used internally for pread/pwrite via `FileExt`.
+#[allow(dead_code)]
+pub(crate) struct AlignedBuffer {
+    ptr: *mut u8,
+    layout: Layout,
+    head_pad: usize,
+    user_len: usize,
+    aligned_len: usize,
+    aligned_offset: u64,
+}
+
+#[allow(dead_code)]
+impl AlignedBuffer {
+    /// Create a new aligned buffer for I/O at `offset` of `len` bytes with
+    /// the given `alignment` requirement.
+    ///
+    /// When offset and length are already aligned, `head_pad == 0` and the
+    /// full buffer equals the user's logical portion (no overhead).
+    pub fn new(offset: u64, len: usize, alignment: usize) -> io::Result<Self> {
+        if alignment == 0 || !alignment.is_power_of_two() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "alignment must be a non-zero power of two",
+            ));
+        }
+
+        let mask = alignment as u64 - 1;
+        let aligned_offset = offset & !mask;
+        let head_pad = (offset - aligned_offset) as usize;
+        let min_len = head_pad
+            .checked_add(len)
+            .ok_or_else(|| io::Error::other("aligned buffer length overflow"))?;
+        let aligned_len = if min_len == 0 {
+            0
+        } else {
+            let remainder = min_len % alignment;
+            if remainder == 0 {
+                min_len
+            } else {
+                min_len
+                    .checked_add(alignment - remainder)
+                    .ok_or_else(|| io::Error::other("aligned buffer length overflow"))?
+            }
+        };
+
+        // alloc_zeroed is UB on a zero-sized layout, so round the allocation
+        // up to one alignment unit for the zero-length case. The padding is
+        // never exposed: as_slice/full_slice report aligned_len/user_len (0).
+        let layout = Layout::from_size_align(aligned_len.max(alignment), alignment)
+            .map_err(|e| io::Error::other(format!("invalid aligned layout: {e}")))?;
+        // SAFETY: layout has non-zero size.
+        let ptr = unsafe { alloc_zeroed(layout) };
+        if ptr.is_null() {
+            return Err(io::Error::new(
+                io::ErrorKind::OutOfMemory,
+                "aligned allocation failed",
+            ));
+        }
+
+        Ok(AlignedBuffer {
+            ptr,
+            layout,
+            head_pad,
+            user_len: len,
+            aligned_len,
+            aligned_offset,
+        })
+    }
+
+    /// The caller's logical portion of the buffer (read-only).
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: ptr is valid for layout.size() bytes; head_pad + user_len <= layout.size().
+        unsafe { slice::from_raw_parts(self.ptr.add(self.head_pad), self.user_len) }
+    }
+
+    /// The caller's logical portion of the buffer (mutable).
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: ptr is valid for layout.size() bytes; head_pad + user_len <= layout.size().
+        unsafe { slice::from_raw_parts_mut(self.ptr.add(self.head_pad), self.user_len) }
+    }
+
+    fn full_slice(&self) -> &[u8] {
+        // SAFETY: ptr is valid for layout.size() bytes; aligned_len <= layout.size().
+        unsafe { slice::from_raw_parts(self.ptr, self.aligned_len) }
+    }
+
+    fn full_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: ptr is valid for layout.size() bytes; aligned_len <= layout.size().
+        unsafe { slice::from_raw_parts_mut(self.ptr, self.aligned_len) }
+    }
+
+    /// Read the full aligned region from `f` into this buffer.
+    pub fn read_exact_from(&mut self, f: &impl FileExt) -> io::Result<()> {
+        let offset = self.aligned_offset;
+        f.read_exact_at(self.full_mut_slice(), offset)
+    }
+
+    /// Read into the buffer from `f`, tolerating a short read at EOF.
+    ///
+    /// Returns the number of caller-logical bytes now valid in `as_slice()`,
+    /// accounting for head padding and any short read.
+    pub fn read_from(&mut self, f: &impl FileExt) -> io::Result<usize> {
+        let mut total = 0usize;
+        while total < self.aligned_len {
+            let offset = self
+                .aligned_offset
+                .checked_add(total as u64)
+                .ok_or_else(|| io::Error::other("aligned buffer offset overflow"))?;
+            match f.read_at(&mut self.full_mut_slice()[total..], offset) {
+                Ok(0) => break,
+                Ok(n) => total += n,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(total.saturating_sub(self.head_pad).min(self.user_len))
+    }
+
+    /// Write the full aligned region from this buffer to `f`.
+    pub fn write_to(&self, f: &impl FileExt) -> io::Result<()> {
+        f.write_all_at(self.full_slice(), self.aligned_offset)
+    }
+}
+
+impl Drop for AlignedBuffer {
+    fn drop(&mut self) {
+        // SAFETY: ptr was allocated by alloc_zeroed with self.layout.
+        unsafe { dealloc(self.ptr, self.layout) };
+    }
+}
+
+// SAFETY: The buffer is a plain heap allocation with no interior references.
+unsafe impl Send for AlignedBuffer {}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::os::unix::fs::FileExt;
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+
+    fn create_pattern_file(size: usize) -> TempFile {
+        let tf = TempFile::new().unwrap();
+        let pattern: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        tf.as_file().write_all(&pattern).unwrap();
+        tf.as_file().sync_all().unwrap();
+        tf
+    }
+
+    #[test]
+    fn test_read_aligned() {
+        let size = 4096usize;
+        let tf = create_pattern_file(size);
+        let alignment = 512;
+
+        let mut abuf = AlignedBuffer::new(0, size, alignment).unwrap();
+        abuf.read_exact_from(tf.as_file()).unwrap();
+
+        let expected: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        assert_eq!(abuf.as_slice(), &expected[..]);
+    }
+
+    #[test]
+    fn test_zero_len_is_noop() {
+        let tf = create_pattern_file(512);
+        let mut abuf = AlignedBuffer::new(100, 0, 512).unwrap();
+
+        abuf.read_exact_from(tf.as_file()).unwrap();
+        abuf.write_to(tf.as_file()).unwrap();
+
+        assert!(abuf.as_slice().is_empty());
+        assert!(abuf.as_mut_slice().is_empty());
+    }
+
+    #[test]
+    fn test_read_unaligned_offset() {
+        let file_size = 8192usize;
+        let tf = create_pattern_file(file_size);
+        let alignment = 512;
+
+        let offset = 100u64;
+        let len = 200usize;
+        let mut abuf = AlignedBuffer::new(offset, len, alignment).unwrap();
+        abuf.read_exact_from(tf.as_file()).unwrap();
+
+        let expected: Vec<u8> = (offset as usize..offset as usize + len)
+            .map(|i| (i % 251) as u8)
+            .collect();
+        assert_eq!(abuf.as_slice(), &expected[..]);
+    }
+
+    #[test]
+    fn test_write_aligned() {
+        let size = 4096usize;
+        let tf = create_pattern_file(size);
+        let alignment = 512;
+
+        let data: Vec<u8> = (0..size).map(|i| ((i + 1) % 251) as u8).collect();
+        let mut abuf = AlignedBuffer::new(0, size, alignment).unwrap();
+        abuf.as_mut_slice().copy_from_slice(&data);
+        abuf.write_to(tf.as_file()).unwrap();
+
+        let mut readback = vec![0u8; size];
+        tf.as_file().read_exact_at(&mut readback, 0).unwrap();
+        assert_eq!(readback, data);
+    }
+
+    #[test]
+    fn test_write_unaligned_offset_rmw() {
+        let file_size = 8192usize;
+        let tf = create_pattern_file(file_size);
+        let alignment = 512;
+
+        let offset = 100u64;
+        let len = 200usize;
+        let data: Vec<u8> = (0..len).map(|i| ((i + 1) % 239) as u8).collect();
+
+        let mut abuf = AlignedBuffer::new(offset, len, alignment).unwrap();
+        abuf.read_exact_from(tf.as_file()).unwrap();
+        abuf.as_mut_slice().copy_from_slice(&data);
+        abuf.write_to(tf.as_file()).unwrap();
+
+        let mut whole = vec![0u8; file_size];
+        tf.as_file().read_exact_at(&mut whole, 0).unwrap();
+
+        let before: Vec<u8> = (0..offset as usize).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[..offset as usize], &before[..]);
+        assert_eq!(&whole[offset as usize..offset as usize + len], &data[..]);
+        let after_start = offset as usize + len;
+        let after: Vec<u8> = (after_start..file_size).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[after_start..], &after[..]);
+    }
+
+    #[test]
+    fn test_4096_alignment() {
+        let file_size = 16384usize;
+        let tf = create_pattern_file(file_size);
+        let alignment = 4096;
+
+        let offset = 4096u64;
+        let len = 4096usize;
+        let data: Vec<u8> = (0..len).map(|i| ((i + 1) % 239) as u8).collect();
+
+        let mut abuf = AlignedBuffer::new(offset, len, alignment).unwrap();
+        abuf.read_exact_from(tf.as_file()).unwrap();
+        abuf.as_mut_slice().copy_from_slice(&data);
+        abuf.write_to(tf.as_file()).unwrap();
+
+        let mut abuf = AlignedBuffer::new(offset, len, alignment).unwrap();
+        abuf.read_exact_from(tf.as_file()).unwrap();
+        assert_eq!(abuf.as_slice(), &data[..]);
+
+        let mut whole = vec![0u8; file_size];
+        tf.as_file().read_exact_at(&mut whole, 0).unwrap();
+        let before: Vec<u8> = (0..offset as usize).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[..offset as usize], &before[..]);
+        let after_start = offset as usize + len;
+        let after: Vec<u8> = (after_start..file_size).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[after_start..], &after[..]);
+    }
+}

--- a/block/src/aligned_buffer.rs
+++ b/block/src/aligned_buffer.rs
@@ -102,7 +102,6 @@ impl AlignedBuffer {
     }
 
     /// Read the full aligned region from `f` into this buffer.
-    #[cfg_attr(not(test), expect(dead_code))]
     pub fn read_exact_from(&mut self, f: &impl FileExt) -> io::Result<()> {
         let offset = self.aligned_offset;
         f.read_exact_at(self.full_mut_slice(), offset)

--- a/block/src/aligned_buffer.rs
+++ b/block/src/aligned_buffer.rs
@@ -13,7 +13,6 @@ use std::{io, slice};
 /// at `as_slice()`/`as_mut_slice()` (accounting for head padding when the
 /// requested offset is not alignment-aligned). The full aligned region is
 /// used internally for pread/pwrite via `FileExt`.
-#[allow(dead_code)]
 pub(crate) struct AlignedBuffer {
     ptr: *mut u8,
     layout: Layout,
@@ -23,7 +22,6 @@ pub(crate) struct AlignedBuffer {
     aligned_offset: u64,
 }
 
-#[allow(dead_code)]
 impl AlignedBuffer {
     /// Create a new aligned buffer for I/O at `offset` of `len` bytes with
     /// the given `alignment` requirement.
@@ -104,6 +102,7 @@ impl AlignedBuffer {
     }
 
     /// Read the full aligned region from `f` into this buffer.
+    #[cfg_attr(not(test), expect(dead_code))]
     pub fn read_exact_from(&mut self, f: &impl FileExt) -> io::Result<()> {
         let offset = self.aligned_offset;
         f.read_exact_at(self.full_mut_slice(), offset)

--- a/block/src/aligned_file.rs
+++ b/block/src/aligned_file.rs
@@ -68,6 +68,13 @@ impl AlignedFile {
             alignment: self.alignment,
         })
     }
+
+    /// Wrap `file` with an explicit alignment, bypassing the probe. Used by
+    /// tests to force the bounce/RMW path without a real O_DIRECT fd.
+    #[cfg(test)]
+    pub fn with_alignment(file: File, alignment: usize) -> Self {
+        AlignedFile { file, alignment }
+    }
 }
 
 impl FileExt for AlignedFile {

--- a/block/src/aligned_file.rs
+++ b/block/src/aligned_file.rs
@@ -31,7 +31,6 @@ pub(crate) struct AlignedFile {
     alignment: usize,
 }
 
-#[cfg_attr(not(test), expect(dead_code))]
 impl AlignedFile {
     /// Wrap `file`, probing the O_DIRECT block alignment when `direct_io`.
     pub fn new(file: File, direct_io: bool) -> Self {

--- a/block/src/aligned_file.rs
+++ b/block/src/aligned_file.rs
@@ -1,0 +1,190 @@
+// Copyright 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::File;
+use std::io;
+use std::os::unix::fs::FileExt;
+
+use crate::aligned_buffer::AlignedBuffer;
+
+/// O_DIRECT block-alignment candidates, smallest first.
+const BLK_ALIGNMENTS: [usize; 2] = [512, 4096];
+
+/// True when `buf_ptr`/`len`/`offset` already satisfy `alignment`
+/// (`alignment == 0` means no O_DIRECT, so everything is "aligned").
+fn is_aligned(alignment: usize, buf_ptr: usize, len: usize, offset: u64) -> bool {
+    alignment == 0
+        || (buf_ptr.is_multiple_of(alignment)
+            && len.is_multiple_of(alignment)
+            && offset.is_multiple_of(alignment as u64))
+}
+
+/// A `File` that transparently satisfies O_DIRECT alignment requirements.
+///
+/// `alignment == 0` means no O_DIRECT (all I/O passes straight through).
+/// For unaligned requests under O_DIRECT, I/O is bounced through an
+/// `AlignedBuffer` (read-modify-write for writes).
+#[derive(Debug)]
+pub(crate) struct AlignedFile {
+    file: File,
+    alignment: usize,
+}
+
+#[cfg_attr(not(test), expect(dead_code))]
+impl AlignedFile {
+    /// Wrap `file`, probing the O_DIRECT block alignment when `direct_io`.
+    pub fn new(file: File, direct_io: bool) -> Self {
+        let mut alignment = 0;
+        if direct_io {
+            for align in &BLK_ALIGNMENTS {
+                // Probe: an aligned read at `align` succeeds (a short read at
+                // EOF still counts) iff the fd accepts that O_DIRECT block size.
+                let ok = AlignedBuffer::new(*align as u64, *align, *align)
+                    .is_ok_and(|mut b| b.read_from(&file).is_ok());
+                if ok {
+                    alignment = *align;
+                    break;
+                }
+            }
+        }
+        AlignedFile { file, alignment }
+    }
+
+    pub fn alignment(&self) -> usize {
+        self.alignment
+    }
+
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    pub fn file_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(AlignedFile {
+            file: self.file.try_clone()?,
+            alignment: self.alignment,
+        })
+    }
+}
+
+impl FileExt for AlignedFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if is_aligned(self.alignment, buf.as_ptr() as usize, buf.len(), offset) {
+            return self.file.read_at(buf, offset);
+        }
+        let mut abuf = AlignedBuffer::new(offset, buf.len(), self.alignment)?;
+        let n = abuf.read_from(&self.file)?;
+        buf[..n].copy_from_slice(&abuf.as_slice()[..n]);
+        Ok(n)
+    }
+
+    fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if is_aligned(self.alignment, buf.as_ptr() as usize, buf.len(), offset) {
+            return self.file.write_at(buf, offset);
+        }
+        let mut abuf = AlignedBuffer::new(offset, buf.len(), self.alignment)?;
+        abuf.read_from(&self.file)?; // RMW: preserve head/tail padding
+        abuf.as_mut_slice().copy_from_slice(buf);
+        abuf.write_to(&self.file)?;
+        Ok(buf.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::os::unix::fs::FileExt;
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+
+    fn pattern_file(size: usize) -> TempFile {
+        let tf = TempFile::new().unwrap();
+        let p: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        tf.as_file().write_all(&p).unwrap();
+        tf.as_file().sync_all().unwrap();
+        tf
+    }
+
+    fn forced(file: File, alignment: usize) -> AlignedFile {
+        AlignedFile { file, alignment }
+    }
+
+    #[test]
+    fn new_probes_alignment_and_accessors() {
+        let tf = pattern_file(8192);
+        // Non-O_DIRECT tempfile: an aligned read at `align` still succeeds,
+        // so the probe selects 512 (exercises new + probe).
+        let mut af = AlignedFile::new(tf.as_file().try_clone().unwrap(), true);
+        assert_eq!(af.alignment(), 512);
+        let _ = af.file();
+        let _ = af.file_mut();
+        let _ = af.try_clone().unwrap();
+
+        let plain = AlignedFile::new(tf.as_file().try_clone().unwrap(), false);
+        assert_eq!(plain.alignment(), 0);
+    }
+
+    #[test]
+    fn read_unaligned_offset_matches_contents() {
+        let tf = pattern_file(8192);
+        let af = forced(tf.as_file().try_clone().unwrap(), 512);
+        let mut buf = vec![0u8; 200];
+        assert_eq!(af.read_at(&mut buf, 100).unwrap(), 200);
+        let want: Vec<u8> = (100..300).map(|i| (i % 251) as u8).collect();
+        assert_eq!(buf, want);
+    }
+
+    #[test]
+    fn read_unaligned_short_at_eof() {
+        let tf = pattern_file(100);
+        let af = forced(tf.as_file().try_clone().unwrap(), 512);
+        let mut buf = vec![0u8; 200];
+        assert_eq!(af.read_at(&mut buf, 10).unwrap(), 90);
+    }
+
+    #[test]
+    fn write_unaligned_offset_is_rmw() {
+        let tf = pattern_file(8192);
+        let af = forced(tf.as_file().try_clone().unwrap(), 512);
+        let data: Vec<u8> = (0..200).map(|i| ((i + 1) % 239) as u8).collect();
+        assert_eq!(af.write_at(&data, 100).unwrap(), 200);
+
+        let mut whole = vec![0u8; 8192];
+        tf.as_file().read_exact_at(&mut whole, 0).unwrap();
+        let before: Vec<u8> = (0..100).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[..100], &before[..]);
+        assert_eq!(&whole[100..300], &data[..]);
+        let after: Vec<u8> = (300..8192).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[300..], &after[..]);
+    }
+
+    #[test]
+    fn aligned_passthrough_roundtrip() {
+        let tf = pattern_file(4096);
+        let af = forced(tf.as_file().try_clone().unwrap(), 512);
+        let mut buf = vec![0u8; 512];
+        assert_eq!(af.read_at(&mut buf, 512).unwrap(), 512);
+        let want: Vec<u8> = (512..1024).map(|i| (i % 251) as u8).collect();
+        assert_eq!(buf, want);
+    }
+
+    #[test]
+    fn no_alignment_is_plain_passthrough() {
+        let tf = pattern_file(100);
+        let af = forced(tf.as_file().try_clone().unwrap(), 0);
+        let mut buf = vec![0u8; 50];
+        assert_eq!(af.read_at(&mut buf, 10).unwrap(), 50);
+    }
+}

--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -114,7 +114,7 @@ fn open_vhdx(
 ) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
     info!("Opening VHDX disk file with synchronous backend");
     Ok(Box::new(
-        VhdxDisk::new(file).map_err(|e| e.with_path(options.path))?,
+        VhdxDisk::new(file, options.direct).map_err(|e| e.with_path(options.path))?,
     ))
 }
 

--- a/block/src/formats/qcow/common.rs
+++ b/block/src/formats/qcow/common.rs
@@ -7,52 +7,12 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 //! Shared helpers for QCOW2 sync and async backends.
-//!
-//! Position-independent I/O helpers used by both `qcow_sync` and `qcow_async`.
 
 use std::io;
-use std::os::fd::RawFd;
 
 #[cfg(test)]
 use super::internal;
 use super::internal::decoder::Decoder;
-
-// -- Position independent I/O helpers --
-//
-// Duplicated file descriptors share the kernel file description and thus the
-// file position. Using seek then read from multiple queues races on that
-// shared position. pread64 and pwrite64 are atomic and never touch the position.
-
-/// Read exactly the requested bytes at offset, looping on short reads.
-pub fn pread_exact(fd: RawFd, buf: &mut [u8], offset: u64) -> io::Result<()> {
-    let mut total = 0usize;
-    while total < buf.len() {
-        // SAFETY: buf and fd are valid for the lifetime of the call.
-        let ret = unsafe {
-            libc::pread64(
-                fd,
-                buf[total..].as_mut_ptr().cast(),
-                buf.len() - total,
-                (offset + total as u64) as libc::off_t,
-            )
-        };
-        if ret < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        if ret == 0 {
-            return Err(io::Error::from(io::ErrorKind::UnexpectedEof));
-        }
-        total += ret as usize;
-    }
-    Ok(())
-}
-
-/// Allocate a buffer and pread exactly `len` bytes at `offset`.
-pub fn pread_alloc(fd: RawFd, offset: u64, len: usize) -> io::Result<Vec<u8>> {
-    let mut buf = vec![0u8; len];
-    pread_exact(fd, &mut buf, offset)?;
-    Ok(buf)
-}
 
 /// Decompress a full QCOW2 cluster from compressed data.
 ///
@@ -74,44 +34,17 @@ pub fn decompress_cluster(
     Ok(decompressed)
 }
 
-/// Write all bytes to fd at offset, looping on short writes.
-pub fn pwrite_all(fd: RawFd, buf: &[u8], offset: u64) -> io::Result<()> {
-    let mut total = 0usize;
-    while total < buf.len() {
-        // SAFETY: buf and fd are valid for the lifetime of the call.
-        let ret = unsafe {
-            libc::pwrite64(
-                fd,
-                buf[total..].as_ptr().cast(),
-                buf.len() - total,
-                (offset + total as u64) as libc::off_t,
-            )
-        };
-        if ret < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        if ret == 0 {
-            return Err(io::Error::other("pwrite64 wrote 0 bytes"));
-        }
-        total += ret as usize;
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 pub(crate) mod unit_tests {
     use std::fs::File;
     use std::io::{Read, Seek, SeekFrom, Write};
-    use std::os::unix::fs::FileExt;
-    use std::os::unix::io::AsRawFd;
 
     use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
     use flate2::Compression;
     use flate2::write::DeflateEncoder;
-    use vmm_sys_util::tempfile::TempFile;
 
+    use super::decompress_cluster;
     use super::internal::decoder::ZlibDecoder;
-    use super::{decompress_cluster, pread_alloc};
 
     const COMPRESSED_FLAG: u64 = 1 << 62;
     const CLUSTER_USED_FLAG: u64 = 1 << 63;
@@ -134,10 +67,6 @@ pub(crate) mod unit_tests {
     }
 
     /// Compress every allocated cluster in a QCOW2 image file in place.
-    ///
-    /// Walks L1 -> L2 tables, compresses each standard cluster with raw
-    /// deflate, appends the compressed payload at the end of the file,
-    /// and rewrites the L2 entry with the compressed layout.
     pub fn compress_allocated_clusters(file: &mut File) {
         file.seek(SeekFrom::Start(HEADER_CLUSTER_BITS_OFFSET))
             .unwrap();
@@ -190,12 +119,6 @@ pub(crate) mod unit_tests {
                 file.seek(SeekFrom::Start(append_offset)).unwrap();
                 file.write_all(&compressed).unwrap();
 
-                // The L2 entry encodes the compressed size in units of
-                // 512 byte sectors. The reader decodes the sector count
-                // back and computes: nsectors * 512 - (addr & 511).
-                // Because addr is 512 aligned, this yields nsectors * 512
-                // which rounds up to the next sector boundary. The file
-                // must contain enough bytes for that rounded up pread.
                 let padded_len = (compressed.len() + 511) & !511;
                 if padded_len > compressed.len() {
                     let padding = vec![0u8; padded_len - compressed.len()];
@@ -212,22 +135,6 @@ pub(crate) mod unit_tests {
         }
 
         file.flush().unwrap();
-    }
-
-    #[test]
-    fn test_pread_alloc() {
-        let temp = TempFile::new().unwrap();
-        let file = temp.as_file();
-        let data: Vec<u8> = (0..=255).cycle().take(4096).collect();
-        file.write_all_at(&data, 0).unwrap();
-
-        let buf = pread_alloc(file.as_raw_fd(), 0, 4096).unwrap();
-        assert_eq!(buf, data);
-
-        let buf = pread_alloc(file.as_raw_fd(), 100, 200).unwrap();
-        assert_eq!(buf, &data[100..300]);
-
-        pread_alloc(file.as_raw_fd(), 4000, 200).unwrap_err();
     }
 
     #[test]

--- a/block/src/formats/qcow/common.rs
+++ b/block/src/formats/qcow/common.rs
@@ -10,9 +10,8 @@
 //!
 //! Position-independent I/O helpers used by both `qcow_sync` and `qcow_async`.
 
-use std::alloc::{Layout, alloc_zeroed, dealloc};
+use std::io;
 use std::os::fd::RawFd;
-use std::{io, slice};
 
 #[cfg(test)]
 use super::internal;
@@ -97,98 +96,6 @@ pub fn pwrite_all(fd: RawFd, buf: &[u8], offset: u64) -> io::Result<()> {
         total += ret as usize;
     }
     Ok(())
-}
-
-/// RAII wrapper for an aligned heap buffer required by O_DIRECT.
-pub struct AlignedBuf {
-    ptr: *mut u8,
-    layout: Layout,
-}
-
-impl AlignedBuf {
-    pub fn new(size: usize, alignment: usize) -> io::Result<Self> {
-        let size = size.max(1).next_multiple_of(alignment);
-        let layout = Layout::from_size_align(size, alignment)
-            .map_err(|e| io::Error::other(format!("invalid aligned layout: {e}")))?;
-        // SAFETY: layout has non-zero size.
-        let ptr = unsafe { alloc_zeroed(layout) };
-        if ptr.is_null() {
-            return Err(io::Error::new(
-                io::ErrorKind::OutOfMemory,
-                "aligned allocation failed",
-            ));
-        }
-        Ok(AlignedBuf { ptr, layout })
-    }
-
-    pub fn as_mut_slice(&mut self, len: usize) -> &mut [u8] {
-        let len = len.min(self.layout.size());
-        // SAFETY: ptr is valid for layout.size() bytes; len <= layout.size().
-        unsafe { slice::from_raw_parts_mut(self.ptr, len) }
-    }
-
-    pub fn as_slice(&self, len: usize) -> &[u8] {
-        let len = len.min(self.layout.size());
-        // SAFETY: ptr is valid for layout.size() bytes; len <= layout.size().
-        unsafe { slice::from_raw_parts(self.ptr, len) }
-    }
-
-    #[cfg(test)]
-    pub fn layout(&self) -> &Layout {
-        &self.layout
-    }
-
-    #[cfg(test)]
-    pub fn ptr(&self) -> *const u8 {
-        self.ptr
-    }
-}
-
-impl Drop for AlignedBuf {
-    fn drop(&mut self) {
-        // SAFETY: ptr was allocated by alloc_zeroed with self.layout.
-        unsafe { dealloc(self.ptr, self.layout) };
-    }
-}
-
-/// Read into `buf` via an aligned bounce buffer when O_DIRECT requires it.
-pub fn aligned_pread(fd: RawFd, buf: &mut [u8], offset: u64, alignment: usize) -> io::Result<()> {
-    if alignment == 0
-        || ((buf.as_ptr() as usize).is_multiple_of(alignment)
-            && buf.len().is_multiple_of(alignment)
-            && (offset as usize).is_multiple_of(alignment))
-    {
-        return pread_exact(fd, buf, offset);
-    }
-
-    let aligned_offset = offset & !(alignment as u64 - 1);
-    let head = (offset - aligned_offset) as usize;
-    let aligned_len = (head + buf.len()).next_multiple_of(alignment);
-    let mut bounce = AlignedBuf::new(aligned_len, alignment)?;
-    pread_exact(fd, bounce.as_mut_slice(aligned_len), aligned_offset)?;
-    buf.copy_from_slice(&bounce.as_slice(aligned_len)[head..head + buf.len()]);
-    Ok(())
-}
-
-/// Write `buf` via an aligned bounce buffer when O_DIRECT requires it.
-pub fn aligned_pwrite(fd: RawFd, buf: &[u8], offset: u64, alignment: usize) -> io::Result<()> {
-    if alignment == 0
-        || ((buf.as_ptr() as usize).is_multiple_of(alignment)
-            && buf.len().is_multiple_of(alignment)
-            && (offset as usize).is_multiple_of(alignment))
-    {
-        return pwrite_all(fd, buf, offset);
-    }
-
-    let aligned_offset = offset & !(alignment as u64 - 1);
-    let head = (offset - aligned_offset) as usize;
-    let aligned_len = (head + buf.len()).next_multiple_of(alignment);
-    let mut bounce = AlignedBuf::new(aligned_len, alignment)?;
-
-    // Read-modify-write: read the existing aligned region, overlay our data.
-    pread_exact(fd, bounce.as_mut_slice(aligned_len), aligned_offset)?;
-    bounce.as_mut_slice(aligned_len)[head..head + buf.len()].copy_from_slice(buf);
-    pwrite_all(fd, bounce.as_slice(aligned_len), aligned_offset)
 }
 
 #[cfg(test)]

--- a/block/src/formats/qcow/internal/backing.rs
+++ b/block/src/formats/qcow/internal/backing.rs
@@ -6,23 +6,25 @@
 
 //! Thread safe backing file readers for QCOW2 images.
 
+use std::fs::File;
 use std::io;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::fs::FileExt;
 use std::sync::Arc;
 
 use super::decoder::Decoder;
 use super::metadata::{BackingRead, ClusterReadMapping, QcowMetadata};
 use super::{BackingFile, BackingKind, Error as QcowError};
 use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
-use crate::formats::qcow::common::{decompress_cluster, pread_alloc, pread_exact};
+use crate::formats::qcow::common::decompress_cluster;
 
-/// Raw backing file using pread64 on a duplicated fd.
+/// Raw backing file using position-independent reads on a duplicated fd.
 pub(crate) struct RawBacking {
-    pub(crate) fd: OwnedFd,
+    pub(crate) file: File,
     pub(crate) virtual_size: u64,
 }
 
-// SAFETY: The only I/O operation is pread64 which is position independent
+// SAFETY: The only I/O operation is read_at which is position independent
 // and safe for concurrent use from multiple threads.
 unsafe impl Sync for RawBacking {}
 
@@ -34,9 +36,9 @@ impl BackingRead for RawBacking {
         }
         let available = (self.virtual_size - address) as usize;
         if available >= buf.len() {
-            pread_exact(self.fd.as_raw_fd(), buf, address)
+            self.file.read_exact_at(buf, address)
         } else {
-            pread_exact(self.fd.as_raw_fd(), &mut buf[..available], address)?;
+            self.file.read_exact_at(&mut buf[..available], address)?;
             buf[available..].fill(0);
             Ok(())
         }
@@ -51,14 +53,14 @@ impl BackingRead for RawBacking {
 /// are handled recursively via the optional `backing_file` field.
 pub(crate) struct Qcow2Backing {
     pub(crate) metadata: Arc<QcowMetadata>,
-    pub(crate) data_fd: OwnedFd,
+    pub(crate) data_file: File,
     pub(crate) backing_file: Option<Arc<dyn BackingRead>>,
     pub(crate) cluster_size: u64,
     pub(crate) decoder: Arc<dyn Decoder>,
 }
 
 // SAFETY: All reads go through QcowMetadata which uses RwLock
-// and pread64 which is position independent and thread safe.
+// and read_exact_at which is position independent and thread safe.
 unsafe impl Sync for Qcow2Backing {}
 
 impl BackingRead for Qcow2Backing {
@@ -79,8 +81,6 @@ impl BackingRead for Qcow2Backing {
 }
 
 impl Qcow2Backing {
-    /// Resolve cluster mappings via metadata then read allocated clusters
-    /// with pread64.
     fn read_clusters(&self, address: u64, buf: &mut [u8]) -> io::Result<()> {
         let total_len = buf.len();
         let has_backing = self.backing_file.is_some();
@@ -100,8 +100,7 @@ impl Qcow2Backing {
                     offset: host_offset,
                     length,
                 } => {
-                    pread_exact(
-                        self.data_fd.as_raw_fd(),
+                    self.data_file.read_exact_at(
                         &mut buf[buf_offset..buf_offset + length as usize],
                         host_offset,
                     )?;
@@ -113,8 +112,8 @@ impl Qcow2Backing {
                     cluster_offset,
                     length,
                 } => {
-                    let compressed =
-                        pread_alloc(self.data_fd.as_raw_fd(), host_offset, compressed_size)?;
+                    let mut compressed = vec![0u8; compressed_size];
+                    self.data_file.read_exact_at(&mut compressed, host_offset)?;
                     let decompressed = decompress_cluster(
                         &compressed,
                         self.cluster_size as usize,
@@ -162,17 +161,17 @@ pub fn shared_backing_from(bf: BackingFile) -> BlockResult<Arc<dyn BackingRead>>
 
     match kind {
         BackingKind::Raw(raw_file) => {
-            let fd = dup_fd(raw_file.as_fd())?;
-            Ok(Arc::new(RawBacking { fd, virtual_size }))
+            let file = File::from(dup_fd(raw_file.as_fd())?);
+            Ok(Arc::new(RawBacking { file, virtual_size }))
         }
         BackingKind::Qcow { inner, backing } => {
-            let data_fd = dup_fd(inner.raw_file.as_fd())?;
+            let data_file = File::from(dup_fd(inner.raw_file.as_fd())?);
             let metadata = Arc::new(QcowMetadata::new(*inner));
             Ok(Arc::new(Qcow2Backing {
                 cluster_size: metadata.cluster_size(),
                 decoder: metadata.decoder(),
                 metadata,
-                data_fd,
+                data_file,
                 backing_file: backing.map(|bf| shared_backing_from(*bf)).transpose()?,
             }))
         }

--- a/block/src/formats/qcow/internal/raw_file.rs
+++ b/block/src/formats/qcow/internal/raw_file.rs
@@ -19,82 +19,47 @@ use vmm_sys_util::file_traits::FileSync;
 use vmm_sys_util::seek_hole::SeekHole;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
-use crate::aligned_buffer::AlignedBuffer;
+use crate::aligned_file::AlignedFile;
 use crate::{BlockBackend, query_device_size};
 
 #[derive(Debug)]
 pub struct RawFile {
-    file: File,
-    alignment: usize,
+    aligned: AlignedFile,
     position: u64,
     direct_io: bool,
 }
 
-const BLK_ALIGNMENTS: [usize; 2] = [512, 4096];
-
-fn is_valid_alignment(file: &File, alignment: usize) -> bool {
-    let mut abuf = match AlignedBuffer::new(alignment as u64, alignment, alignment) {
-        Ok(b) => b,
-        Err(_) => return false,
-    };
-    abuf.read_from(file).is_ok()
-}
-
 impl RawFile {
     pub fn new(file: File, direct_io: bool) -> Self {
-        // Assume no alignment restrictions if we aren't using O_DIRECT.
-        let mut alignment = 0;
-        if direct_io {
-            for align in &BLK_ALIGNMENTS {
-                if is_valid_alignment(&file, *align) {
-                    alignment = *align;
-                    break;
-                }
-            }
-        }
         RawFile {
-            file,
-            alignment,
+            aligned: AlignedFile::new(file, direct_io),
             position: 0,
             direct_io,
         }
     }
 
-    fn is_aligned(&self, buf: &[u8]) -> bool {
-        if self.alignment == 0 {
-            return true;
-        }
-
-        let align64: u64 = self.alignment.try_into().unwrap();
-
-        self.position.is_multiple_of(align64)
-            && (buf.as_ptr() as usize).is_multiple_of(self.alignment)
-            && buf.len().is_multiple_of(self.alignment)
-    }
-
     pub fn set_len(&self, size: u64) -> io::Result<()> {
-        self.file.set_len(size)
+        self.aligned.file().set_len(size)
     }
 
     pub fn metadata(&self) -> io::Result<Metadata> {
-        self.file.metadata()
+        self.aligned.file().metadata()
     }
 
     pub fn try_clone(&self) -> io::Result<RawFile> {
         Ok(RawFile {
-            file: self.file.try_clone().expect("RawFile cloning failed"),
-            alignment: self.alignment,
+            aligned: self.aligned.try_clone()?,
             position: self.position,
             direct_io: self.direct_io,
         })
     }
 
     pub fn sync_all(&self) -> io::Result<()> {
-        self.file.sync_all()
+        self.aligned.file().sync_all()
     }
 
     pub fn sync_data(&self) -> io::Result<()> {
-        self.file.sync_data()
+        self.aligned.file().sync_data()
     }
 
     pub fn is_direct(&self) -> bool {
@@ -102,13 +67,13 @@ impl RawFile {
     }
 
     pub fn alignment(&self) -> usize {
-        self.alignment
+        self.aligned.alignment()
     }
 
     /// Returns true if the file was opened with write access.
     pub fn is_writable(&self) -> bool {
         // SAFETY: fcntl with F_GETFL is safe and doesn't modify the file descriptor
-        let flags = unsafe { libc::fcntl(self.file.as_raw_fd(), libc::F_GETFL) };
+        let flags = unsafe { libc::fcntl(self.aligned.file().as_raw_fd(), libc::F_GETFL) };
         if flags < 0 {
             return false;
         }
@@ -119,92 +84,66 @@ impl RawFile {
 
 impl Read for RawFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if buf.is_empty() {
-            return Ok(0);
-        }
-
-        if self.is_aligned(buf) {
-            match self.file.read(buf) {
-                Ok(r) => {
-                    self.position = self.position.checked_add(r.try_into().unwrap()).unwrap();
-                    Ok(r)
-                }
-                Err(e) => Err(e),
-            }
-        } else {
-            let buf_len = buf.len();
-            let mut abuf = AlignedBuffer::new(self.position, buf_len, self.alignment)?;
-            let bytes_read = abuf.read_from(&self.file)?;
-            buf[..bytes_read].copy_from_slice(&abuf.as_slice()[..bytes_read]);
-            self.seek(SeekFrom::Current(bytes_read.try_into().unwrap()))?;
-            Ok(bytes_read)
-        }
+        let n = self.aligned.read_at(buf, self.position)?;
+        self.position += n as u64;
+        Ok(n)
     }
 }
 
 impl Write for RawFile {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if buf.is_empty() {
-            return Ok(0);
-        }
-
-        if self.is_aligned(buf) {
-            match self.file.write(buf) {
-                Ok(r) => {
-                    self.position = self.position.checked_add(r.try_into().unwrap()).unwrap();
-                    Ok(r)
-                }
-                Err(e) => Err(e),
-            }
-        } else {
-            let buf_len = buf.len();
-            let mut abuf = AlignedBuffer::new(self.position, buf_len, self.alignment)?;
-            abuf.read_from(&self.file)?;
-            abuf.as_mut_slice().copy_from_slice(buf);
-            abuf.write_to(&self.file)?;
-            self.seek(SeekFrom::Current(buf_len.try_into().unwrap()))?;
-            Ok(buf_len)
-        }
+        let n = self.aligned.write_at(buf, self.position)?;
+        self.position += n as u64;
+        Ok(n)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.file.sync_all()
+        self.aligned.file().sync_all()
     }
 }
 
 impl Seek for RawFile {
-    fn seek(&mut self, newpos: SeekFrom) -> io::Result<u64> {
-        match self.file.seek(newpos) {
-            Ok(pos) => {
-                self.position = pos;
-                Ok(pos)
-            }
-            Err(e) => Err(e),
-        }
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let newpos = match pos {
+            SeekFrom::Start(o) => o,
+            SeekFrom::Current(d) => self
+                .position
+                .checked_add_signed(d)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid seek"))?,
+            SeekFrom::End(d) => self
+                .aligned
+                .file()
+                .metadata()?
+                .len()
+                .checked_add_signed(d)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid seek"))?,
+        };
+        self.position = newpos;
+        Ok(newpos)
     }
 }
 
 impl WriteZeroesAt for RawFile {
     fn write_zeroes_at(&mut self, offset: u64, length: usize) -> io::Result<usize> {
-        self.file.write_zeroes_at(offset, length)
+        self.aligned.file_mut().write_zeroes_at(offset, length)
     }
 }
 
 impl PunchHole for RawFile {
     fn punch_hole(&mut self, offset: u64, length: u64) -> io::Result<()> {
-        self.file.punch_hole(offset, length)
+        self.aligned.file_mut().punch_hole(offset, length)
     }
 }
 
 impl FileSync for RawFile {
     fn fsync(&mut self) -> io::Result<()> {
-        self.file.fsync()
+        self.aligned.file_mut().fsync()
     }
 }
 
 impl SeekHole for RawFile {
     fn seek_hole(&mut self, offset: u64) -> io::Result<Option<u64>> {
-        match self.file.seek_hole(offset) {
+        match self.aligned.file_mut().seek_hole(offset) {
             Ok(pos) => {
                 if let Some(p) = pos {
                     self.position = p;
@@ -216,7 +155,7 @@ impl SeekHole for RawFile {
     }
 
     fn seek_data(&mut self, offset: u64) -> io::Result<Option<u64>> {
-        match self.file.seek_data(offset) {
+        match self.aligned.file_mut().seek_data(offset) {
             Ok(pos) => {
                 if let Some(p) = pos {
                     self.position = p;
@@ -230,13 +169,13 @@ impl SeekHole for RawFile {
 
 impl BlockBackend for RawFile {
     fn logical_size(&self) -> result::Result<u64, crate::Error> {
-        Ok(query_device_size(&self.file)
+        Ok(query_device_size(self.aligned.file())
             .map_err(crate::Error::RawFileError)?
             .0)
     }
 
     fn physical_size(&self) -> result::Result<u64, crate::Error> {
-        Ok(query_device_size(&self.file)
+        Ok(query_device_size(self.aligned.file())
             .map_err(crate::Error::RawFileError)?
             .1)
     }
@@ -245,8 +184,7 @@ impl BlockBackend for RawFile {
 impl Clone for RawFile {
     fn clone(&self) -> Self {
         RawFile {
-            file: self.file.try_clone().expect("RawFile cloning failed"),
-            alignment: self.alignment,
+            aligned: self.aligned.try_clone().expect("RawFile cloning failed"),
             position: self.position,
             direct_io: self.direct_io,
         }
@@ -255,23 +193,23 @@ impl Clone for RawFile {
 
 impl AsRawFd for RawFile {
     fn as_raw_fd(&self) -> RawFd {
-        self.file.as_raw_fd()
+        self.aligned.file().as_raw_fd()
     }
 }
 
 impl AsFd for RawFile {
     fn as_fd(&self) -> BorrowedFd<'_> {
-        self.file.as_fd()
+        self.aligned.file().as_fd()
     }
 }
 
 impl FileExt for RawFile {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
-        self.file.read_at(buf, offset)
+        self.aligned.read_at(buf, offset)
     }
 
     fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
-        self.file.write_at(buf, offset)
+        self.aligned.write_at(buf, offset)
     }
 }
 
@@ -296,19 +234,11 @@ mod tests {
     }
 
     fn raw_with_alignment(file: File) -> RawFile {
-        RawFile {
-            file,
-            alignment: TEST_ALIGNMENT,
-            position: 0,
-            direct_io: true,
-        }
-    }
-
-    #[test]
-    fn test_alignment_probe_accepts_short_read() {
-        let tf = create_pattern_file(1);
-
-        assert!(is_valid_alignment(tf.as_file(), TEST_ALIGNMENT));
+        // A tempfile is not O_DIRECT, but its aligned probe read still
+        // succeeds, so RawFile::new selects the smallest candidate (512).
+        let raw = RawFile::new(file, true);
+        assert_eq!(raw.alignment(), TEST_ALIGNMENT);
+        raw
     }
 
     #[test]

--- a/block/src/formats/qcow/internal/raw_file.rs
+++ b/block/src/formats/qcow/internal/raw_file.rs
@@ -8,18 +8,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::alloc::{Layout, alloc_zeroed, dealloc};
 use std::fs::{File, Metadata};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::fs::FileExt;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::{result, slice};
+use std::result;
 
 use vmm_sys_util::file_traits::FileSync;
 use vmm_sys_util::seek_hole::SeekHole;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
+use crate::aligned_buffer::AlignedBuffer;
 use crate::{BlockBackend, query_device_size};
 
 #[derive(Debug)]
@@ -32,19 +32,12 @@ pub struct RawFile {
 
 const BLK_ALIGNMENTS: [usize; 2] = [512, 4096];
 
-fn is_valid_alignment(fd: RawFd, alignment: usize) -> bool {
-    let layout = Layout::from_size_align(alignment, alignment).unwrap();
-    // SAFETY: layout has non-zero size
-    let ptr = unsafe { alloc_zeroed(layout) };
-    assert!(!ptr.is_null());
-
-    // SAFETY: FFI call
-    let ret = unsafe { ::libc::pread(fd, ptr.cast(), alignment, alignment.try_into().unwrap()) };
-
-    // SAFETY: ptr was allocated by alloc_zeroed with layout
-    unsafe { dealloc(ptr, layout) };
-
-    ret >= 0
+fn is_valid_alignment(file: &File, alignment: usize) -> bool {
+    let mut abuf = match AlignedBuffer::new(alignment as u64, alignment, alignment) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    abuf.read_from(file).is_ok()
 }
 
 impl RawFile {
@@ -53,7 +46,7 @@ impl RawFile {
         let mut alignment = 0;
         if direct_io {
             for align in &BLK_ALIGNMENTS {
-                if is_valid_alignment(file.as_raw_fd(), *align) {
+                if is_valid_alignment(&file, *align) {
                     alignment = *align;
                     break;
                 }
@@ -65,16 +58,6 @@ impl RawFile {
             position: 0,
             direct_io,
         }
-    }
-
-    fn round_up(&self, offset: u64) -> u64 {
-        let align: u64 = self.alignment.try_into().unwrap();
-        offset.div_ceil(align) * align
-    }
-
-    fn round_down(&self, offset: u64) -> u64 {
-        let align: u64 = self.alignment.try_into().unwrap();
-        (offset / align) * align
     }
 
     fn is_aligned(&self, buf: &[u8]) -> bool {
@@ -136,6 +119,10 @@ impl RawFile {
 
 impl Read for RawFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
         if self.is_aligned(buf) {
             match self.file.read(buf) {
                 Ok(r) => {
@@ -145,77 +132,22 @@ impl Read for RawFile {
                 Err(e) => Err(e),
             }
         } else {
-            let rounded_pos: u64 = self.round_down(self.position);
-            let file_offset: usize = self
-                .position
-                .checked_sub(rounded_pos)
-                .unwrap()
-                .try_into()
-                .unwrap();
-            let buf_len: usize = buf.len();
-            let rounded_len: usize = self
-                .round_up(
-                    file_offset
-                        .checked_add(buf_len)
-                        .unwrap()
-                        .try_into()
-                        .unwrap(),
-                )
-                .try_into()
-                .unwrap();
-
-            let layout = Layout::from_size_align(rounded_len, self.alignment).unwrap();
-            // SAFETY: layout has non-zero size
-            let tmp_ptr = unsafe { alloc_zeroed(layout) };
-            if tmp_ptr.is_null() {
-                return Err(io::Error::last_os_error());
-            }
-
-            // SAFETY: tmp_ptr is valid and at least rounded_len long
-            let tmp_buf = unsafe { slice::from_raw_parts_mut(tmp_ptr, rounded_len) };
-
-            // This can eventually replaced with read_at once its interface
-            // has been stabilized.
-            // SAFETY: FFI call. All parameters are valid.
-            let ret = unsafe {
-                ::libc::pread64(
-                    self.file.as_raw_fd(),
-                    tmp_buf.as_mut_ptr().cast(),
-                    tmp_buf.len(),
-                    rounded_pos.try_into().unwrap(),
-                )
-            };
-            if ret < 0 {
-                // SAFETY: tmp_ptr was allocated by alloc_zeroed with layout
-                unsafe { dealloc(tmp_ptr, layout) };
-                return Err(io::Error::last_os_error());
-            }
-
-            let read: usize = ret.try_into().unwrap();
-            if read < file_offset {
-                // SAFETY: tmp_ptr was allocated by alloc_zeroed with layout
-                unsafe { dealloc(tmp_ptr, layout) };
-                return Ok(0);
-            }
-
-            let mut to_copy = read - file_offset;
-            if to_copy > buf_len {
-                to_copy = buf_len;
-            }
-
-            buf.copy_from_slice(&tmp_buf[file_offset..(file_offset + buf_len)]);
-            // SAFETY: tmp_ptr was allocated by alloc_zeroed with layout
-            unsafe { dealloc(tmp_ptr, layout) };
-
-            self.seek(SeekFrom::Current(to_copy.try_into().unwrap()))
-                .unwrap();
-            Ok(to_copy)
+            let buf_len = buf.len();
+            let mut abuf = AlignedBuffer::new(self.position, buf_len, self.alignment)?;
+            let bytes_read = abuf.read_from(&self.file)?;
+            buf[..bytes_read].copy_from_slice(&abuf.as_slice()[..bytes_read]);
+            self.seek(SeekFrom::Current(bytes_read.try_into().unwrap()))?;
+            Ok(bytes_read)
         }
     }
 }
 
 impl Write for RawFile {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
         if self.is_aligned(buf) {
             match self.file.write(buf) {
                 Ok(r) => {
@@ -225,86 +157,13 @@ impl Write for RawFile {
                 Err(e) => Err(e),
             }
         } else {
-            let rounded_pos: u64 = self.round_down(self.position);
-            let file_offset: usize = self
-                .position
-                .checked_sub(rounded_pos)
-                .unwrap()
-                .try_into()
-                .unwrap();
-            let buf_len: usize = buf.len();
-            let rounded_len: usize = self
-                .round_up(
-                    file_offset
-                        .checked_add(buf_len)
-                        .unwrap()
-                        .try_into()
-                        .unwrap(),
-                )
-                .try_into()
-                .unwrap();
-
-            let layout = Layout::from_size_align(rounded_len, self.alignment).unwrap();
-            // SAFETY: layout has non-zero size
-            let tmp_ptr = unsafe { alloc_zeroed(layout) };
-            if tmp_ptr.is_null() {
-                return Err(io::Error::last_os_error());
-            }
-
-            // SAFETY: tmp_ptr is at least rounded_len long
-            let tmp_buf = unsafe { slice::from_raw_parts_mut(tmp_ptr, rounded_len) };
-
-            // This can eventually replaced with read_at once its interface
-            // has been stabilized.
-            // SAFETY: FFI call
-            let ret = unsafe {
-                ::libc::pread64(
-                    self.file.as_raw_fd(),
-                    tmp_buf.as_mut_ptr().cast(),
-                    tmp_buf.len(),
-                    rounded_pos.try_into().unwrap(),
-                )
-            };
-            if ret < 0 {
-                // SAFETY: tmp_ptr was allocated by alloc_zeroed with layout
-                unsafe { dealloc(tmp_ptr, layout) };
-                return Err(io::Error::last_os_error());
-            }
-
-            tmp_buf[file_offset..(file_offset + buf_len)].copy_from_slice(buf);
-
-            // This can eventually replaced with write_at once its interface
-            // has been stabilized.
-            // SAFETY: FFI call
-            let ret = unsafe {
-                ::libc::pwrite64(
-                    self.file.as_raw_fd(),
-                    tmp_buf.as_ptr().cast(),
-                    tmp_buf.len(),
-                    rounded_pos.try_into().unwrap(),
-                )
-            };
-
-            // SAFETY: tmp_ptr was allocated by alloc_zeroed with layout
-            unsafe { dealloc(tmp_ptr, layout) };
-
-            if ret < 0 {
-                return Err(io::Error::last_os_error());
-            }
-
-            let written: usize = ret.try_into().unwrap();
-            if written < file_offset {
-                Ok(0)
-            } else {
-                let mut to_seek = written - file_offset;
-                if to_seek > buf_len {
-                    to_seek = buf_len;
-                }
-
-                self.seek(SeekFrom::Current(to_seek.try_into().unwrap()))
-                    .unwrap();
-                Ok(to_seek)
-            }
+            let buf_len = buf.len();
+            let mut abuf = AlignedBuffer::new(self.position, buf_len, self.alignment)?;
+            abuf.read_from(&self.file)?;
+            abuf.as_mut_slice().copy_from_slice(buf);
+            abuf.write_to(&self.file)?;
+            self.seek(SeekFrom::Current(buf_len.try_into().unwrap()))?;
+            Ok(buf_len)
         }
     }
 
@@ -413,5 +272,103 @@ impl FileExt for RawFile {
 
     fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
         self.file.write_at(buf, offset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::os::unix::fs::FileExt;
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+
+    const TEST_ALIGNMENT: usize = 512;
+
+    fn create_pattern_file(size: usize) -> TempFile {
+        let tf = TempFile::new().unwrap();
+        let pattern: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        tf.as_file().write_all(&pattern).unwrap();
+        tf.as_file().sync_all().unwrap();
+        tf
+    }
+
+    fn raw_with_alignment(file: File) -> RawFile {
+        RawFile {
+            file,
+            alignment: TEST_ALIGNMENT,
+            position: 0,
+            direct_io: true,
+        }
+    }
+
+    #[test]
+    fn test_alignment_probe_accepts_short_read() {
+        let tf = create_pattern_file(1);
+
+        assert!(is_valid_alignment(tf.as_file(), TEST_ALIGNMENT));
+    }
+
+    #[test]
+    fn test_unaligned_read_returns_short_read_at_eof() {
+        let file_size = 100usize;
+        let tf = create_pattern_file(file_size);
+        let mut raw = raw_with_alignment(tf.as_file().try_clone().unwrap());
+        raw.seek(SeekFrom::Start(10)).unwrap();
+
+        let mut buf = vec![0u8; 200];
+        let bytes_read = raw.read(&mut buf).unwrap();
+
+        let expected: Vec<u8> = (10..file_size).map(|i| (i % 251) as u8).collect();
+        assert_eq!(bytes_read, expected.len());
+        assert_eq!(&buf[..bytes_read], &expected[..]);
+        assert_eq!(raw.position, file_size as u64);
+    }
+
+    #[test]
+    fn test_unaligned_read_beyond_eof_returns_zero() {
+        let tf = create_pattern_file(100);
+        let mut raw = raw_with_alignment(tf.as_file().try_clone().unwrap());
+        raw.seek(SeekFrom::Start(200)).unwrap();
+
+        let mut buf = vec![0u8; 16];
+        let bytes_read = raw.read(&mut buf).unwrap();
+
+        assert_eq!(bytes_read, 0);
+        assert_eq!(raw.position, 200);
+    }
+
+    #[test]
+    fn test_unaligned_write_extends_at_eof() {
+        let file_size = 100usize;
+        let tf = create_pattern_file(file_size);
+        let mut raw = raw_with_alignment(tf.as_file().try_clone().unwrap());
+        raw.seek(SeekFrom::Start(file_size as u64)).unwrap();
+
+        let data = b"xyz";
+        let bytes_written = raw.write(data).unwrap();
+
+        assert_eq!(bytes_written, data.len());
+        assert_eq!(raw.position, (file_size + data.len()) as u64);
+
+        let mut readback = vec![0u8; file_size + data.len()];
+        tf.as_file().read_exact_at(&mut readback, 0).unwrap();
+        let expected_prefix: Vec<u8> = (0..file_size).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&readback[..file_size], &expected_prefix[..]);
+        assert_eq!(&readback[file_size..], data);
+    }
+
+    #[test]
+    fn test_empty_unaligned_io_is_noop() {
+        let tf = create_pattern_file(100);
+        let mut raw = raw_with_alignment(tf.as_file().try_clone().unwrap());
+        raw.seek(SeekFrom::Start(1)).unwrap();
+
+        let mut read_buf = [];
+        assert_eq!(raw.read(&mut read_buf).unwrap(), 0);
+        assert_eq!(raw.write(&[]).unwrap(), 0);
+        assert_eq!(raw.position, 1);
     }
 }

--- a/block/src/formats/qcow/internal/raw_file.rs
+++ b/block/src/formats/qcow/internal/raw_file.rs
@@ -12,6 +12,7 @@ use std::alloc::{Layout, alloc_zeroed, dealloc};
 use std::fs::{File, Metadata};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::os::fd::{AsFd, BorrowedFd};
+use std::os::unix::fs::FileExt;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::{result, slice};
 
@@ -402,5 +403,15 @@ impl AsRawFd for RawFile {
 impl AsFd for RawFile {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.file.as_fd()
+    }
+}
+
+impl FileExt for RawFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        self.file.read_at(buf, offset)
+    }
+
+    fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
+        self.file.write_at(buf, offset)
     }
 }

--- a/block/src/formats/qcow/worker/async_uring.rs
+++ b/block/src/formats/qcow/worker/async_uring.rs
@@ -10,13 +10,14 @@
 
 use std::cmp::{max, min};
 use std::io;
+use std::os::unix::fs::FileExt;
 use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
 
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
-use super::common::{decompress_cluster, pread_alloc, pread_exact, pwrite_all};
+use super::common::decompress_cluster;
 use super::internal::decoder::Decoder;
 use super::internal::metadata::{
     BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
@@ -399,7 +400,9 @@ impl QcowAsync {
                             .map_err(AsyncIoError::ReadVectored)?;
                     } else {
                         let mut buf = vec![0u8; len];
-                        pread_exact(data_file.as_raw_fd(), &mut buf, host_offset)
+                        data_file
+                            .file()
+                            .read_exact_at(&mut buf, host_offset)
                             .map_err(AsyncIoError::ReadVectored)?;
                         op.write_bytes_at(buf_offset, &buf)
                             .map_err(AsyncIoError::ReadVectored)?;
@@ -412,9 +415,11 @@ impl QcowAsync {
                     cluster_offset,
                     length,
                 } => {
-                    let compressed =
-                        pread_alloc(data_file.as_raw_fd(), host_offset, compressed_size)
-                            .map_err(AsyncIoError::ReadVectored)?;
+                    let mut compressed = vec![0u8; compressed_size];
+                    data_file
+                        .file()
+                        .read_exact_at(&mut compressed, host_offset)
+                        .map_err(AsyncIoError::ReadVectored)?;
                     let decompressed =
                         decompress_cluster(&compressed, cluster_size as usize, decoder)
                             .map_err(AsyncIoError::ReadVectored)?;
@@ -498,7 +503,9 @@ impl QcowAsync {
                         let mut buf = vec![0u8; count];
                         op.read_bytes_at(buf_offset, &mut buf)
                             .map_err(AsyncIoError::WriteVectored)?;
-                        pwrite_all(data_file.as_raw_fd(), &buf, host_offset)
+                        data_file
+                            .file()
+                            .write_all_at(&buf, host_offset)
                             .map_err(AsyncIoError::WriteVectored)?;
                     }
                 }

--- a/block/src/formats/qcow/worker/async_uring.rs
+++ b/block/src/formats/qcow/worker/async_uring.rs
@@ -16,16 +16,14 @@ use std::sync::Arc;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
-use super::common::{
-    AlignedBuf, aligned_pread, aligned_pwrite, decompress_cluster, pread_alloc, pread_exact,
-    pwrite_all,
-};
+use super::common::{decompress_cluster, pread_alloc, pread_exact, pwrite_all};
 use super::internal::decoder::Decoder;
 use super::internal::metadata::{
     BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
 };
 use super::internal::qcow_raw_file::QcowRawFile;
 use crate::SECTOR_SIZE;
+use crate::aligned_buffer::AlignedBuffer;
 use crate::async_io::{
     AsyncIo, AsyncIoCompletion, AsyncIoError, AsyncIoOperation, AsyncIoResult, UringDataIo,
 };
@@ -393,16 +391,11 @@ impl QcowAsync {
                 } => {
                     let len = length as usize;
                     if alignment > 0 {
-                        let mut abuf =
-                            AlignedBuf::new(len, alignment).map_err(AsyncIoError::ReadVectored)?;
-                        aligned_pread(
-                            data_file.as_raw_fd(),
-                            abuf.as_mut_slice(len),
-                            host_offset,
-                            alignment,
-                        )
-                        .map_err(AsyncIoError::ReadVectored)?;
-                        op.write_bytes_at(buf_offset, abuf.as_slice(len))
+                        let mut abuf = AlignedBuffer::new(host_offset, len, alignment)
+                            .map_err(AsyncIoError::ReadVectored)?;
+                        abuf.read_exact_from(data_file.file())
+                            .map_err(AsyncIoError::ReadVectored)?;
+                        op.write_bytes_at(buf_offset, abuf.as_slice())
                             .map_err(AsyncIoError::ReadVectored)?;
                     } else {
                         let mut buf = vec![0u8; len];
@@ -493,20 +486,15 @@ impl QcowAsync {
                     offset: host_offset,
                 } => {
                     if alignment > 0 {
-                        // O_DIRECT, gather directly into aligned buffer.
-                        let mut abuf = AlignedBuf::new(count, alignment)
+                        let mut abuf = AlignedBuffer::new(host_offset, count, alignment)
                             .map_err(AsyncIoError::WriteVectored)?;
-                        op.read_bytes_at(buf_offset, abuf.as_mut_slice(count))
+                        abuf.read_exact_from(data_file.file())
                             .map_err(AsyncIoError::WriteVectored)?;
-                        aligned_pwrite(
-                            data_file.as_raw_fd(),
-                            abuf.as_slice(count),
-                            host_offset,
-                            alignment,
-                        )
-                        .map_err(AsyncIoError::WriteVectored)?;
+                        op.read_bytes_at(buf_offset, abuf.as_mut_slice())
+                            .map_err(AsyncIoError::WriteVectored)?;
+                        abuf.write_to(data_file.file())
+                            .map_err(AsyncIoError::WriteVectored)?;
                     } else {
-                        // No O_DIRECT, plain buffer is fine.
                         let mut buf = vec![0u8; count];
                         op.read_bytes_at(buf_offset, &mut buf)
                             .map_err(AsyncIoError::WriteVectored)?;

--- a/block/src/formats/qcow/worker/sync.rs
+++ b/block/src/formats/qcow/worker/sync.rs
@@ -6,13 +6,13 @@
 
 use std::cmp::min;
 use std::collections::VecDeque;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::fs::FileExt;
 use std::sync::Arc;
 
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
-use super::common::{decompress_cluster, pread_alloc, pread_exact, pwrite_all};
+use super::common::decompress_cluster;
 use super::internal::decoder::Decoder;
 use super::internal::metadata::{
     BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
@@ -109,7 +109,9 @@ impl QcowSync {
                             .map_err(AsyncIoError::ReadVectored)?;
                     } else {
                         let mut buf = vec![0u8; len];
-                        pread_exact(self.data_file.as_raw_fd(), &mut buf, host_offset)
+                        self.data_file
+                            .file()
+                            .read_exact_at(&mut buf, host_offset)
                             .map_err(AsyncIoError::ReadVectored)?;
                         op.write_bytes_at(buf_offset, &buf)
                             .map_err(AsyncIoError::ReadVectored)?;
@@ -122,9 +124,11 @@ impl QcowSync {
                     cluster_offset,
                     length,
                 } => {
-                    let compressed =
-                        pread_alloc(self.data_file.as_raw_fd(), host_offset, compressed_size)
-                            .map_err(AsyncIoError::ReadVectored)?;
+                    let mut compressed = vec![0u8; compressed_size];
+                    self.data_file
+                        .file()
+                        .read_exact_at(&mut compressed, host_offset)
+                        .map_err(AsyncIoError::ReadVectored)?;
                     let decompressed =
                         decompress_cluster(&compressed, self.cluster_size as usize, &*self.decoder)
                             .map_err(AsyncIoError::ReadVectored)?;
@@ -205,7 +209,9 @@ impl QcowSync {
                         let mut buf = vec![0u8; count];
                         op.read_bytes_at(buf_offset, &mut buf)
                             .map_err(AsyncIoError::WriteVectored)?;
-                        pwrite_all(self.data_file.as_raw_fd(), &buf, host_offset)
+                        self.data_file
+                            .file()
+                            .write_all_at(&buf, host_offset)
                             .map_err(AsyncIoError::WriteVectored)?;
                     }
                 }

--- a/block/src/formats/qcow/worker/sync.rs
+++ b/block/src/formats/qcow/worker/sync.rs
@@ -12,15 +12,13 @@ use std::sync::Arc;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
-use super::common::{
-    AlignedBuf, aligned_pread, aligned_pwrite, decompress_cluster, pread_alloc, pread_exact,
-    pwrite_all,
-};
+use super::common::{decompress_cluster, pread_alloc, pread_exact, pwrite_all};
 use super::internal::decoder::Decoder;
 use super::internal::metadata::{
     BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
 };
 use super::internal::qcow_raw_file::QcowRawFile;
+use crate::aligned_buffer::AlignedBuffer;
 use crate::async_io::{AsyncIo, AsyncIoCompletion, AsyncIoError, AsyncIoOperation, AsyncIoResult};
 
 pub struct QcowSync {
@@ -103,20 +101,13 @@ impl QcowSync {
                 } => {
                     let len = length as usize;
                     if self.alignment > 0 {
-                        // O_DIRECT, aligned buffer avoids bounce copy.
-                        let mut abuf = AlignedBuf::new(len, self.alignment)
+                        let mut abuf = AlignedBuffer::new(host_offset, len, self.alignment)
                             .map_err(AsyncIoError::ReadVectored)?;
-                        aligned_pread(
-                            self.data_file.as_raw_fd(),
-                            abuf.as_mut_slice(len),
-                            host_offset,
-                            self.alignment,
-                        )
-                        .map_err(AsyncIoError::ReadVectored)?;
-                        op.write_bytes_at(buf_offset, abuf.as_slice(len))
+                        abuf.read_exact_from(self.data_file.file())
+                            .map_err(AsyncIoError::ReadVectored)?;
+                        op.write_bytes_at(buf_offset, abuf.as_slice())
                             .map_err(AsyncIoError::ReadVectored)?;
                     } else {
-                        // No O_DIRECT, plain buffer is fine.
                         let mut buf = vec![0u8; len];
                         pread_exact(self.data_file.as_raw_fd(), &mut buf, host_offset)
                             .map_err(AsyncIoError::ReadVectored)?;
@@ -202,20 +193,15 @@ impl QcowSync {
                     offset: host_offset,
                 } => {
                     if self.alignment > 0 {
-                        // O_DIRECT, gather directly into aligned buffer.
-                        let mut abuf = AlignedBuf::new(count, self.alignment)
+                        let mut abuf = AlignedBuffer::new(host_offset, count, self.alignment)
                             .map_err(AsyncIoError::WriteVectored)?;
-                        op.read_bytes_at(buf_offset, abuf.as_mut_slice(count))
+                        abuf.read_exact_from(self.data_file.file())
                             .map_err(AsyncIoError::WriteVectored)?;
-                        aligned_pwrite(
-                            self.data_file.as_raw_fd(),
-                            abuf.as_slice(count),
-                            host_offset,
-                            self.alignment,
-                        )
-                        .map_err(AsyncIoError::WriteVectored)?;
+                        op.read_bytes_at(buf_offset, abuf.as_mut_slice())
+                            .map_err(AsyncIoError::WriteVectored)?;
+                        abuf.write_to(self.data_file.file())
+                            .map_err(AsyncIoError::WriteVectored)?;
                     } else {
-                        // No O_DIRECT, plain buffer is fine.
                         let mut buf = vec![0u8; count];
                         op.read_bytes_at(buf_offset, &mut buf)
                             .map_err(AsyncIoError::WriteVectored)?;
@@ -340,7 +326,6 @@ impl AsyncIo for QcowSync {
 mod unit_tests {
     use std::fs::{File, OpenOptions, create_dir};
     use std::io::{Read, Seek, SeekFrom, Write};
-    use std::os::fd::RawFd;
     use std::path::Path;
     use std::sync::Arc;
     use std::{env, thread};
@@ -1992,198 +1977,6 @@ mod unit_tests {
     #[test]
     fn test_multi_iovec_read_write_direct_io() {
         test_multi_iovec_read_write_impl(true);
-    }
-
-    // -- Low level aligned I/O function tests --
-    //
-    // Test aligned_pread and aligned_pwrite directly with controlled
-    // alignment values on a plain temp file.
-
-    /// Create a temp file filled with a repeating pattern of the given size.
-    /// Returns the TempFile (must be kept alive) and the raw fd.
-    fn create_pattern_file(size: usize) -> (TempFile, RawFd) {
-        let tf = TempFile::new().unwrap();
-        let pattern: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
-        tf.as_file().write_all(&pattern).unwrap();
-        tf.as_file().sync_all().unwrap();
-        let fd = tf.as_file().as_raw_fd();
-        (tf, fd)
-    }
-
-    #[test]
-    fn test_aligned_pread_pass_through() {
-        // When buffer address, length, and offset are all aligned,
-        // aligned_pread should take the fast path (no bounce buffer).
-        let size = 4096usize;
-        let (_tf, fd) = create_pattern_file(size);
-        let alignment = 512;
-
-        // Use AlignedBuf to guarantee buffer address alignment.
-        let mut abuf = AlignedBuf::new(size, alignment).unwrap();
-        aligned_pread(fd, abuf.as_mut_slice(size), 0, alignment).unwrap();
-
-        let expected: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
-        assert_eq!(abuf.as_slice(size), &expected[..]);
-    }
-
-    #[test]
-    fn test_aligned_pread_bounce_unaligned_buffer() {
-        // Force a misaligned buffer so aligned_pread must take the
-        // bounce path. A plain vec![0u8; 4096] is often page-aligned
-        // by the allocator, which would skip the bounce entirely.
-        let size = 4096usize;
-        let (_tf, fd) = create_pattern_file(size);
-        let alignment = 512;
-
-        let mut backing = vec![0u8; size + 1];
-        let buf = &mut backing[1..size + 1];
-        aligned_pread(fd, buf, 0, alignment).unwrap();
-
-        let expected: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
-        assert_eq!(buf, &expected[..]);
-    }
-
-    #[test]
-    fn test_aligned_pread_unaligned_offset() {
-        // Read at an offset that is not a multiple of alignment.
-        // aligned_pread should round down the offset, read an aligned
-        // region, then copy the correct slice into the caller buffer.
-        let file_size = 8192usize;
-        let (_tf, fd) = create_pattern_file(file_size);
-        let alignment = 512;
-
-        let offset = 100u64;
-        let len = 200usize;
-        let mut buf = vec![0u8; len];
-        aligned_pread(fd, &mut buf, offset, alignment).unwrap();
-
-        let expected: Vec<u8> = (offset as usize..offset as usize + len)
-            .map(|i| (i % 251) as u8)
-            .collect();
-        assert_eq!(buf, expected);
-    }
-
-    #[test]
-    fn test_aligned_pwrite_pass_through() {
-        // When buffer address, length, and offset are all aligned,
-        // aligned_pwrite should take the fast path.
-        let size = 4096usize;
-        let (_tf, fd) = create_pattern_file(size);
-        let alignment = 512;
-
-        let data: Vec<u8> = (0..size).map(|i| ((i + 1) % 251) as u8).collect();
-        let mut abuf = AlignedBuf::new(size, alignment).unwrap();
-        abuf.as_mut_slice(size).copy_from_slice(&data);
-        aligned_pwrite(fd, abuf.as_slice(size), 0, alignment).unwrap();
-
-        let mut readback = vec![0u8; size];
-        pread_exact(fd, &mut readback, 0).unwrap();
-        assert_eq!(readback, data);
-    }
-
-    #[test]
-    fn test_aligned_pwrite_bounce_unaligned_buffer() {
-        // Force a misaligned buffer so aligned_pwrite must take the
-        // bounce path. A plain vec![0u8; 4096] is often page-aligned
-        // by the allocator, which would skip the bounce entirely.
-        let size = 4096usize;
-        let (_tf, fd) = create_pattern_file(size);
-        let alignment = 512;
-
-        let backing: Vec<u8> = (0..size + 1).map(|i| ((i + 1) % 251) as u8).collect();
-        let data = &backing[1..size + 1];
-        aligned_pwrite(fd, data, 0, alignment).unwrap();
-
-        let mut readback = vec![0u8; size];
-        pread_exact(fd, &mut readback, 0).unwrap();
-        assert_eq!(readback, data);
-    }
-
-    #[test]
-    fn test_aligned_pwrite_unaligned_offset() {
-        // Write at an offset that is not a multiple of alignment.
-        // aligned_pwrite should do read-modify-write and preserve
-        // surrounding data.
-        let file_size = 8192usize;
-        let (_tf, fd) = create_pattern_file(file_size);
-        let alignment = 512;
-
-        let offset = 100u64;
-        let len = 200usize;
-        let data: Vec<u8> = (0..len).map(|i| ((i + 1) % 239) as u8).collect();
-        aligned_pwrite(fd, &data, offset, alignment).unwrap();
-
-        // Read entire file and verify the written region plus untouched areas.
-        let mut whole = vec![0u8; file_size];
-        pread_exact(fd, &mut whole, 0).unwrap();
-
-        // Before the write region: original pattern.
-        let before: Vec<u8> = (0..offset as usize).map(|i| (i % 251) as u8).collect();
-        assert_eq!(&whole[..offset as usize], &before[..]);
-
-        // The written region.
-        assert_eq!(&whole[offset as usize..offset as usize + len], &data[..]);
-
-        // After the write region: original pattern.
-        let after_start = offset as usize + len;
-        let after: Vec<u8> = (after_start..file_size).map(|i| (i % 251) as u8).collect();
-        assert_eq!(&whole[after_start..], &after[..]);
-    }
-
-    #[test]
-    fn test_aligned_pread_pwrite_4096_alignment() {
-        // Exercise aligned I/O with 4096 byte alignment.
-        let file_size = 16384usize;
-        let (_tf, fd) = create_pattern_file(file_size);
-        let alignment = 4096;
-
-        // Write 4096 bytes at offset 4096 via unaligned Vec<u8>.
-        let offset = 4096u64;
-        let len = 4096usize;
-        let data: Vec<u8> = (0..len).map(|i| ((i + 1) % 239) as u8).collect();
-        aligned_pwrite(fd, &data, offset, alignment).unwrap();
-
-        // Read back the written region via unaligned Vec<u8>.
-        let mut buf = vec![0u8; len];
-        aligned_pread(fd, &mut buf, offset, alignment).unwrap();
-        assert_eq!(buf, data);
-
-        // Verify untouched regions.
-        let mut whole = vec![0u8; file_size];
-        pread_exact(fd, &mut whole, 0).unwrap();
-        let before: Vec<u8> = (0..offset as usize).map(|i| (i % 251) as u8).collect();
-        assert_eq!(&whole[..offset as usize], &before[..]);
-        let after_start = offset as usize + len;
-        let after: Vec<u8> = (after_start..file_size).map(|i| (i % 251) as u8).collect();
-        assert_eq!(&whole[after_start..], &after[..]);
-    }
-
-    #[test]
-    fn test_aligned_buf_allocation_and_access() {
-        for alignment in [512, 4096] {
-            let size = 1024usize;
-            let mut abuf = AlignedBuf::new(size, alignment).unwrap();
-            let aligned_size = size.next_multiple_of(alignment);
-
-            assert!(
-                (abuf.ptr() as usize).is_multiple_of(alignment),
-                "ptr not aligned to {alignment}"
-            );
-            assert!(abuf.as_slice(aligned_size).iter().all(|&b| b == 0));
-
-            let pattern: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
-            abuf.as_mut_slice(size).copy_from_slice(&pattern);
-            assert_eq!(abuf.as_slice(size), &pattern[..]);
-        }
-    }
-
-    #[test]
-    fn test_aligned_buf_size_rounds_up() {
-        let abuf = AlignedBuf::new(1, 512).unwrap();
-        assert_eq!(abuf.layout().size(), 512);
-
-        let abuf = AlignedBuf::new(513, 512).unwrap();
-        assert_eq!(abuf.layout().size(), 1024);
     }
 
     #[test]

--- a/block/src/formats/vhdx/internal/bat.rs
+++ b/block/src/formats/vhdx/internal/bat.rs
@@ -2,17 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::File;
-use std::io::{self, Seek, SeekFrom};
 use std::mem::size_of;
-use std::result;
+use std::os::unix::fs::FileExt;
+use std::{io, result};
 
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{ByteOrder, LittleEndian};
 use remain::sorted;
 use thiserror::Error;
 
 use super::header::RegionTableEntry;
 use super::metadata::DiskSpec;
+use crate::aligned_file::AlignedFile;
 
 // Payload BAT Entry States
 pub const PAYLOAD_BLOCK_NOT_PRESENT: u64 = 0;
@@ -48,7 +48,7 @@ pub struct BatEntry(pub u64);
 impl BatEntry {
     // Read all BAT entries presented on the disk and insert them to a vector
     pub fn collect_bat_entries(
-        f: &mut File,
+        f: &AlignedFile,
         disk_spec: &DiskSpec,
         bat_entry: &RegionTableEntry,
     ) -> Result<Vec<BatEntry>> {
@@ -64,14 +64,10 @@ impl BatEntry {
         let mut bat: Vec<BatEntry> = Vec::with_capacity(bat_entry.length as usize);
         let offset = bat_entry.file_offset;
         for i in 0..entry_count {
-            f.seek(SeekFrom::Start(offset + i * size_of::<u64>() as u64))
+            let mut entry = [0u8; size_of::<u64>()];
+            f.read_exact_at(&mut entry, offset + i * size_of::<u64>() as u64)
                 .map_err(VhdxBatError::ReadBat)?;
-
-            let bat_entry = BatEntry(
-                f.read_u64::<LittleEndian>()
-                    .map_err(VhdxBatError::ReadBat)?,
-            );
-            bat.insert(i as usize, bat_entry);
+            bat.insert(i as usize, BatEntry(LittleEndian::read_u64(&entry)));
         }
 
         Ok(bat)
@@ -85,13 +81,11 @@ impl BatEntry {
 
     // Routine for writing BAT entries to the disk
     pub fn write_bat_entries(
-        f: &mut File,
+        f: &AlignedFile,
         bat_offset: u64,
         bat_entries: &[BatEntry],
     ) -> Result<()> {
         for i in 0..bat_entries.len() as u64 {
-            f.seek(SeekFrom::Start(bat_offset + i * size_of::<u64>() as u64))
-                .map_err(VhdxBatError::WriteBat)?;
             let bat_entry = match bat_entries.get(i as usize) {
                 Some(entry) => entry.0,
                 None => {
@@ -99,7 +93,9 @@ impl BatEntry {
                 }
             };
 
-            f.write_u64::<LittleEndian>(bat_entry)
+            let mut buf = [0u8; size_of::<u64>()];
+            LittleEndian::write_u64(&mut buf, bat_entry);
+            f.write_all_at(&buf, bat_offset + i * size_of::<u64>() as u64)
                 .map_err(VhdxBatError::WriteBat)?;
         }
         Ok(())

--- a/block/src/formats/vhdx/internal/header.rs
+++ b/block/src/formats/vhdx/internal/header.rs
@@ -3,15 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::btree_map::BTreeMap;
-use std::fs::File;
-use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
-use std::{result, slice};
+use std::os::unix::fs::FileExt;
+use std::{io, result, slice};
 
-use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
+use byteorder::{ByteOrder, LittleEndian};
 use remain::sorted;
 use thiserror::Error;
 use uuid::Uuid;
+
+use crate::aligned_file::AlignedFile;
 
 const VHDX_SIGN: u64 = 0x656C_6966_7864_6876; // "vhdxfile"
 const HEADER_SIGN: u32 = 0x6461_6568; // "head"
@@ -72,14 +73,6 @@ pub enum VhdxHeaderError {
     RegionOverlap,
     #[error("Reserved region has non-zero value")]
     ReservedIsNonZero,
-    #[error("Failed to seek in File Type Identifier {0}")]
-    SeekFileTypeIdentifier(#[source] io::Error),
-    #[error("Failed to seek in headers {0}")]
-    SeekHeader(#[source] io::Error),
-    #[error("Failed to seek in region table entries {0}")]
-    SeekRegionTableEntries(#[source] io::Error),
-    #[error("Failed to seek in region table header {0}")]
-    SeekRegionTableHeader(#[source] io::Error),
     #[error("We do not recognize this entry")]
     UnrecognizedRegionEntry,
     #[error("Failed to write header {0}")]
@@ -95,12 +88,11 @@ pub struct FileTypeIdentifier {
 
 impl FileTypeIdentifier {
     /// Reads the File Type Identifier structure from a reference VHDx file
-    pub fn new(f: &mut File) -> Result<FileTypeIdentifier> {
-        f.seek(SeekFrom::Start(FILE_START))
-            .map_err(VhdxHeaderError::SeekFileTypeIdentifier)?;
-        let _signature = f
-            .read_u64::<LittleEndian>()
+    pub fn new(f: &AlignedFile) -> Result<FileTypeIdentifier> {
+        let mut buf = [0u8; size_of::<u64>()];
+        f.read_exact_at(&mut buf, FILE_START)
             .map_err(VhdxHeaderError::ReadFileTypeIdentifier)?;
+        let _signature = LittleEndian::read_u64(&buf);
         if _signature != VHDX_SIGN {
             return Err(VhdxHeaderError::InvalidVHDXSign);
         }
@@ -126,13 +118,11 @@ pub struct Header {
 
 impl Header {
     /// Reads the Header structure from a reference VHDx file
-    pub fn new(f: &mut File, start: u64) -> Result<Header> {
+    pub fn new(f: &AlignedFile, start: u64) -> Result<Header> {
         // Read the whole header into a buffer. We will need it for
         // calculating checksum.
         let mut buffer = [0; HEADER_SIZE as usize];
-        f.seek(SeekFrom::Start(start))
-            .map_err(VhdxHeaderError::SeekHeader)?;
-        f.read_exact(&mut buffer)
+        f.read_exact_at(&mut buffer, start)
             .map_err(VhdxHeaderError::ReadHeader)?;
 
         // SAFETY: buffer is of correct size and has been successfully filled.
@@ -159,7 +149,7 @@ impl Header {
 
     /// Creates and returns new updated header from the provided current header
     fn update_header(
-        f: &mut File,
+        f: &AlignedFile,
         current_header: &Header,
         change_data_guid: bool,
         mut file_write_guid: u128,
@@ -193,9 +183,8 @@ impl Header {
         new_header.checksum = calculate_checksum(&mut buffer, size_of::<u32>());
         new_header.write_to_buffer(&mut buffer);
 
-        f.seek(SeekFrom::Start(start))
-            .map_err(VhdxHeaderError::SeekHeader)?;
-        f.write(&buffer).map_err(VhdxHeaderError::WriteHeader)?;
+        f.write_all_at(&buffer, start)
+            .map_err(VhdxHeaderError::WriteHeader)?;
 
         Ok(new_header)
     }
@@ -212,13 +201,11 @@ struct RegionTableHeader {
 
 impl RegionTableHeader {
     /// Reads the Region Table Header structure from a reference VHDx file
-    pub fn new(f: &mut File, start: u64) -> Result<RegionTableHeader> {
+    pub fn new(f: &AlignedFile, start: u64) -> Result<RegionTableHeader> {
         // Read the whole header into a buffer. We will need it for calculating
         // checksum.
         let mut buffer = [0u8; REGION_SIZE as usize];
-        f.seek(SeekFrom::Start(start))
-            .map_err(VhdxHeaderError::SeekRegionTableHeader)?;
-        f.read_exact(&mut buffer)
+        f.read_exact_at(&mut buffer, start)
             .map_err(VhdxHeaderError::ReadRegionTableHeader)?;
 
         // SAFETY: buffer is of correct size and has been successfully filled.
@@ -253,7 +240,7 @@ pub struct RegionInfo {
 impl RegionInfo {
     /// Collect all entries in a BTreeMap from the Region Table and identifies
     /// BAT and metadata regions
-    pub fn new(f: &mut File, region_start: u64, entry_count: u32) -> Result<RegionInfo> {
+    pub fn new(f: &AlignedFile, region_start: u64, entry_count: u32) -> Result<RegionInfo> {
         let mut bat_entry: Option<RegionTableEntry> = None;
         let mut mdr_entry: Option<RegionTableEntry> = None;
 
@@ -261,13 +248,12 @@ impl RegionInfo {
         let mut region_entries = BTreeMap::new();
 
         let mut buffer = [0; REGION_SIZE as usize];
-        // Seek after the Region Table Header
-        f.seek(SeekFrom::Start(
+        // Read after the Region Table Header
+        f.read_exact_at(
+            &mut buffer,
             region_start + size_of::<RegionTableHeader>() as u64,
-        ))
-        .map_err(VhdxHeaderError::SeekRegionTableEntries)?;
-        f.read_exact(&mut buffer)
-            .map_err(VhdxHeaderError::ReadRegionTableEntries)?;
+        )
+        .map_err(VhdxHeaderError::ReadRegionTableEntries)?;
 
         for _ in 0..entry_count {
             let entry =
@@ -366,7 +352,7 @@ pub struct VhdxHeader {
 
 impl VhdxHeader {
     /// Creates a VhdxHeader from a reference to a file
-    pub fn new(f: &mut File) -> Result<VhdxHeader> {
+    pub fn new(f: &AlignedFile) -> Result<VhdxHeader> {
         Ok(VhdxHeader {
             _file_type_identifier: FileTypeIdentifier::new(f)?,
             header_1: Header::new(f, HEADER_1_START)?,
@@ -403,7 +389,7 @@ impl VhdxHeader {
     /// current one. Returns both headers as a tuple sequenced the way it was
     /// received from the parameter list.
     fn update_header(
-        f: &mut File,
+        f: &AlignedFile,
         header_1: Result<Header>,
         header_2: Result<Header>,
         guid: u128,
@@ -426,7 +412,7 @@ impl VhdxHeader {
 
     // Update the provided headers according to the spec
     fn update_headers(
-        f: &mut File,
+        f: &AlignedFile,
         header_1: Result<Header>,
         header_2: Result<Header>,
         guid: u128,
@@ -436,7 +422,7 @@ impl VhdxHeader {
         VhdxHeader::update_header(f, Ok(header_1), Ok(header_2), guid)
     }
 
-    pub fn update(&mut self, f: &mut File) -> Result<()> {
+    pub fn update(&mut self, f: &AlignedFile) -> Result<()> {
         let headers = VhdxHeader::update_headers(f, Ok(self.header_1), Ok(self.header_2), 0)?;
         self.header_1 = headers.0;
         self.header_2 = headers.1;

--- a/block/src/formats/vhdx/internal/io.rs
+++ b/block/src/formats/vhdx/internal/io.rs
@@ -2,15 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::File;
-use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::result;
+use std::os::unix::fs::FileExt;
+use std::{io, result};
 
 use remain::sorted;
 use thiserror::Error;
 
 use super::bat::{self, BatEntry, VhdxBatError};
 use super::metadata::{self, DiskSpec};
+use crate::aligned_file::AlignedFile;
 
 const SECTOR_SIZE: u64 = 512;
 
@@ -87,7 +87,7 @@ impl Sector {
 /// VHDx IO read routine: requires relative sector index and count for the
 /// requested data.
 pub fn read(
-    f: &mut File,
+    f: &AlignedFile,
     buf: &mut [u8],
     disk_spec: &DiskSpec,
     bat: &[BatEntry],
@@ -115,11 +115,10 @@ pub fn read(
             | bat::PAYLOAD_BLOCK_UNMAPPED
             | bat::PAYLOAD_BLOCK_ZERO => {}
             bat::PAYLOAD_BLOCK_FULLY_PRESENT => {
-                f.seek(SeekFrom::Start(sector.file_offset))
-                    .map_err(VhdxIoError::ReadSectorBlock)?;
-                f.read_exact(
+                f.read_exact_at(
                     &mut buf
                         [read_count..(read_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
+                    sector.file_offset,
                 )
                 .map_err(VhdxIoError::ReadSectorBlock)?;
             }
@@ -140,7 +139,7 @@ pub fn read(
 /// VHDx IO write routine: requires relative sector index and count for the
 /// requested data.
 pub fn write(
-    f: &mut File,
+    f: &AlignedFile,
     buf: &[u8],
     disk_spec: &mut DiskSpec,
     bat_offset: u64,
@@ -173,7 +172,9 @@ pub fn write(
                     .checked_add(disk_spec.block_size as u64)
                     .ok_or(VhdxIoError::InvalidDiskSize)?;
 
-                f.set_len(new_size).map_err(VhdxIoError::ResizeFile)?;
+                f.file()
+                    .set_len(new_size)
+                    .map_err(VhdxIoError::ResizeFile)?;
                 disk_spec.image_size = new_size;
 
                 let new_bat_entry =
@@ -185,10 +186,9 @@ pub fn write(
                     break;
                 }
 
-                f.seek(SeekFrom::Start(file_offset))
-                    .map_err(VhdxIoError::ReadSectorBlock)?;
-                f.write_all(
+                f.write_all_at(
                     &buf[write_count..(write_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
+                    file_offset,
                 )
                 .map_err(VhdxIoError::ReadSectorBlock)?;
             }
@@ -197,10 +197,9 @@ pub fn write(
                     break;
                 }
 
-                f.seek(SeekFrom::Start(sector.file_offset))
-                    .map_err(VhdxIoError::ReadSectorBlock)?;
-                f.write_all(
+                f.write_all_at(
                     &buf[write_count..(write_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
+                    sector.file_offset,
                 )
                 .map_err(VhdxIoError::ReadSectorBlock)?;
             }

--- a/block/src/formats/vhdx/internal/metadata.rs
+++ b/block/src/formats/vhdx/internal/metadata.rs
@@ -2,17 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::File;
-use std::io::{self, Read, Seek, SeekFrom};
 use std::mem::size_of;
-use std::result;
+use std::os::unix::fs::FileExt;
+use std::{io, result};
 
-use byteorder::{LittleEndian, ReadBytesExt};
+use byteorder::{ByteOrder, LittleEndian};
 use remain::sorted;
 use thiserror::Error;
 use uuid::Uuid;
 
 use super::header::RegionTableEntry;
+use crate::aligned_file::AlignedFile;
 
 const METADATA_SIGN: u64 = 0x6174_6164_6174_656D;
 const METADATA_ENTRY_SIZE: usize = 32;
@@ -103,17 +103,18 @@ pub struct DiskSpec {
 impl DiskSpec {
     /// Parse all metadata from the provided file and store info in DiskSpec
     /// structure.
-    pub fn new(f: &mut File, metadata_region: &RegionTableEntry) -> Result<DiskSpec> {
+    pub fn new(f: &AlignedFile, metadata_region: &RegionTableEntry) -> Result<DiskSpec> {
         let mut disk_spec = DiskSpec::default();
         let mut metadata_presence: u16 = 0;
         let mut offset = 0;
-        let metadata = f.metadata().map_err(VhdxMetadataError::ReadMetadata)?;
+        let metadata = f
+            .file()
+            .metadata()
+            .map_err(VhdxMetadataError::ReadMetadata)?;
         disk_spec.image_size = metadata.len();
 
         let mut buffer = [0u8; METADATA_TABLE_MAX_SIZE];
-        f.seek(SeekFrom::Start(metadata_region.file_offset))
-            .map_err(VhdxMetadataError::ReadMetadata)?;
-        f.read_exact(&mut buffer)
+        f.read_exact_at(&mut buffer, metadata_region.file_offset)
             .map_err(VhdxMetadataError::ReadMetadata)?;
 
         let metadata_header =
@@ -124,18 +125,16 @@ impl DiskSpec {
             let metadata_entry =
                 MetadataTableEntry::new(&buffer[offset..offset + size_of::<MetadataTableEntry>()])?;
 
-            f.seek(SeekFrom::Start(
-                metadata_region.file_offset + metadata_entry.offset as u64,
-            ))
-            .map_err(VhdxMetadataError::ReadMetadata)?;
+            let item_offset = metadata_region.file_offset + metadata_entry.offset as u64;
 
             if metadata_entry.item_id
                 == Uuid::parse_str(METADATA_FILE_PARAMETER)
                     .map_err(VhdxMetadataError::InvalidUuid)?
             {
-                disk_spec.block_size = f
-                    .read_u32::<LittleEndian>()
+                let mut item = [0u8; 2 * size_of::<u32>()];
+                f.read_exact_at(&mut item, item_offset)
                     .map_err(VhdxMetadataError::ReadMetadata)?;
+                disk_spec.block_size = LittleEndian::read_u32(&item[0..4]);
 
                 // MUST be at least 1 MiB and not greater than 256 MiB
                 if disk_spec.block_size < BLOCK_SIZE_MIN || disk_spec.block_size > BLOCK_SIZE_MAX {
@@ -147,9 +146,7 @@ impl DiskSpec {
                     return Err(VhdxMetadataError::InvalidBlockSize);
                 }
 
-                let bits = f
-                    .read_u32::<LittleEndian>()
-                    .map_err(VhdxMetadataError::ReadMetadata)?;
+                let bits = LittleEndian::read_u32(&item[4..8]);
                 disk_spec.has_parent = bits & BLOCK_HAS_PARENT != 0;
 
                 metadata_presence |= METADATA_FILE_PARAMETER_PRESENT;
@@ -157,27 +154,30 @@ impl DiskSpec {
                 == Uuid::parse_str(METADATA_VIRTUAL_DISK_SIZE)
                     .map_err(VhdxMetadataError::InvalidUuid)?
             {
-                disk_spec.virtual_disk_size = f
-                    .read_u64::<LittleEndian>()
+                let mut item = [0u8; size_of::<u64>()];
+                f.read_exact_at(&mut item, item_offset)
                     .map_err(VhdxMetadataError::ReadMetadata)?;
+                disk_spec.virtual_disk_size = LittleEndian::read_u64(&item);
 
                 metadata_presence |= METADATA_VIRTUAL_DISK_SIZE_PRESENT;
             } else if metadata_entry.item_id
                 == Uuid::parse_str(METADATA_VIRTUAL_DISK_ID)
                     .map_err(VhdxMetadataError::InvalidUuid)?
             {
-                disk_spec.disk_id = f
-                    .read_u128::<LittleEndian>()
+                let mut item = [0u8; size_of::<u128>()];
+                f.read_exact_at(&mut item, item_offset)
                     .map_err(VhdxMetadataError::ReadMetadata)?;
+                disk_spec.disk_id = LittleEndian::read_u128(&item);
 
                 metadata_presence |= METADATA_VIRTUAL_DISK_ID_PRESENT;
             } else if metadata_entry.item_id
                 == Uuid::parse_str(METADATA_LOGICAL_SECTOR_SIZE)
                     .map_err(VhdxMetadataError::InvalidUuid)?
             {
-                disk_spec.logical_sector_size = f
-                    .read_u32::<LittleEndian>()
+                let mut item = [0u8; size_of::<u32>()];
+                f.read_exact_at(&mut item, item_offset)
                     .map_err(VhdxMetadataError::ReadMetadata)?;
+                disk_spec.logical_sector_size = LittleEndian::read_u32(&item);
                 if !(disk_spec.logical_sector_size == 512 || disk_spec.logical_sector_size == 4096)
                 {
                     return Err(VhdxMetadataError::InvalidLogicalSectorSize);
@@ -188,9 +188,10 @@ impl DiskSpec {
                 == Uuid::parse_str(METADATA_PHYSICAL_SECTOR_SIZE)
                     .map_err(VhdxMetadataError::InvalidUuid)?
             {
-                disk_spec.physical_sector_size = f
-                    .read_u32::<LittleEndian>()
+                let mut item = [0u8; size_of::<u32>()];
+                f.read_exact_at(&mut item, item_offset)
                     .map_err(VhdxMetadataError::ReadMetadata)?;
+                disk_spec.physical_sector_size = LittleEndian::read_u32(&item);
                 if !(disk_spec.physical_sector_size == 512
                     || disk_spec.physical_sector_size == 4096)
                 {

--- a/block/src/formats/vhdx/internal/mod.rs
+++ b/block/src/formats/vhdx/internal/mod.rs
@@ -20,6 +20,7 @@ use self::header::{RegionInfo, RegionTableEntry, VhdxHeader, VhdxHeaderError};
 use self::io::VhdxIoError;
 use self::metadata::{DiskSpec, VhdxMetadataError};
 use crate::BlockBackend;
+use crate::aligned_file::AlignedFile;
 
 mod bat;
 mod header;
@@ -49,7 +50,7 @@ pub type Result<T> = result::Result<T, VhdxError>;
 
 #[derive(Debug)]
 pub struct Vhdx {
-    file: File,
+    aligned: AlignedFile,
     vhdx_header: VhdxHeader,
     region_entries: BTreeMap<u64, u64>,
     bat_entry: RegionTableEntry,
@@ -63,11 +64,13 @@ pub struct Vhdx {
 impl Vhdx {
     /// Parse the Vhdx header, BAT, and metadata from a file and store info
     // in Vhdx structure.
-    pub fn new(mut file: File) -> Result<Vhdx> {
-        let vhdx_header = VhdxHeader::new(&mut file).map_err(VhdxError::ParseVhdxHeader)?;
+    pub fn new(file: File, direct_io: bool) -> Result<Vhdx> {
+        let aligned = AlignedFile::new(file, direct_io);
+
+        let vhdx_header = VhdxHeader::new(&aligned).map_err(VhdxError::ParseVhdxHeader)?;
 
         let collected_entries = RegionInfo::new(
-            &mut file,
+            &aligned,
             header::REGION_TABLE_1_START,
             vhdx_header.region_entry_count(),
         )
@@ -77,12 +80,12 @@ impl Vhdx {
         let mdr_entry = collected_entries.mdr_entry;
 
         let disk_spec =
-            DiskSpec::new(&mut file, &mdr_entry).map_err(VhdxError::ParseVhdxMetadata)?;
-        let bat_entries = BatEntry::collect_bat_entries(&mut file, &disk_spec, &bat_entry)
+            DiskSpec::new(&aligned, &mdr_entry).map_err(VhdxError::ParseVhdxMetadata)?;
+        let bat_entries = BatEntry::collect_bat_entries(&aligned, &disk_spec, &bat_entry)
             .map_err(VhdxError::ReadBatEntry)?;
 
         Ok(Vhdx {
-            file,
+            aligned,
             vhdx_header,
             region_entries: collected_entries.region_entries,
             bat_entry,
@@ -107,7 +110,7 @@ impl Read for Vhdx {
         let sector_index = self.current_offset / self.disk_spec.logical_sector_size as u64;
 
         let result = io::read(
-            &mut self.file,
+            &self.aligned,
             buf,
             &self.disk_spec,
             &self.bat_entries,
@@ -128,7 +131,7 @@ impl Read for Vhdx {
 
 impl Write for Vhdx {
     fn flush(&mut self) -> IoResult<()> {
-        self.file.flush()
+        self.aligned.file_mut().flush()
     }
 
     /// Wrapper function to satisfy Write trait implementation for VHDx disk.
@@ -140,12 +143,12 @@ impl Write for Vhdx {
         if self.first_write {
             self.first_write = false;
             self.vhdx_header
-                .update(&mut self.file)
+                .update(&self.aligned)
                 .map_err(|e| IoError::other(format!("Failed to update VHDx header: {e}")))?;
         }
 
         let result = io::write(
-            &mut self.file,
+            &self.aligned,
             buf,
             &mut self.disk_spec,
             self.bat_entry.file_offset,
@@ -210,7 +213,8 @@ impl BlockBackend for Vhdx {
     }
 
     fn physical_size(&self) -> result::Result<u64, crate::Error> {
-        self.file
+        self.aligned
+            .file()
             .metadata()
             .map(|m| m.len())
             .map_err(crate::Error::GetFileMetadata)
@@ -220,7 +224,7 @@ impl BlockBackend for Vhdx {
 impl Clone for Vhdx {
     fn clone(&self) -> Self {
         Vhdx {
-            file: self.file.try_clone().unwrap(),
+            aligned: self.aligned.try_clone().unwrap(),
             vhdx_header: self.vhdx_header.clone(),
             region_entries: self.region_entries.clone(),
             bat_entry: self.bat_entry,
@@ -235,7 +239,7 @@ impl Clone for Vhdx {
 
 impl AsRawFd for Vhdx {
     fn as_raw_fd(&self) -> RawFd {
-        self.file.as_raw_fd()
+        self.aligned.file().as_raw_fd()
     }
 }
 
@@ -249,4 +253,65 @@ pub(crate) fn uuid_from_guid(buf: &[u8]) -> Uuid {
         BigEndian::read_u16(&buf[6..8]),
         buf[8..16].try_into().unwrap(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+
+    /// Generate a small dynamic VHDX with `qemu-img`. Returns `None` (and the
+    /// test is skipped) when `qemu-img` is unavailable, e.g. in minimal CI.
+    fn dynamic_vhdx(size_mib: u64) -> Option<TempFile> {
+        let tf = TempFile::new().unwrap();
+        let path = tf.as_path();
+        let status = Command::new("qemu-img")
+            .args(["create", "-f", "vhdx", "-o", "subformat=dynamic"])
+            .arg(path)
+            .arg(format!("{size_mib}M"))
+            .status();
+        match status {
+            Ok(s) if s.success() => Some(tf),
+            _ => None,
+        }
+    }
+
+    /// An unaligned sector write under a forced O_DIRECT alignment must go
+    /// through `AlignedFile`'s read-modify-write bounce (the data block and the
+    /// BAT update both land at unaligned host offsets) and read back intact.
+    #[test]
+    fn unaligned_write_is_rmw() {
+        let Some(tf) = dynamic_vhdx(16) else {
+            eprintln!("skipping unaligned_write_is_rmw: qemu-img unavailable");
+            return;
+        };
+
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(tf.as_path())
+            .unwrap();
+        let mut vhdx = Vhdx::new(file, false).unwrap();
+
+        // Force a non-zero alignment so all of vhdx's positioned I/O exercises
+        // the bounce/RMW path even though the tempfile is not really O_DIRECT.
+        vhdx.aligned = AlignedFile::with_alignment(vhdx.aligned.file().try_clone().unwrap(), 512);
+
+        let sector = vhdx.disk_spec.logical_sector_size as usize;
+        let data: Vec<u8> = (0..sector).map(|i| ((i + 1) % 251) as u8).collect();
+
+        // Write at virtual offset 0 (allocates a new data block + rewrites BAT).
+        vhdx.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(vhdx.write(&data).unwrap(), data.len());
+        vhdx.flush().unwrap();
+
+        // Read it back through a fresh, forced-alignment handle.
+        let mut readback = vec![0u8; sector];
+        vhdx.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(vhdx.read(&mut readback).unwrap(), readback.len());
+        assert_eq!(readback, data);
+    }
 }

--- a/block/src/formats/vhdx/mod.rs
+++ b/block/src/formats/vhdx/mod.rs
@@ -38,9 +38,9 @@ pub struct VhdxDisk {
 }
 
 impl VhdxDisk {
-    pub fn new(f: File) -> BlockResult<Self> {
+    pub fn new(f: File, direct_io: bool) -> BlockResult<Self> {
         Ok(VhdxDisk {
-            vhdx_file: Arc::new(Mutex::new(Vhdx::new(f).map_err(|e| {
+            vhdx_file: Arc::new(Mutex::new(Vhdx::new(f, direct_io).map_err(|e| {
                 let kind = match &e {
                     VhdxError::NotVhdx(_)
                     | VhdxError::ParseVhdxHeader(_)

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -14,6 +14,7 @@ pub mod factory;
 #[path = "io/mod.rs"]
 mod io_impl;
 pub use io_impl::{async_io, fcntl, request};
+pub(crate) mod aligned_buffer;
 pub mod formats;
 mod sparse;
 use std::alloc::{Layout, alloc_zeroed};

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -15,6 +15,7 @@ pub mod factory;
 mod io_impl;
 pub use io_impl::{async_io, fcntl, request};
 pub(crate) mod aligned_buffer;
+pub(crate) mod aligned_file;
 pub mod formats;
 mod sparse;
 use std::alloc::{Layout, alloc_zeroed};

--- a/fuzz/fuzz_targets/vhdx.rs
+++ b/fuzz/fuzz_targets/vhdx.rs
@@ -22,7 +22,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
     disk_file.write_all(&bytes[..]).unwrap();
     disk_file.seek(SeekFrom::Start(0)).unwrap();
 
-    let mut vhdx = match Vhdx::new(disk_file) {
+    let mut vhdx = match Vhdx::new(disk_file, false) {
         Ok(vhdx) => vhdx,
         Err(_) => return Corpus::Reject,
     };

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -112,6 +112,7 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_fallocate, vec![]),
         (libc::SYS_fcntl, vec![]),
         (libc::SYS_fdatasync, vec![]),
+        (libc::SYS_fstat, vec![]),
         (libc::SYS_fsync, vec![]),
         (libc::SYS_ftruncate, vec![]),
         (libc::SYS_getrandom, vec![]),
@@ -121,6 +122,7 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_io_submit, vec![]),
         (libc::SYS_io_uring_enter, vec![]),
         (libc::SYS_lseek, vec![]),
+        (libc::SYS_newfstatat, vec![]),
         (libc::SYS_pread64, vec![]),
         (libc::SYS_preadv, vec![]),
         (libc::SYS_pwritev, vec![]),
@@ -128,6 +130,7 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_sched_getaffinity, vec![]),
         (libc::SYS_sched_setaffinity, vec![]),
         (libc::SYS_set_robust_list, vec![]),
+        (libc::SYS_statx, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
     ]
 }


### PR DESCRIPTION
- **block: Implement FileExt for RawFile**
- **block: Add AlignedBuffer**
- **block: qcow: Port RawFile to AlignedBuffer**
- **block: qcow: Port backing file support to FileExt**
- **block: qcow: Port to AlignedBuffer**
- **block: qcow: Port to FileExt**
- **block: Add AlignedFile**
- **block: qcow: Port RawFile to AlignedFile**
- **block: vhdx: Use AlignedFile for O_DIRECT-safe I/O**
