### PR TITLE
devices, arch, hypervisor: reevaluate #[allow] attributes

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -204,7 +204,7 @@ pub fn get_cache_shared(cache_level: CacheLevel) -> bool {
 }
 
 /// Creates the flattened device tree for this aarch64 VM.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn create_fdt<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
     guest_mem: &GuestMemoryMmap,
     cmdline: &str,

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -121,7 +121,7 @@ pub fn arch_memory_regions() -> Vec<(GuestAddress, usize, RegionType)> {
 }
 
 /// Configures the system and should be called once per vm before starting vcpu threads.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
     guest_mem: &GuestMemoryMmap,
     cmdline: &str,

--- a/arch/src/riscv64/fdt.rs
+++ b/arch/src/riscv64/fdt.rs
@@ -61,7 +61,7 @@ pub enum Error {
 type Result<T> = result::Result<T, Error>;
 
 /// Creates the flattened device tree for this riscv64 VM.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn create_fdt<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
     guest_mem: &GuestMemoryMmap,
     cmdline: &str,

--- a/arch/src/riscv64/mod.rs
+++ b/arch/src/riscv64/mod.rs
@@ -160,7 +160,6 @@ fn isa_string_from_host() -> Result<String, Error> {
 }
 
 /// Configures the system and should be called once per vm before starting vcpu threads.
-#[allow(clippy::too_many_arguments)]
 pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
     guest_mem: &GuestMemoryMmap,
     cmdline: &str,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -913,7 +913,7 @@ fn common_cpuid_tdx_configuration(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn configure_vcpu(
     vcpu: &dyn hypervisor::Vcpu,
     id: u32,
@@ -1053,7 +1053,7 @@ pub fn arch_memory_regions() -> Vec<(GuestAddress, usize, RegionType)> {
 /// * `cmdline_addr` - Address in `guest_mem` where the kernel command line was loaded.
 /// * `cmdline_size` - Size of the kernel command line in bytes including the null terminator.
 /// * `num_cpus` - Number of virtual CPUs the guest will have.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn configure_system(
     guest_mem: &GuestMemoryMmap,
     cmdline_addr: GuestAddress,

--- a/arch/src/x86_64/mpspec.rs
+++ b/arch/src/x86_64/mpspec.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
-#![allow(non_camel_case_types)]
 use vm_memory::ByteValued;
 
 pub const MP_PROCESSOR: ::std::os::raw::c_uint = 0;

--- a/devices/src/aia.rs
+++ b/devices/src/aia.rs
@@ -39,7 +39,7 @@ pub struct Aia {
 }
 
 impl Aia {
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn new(
         vcpu_count: u32,
         interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -38,7 +38,7 @@ pub struct Gic {
 }
 
 impl Gic {
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     pub fn new(
         vcpu_count: u32,
         interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,

--- a/hypervisor/src/arch/aarch64/regs.rs
+++ b/hypervisor/src/arch/aarch64/regs.rs
@@ -165,7 +165,7 @@ pub enum ExceptionClass {
     BRK = 0b111100,
 }
 
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 // PSR (Processor State Register) bits.
 // Taken from arch/arm64/include/uapi/asm/ptrace.h.
 const PSR_MODE_EL1h: u64 = 0x0000_0005;

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#![allow(non_camel_case_types)]
+#![expect(non_camel_case_types)]
 
 //
 // MOV-Move

--- a/hypervisor/src/arch/x86/emulator/instructions/movs.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/movs.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#![allow(non_camel_case_types)]
+#![expect(non_camel_case_types)]
 
 //
 // MOVS - Move Data from String to String

--- a/hypervisor/src/arch/x86/emulator/instructions/or.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/or.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#![allow(non_camel_case_types)]
+#![expect(non_camel_case_types)]
 
 //
 // OR - Logical inclusive OR

--- a/hypervisor/src/arch/x86/emulator/instructions/stos.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/stos.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#![allow(non_camel_case_types)]
+#![expect(non_camel_case_types)]
 
 //
 // STOS - Store String

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -20,9 +20,7 @@ use crate::CpuVendor;
 #[cfg(all(feature = "mshv_emulator", target_arch = "x86_64"))]
 pub mod emulator;
 pub mod gdt;
-#[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 pub mod msr_index;
 
 // MTRR constants

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1512,7 +1512,7 @@ pub type KvmResult<T> = result::Result<T, KvmError>;
 
 impl KvmHypervisor {
     /// Create a hypervisor based on Kvm
-    #[allow(clippy::new_ret_no_self)]
+    #[expect(clippy::new_ret_no_self)]
     pub fn new() -> hypervisor::Result<Arc<dyn hypervisor::Hypervisor>> {
         let kvm_obj = Kvm::new().map_err(|e| hypervisor::HypervisorError::VmCreate(e.into()))?;
         let api_version = kvm_obj.get_api_version();

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -233,7 +233,7 @@ pub struct MshvHypervisor {
 
 impl MshvHypervisor {
     /// Create a hypervisor based on Mshv
-    #[allow(clippy::new_ret_no_self)]
+    #[expect(clippy::new_ret_no_self)]
     pub fn new() -> hypervisor::Result<Arc<dyn hypervisor::Hypervisor>> {
         let mshv_obj =
             Mshv::new().map_err(|e| hypervisor::HypervisorError::HypervisorCreate(e.into()))?;
@@ -589,7 +589,7 @@ impl cpu::Vcpu for MshvVcpu {
         Ok(())
     }
 
-    #[allow(non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn run(&mut self) -> std::result::Result<cpu::VmExit, cpu::HypervisorCpuError> {
         match self.fd.run() {
             Ok(x) => match x.header.message_type {

--- a/hypervisor/src/mshv/x86_64/emulator.rs
+++ b/hypervisor/src/mshv/x86_64/emulator.rs
@@ -23,7 +23,7 @@ pub struct MshvEmulatorContext<'a> {
 
 impl MshvEmulatorContext<'_> {
     // Do the actual gva -> gpa translation
-    #[allow(non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn translate(&self, gva: u64, flags: u32) -> Result<u64, PlatformError> {
         if let Some((cached_gva, cached_gpa)) = self.mapping
             && cached_gva == gva


### PR DESCRIPTION
Part of #8326. Follows #8373 and #8363.

Covers `devices`, `arch`, and `hypervisor` - one commit per crate. Each
`#[allow]` was classified by running clippy and either:
- deleted if the lint no longer fires in any config,
- converted to `#[expect]` if it fires unconditionally, or
- kept as `#[allow]` if it fires only under some arch/feature combo.

Verified across x86_64 and aarch64, kvm/mshv (and kvm+mshv together,
plus sev_snp/tdx for `hypervisor`). The combined kvm+mshv build mattered:
a `large_enum_variant` in `hypervisor` only fires when both backends are
enabled, so it is kept as `#[allow]` rather than removed. The many
`unreachable_patterns` allows in `hypervisor` are feature-gated and are
intentionally left as `#[allow]`.

Remaining crates (`block`, `net_util`, `cloud-hypervisor`, `tracer`,
`vm-allocator`, `vhost_user_net`, `performance-metrics`, `test_infra`)
will follow in a subsequent batch.
