### PR TITLE
vm-virtio: trim qualified paths

### DIFF
--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -179,6 +179,8 @@ where
 
 #[cfg(test)]
 mod unit_tests {
+    use std::io;
+
     use virtio_bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
     use virtio_queue::{Queue, QueueT};
     use vm_memory::bitmap::AtomicBitmap;
@@ -401,10 +403,10 @@ mod unit_tests {
     }
 
     impl AccessPlatform for OffsetTranslator {
-        fn translate_gva(&self, base: u64, _size: u64) -> std::io::Result<u64> {
+        fn translate_gva(&self, base: u64, _size: u64) -> io::Result<u64> {
             Ok(base - self.gva_base + self.gpa_base)
         }
-        fn translate_gpa(&self, base: u64, _size: u64) -> std::io::Result<u64> {
+        fn translate_gpa(&self, base: u64, _size: u64) -> io::Result<u64> {
             Ok(base - self.gpa_base + self.gva_base)
         }
     }
@@ -436,11 +438,11 @@ mod unit_tests {
     struct FailingTranslator;
 
     impl AccessPlatform for FailingTranslator {
-        fn translate_gva(&self, _base: u64, _size: u64) -> std::io::Result<u64> {
-            Err(std::io::Error::other("translation failed"))
+        fn translate_gva(&self, _base: u64, _size: u64) -> io::Result<u64> {
+            Err(io::Error::other("translation failed"))
         }
-        fn translate_gpa(&self, _base: u64, _size: u64) -> std::io::Result<u64> {
-            Err(std::io::Error::other("translation failed"))
+        fn translate_gpa(&self, _base: u64, _size: u64) -> io::Result<u64> {
+            Err(io::Error::other("translation failed"))
         }
     }
 

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -11,6 +11,7 @@
 //! Implements virtio queues
 
 use std::fmt::{self, Debug};
+use std::io;
 
 use virtio_queue::{Queue, QueueT};
 use vm_memory::GuestAddress;
@@ -97,9 +98,9 @@ impl fmt::Display for VirtioDeviceType {
 /// translated.
 pub trait AccessPlatform: Send + Sync + Debug {
     /// Provide a way to translate GVA address ranges into GPAs.
-    fn translate_gva(&self, base: u64, size: u64) -> std::result::Result<u64, std::io::Error>;
+    fn translate_gva(&self, base: u64, size: u64) -> io::Result<u64>;
     /// Provide a way to translate GPA address ranges into GVAs.
-    fn translate_gpa(&self, base: u64, size: u64) -> std::result::Result<u64, std::io::Error>;
+    fn translate_gpa(&self, base: u64, size: u64) -> io::Result<u64>;
 }
 
 pub trait Translatable {
@@ -107,14 +108,14 @@ pub trait Translatable {
         &self,
         access_platform: Option<&dyn AccessPlatform>,
         len: usize,
-    ) -> std::result::Result<Self, std::io::Error>
+    ) -> io::Result<Self>
     where
         Self: Sized;
     fn translate_gpa(
         &self,
         access_platform: Option<&dyn AccessPlatform>,
         len: usize,
-    ) -> std::result::Result<Self, std::io::Error>
+    ) -> io::Result<Self>
     where
         Self: Sized;
 }
@@ -124,14 +125,14 @@ impl Translatable for GuestAddress {
         &self,
         access_platform: Option<&dyn AccessPlatform>,
         len: usize,
-    ) -> std::result::Result<Self, std::io::Error> {
+    ) -> io::Result<Self> {
         Ok(GuestAddress(self.0.translate_gva(access_platform, len)?))
     }
     fn translate_gpa(
         &self,
         access_platform: Option<&dyn AccessPlatform>,
         len: usize,
-    ) -> std::result::Result<Self, std::io::Error> {
+    ) -> io::Result<Self> {
         Ok(GuestAddress(self.0.translate_gpa(access_platform, len)?))
     }
 }
@@ -141,7 +142,7 @@ impl Translatable for u64 {
         &self,
         access_platform: Option<&dyn AccessPlatform>,
         len: usize,
-    ) -> std::result::Result<Self, std::io::Error> {
+    ) -> io::Result<Self> {
         if let Some(access_platform) = access_platform {
             access_platform.translate_gva(*self, len as u64)
         } else {
@@ -152,7 +153,7 @@ impl Translatable for u64 {
         &self,
         access_platform: Option<&dyn AccessPlatform>,
         len: usize,
-    ) -> std::result::Result<Self, std::io::Error> {
+    ) -> io::Result<Self> {
         if let Some(access_platform) = access_platform {
             access_platform.translate_gpa(*self, len as u64)
         } else {


### PR DESCRIPTION
Part of #7670.

Import the std modules used in the crate instead of spelling the
fully-qualified paths at every use site:

- `std::result::Result<T, std::io::Error>` → `io::Result<T>` (the `AccessPlatform` / `Translatable` trait methods and impls in `lib.rs`)
- `std::io::Result<u64>` / `std::io::Error::other` → `io::…` (the test `AccessPlatform` stubs in `checked_descriptor.rs`)

Readability-only change; no functional impact. Latest in the series of
per-crate cleanups for #7670 — same approach as the most recently merged
#8385, #8386, #8387.