### PR TITLE
ci: improve mshv CI for merge group event

### DIFF
--- a/.github/workflows/mshv-integration.yaml
+++ b/.github/workflows/mshv-integration.yaml
@@ -47,11 +47,12 @@ jobs:
               git clone --depth 1 "$REPO_URL" "$REPO_DIR"
               cd "$REPO_DIR"
               git fetch origin pull/${{ github.event.pull_request.number }}/merge
-              git checkout FETCH_HEAD
             else
-              git clone --depth 1 --single-branch --branch "${{ github.ref_name }}" "$REPO_URL" "$REPO_DIR"
+              git clone --depth 1 "$REPO_URL" "$REPO_DIR"
               cd "$REPO_DIR"
+              git fetch origin "${{ github.sha }}":refs/remotes/origin/ci-target
             fi
+            git checkout FETCH_HEAD
 
             echo "Loading VDPA kernel modules..."
             sudo modprobe vdpa


### PR DESCRIPTION
Refactor the checkout logic to resolve intermittent 'remote branch not found' errors caused by ephermal merge queue branches and shallow clone limitations. 
- Replace branch-based cloning with shallow clone of repo base followed by explicit fetch of the target commit SHA.
- Used refspec mapping (:refs/remotes/origin/ci-target) to ensure Git correctly anchors the fetched commit.

Failure: https://github.com/cloud-hypervisor/cloud-hypervisor/actions/runs/27276351115/job/80564214669#:~:text=warning%3A%20Could%20not,58