### PR TITLE
build: Consolidate sev_snp feature usage

### DIFF
--- a/cloud-hypervisor/tests/integration_cvm.rs
+++ b/cloud-hypervisor/tests/integration_cvm.rs
@@ -10,7 +10,7 @@
 #![allow(dead_code)]
 mod common;
 
-#[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+#[cfg(feature = "sev_snp")]
 mod common_cvm {
     use block::ImageType;
     use common::tests_wrappers::*;

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -576,9 +576,9 @@ pub struct KvmVm {
     fd: Arc<VmFd>,
     #[cfg(target_arch = "x86_64")]
     msrs: Vec<MsrEntry>,
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(feature = "sev_snp")]
     sev_fd: Option<x86_64::sev::SevFd>,
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(feature = "sev_snp")]
     snp_guest_policy: std::sync::OnceLock<u64>,
     dirty_log_slots: RwLock<HashMap<u32, KvmDirtyLogSlot>>,
     memory_slots: Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
@@ -700,7 +700,7 @@ impl KvmVm {
 /// let vm = hypervisor.create_vm(HypervisorVmConfig::default()).expect("new VM fd creation failed");
 /// ```
 impl vm::Vm for KvmVm {
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(feature = "sev_snp")]
     fn sev_snp_init(&self, guest_policy: igvm_defs::SnpPolicy) -> vm::Result<()> {
         self.sev_fd
             .as_ref()
@@ -713,7 +713,7 @@ impl vm::Vm for KvmVm {
         Ok(())
     }
 
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(feature = "sev_snp")]
     fn import_isolated_pages(
         &self,
         page_type: u32,
@@ -751,7 +751,7 @@ impl vm::Vm for KvmVm {
         Ok(())
     }
 
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(feature = "sev_snp")]
     fn complete_isolated_import(
         &self,
         snp_id_block: igvm_defs::IGVM_VHS_SNP_ID_BLOCK,

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -447,10 +447,7 @@ pub struct MshvVcpu {
     #[cfg(target_arch = "x86_64")]
     msrs: Vec<MsrEntry>,
     vm_ops: Option<Arc<dyn vm::VmOps>>,
-    #[cfg_attr(
-        all(not(target_arch = "x86_64"), not(feature = "sev_snp")),
-        expect(dead_code)
-    )]
+    #[cfg_attr(not(target_arch = "x86_64"), expect(dead_code))]
     vm_fd: Arc<VmFd>,
     #[cfg(feature = "sev_snp")]
     ghcb: Option<Ghcb>,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -368,7 +368,7 @@ pub enum ValidationError {
     #[cfg(feature = "sev_snp")]
     #[error("Invalid host data format")]
     InvalidHostData,
-    #[cfg(all(feature = "sev_snp", feature = "igvm"))]
+    #[cfg(feature = "sev_snp")]
     #[error("SEV-SNP requires an IGVM payload (--payload igvm=<path>)")]
     SevSnpRequiresIgvm,
     /// Restore expects all net ids that have fds

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -41,12 +41,7 @@ use crate::cpu::CpuManager;
 use crate::igvm::loader::Loader;
 use crate::igvm::{BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, StartupMemoryType};
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
-#[cfg(all(
-    feature = "kvm",
-    feature = "sev_snp",
-    feature = "fw_cfg",
-    target_arch = "x86_64"
-))]
+#[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
 use crate::sev::{MeasuredBootInfo, SEV_HASH_BLOCK_ADDRESS, SEV_HASH_BLOCK_SIZE};
 
 #[cfg(feature = "sev_snp")]
@@ -107,20 +102,10 @@ pub enum Error {
     MissingIgvm,
     #[error("Error applying VMSA to vCPU registers: {0}")]
     SetVmsa(#[source] crate::cpu::Error),
-    #[cfg(all(
-        feature = "kvm",
-        feature = "sev_snp",
-        feature = "fw_cfg",
-        target_arch = "x86_64"
-    ))]
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
     #[error("Error building SEV-SNP measured boot hash block")]
     MeasuredBoot(#[source] vmm_sys_util::errno::Error),
-    #[cfg(all(
-        feature = "kvm",
-        feature = "sev_snp",
-        feature = "fw_cfg",
-        target_arch = "x86_64"
-    ))]
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
     #[error(
         "igvmfile inserts unmeasured parameter area [0x{region_start:x}, 0x{region_end:x}) over SEV-SNP kernel hashes region [0x{hash_start:x}, 0x{hash_end:x})"
     )]
@@ -279,13 +264,9 @@ pub fn load_igvm(
     memory_manager: Arc<Mutex<MemoryManager>>,
     cpu_manager: Arc<Mutex<CpuManager>>,
     cmdline: &str,
-    #[cfg(all(
-        feature = "kvm",
-        feature = "sev_snp",
-        feature = "fw_cfg",
-        target_arch = "x86_64"
-    ))]
-    measured_boot: Option<MeasuredBootInfo>,
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))] measured_boot: Option<
+        MeasuredBootInfo,
+    >,
     #[cfg(feature = "sev_snp")] host_data: &Option<String>,
 ) -> Result<Box<IgvmLoadedInfo>, Error> {
     let hypervisor_type = cpu_manager.lock().unwrap().hypervisor_type();
@@ -338,12 +319,7 @@ pub fn load_igvm(
     let mut loader = Loader::new(memory);
 
     let mut parameter_areas: HashMap<u32, ParameterAreaState> = HashMap::new();
-    #[cfg(all(
-        feature = "kvm",
-        feature = "sev_snp",
-        feature = "fw_cfg",
-        target_arch = "x86_64"
-    ))]
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
     let measured_boot_hash_block = if hypervisor_type == HypervisorType::Kvm {
         measured_boot
             .as_ref()
@@ -356,26 +332,11 @@ pub fn load_igvm(
     } else {
         None
     };
-    #[cfg(all(
-        feature = "kvm",
-        feature = "sev_snp",
-        feature = "fw_cfg",
-        target_arch = "x86_64"
-    ))]
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
     let measured_boot_hash_page_base = SEV_HASH_BLOCK_ADDRESS / HV_PAGE_SIZE;
-    #[cfg(all(
-        feature = "kvm",
-        feature = "sev_snp",
-        feature = "fw_cfg",
-        target_arch = "x86_64"
-    ))]
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
     let measured_boot_hash_offset = (SEV_HASH_BLOCK_ADDRESS % HV_PAGE_SIZE) as usize;
-    #[cfg(all(
-        feature = "kvm",
-        feature = "sev_snp",
-        feature = "fw_cfg",
-        target_arch = "x86_64"
-    ))]
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
     let mut measured_boot_hash_block_inserted = measured_boot_hash_block.is_none();
 
     for header in igvm_file.directives() {
@@ -529,12 +490,7 @@ pub fn load_igvm(
                         .map_err(Error::Loader)?;
                     imported_page = true;
                 }
-                #[cfg(all(
-                    feature = "kvm",
-                    feature = "sev_snp",
-                    feature = "fw_cfg",
-                    target_arch = "x86_64"
-                ))]
+                #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
                 if let Some(hash_block) = measured_boot_hash_block.as_ref().filter(|_| {
                     !imported_page && gpa / HV_PAGE_SIZE == measured_boot_hash_page_base
                 }) {
@@ -732,12 +688,7 @@ pub fn load_igvm(
                 };
                 match area {
                     ParameterAreaState::Allocated { data, max_size } => {
-                        #[cfg(all(
-                            feature = "kvm",
-                            feature = "sev_snp",
-                            feature = "fw_cfg",
-                            target_arch = "x86_64"
-                        ))]
+                        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
                         if measured_boot_hash_block.is_some() {
                             let region_end = *gpa + *max_size;
                             let hash_end = SEV_HASH_BLOCK_ADDRESS + SEV_HASH_BLOCK_SIZE as u64;
@@ -794,12 +745,7 @@ pub fn load_igvm(
         }
     }
 
-    #[cfg(all(
-        feature = "kvm",
-        feature = "sev_snp",
-        feature = "fw_cfg",
-        target_arch = "x86_64"
-    ))]
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
     if let Some(hash_block) = measured_boot_hash_block.as_ref()
         && !measured_boot_hash_block_inserted
     {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -89,12 +89,7 @@ pub mod migration_transport;
 mod pci_segment;
 pub mod seccomp_filters;
 mod serial_manager;
-#[cfg(all(
-    feature = "kvm",
-    feature = "sev_snp",
-    feature = "fw_cfg",
-    target_arch = "x86_64"
-))]
+#[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
 pub(crate) mod sev;
 mod sigwinch_listener;
 mod sync_utils;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -105,12 +105,7 @@ use crate::migration::get_vm_snapshot;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::migration::url_to_file;
 use crate::migration::{SNAPSHOT_CONFIG_FILE, SNAPSHOT_STATE_FILE, url_to_path};
-#[cfg(all(
-    feature = "kvm",
-    feature = "sev_snp",
-    feature = "fw_cfg",
-    target_arch = "x86_64"
-))]
+#[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
 use crate::sev::MeasuredBootInfo;
 #[cfg(feature = "fw_cfg")]
 use crate::vm_config::FwCfgConfig;
@@ -1566,13 +1561,9 @@ impl Vm {
         igvm_file: IgvmFile,
         memory_manager: Arc<Mutex<MemoryManager>>,
         cpu_manager: Arc<Mutex<cpu::CpuManager>>,
-        #[cfg(all(
-            feature = "kvm",
-            feature = "sev_snp",
-            feature = "fw_cfg",
-            target_arch = "x86_64"
-        ))]
-        measured_boot: Option<MeasuredBootInfo>,
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))] measured_boot: Option<
+            MeasuredBootInfo,
+        >,
         #[cfg(feature = "sev_snp")] host_data: &Option<String>,
     ) -> Result<EntryPoint> {
         // Only reserve bootloader/VMSA regions for KVM + SEV-SNP; other hypervisors
@@ -1589,12 +1580,7 @@ impl Vm {
             memory_manager,
             cpu_manager.clone(),
             "",
-            #[cfg(all(
-                feature = "kvm",
-                feature = "sev_snp",
-                feature = "fw_cfg",
-                target_arch = "x86_64"
-            ))]
+            #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
             measured_boot,
             #[cfg(feature = "sev_snp")]
             host_data,
@@ -1690,12 +1676,7 @@ impl Vm {
             if payload.igvm.is_some() {
                 let igvm_file =
                     igvm_file.ok_or(Error::IgvmLoad(igvm_loader::Error::MissingIgvm))?;
-                #[cfg(all(
-                    feature = "kvm",
-                    feature = "sev_snp",
-                    feature = "fw_cfg",
-                    target_arch = "x86_64"
-                ))]
+                #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
                 let measured_boot = if let (true, Some(kernel_path), Some(_cmdline)) = (
                     payload
                         .fw_cfg_config
@@ -1738,12 +1719,7 @@ impl Vm {
                     igvm_file,
                     memory_manager,
                     cpu_manager,
-                    #[cfg(all(
-                        feature = "kvm",
-                        feature = "sev_snp",
-                        feature = "fw_cfg",
-                        target_arch = "x86_64"
-                    ))]
+                    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
                     measured_boot,
                     #[cfg(feature = "sev_snp")]
                     &payload.host_data,


### PR DESCRIPTION
Since igvm is a required feature of sev_snp and also sev_snp is x86-64
only the cfg attributes at build time can be consolidated & simplified.

Signed-off-by: Rob Bradford <rbradford@meta.com>
