### PR TITLE
block: trim qualified paths in formats

### DIFF
--- a/block/src/formats/qcow/internal/decoder.rs
+++ b/block/src/formats/qcow/internal/decoder.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{io, result};
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -11,12 +13,12 @@ pub enum Error {
     #[error("Zlib unexpected status: {0:?}")]
     ZlibUnexpectedStatus(flate2::Status),
     #[error("Zstd decompress error")]
-    ZstdDecompress(#[source] std::io::Error),
+    ZstdDecompress(#[source] io::Error),
     #[error("Zstd: failed to fill buffer")]
-    ZstdFillBuffer(#[source] std::io::Error),
+    ZstdFillBuffer(#[source] io::Error),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
 
 /// Generic trait for decoding zlib/zstd formats
 pub trait Decoder: Send + Sync {

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -21,7 +21,7 @@ use std::io::{self, Seek, SeekFrom};
 use std::mem::size_of;
 use std::os::fd::AsRawFd;
 use std::path::Path;
-use std::str;
+use std::{result, str};
 
 pub use header::{
     BackingFileConfig, CompressionType, ImageType, IncompatFeatures, MissingFeatureError,
@@ -159,7 +159,7 @@ pub enum Error {
     WritingHeader(#[source] io::Error),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
 
 /// Concrete backing file variants.
 pub(crate) enum BackingKind {

--- a/block/src/formats/qcow/internal/qcow_raw_file.rs
+++ b/block/src/formats/qcow/internal/qcow_raw_file.rs
@@ -328,7 +328,7 @@ impl QcowRawFile {
         self.file.write_all(&data[0..cluster_size])
     }
 
-    pub fn physical_size(&self) -> Result<u64, std::io::Error> {
+    pub fn physical_size(&self) -> io::Result<u64> {
         self.file.metadata().map(|m| m.len())
     }
 }
@@ -361,13 +361,14 @@ impl AsFd for QcowRawFile {
 #[cfg(test)]
 mod unit_tests {
     use std::io::{Read, Seek, SeekFrom};
+    use std::mem;
 
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
 
     fn be_bytes(entries: &[u64]) -> Vec<u8> {
-        let mut v = Vec::with_capacity(std::mem::size_of_val(entries));
+        let mut v = Vec::with_capacity(mem::size_of_val(entries));
         for e in entries {
             v.extend_from_slice(&e.to_be_bytes());
         }

--- a/block/src/formats/qcow/internal/raw_file.rs
+++ b/block/src/formats/qcow/internal/raw_file.rs
@@ -13,7 +13,7 @@ use std::fs::{File, Metadata};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::slice;
+use std::{result, slice};
 
 use vmm_sys_util::file_traits::FileSync;
 use vmm_sys_util::seek_hole::SeekHole;
@@ -88,15 +88,15 @@ impl RawFile {
             && buf.len().is_multiple_of(self.alignment)
     }
 
-    pub fn set_len(&self, size: u64) -> std::io::Result<()> {
+    pub fn set_len(&self, size: u64) -> io::Result<()> {
         self.file.set_len(size)
     }
 
-    pub fn metadata(&self) -> std::io::Result<Metadata> {
+    pub fn metadata(&self) -> io::Result<Metadata> {
         self.file.metadata()
     }
 
-    pub fn try_clone(&self) -> std::io::Result<RawFile> {
+    pub fn try_clone(&self) -> io::Result<RawFile> {
         Ok(RawFile {
             file: self.file.try_clone().expect("RawFile cloning failed"),
             alignment: self.alignment,
@@ -105,11 +105,11 @@ impl RawFile {
         })
     }
 
-    pub fn sync_all(&self) -> std::io::Result<()> {
+    pub fn sync_all(&self) -> io::Result<()> {
         self.file.sync_all()
     }
 
-    pub fn sync_data(&self) -> std::io::Result<()> {
+    pub fn sync_data(&self) -> io::Result<()> {
         self.file.sync_data()
     }
 
@@ -134,7 +134,7 @@ impl RawFile {
 }
 
 impl Read for RawFile {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.is_aligned(buf) {
             match self.file.read(buf) {
                 Ok(r) => {
@@ -214,7 +214,7 @@ impl Read for RawFile {
 }
 
 impl Write for RawFile {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if self.is_aligned(buf) {
             match self.file.write(buf) {
                 Ok(r) => {
@@ -307,13 +307,13 @@ impl Write for RawFile {
         }
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
+    fn flush(&mut self) -> io::Result<()> {
         self.file.sync_all()
     }
 }
 
 impl Seek for RawFile {
-    fn seek(&mut self, newpos: SeekFrom) -> std::io::Result<u64> {
+    fn seek(&mut self, newpos: SeekFrom) -> io::Result<u64> {
         match self.file.seek(newpos) {
             Ok(pos) => {
                 self.position = pos;
@@ -325,25 +325,25 @@ impl Seek for RawFile {
 }
 
 impl WriteZeroesAt for RawFile {
-    fn write_zeroes_at(&mut self, offset: u64, length: usize) -> std::io::Result<usize> {
+    fn write_zeroes_at(&mut self, offset: u64, length: usize) -> io::Result<usize> {
         self.file.write_zeroes_at(offset, length)
     }
 }
 
 impl PunchHole for RawFile {
-    fn punch_hole(&mut self, offset: u64, length: u64) -> std::io::Result<()> {
+    fn punch_hole(&mut self, offset: u64, length: u64) -> io::Result<()> {
         self.file.punch_hole(offset, length)
     }
 }
 
 impl FileSync for RawFile {
-    fn fsync(&mut self) -> std::io::Result<()> {
+    fn fsync(&mut self) -> io::Result<()> {
         self.file.fsync()
     }
 }
 
 impl SeekHole for RawFile {
-    fn seek_hole(&mut self, offset: u64) -> std::io::Result<Option<u64>> {
+    fn seek_hole(&mut self, offset: u64) -> io::Result<Option<u64>> {
         match self.file.seek_hole(offset) {
             Ok(pos) => {
                 if let Some(p) = pos {
@@ -355,7 +355,7 @@ impl SeekHole for RawFile {
         }
     }
 
-    fn seek_data(&mut self, offset: u64) -> std::io::Result<Option<u64>> {
+    fn seek_data(&mut self, offset: u64) -> io::Result<Option<u64>> {
         match self.file.seek_data(offset) {
             Ok(pos) => {
                 if let Some(p) = pos {
@@ -369,13 +369,13 @@ impl SeekHole for RawFile {
 }
 
 impl BlockBackend for RawFile {
-    fn logical_size(&self) -> std::result::Result<u64, crate::Error> {
+    fn logical_size(&self) -> result::Result<u64, crate::Error> {
         Ok(query_device_size(&self.file)
             .map_err(crate::Error::RawFileError)?
             .0)
     }
 
-    fn physical_size(&self) -> std::result::Result<u64, crate::Error> {
+    fn physical_size(&self) -> result::Result<u64, crate::Error> {
         Ok(query_device_size(&self.file)
             .map_err(crate::Error::RawFileError)?
             .1)

--- a/block/src/formats/qcow/internal/refcount.rs
+++ b/block/src/formats/qcow/internal/refcount.rs
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::io;
+use std::{io, result};
 
 use libc::EINVAL;
 use thiserror::Error;
@@ -41,7 +41,7 @@ pub enum Error {
     },
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
 
 /// Represents the refcount entries for an open qcow file.
 #[derive(Clone, Debug)]
@@ -174,7 +174,7 @@ impl RefCount {
             if addr != 0 {
                 raw_file.write_refcount_block(addr, block.get_values())?;
             } else {
-                return Err(std::io::Error::from_raw_os_error(EINVAL));
+                return Err(io::Error::from_raw_os_error(EINVAL));
             }
             block.mark_clean();
         }

--- a/block/src/formats/qcow/mod.rs
+++ b/block/src/formats/qcow/mod.rs
@@ -15,6 +15,8 @@ use std::fs::File;
 #[cfg(any(test, feature = "test-utils"))]
 use std::io::Seek;
 use std::os::unix::io::AsRawFd;
+#[cfg(any(test, feature = "test-utils"))]
+use std::path::Path;
 use std::sync::Arc;
 use std::{fmt, io};
 
@@ -211,7 +213,7 @@ impl QcowTempDisk {
         Ok(Self { tmp, disk })
     }
 
-    pub fn path(&self) -> &std::path::Path {
+    pub fn path(&self) -> &Path {
         self.tmp.as_path()
     }
 

--- a/block/src/formats/qcow/worker/async_uring.rs
+++ b/block/src/formats/qcow/worker/async_uring.rs
@@ -525,7 +525,7 @@ impl QcowAsync {
 mod unit_tests {
     use std::io::Write;
     use std::sync::Arc;
-    use std::thread;
+    use std::{mem, thread};
 
     use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
     use vmm_sys_util::tempfile::TempFile;
@@ -902,7 +902,7 @@ mod unit_tests {
         let mut completion_a = wait_for_completion(async_io.as_mut());
         let mut completion_b = wait_for_completion(async_io.as_mut());
         if completion_a.user_data > completion_b.user_data {
-            std::mem::swap(&mut completion_a, &mut completion_b);
+            mem::swap(&mut completion_a, &mut completion_b);
         }
         assert_eq!(completion_tuple(&completion_a), (30, 4096));
         assert_eq!(completion_tuple(&completion_b), (40, 4096));

--- a/block/src/formats/qcow/worker/sync.rs
+++ b/block/src/formats/qcow/worker/sync.rs
@@ -338,7 +338,7 @@ impl AsyncIo for QcowSync {
 
 #[cfg(test)]
 mod unit_tests {
-    use std::fs::{File, OpenOptions};
+    use std::fs::{File, OpenOptions, create_dir};
     use std::io::{Read, Seek, SeekFrom, Write};
     use std::os::fd::RawFd;
     use std::path::Path;
@@ -969,8 +969,8 @@ mod unit_tests {
         let test_dir = TempDir::new_with_prefix("/tmp/ch").unwrap();
         let overlay_dir = test_dir.as_path().join("overlay");
         let sibling_dir = test_dir.as_path().join("sibling");
-        std::fs::create_dir(&overlay_dir).unwrap();
-        std::fs::create_dir(&sibling_dir).unwrap();
+        create_dir(&overlay_dir).unwrap();
+        create_dir(&sibling_dir).unwrap();
 
         let backing_path = sibling_dir.join("backing.raw");
         let overlay_path = overlay_dir.join("overlay.qcow2");

--- a/block/src/formats/raw/worker/sync.rs
+++ b/block/src/formats/raw/worker/sync.rs
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::collections::VecDeque;
+use std::io;
 use std::os::unix::io::RawFd;
 
 use vmm_sys_util::eventfd::EventFd;
@@ -74,7 +75,7 @@ impl AsyncIo for RawSync {
             }
         };
         if result < 0 {
-            let error = std::io::Error::last_os_error();
+            let error = io::Error::last_os_error();
             return Err(if is_read {
                 AsyncIoError::ReadVectored(error)
             } else {
@@ -93,7 +94,7 @@ impl AsyncIo for RawSync {
         // SAFETY: FFI call
         let result = unsafe { libc::fsync(self.fd as libc::c_int) };
         if result < 0 {
-            return Err(AsyncIoError::Fsync(std::io::Error::last_os_error()));
+            return Err(AsyncIoError::Fsync(io::Error::last_os_error()));
         }
 
         if let Some(user_data) = user_data {

--- a/block/src/formats/vhd/internal/fixed.rs
+++ b/block/src/formats/vhd/internal/fixed.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use super::footer::VhdFooter;
@@ -17,7 +17,7 @@ pub struct FixedVhd {
 }
 
 impl FixedVhd {
-    pub fn new(mut file: File) -> std::io::Result<Self> {
+    pub fn new(mut file: File) -> io::Result<Self> {
         let footer = VhdFooter::new(&mut file)?;
 
         Ok(Self {
@@ -35,7 +35,7 @@ impl AsRawFd for FixedVhd {
 }
 
 impl Read for FixedVhd {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self.file.read(buf) {
             Ok(r) => {
                 self.position = self.position.checked_add(r.try_into().unwrap()).unwrap();
@@ -47,7 +47,7 @@ impl Read for FixedVhd {
 }
 
 impl Write for FixedVhd {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self.file.write(buf) {
             Ok(r) => {
                 self.position = self.position.checked_add(r.try_into().unwrap()).unwrap();
@@ -57,13 +57,13 @@ impl Write for FixedVhd {
         }
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
+    fn flush(&mut self) -> io::Result<()> {
         self.file.sync_all()
     }
 }
 
 impl Seek for FixedVhd {
-    fn seek(&mut self, newpos: SeekFrom) -> std::io::Result<u64> {
+    fn seek(&mut self, newpos: SeekFrom) -> io::Result<u64> {
         match self.file.seek(newpos) {
             Ok(pos) => {
                 self.position = pos;

--- a/block/src/formats/vhd/internal/footer.rs
+++ b/block/src/formats/vhd/internal/footer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs::File;
-use std::io::{Seek, SeekFrom};
+use std::io::{self, Seek, SeekFrom};
 
 use crate::{DiskTopology, read_aligned_block_size};
 
@@ -31,7 +31,7 @@ pub struct VhdFooter {
 }
 
 impl VhdFooter {
-    pub fn new(file: &mut File) -> std::io::Result<VhdFooter> {
+    pub fn new(file: &mut File) -> io::Result<VhdFooter> {
         let blocksize = DiskTopology::probe(file)?.logical_block_size as usize;
 
         // Place the cursor in the last block of the file
@@ -120,7 +120,7 @@ impl VhdFooter {
 }
 
 /// Determine image type through file parsing.
-pub fn is_fixed_vhd(f: &mut File) -> std::io::Result<bool> {
+pub fn is_fixed_vhd(f: &mut File) -> io::Result<bool> {
     let footer = VhdFooter::new(f)?;
 
     // "conectix" => 0x636f6e6563746978

--- a/block/src/formats/vhd/mod.rs
+++ b/block/src/formats/vhd/mod.rs
@@ -140,7 +140,7 @@ mod unit_tests {
     use super::*;
     use crate::async_io::AsyncIo;
     #[cfg(feature = "io_uring")]
-    use crate::async_io::{AsyncIoOperation, OwnedIoBuffer};
+    use crate::async_io::{AsyncIoError, AsyncIoOperation, OwnedIoBuffer};
     use crate::disk_file::{AsyncDiskFile, DiskSize, PhysicalSize, Resizable};
 
     /// Minimal fixed VHD footer (disk type = 2, current_size = 0x11223344).
@@ -214,7 +214,7 @@ mod unit_tests {
 
         assert!(matches!(
             async_io.submit_batch_requests(vec![op]),
-            Err(crate::async_io::AsyncIoError::ReadVectored(_))
+            Err(AsyncIoError::ReadVectored(_))
         ));
     }
 

--- a/block/src/formats/vhd/worker/async_uring.rs
+++ b/block/src/formats/vhd/worker/async_uring.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io;
 use std::os::unix::io::RawFd;
 
 use vmm_sys_util::eventfd::EventFd;
@@ -42,8 +43,8 @@ impl FixedVhdAsync {
     }
 
     fn bounds_error(&self, op: &AsyncIoOperation) -> AsyncIoError {
-        let error = std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
+        let error = io::Error::new(
+            io::ErrorKind::InvalidData,
             format!(
                 "Invalid request offset {} and length {}, can't exceed file size {}",
                 op.offset(),
@@ -78,13 +79,13 @@ impl AsyncIo for FixedVhdAsync {
     }
 
     fn punch_hole(&mut self, _offset: u64, _length: u64, _user_data: u64) -> AsyncIoResult<()> {
-        Err(AsyncIoError::PunchHole(std::io::Error::other(
+        Err(AsyncIoError::PunchHole(io::Error::other(
             "punch_hole not supported for fixed VHD",
         )))
     }
 
     fn write_zeroes(&mut self, _offset: u64, _length: u64, _user_data: u64) -> AsyncIoResult<()> {
-        Err(AsyncIoError::WriteZeroes(std::io::Error::other(
+        Err(AsyncIoError::WriteZeroes(io::Error::other(
             "write_zeroes not supported for fixed VHD",
         )))
     }

--- a/block/src/formats/vhd/worker/sync.rs
+++ b/block/src/formats/vhd/worker/sync.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io;
 use std::os::unix::io::RawFd;
 
 use vmm_sys_util::eventfd::EventFd;
@@ -17,7 +18,7 @@ pub struct FixedVhdSync {
 }
 
 impl FixedVhdSync {
-    pub fn new(fd: RawFd, size: u64) -> std::io::Result<Self> {
+    pub fn new(fd: RawFd, size: u64) -> io::Result<Self> {
         Ok(FixedVhdSync {
             raw_file_sync: RawSync::new(fd),
             size,
@@ -33,8 +34,8 @@ impl AsyncIo for FixedVhdSync {
     fn submit_data_operation(&mut self, op: AsyncIoOperation) -> AsyncIoResult<()> {
         let offset = op.offset();
         if offset as u64 >= self.size {
-            let error = std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
+            let error = io::Error::new(
+                io::ErrorKind::InvalidData,
                 format!(
                     "Invalid offset {}, can't be larger than file size {}",
                     offset, self.size
@@ -59,13 +60,13 @@ impl AsyncIo for FixedVhdSync {
     }
 
     fn punch_hole(&mut self, _offset: u64, _length: u64, _user_data: u64) -> AsyncIoResult<()> {
-        Err(AsyncIoError::PunchHole(std::io::Error::other(
+        Err(AsyncIoError::PunchHole(io::Error::other(
             "punch_hole not supported for fixed VHD",
         )))
     }
 
     fn write_zeroes(&mut self, _offset: u64, _length: u64, _user_data: u64) -> AsyncIoResult<()> {
-        Err(AsyncIoError::WriteZeroes(std::io::Error::other(
+        Err(AsyncIoError::WriteZeroes(io::Error::other(
             "write_zeroes not supported for fixed VHD",
         )))
     }

--- a/block/src/formats/vhdx/internal/bat.rs
+++ b/block/src/formats/vhdx/internal/bat.rs
@@ -5,6 +5,7 @@
 use std::fs::File;
 use std::io::{self, Seek, SeekFrom};
 use std::mem::size_of;
+use std::result;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use remain::sorted;
@@ -39,7 +40,7 @@ pub enum VhdxBatError {
     WriteBat(#[source] io::Error),
 }
 
-pub type Result<T> = std::result::Result<T, VhdxBatError>;
+pub type Result<T> = result::Result<T, VhdxBatError>;
 
 #[derive(Default, Clone, Debug)]
 pub struct BatEntry(pub u64);

--- a/block/src/formats/vhdx/internal/header.rs
+++ b/block/src/formats/vhdx/internal/header.rs
@@ -6,6 +6,7 @@ use std::collections::btree_map::BTreeMap;
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
+use std::{result, slice};
 
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
 use remain::sorted;
@@ -60,7 +61,7 @@ pub enum VhdxHeaderError {
     #[error("Failed to read headers {0}")]
     ReadHeader(#[source] io::Error),
     #[error("Failed to read metadata {0}")]
-    ReadMetadata(#[source] std::io::Error),
+    ReadMetadata(#[source] io::Error),
     #[error("Failed to read region table entries {0}")]
     ReadRegionTableEntries(#[source] io::Error),
     #[error("Failed to read region table header {0}")]
@@ -85,7 +86,7 @@ pub enum VhdxHeaderError {
     WriteHeader(#[source] io::Error),
 }
 
-pub type Result<T> = std::result::Result<T, VhdxHeaderError>;
+pub type Result<T> = result::Result<T, VhdxHeaderError>;
 
 #[derive(Clone, Debug)]
 pub struct FileTypeIdentifier {
@@ -152,7 +153,7 @@ impl Header {
     fn write_to_buffer(&self, buffer: &mut [u8; HEADER_SIZE as usize]) {
         // SAFETY: self is a valid header.
         let reference =
-            unsafe { std::slice::from_raw_parts((&raw const *self).cast(), HEADER_SIZE as usize) };
+            unsafe { slice::from_raw_parts((&raw const *self).cast(), HEADER_SIZE as usize) };
         *buffer = reference.try_into().unwrap();
     }
 
@@ -337,7 +338,7 @@ pub struct RegionTableEntry {
 impl RegionTableEntry {
     /// Reads one Region Entry from a Region Table index that starts from 0
     pub fn new(buffer: &[u8]) -> Result<RegionTableEntry> {
-        assert!(buffer.len() == std::mem::size_of::<RegionTableEntry>());
+        assert!(buffer.len() == size_of::<RegionTableEntry>());
         // SAFETY: the assertion above makes sure the buffer size is correct.
         let mut region_table_entry: RegionTableEntry = unsafe { *(buffer.as_ptr().cast()) };
 

--- a/block/src/formats/vhdx/internal/io.rs
+++ b/block/src/formats/vhdx/internal/io.rs
@@ -4,6 +4,7 @@
 
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::result;
 
 use remain::sorted;
 use thiserror::Error;
@@ -32,7 +33,7 @@ pub enum VhdxIoError {
     WriteBat(#[source] VhdxBatError),
 }
 
-pub type Result<T> = std::result::Result<T, VhdxIoError>;
+pub type Result<T> = result::Result<T, VhdxIoError>;
 
 macro_rules! align {
     ($n:expr, $align:expr) => {{ $n.div_ceil($align) * $align }};

--- a/block/src/formats/vhdx/internal/metadata.rs
+++ b/block/src/formats/vhdx/internal/metadata.rs
@@ -5,6 +5,7 @@
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::mem::size_of;
+use std::result;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use remain::sorted;
@@ -83,7 +84,7 @@ pub enum VhdxMetadataError {
     UnsupportedFlag,
 }
 
-pub type Result<T> = std::result::Result<T, VhdxMetadataError>;
+pub type Result<T> = result::Result<T, VhdxMetadataError>;
 
 #[derive(Default, Clone, Debug)]
 pub struct DiskSpec {
@@ -278,7 +279,7 @@ struct MetadataTableHeader {
 
 impl MetadataTableHeader {
     pub fn new(buffer: &[u8]) -> Result<MetadataTableHeader> {
-        assert!(buffer.len() == std::mem::size_of::<MetadataTableHeader>());
+        assert!(buffer.len() == size_of::<MetadataTableHeader>());
         // SAFETY: the assertion above makes sure the buffer size is correct.
         let metadata_table_header: MetadataTableHeader = unsafe { *(buffer.as_ptr().cast()) };
 
@@ -311,7 +312,7 @@ pub struct MetadataTableEntry {
 impl MetadataTableEntry {
     /// Parse one metadata entry from the buffer
     fn new(buffer: &[u8]) -> Result<MetadataTableEntry> {
-        assert!(buffer.len() == std::mem::size_of::<MetadataTableEntry>());
+        assert!(buffer.len() == size_of::<MetadataTableEntry>());
         // SAFETY: the assertion above makes sure the buffer size is correct.
         let mut metadata_table_entry: MetadataTableEntry = unsafe { *(buffer.as_ptr().cast()) };
 

--- a/block/src/formats/vhdx/internal/mod.rs
+++ b/block/src/formats/vhdx/internal/mod.rs
@@ -4,8 +4,11 @@
 
 use std::collections::btree_map::BTreeMap;
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{
+    Error as IoError, ErrorKind as IoErrorKind, Read, Result as IoResult, Seek, SeekFrom, Write,
+};
 use std::os::fd::{AsRawFd, RawFd};
+use std::result;
 
 use byteorder::{BigEndian, ByteOrder};
 use remain::sorted;
@@ -42,7 +45,7 @@ pub enum VhdxError {
     WriteFailed(#[source] VhdxIoError),
 }
 
-pub type Result<T> = std::result::Result<T, VhdxError>;
+pub type Result<T> = result::Result<T, VhdxError>;
 
 #[derive(Debug)]
 pub struct Vhdx {
@@ -99,7 +102,7 @@ impl Vhdx {
 impl Read for Vhdx {
     /// Wrapper function to satisfy Read trait implementation for VHDx disk.
     /// Convert the offset to sector index and buffer length to sector count.
-    fn read(&mut self, buf: &mut [u8]) -> std::result::Result<usize, std::io::Error> {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
         let sector_count = (buf.len() as u64).div_ceil(self.disk_spec.logical_sector_size as u64);
         let sector_index = self.current_offset / self.disk_spec.logical_sector_size as u64;
 
@@ -112,7 +115,7 @@ impl Read for Vhdx {
             sector_count,
         )
         .map_err(|e| {
-            std::io::Error::other(format!(
+            IoError::other(format!(
                 "Failed reading {sector_count} sectors from VHDx at index {sector_index}: {e}"
             ))
         })?;
@@ -124,13 +127,13 @@ impl Read for Vhdx {
 }
 
 impl Write for Vhdx {
-    fn flush(&mut self) -> std::result::Result<(), std::io::Error> {
+    fn flush(&mut self) -> IoResult<()> {
         self.file.flush()
     }
 
     /// Wrapper function to satisfy Write trait implementation for VHDx disk.
     /// Convert the offset to sector index and buffer length to sector count.
-    fn write(&mut self, buf: &[u8]) -> std::result::Result<usize, std::io::Error> {
+    fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
         let sector_count = (buf.len() as u64).div_ceil(self.disk_spec.logical_sector_size as u64);
         let sector_index = self.current_offset / self.disk_spec.logical_sector_size as u64;
 
@@ -138,7 +141,7 @@ impl Write for Vhdx {
             self.first_write = false;
             self.vhdx_header
                 .update(&mut self.file)
-                .map_err(|e| std::io::Error::other(format!("Failed to update VHDx header: {e}")))?;
+                .map_err(|e| IoError::other(format!("Failed to update VHDx header: {e}")))?;
         }
 
         let result = io::write(
@@ -151,7 +154,7 @@ impl Write for Vhdx {
             sector_count,
         )
         .map_err(|e| {
-            std::io::Error::other(format!(
+            IoError::other(format!(
                 "Failed writing {sector_count} sectors on VHDx at index {sector_index}: {e}"
             ))
         })?;
@@ -165,7 +168,7 @@ impl Write for Vhdx {
 impl Seek for Vhdx {
     /// Wrapper function to satisfy Seek trait implementation for VHDx disk.
     /// Updates the offset field in the Vhdx struct.
-    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+    fn seek(&mut self, pos: SeekFrom) -> IoResult<u64> {
         let new_offset: Option<u64> = match pos {
             SeekFrom::Start(off) => Some(off),
             SeekFrom::End(off) => {
@@ -194,19 +197,19 @@ impl Seek for Vhdx {
             return Ok(o);
         }
 
-        Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
+        Err(IoError::new(
+            IoErrorKind::InvalidData,
             "Failed seek operation",
         ))
     }
 }
 
 impl BlockBackend for Vhdx {
-    fn logical_size(&self) -> std::result::Result<u64, crate::Error> {
+    fn logical_size(&self) -> result::Result<u64, crate::Error> {
         Ok(self.virtual_disk_size())
     }
 
-    fn physical_size(&self) -> std::result::Result<u64, crate::Error> {
+    fn physical_size(&self) -> result::Result<u64, crate::Error> {
         self.file
             .metadata()
             .map(|m| m.len())

--- a/block/src/formats/vhdx/mod.rs
+++ b/block/src/formats/vhdx/mod.rs
@@ -13,6 +13,7 @@ pub mod internal;
 pub(crate) mod worker;
 
 use std::fs::File;
+use std::io;
 use std::os::fd::AsRawFd;
 use std::sync::{Arc, Mutex};
 
@@ -89,7 +90,7 @@ impl disk_file::Resizable for VhdxDisk {
     fn resize(&mut self, _size: u64) -> BlockResult<()> {
         Err(BlockError::new(
             BlockErrorKind::UnsupportedFeature,
-            DiskFileError::ResizeError(std::io::Error::other("resize not supported for VHDX")),
+            DiskFileError::ResizeError(io::Error::other("resize not supported for VHDX")),
         )
         .with_op(ErrorOp::Resize))
     }

--- a/block/src/formats/vhdx/worker/sync.rs
+++ b/block/src/formats/vhdx/worker/sync.rs
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::VecDeque;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::sync::{Arc, Mutex};
 
 use vmm_sys_util::eventfd::EventFd;
@@ -96,13 +96,13 @@ impl AsyncIo for VhdxSync {
     }
 
     fn punch_hole(&mut self, _offset: u64, _length: u64, _user_data: u64) -> AsyncIoResult<()> {
-        Err(AsyncIoError::PunchHole(std::io::Error::other(
+        Err(AsyncIoError::PunchHole(io::Error::other(
             "punch_hole not supported for VHDX",
         )))
     }
 
     fn write_zeroes(&mut self, _offset: u64, _length: u64, _user_data: u64) -> AsyncIoResult<()> {
-        Err(AsyncIoError::WriteZeroes(std::io::Error::other(
+        Err(AsyncIoError::WriteZeroes(io::Error::other(
             "write_zeroes not supported for VHDX",
         )))
     }


### PR DESCRIPTION
Part of #7670.

Import the std/crate modules used in the disk-format handlers (qcow, raw,
vhd, vhdx) instead of spelling fully-qualified paths at every use site:

- `std::io::Error`/`ErrorKind`/`Result<T, io::Error>` → `io::Error`/`io::ErrorKind`/`io::Result<T>`
- `std::result::Result<T, E>` → `result::Result<T, E>` (kept the `result::` cue)
- `std::mem::size_of`, `std::slice::from_raw_parts`, `std::fs::create_dir`, etc. → relative forms

Readability-only; no functional impact. First of two PRs for `block` (this
covers `src/formats/`; a follow-up would cover `src/io` + the crate root).
Same approach as the recently merged #8371, #8362 and #8355.

**One thing to note:** `vhdx/internal/mod.rs` has a local `mod io` that
shadows `std::io`. I resolved it with type aliases (`use std::io::Error as
IoError;` …), matching the existing convention as in `vmm/src/landlock.rs`
and `net_util/src/lib.rs`. Alternatively, I could:

- import the whole module aliased: `use std::io as std_io;` → `std_io::Error`
- rename the local module (e.g. `io` → `sector_io`) so `std::io` trims to plain `io::`