### PR TITLE
vm-device: trim qualified paths

### DIFF
--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -10,7 +10,7 @@
 use std::cmp::Ordering;
 use std::collections::btree_map::BTreeMap;
 use std::sync::{Arc, Barrier, Mutex, RwLock, Weak};
-use std::{convert, io, result};
+use std::{convert, io, ptr, result};
 
 use thiserror::Error;
 
@@ -201,7 +201,7 @@ impl Bus {
 
         for (key, value) in device_list.iter() {
             let value = value.upgrade().unwrap();
-            if core::ptr::eq(Arc::as_ptr(&value), device) {
+            if ptr::eq(Arc::as_ptr(&value), device) {
                 remove_key_list.push(*key);
             }
         }

--- a/vm-device/src/dma_mapping/mod.rs
+++ b/vm-device/src/dma_mapping/mod.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+use std::io;
+
 /// Trait to trigger DMA mapping updates for devices managed by virtio-iommu
 ///
 /// Trait meant for triggering the DMA mapping update related to an external
@@ -10,8 +12,8 @@
 /// guest.
 pub trait ExternalDmaMapping: Send + Sync {
     /// Map a memory range
-    fn map(&self, iova: u64, gpa: u64, size: u64) -> std::result::Result<(), std::io::Error>;
+    fn map(&self, iova: u64, gpa: u64, size: u64) -> io::Result<()>;
 
     /// Unmap a memory range
-    fn unmap(&self, iova: u64, size: u64) -> std::result::Result<(), std::io::Error>;
+    fn unmap(&self, iova: u64, size: u64) -> io::Result<()>;
 }

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -57,14 +57,14 @@
 //! * The virtual device backend requests the interrupt manager to create an interrupt group
 //!   according to guest configuration information
 
-use std::io::{Error, ErrorKind};
+use std::io::{self, Error, ErrorKind};
 use std::sync::{Arc, Mutex};
 
 pub use hypervisor::{InterruptSourceConfig, LegacyIrqSourceConfig, MsiIrqSourceConfig};
 use vmm_sys_util::eventfd::EventFd;
 
 /// Reuse std::io::Result to simplify interoperability among crates.
-pub type Result<T> = std::io::Result<T>;
+pub type Result<T> = io::Result<T>;
 
 /// Data type to store an interrupt source identifier.
 pub type InterruptIndex = u32;


### PR DESCRIPTION
Part of #7670.

Import the std modules used in the crate instead of spelling the
fully-qualified paths at every use site:

- `core::ptr::eq` → `ptr::eq`
- `std::result::Result<(), std::io::Error>` → `io::Result<()>` (the `ExternalDmaMapping` trait's `map`/`unmap`)
- `std::io::Result<T>` → `io::Result<T>` (the `interrupt` module's `Result` alias)

Readability-only change; no functional impact. Latest in the series of
per-crate cleanups for #7670 — same approach as the most recently merged
#8385, #8386, #8387.