### PR TITLE
block: trim qualified paths in io and lib

### DIFF
--- a/block/src/io/async_io.rs
+++ b/block/src/io/async_io.rs
@@ -13,7 +13,7 @@ mod owned_io_buffer;
 #[cfg(feature = "io_uring")]
 mod uring_data_io;
 
-use std::io;
+use std::{io, result};
 
 pub use aio_data_io::AioDataIo;
 pub use completion::AsyncIoCompletion;
@@ -31,21 +31,21 @@ use crate::SECTOR_SIZE;
 pub enum DiskFileError {
     /// Failed getting disk file size.
     #[error("Failed getting disk file size")]
-    Size(#[source] std::io::Error),
+    Size(#[source] io::Error),
     /// Failed creating a new AsyncIo.
     #[error("Failed creating a new AsyncIo")]
-    NewAsyncIo(#[source] std::io::Error),
+    NewAsyncIo(#[source] io::Error),
     /// Unsupported operation.
     #[error("Unsupported operation")]
     Unsupported,
     /// Resize failed
     #[error("Resize failed")]
-    ResizeError(#[source] std::io::Error),
+    ResizeError(#[source] io::Error),
     #[error("Failed cloning disk file")]
-    Clone(#[source] std::io::Error),
+    Clone(#[source] io::Error),
 }
 
-pub type DiskFileResult<T> = std::result::Result<T, DiskFileError>;
+pub type DiskFileResult<T> = result::Result<T, DiskFileError>;
 
 /// A wrapper for [`RawFd`] capturing the lifetime of a corresponding disk file.
 ///
@@ -79,25 +79,25 @@ impl AsRawFd for BorrowedDiskFd<'_> {
 pub enum AsyncIoError {
     /// Failed vectored reading from file.
     #[error("Failed vectored reading from file")]
-    ReadVectored(#[source] std::io::Error),
+    ReadVectored(#[source] io::Error),
     /// Failed vectored writing to file.
     #[error("Failed vectored writing to file")]
-    WriteVectored(#[source] std::io::Error),
+    WriteVectored(#[source] io::Error),
     /// Failed synchronizing file.
     #[error("Failed synchronizing file")]
-    Fsync(#[source] std::io::Error),
+    Fsync(#[source] io::Error),
     /// Failed punching hole.
     #[error("Failed punching hole")]
-    PunchHole(#[source] std::io::Error),
+    PunchHole(#[source] io::Error),
     /// Failed writing zeroes.
     #[error("Failed writing zeroes")]
-    WriteZeroes(#[source] std::io::Error),
+    WriteZeroes(#[source] io::Error),
     /// Failed submitting batch requests.
     #[error("Failed submitting batch requests")]
-    SubmitBatchRequests(#[source] std::io::Error),
+    SubmitBatchRequests(#[source] io::Error),
 }
 
-pub type AsyncIoResult<T> = std::result::Result<T, AsyncIoError>;
+pub type AsyncIoResult<T> = result::Result<T, AsyncIoError>;
 
 pub trait AsyncIo: Send {
     fn notifier(&self) -> &EventFd;

--- a/block/src/io/async_io/aio_data_io.rs
+++ b/block/src/io/async_io/aio_data_io.rs
@@ -7,8 +7,8 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::collections::{HashMap, VecDeque};
-use std::io;
 use std::os::fd::{AsRawFd, RawFd};
+use std::{io, slice};
 
 use log::warn;
 use vmm_sys_util::aio;
@@ -66,7 +66,7 @@ impl AioDataIo {
     pub fn submit_operation(&mut self, fd: RawFd, op: AsyncIoOperation) -> io::Result<()> {
         validate_batch(
             |user_data| self.in_flight.contains_key(&user_data),
-            std::slice::from_ref(&op),
+            slice::from_ref(&op),
         )?;
 
         let user_data = op.user_data();
@@ -171,7 +171,7 @@ impl AioDataIo {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
+    use std::io::{self, Write};
     use std::os::fd::AsRawFd;
     use std::thread::sleep;
     use std::time::Duration;
@@ -208,7 +208,7 @@ mod tests {
 
         assert_eq!(
             data_io.submit_fsync(fd, 7).unwrap_err().kind(),
-            std::io::ErrorKind::AlreadyExists
+            io::ErrorKind::AlreadyExists
         );
 
         let completion = wait_for_completion(&mut data_io);

--- a/block/src/io/async_io/owned_io_buffer.rs
+++ b/block/src/io/async_io/owned_io_buffer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::alloc::{Layout, alloc_zeroed, dealloc};
-use std::{fmt, io};
+use std::{fmt, io, slice};
 
 // Storage owned by an async I/O request for host-memory buffers.
 //
@@ -62,7 +62,7 @@ impl OwnedIoBufferStorage {
             Self::Aligned { ptr, len, .. } => {
                 // SAFETY: alloc_zeroed initialized `len` bytes at `ptr` and the
                 // allocation is owned by Self.
-                unsafe { std::slice::from_raw_parts(*ptr, *len) }
+                unsafe { slice::from_raw_parts(*ptr, *len) }
             }
         }
     }
@@ -74,7 +74,7 @@ impl OwnedIoBufferStorage {
                 // SAFETY: alloc_zeroed initialized `len` bytes at `ptr`,
                 // &mut self ensures unique access, and the allocation is
                 // owned by Self.
-                unsafe { std::slice::from_raw_parts_mut(*ptr, *len) }
+                unsafe { slice::from_raw_parts_mut(*ptr, *len) }
             }
         }
     }

--- a/block/src/io/async_io/uring_data_io.rs
+++ b/block/src/io/async_io/uring_data_io.rs
@@ -272,6 +272,7 @@ impl UringDataIo {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
     use std::os::fd::AsRawFd;
     use std::thread::sleep;
     use std::time::Duration;
@@ -308,18 +309,18 @@ mod tests {
 
         assert_eq!(
             data_io.submit_fsync(fd, 7).unwrap_err().kind(),
-            std::io::ErrorKind::AlreadyExists
+            io::ErrorKind::AlreadyExists
         );
         assert_eq!(
             data_io.submit_nop(7).unwrap_err().kind(),
-            std::io::ErrorKind::AlreadyExists
+            io::ErrorKind::AlreadyExists
         );
         assert_eq!(
             data_io
                 .submit_fallocate(fd, 0, 512, 0, 7)
                 .unwrap_err()
                 .kind(),
-            std::io::ErrorKind::AlreadyExists
+            io::ErrorKind::AlreadyExists
         );
 
         let completion = wait_for_completion(&mut data_io);

--- a/block/src/io/request.rs
+++ b/block/src/io/request.rs
@@ -504,7 +504,7 @@ impl Request {
         for &(data_addr, data_len) in &self.data_descriptors {
             let _: u32 = data_len;
             const _: () = assert!(
-                core::mem::size_of::<u32>() <= core::mem::size_of::<usize>(),
+                mem::size_of::<u32>() <= mem::size_of::<usize>(),
                 "unsupported platform"
             );
             if data_len == 0 {

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -63,17 +63,17 @@ pub enum Error {
     #[error("Guest gave us a descriptor that was too short to use")]
     DescriptorLengthTooSmall,
     #[error("Failed to detect image type")]
-    DetectImageType(#[source] std::io::Error),
+    DetectImageType(#[source] io::Error),
     #[error("Failure in fixed vhd")]
-    FixedVhdError(#[source] std::io::Error),
+    FixedVhdError(#[source] io::Error),
     #[error("Getting a block's metadata failed")]
-    GetFileMetadata(#[source] std::io::Error),
+    GetFileMetadata(#[source] io::Error),
     #[error("The requested operation would cause a seek beyond disk end")]
     InvalidOffset,
     #[error("Failure in qcow")]
     QcowError(#[source] qcow::Error),
     #[error("Failure in raw file")]
-    RawFileError(#[source] std::io::Error),
+    RawFileError(#[source] io::Error),
     #[error("The requested operation does not support multiple descriptors")]
     TooManyDescriptors,
     #[error("Request contains too many segments ({0}, max {MAX_DISCARD_WRITE_ZEROES_SEG})")]
@@ -316,7 +316,7 @@ pub fn block_io_uring_is_supported() -> bool {
 pub(crate) fn is_block_device(fd: RawFd) -> bool {
     // SAFETY: `libc::stat` is POD; zero-initialization is a valid bit pattern
     // and `fstat` overwrites every field it cares about on success.
-    let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+    let mut stat: libc::stat = unsafe { mem::zeroed() };
     // SAFETY: FFI call with a valid fd and a valid out-pointer.
     let ret = unsafe { libc::fstat(fd, &mut stat) };
     ret == 0 && stat.st_mode & S_IFMT == S_IFBLK
@@ -471,7 +471,7 @@ const QCOW_MAGIC: u32 = 0x5146_49fb;
 const VHDX_SIGN: u64 = 0x656C_6966_7864_6876;
 
 /// Read a block into memory aligned by the source block size (needed for O_DIRECT)
-pub fn read_aligned_block_size(f: &mut File) -> std::io::Result<Vec<u8>> {
+pub fn read_aligned_block_size(f: &mut File) -> io::Result<Vec<u8>> {
     let blocksize = DiskTopology::probe(f)?.logical_block_size as usize;
     // SAFETY: We are allocating memory that is naturally aligned (size = alignment) and we meet
     // requirements for safety from Vec::from_raw_parts() as we are using the global allocator
@@ -593,7 +593,7 @@ enum BlockSize {
 
 impl DiskTopology {
     // libc::ioctl() takes different types on different architectures
-    fn query_block_size(f: &File, block_size_type: BlockSize) -> std::io::Result<u64> {
+    fn query_block_size(f: &File, block_size_type: BlockSize) -> io::Result<u64> {
         let mut block_size = 0;
         // SAFETY: FFI call with correct arguments
         let ret = unsafe {
@@ -609,7 +609,7 @@ impl DiskTopology {
             )
         };
         if ret != 0 {
-            return Err(std::io::Error::last_os_error());
+            return Err(io::Error::last_os_error());
         }
 
         Ok(block_size)
@@ -666,7 +666,7 @@ impl DiskTopology {
         SECTOR_SIZE
     }
 
-    pub fn probe(f: &File) -> std::io::Result<Self> {
+    pub fn probe(f: &File) -> io::Result<Self> {
         if !is_block_device(f.as_raw_fd()) {
             // For regular files opened with O_DIRECT, the logical block size
             // must reflect the filesystem DIO alignment so the guest issues
@@ -877,7 +877,7 @@ mod unit_tests {
 
     #[test]
     fn test_query_device_size_rejects_char_device() {
-        let f = std::fs::File::open("/dev/zero").unwrap();
+        let f = File::open("/dev/zero").unwrap();
         let err = query_device_size(&f).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }


### PR DESCRIPTION
Part of #7670.

Import the std modules used in the crate instead of spelling the
fully-qualified paths at every use site, covering the `src/io/` async-IO
modules, `lib.rs` and `request.rs` (follow-on to the `formats/` cleanup in
#8387):

- `std::io::Error` → `io::Error` (the `#[source]` error-enum variants in `async_io.rs` and `lib.rs`)
- `std::result::Result<T, E>` → `result::Result<T, E>` (the `AsyncIoResult` / `DiskFileResult` aliases — keeping the `result::` cue)
- `std::io::Result<T>` / `std::io::ErrorKind` / `std::io::Error::last_os_error()` → `io::…`
- `std::slice::from_raw_parts{,_mut}` / `from_ref` → `slice::…`, `std::mem::zeroed` / `core::mem::size_of` → `mem::…`, `std::fs::File::open` → `File::open`

Readability-only change; no functional impact. Latest in the series of
per-crate cleanups for #7670 — same approach as the most recently merged
#8385, #8386, #8387.