### PR TITLE
rate_limiter: trim qualified paths

### DIFF
--- a/rate_limiter/src/group.rs
+++ b/rate_limiter/src/group.rs
@@ -8,7 +8,7 @@ use core::panic::AssertUnwindSafe;
 use std::fs::File;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::sync::{Arc, Mutex};
-use std::{io, result, thread};
+use std::{io, panic, result, thread};
 
 use log::{error, info, warn};
 use thiserror::Error;
@@ -222,7 +222,7 @@ impl RateLimiterGroup {
         thread::Builder::new()
             .name(format!("rate-limit-group-{}", inner.id))
             .spawn(move || {
-                let res = std::panic::catch_unwind(AssertUnwindSafe(move || {
+                let res = panic::catch_unwind(AssertUnwindSafe(move || {
                     const EPOLL_EVENTS_LEN: usize = 2;
 
                     let mut events =

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -44,11 +44,11 @@
 //! trait and provides an *event-handler* as part of its API. This *event-handler*
 //! needs to be called by the user on every event on the rate limiter's `AsRawFd` FD.
 
-use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
+use std::{cmp, io};
 
 use log::error;
 use thiserror::Error;
@@ -65,7 +65,7 @@ pub enum Error {
     SpuriousRateLimiterEvent(&'static str),
     /// The event handler encounters while TimerFd::wait()
     #[error("Failed to wait for the timer")]
-    TimerFdWaitError(#[source] std::io::Error),
+    TimerFdWaitError(#[source] io::Error),
 }
 
 // Interval at which the refill timer will run when limiter is at capacity.
@@ -220,7 +220,7 @@ impl TokenBucket {
             self.one_time_burst += tokens;
             return;
         }
-        self.budget = std::cmp::min(self.budget + tokens, self.size);
+        self.budget = cmp::min(self.budget + tokens, self.size);
     }
 
     /// Returns the capacity of the token bucket.
@@ -359,7 +359,7 @@ impl RateLimiter {
             libc::fcntl(fd, libc::F_SETFL, flags)
         };
         if ret < 0 {
-            return Err(std::io::Error::last_os_error());
+            return Err(io::Error::last_os_error());
         }
 
         Ok(RateLimiter {
@@ -463,10 +463,10 @@ impl RateLimiter {
             // `timer_fd::wait()` won't block (which is different from its default behavior.)
             match guard.timer_fd.wait() {
                 Err(e) => {
-                    let err: std::io::Error = e.into();
+                    let err: io::Error = e.into();
                     match err.kind() {
-                        std::io::ErrorKind::Interrupted => (),
-                        std::io::ErrorKind::WouldBlock => {
+                        io::ErrorKind::Interrupted => (),
+                        io::ErrorKind::WouldBlock => {
                             return Err(Error::SpuriousRateLimiterEvent(
                                 "Rate limiter event handler called without a present timer",
                             ));


### PR DESCRIPTION
Part of #7670.

Import the std modules used in the crate instead of spelling the
fully-qualified paths at every use site:

- `std::io::Error` / `std::io::ErrorKind` → `io::Error` / `io::ErrorKind`
- `std::io::Error::last_os_error()` → `io::Error::last_os_error()`
- `std::cmp::min` → `cmp::min` (added `use std::{cmp, io};`)
- `std::panic::catch_unwind` → `panic::catch_unwind` (added `panic` to the existing `use std::{...}`)

Readability-only change; no functional impact. Latest in the series of
per-crate cleanups for #7670 — same approach as the most recently merged
#8371, #8362 and #8355.