### PR TITLE
vhost_user_block: trim qualified paths

### DIFF
--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -48,8 +48,8 @@ const BLK_SIZE: u32 = 512;
 // and the overhead of the emulation layer.
 const POLL_QUEUE_US: u128 = 50;
 
-type Result<T> = std::result::Result<T, Error>;
-type VhostUserBackendResult<T> = std::result::Result<T, std::io::Error>;
+type Result<T> = result::Result<T, Error>;
+type VhostUserBackendResult<T> = io::Result<T>;
 
 #[derive(Error, Debug)]
 enum Error {


### PR DESCRIPTION
Part of #7670.

Import the std modules used in the crate instead of spelling the
fully-qualified paths at every use site:

- `std::result::Result<T, Error>` → `result::Result<T, Error>` (keeping the `result::` cue next to the local `Result` alias)
- `std::result::Result<T, std::io::Error>` → `io::Result<T>` (std's alias)

Readability-only change; no functional impact. Latest in the series of
per-crate cleanups for #7670 — same approach as the most recently merged
#8385, #8386, #8387.