### PR TITLE
hypervisor: kvm: skip MSR_IA32_TSC restore for Hyper-V guests so masterclock engages on vm.restore

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -3146,21 +3146,45 @@ impl cpu::Vcpu for KvmVcpu {
         // expected amount, we fallback onto a slower method by setting MSRs
         // by chunks. This is the only way to make sure we try to set as many
         // MSRs as possible, even if some MSRs are not supported.
-        let expected_num_msrs = state.msrs.len();
-        let num_msrs = self.set_msrs(&state.msrs)?;
+        // For Hyper-V (Windows) guests, restoring MSR_IA32_TSC per-vCPU desyncs
+        // the vCPU TSC offsets: KVM_SET_TSC_KHZ first lands a synchronized
+        // offset, then the per-vCPU MSR_IA32_TSC value write re-derives the
+        // offset against a slightly later host TSC, so each vCPU ends with a
+        // different offset. KVM masterclock then never engages and the Hyper-V
+        // TSC reference page is left stale (sequence 0); Windows falls back to
+        // trapping HV_X64_MSR_TIME_REF_COUNT on every QueryPerformanceCounter
+        // (~18x slower clock reads). The synchronized offset from
+        // KVM_SET_TSC_KHZ already gives a consistent guest TSC across vCPUs, so
+        // skip the value restore for Hyper-V guests; reenlightenment handles the
+        // resulting TSC discontinuity. Non-Hyper-V (Linux) guests are unaffected.
+        let msrs_filtered: Vec<MsrEntry>;
+        let msrs: &[MsrEntry] = if state.hyperv_synic {
+            msrs_filtered = state
+                .msrs
+                .iter()
+                .filter(|m| m.index != crate::arch::x86::msr_index::MSR_IA32_TSC)
+                .cloned()
+                .collect();
+            &msrs_filtered
+        } else {
+            &state.msrs
+        };
+
+        let expected_num_msrs = msrs.len();
+        let num_msrs = self.set_msrs(msrs)?;
         if num_msrs != expected_num_msrs {
             let mut faulty_msr_index = num_msrs;
 
             loop {
                 warn!(
                     "Detected faulty MSR 0x{:x} while setting MSRs",
-                    state.msrs[faulty_msr_index].index
+                    msrs[faulty_msr_index].index
                 );
 
                 // Skip the first bad MSR
                 let start_pos = faulty_msr_index + 1;
 
-                let sub_msr_entries = &state.msrs[start_pos..];
+                let sub_msr_entries = &msrs[start_pos..];
 
                 let num_msrs = self.set_msrs(sub_msr_entries)?;
 


### PR DESCRIPTION
Related: #8380 — the CPUID change that lets a Windows guest enable the Hyper-V reference TSC page in the first place. This PR keeps that page working across `vm.restore`; both are needed for Windows to use the fast clock path on cloud-hypervisor.

## Problem

A Hyper-V (Windows) guest brought up via `vm.restore` (snapshot restore or live-migration receive) runs `QueryPerformanceCounter` on the slow path: it never uses the Hyper-V reference TSC page and traps `HV_X64_MSR_TIME_REF_COUNT` (0x40000020) on every clock read (~18x slower), even with the reference-TSC CPUID bit advertised and the existing KVM-clock-restore fixes present (`restore KVM clock before resuming vCPUs`, `notify_guest_clock_paused for Hyper-V guests`, `restore KVM clock in migration`). A fresh boot of the same guest is fast; only `vm.restore` is slow.

## Root cause

KVM only populates the Hyper-V TSC reference page when masterclock is engaged (`use_master_clock=1`), which requires all vCPU TSC offsets to match. During restore, each vCPU's TSC offset is written twice — observable via the `kvm:kvm_write_tsc_offset` / `kvm:kvm_track_tsc` tracepoints:

```
kvm_write_tsc_offset: vcpu=0 prev=0 next=A ; vcpu=0 prev=A next=B
kvm_write_tsc_offset: vcpu=1 prev=0 next=B ; vcpu=1 prev=B next=C
kvm_track_tsc: vcpu_id 1 offsetmatched 1   (first write synchronizes)
kvm_track_tsc: vcpu_id 1 offsetmatched 0   (second write breaks the match)
kvm_update_master_clock: masterclock 0 offsetmatched 0   (never engages)
```

The first offset write comes from `KVM_SET_TSC_KHZ` and lands a synchronized offset (KVM's TSC-sync window forces it to match the previous vCPU). The second comes from the per-vCPU `MSR_IA32_TSC` value restore: KVM derives `offset = saved_value - current_host_tsc`, and because the host TSC advances between each vCPU's write, every vCPU ends with a slightly different offset. So the synchronized state is established and then immediately destroyed. Masterclock never engages, the TSC page sequence stays 0, and Windows uses the reference-counter MSR for the life of the VM. A fresh boot sets all vCPUs to one TSC in a single synchronized batch, stays matched, and is fast.

## Fix

Skip the `MSR_IA32_TSC` value restore for Hyper-V guests (gated on `hyperv_synic`), leaving the synchronized offset from `KVM_SET_TSC_KHZ` intact so masterclock can engage. Preserving the exact guest TSC value across restore is not required for Hyper-V guests: reenlightenment is designed to absorb a TSC offset/frequency discontinuity (and `notify_guest_clock_paused` already signals it), while the partition reference time / wall clock is maintained independently of the raw TSC. Non-Hyper-V (Linux) guests are unaffected — they keep restoring `MSR_IA32_TSC`, which kvmclock relies on. (`KVM_SET_TSC_STATE`, which would let us restore the value and keep vCPUs synchronized, was never merged into mainline KVM and is not exposed by kvm-ioctls.)

## Testing

Nested-KVM host (GCE n2, Cascade Lake, kernel 6.8), `vm.restore` of a Windows 10 22H2 guest: `QueryPerformanceCounter` goes from ~65,000 calls/sec (15 µs/call, an MSR exit every call) to ~1,300,000 calls/sec (no MSR exits). `kvm:kvm_msr` trace confirms `HV_X64_MSR_TIME_REF_COUNT` reads drop from thousands/sec to zero. A Linux guest boots and runs unchanged on the same build (the `hyperv_synic` gate leaves its restore path untouched).
