### PR TITLE
build: Bump some rust-vmm crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "acpi_tables"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad581b2b0fa02638f3df6ff3f852ebc30dc7cfe531e9745d1ca4c0f283a6dbe"
+checksum = "ce821f856a3eb1d033287f2dcfcdf94276d7895dd5bdd8ca45ae17e7d33d4dd9"
 dependencies = [
  "zerocopy",
 ]
@@ -1214,9 +1214,9 @@ checksum = "fd7de3a04f6fd55f171a6682852f7aa360bb848a85e0c610513349e006b3c139"
 
 [[package]]
 name = "iommufd-ioctls"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eabd3414d9c4e716c9a198fbfac484625f088c075605372daf037edfe336e18"
+checksum = "8050f03ef0c6979597140b6d20da076931fb7a06389b8b0eb971b8f65b271748"
 dependencies = [
  "iommufd-bindings",
  "thiserror",
@@ -1300,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
+checksum = "11cf0ca75d59e9d298647c59cf6c5286fa048120caa77972a7a504a0824d234f"
 dependencies = [
  "serde",
  "vmm-sys-util",
@@ -1311,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333f77a20344a448f3f70664918135fddeb804e938f28a99d685bd92926e0b19"
+checksum = "06ac372c120eb893b086d1a12027669cf2b478d1f71204021ffa7adf57948d63"
 dependencies = [
  "bitflags 2.13.0",
  "kvm-bindings",
@@ -2583,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "vfio-ioctls"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b1d98dff7f0d219278e406323e7eda4d426447bd203c7828189baf0d8c07b7"
+checksum = "f2b1110f3ab5703a0f788d569b1b4a2436e8cc434f384b3ef5d77283f8ee03d8"
 dependencies = [
  "byteorder",
  "iommufd-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,16 +52,16 @@ resolver = "3"
 
 [workspace.dependencies]
 # rust-vmm crates
-acpi_tables = "0.2.0"
-iommufd-ioctls = "0.1.0"
-kvm-bindings = "0.14.0"
-kvm-ioctls = "0.24.0"
+acpi_tables = "0.2.1"
+iommufd-ioctls = "0.2.0"
+kvm-bindings = "0.14.1"
+kvm-ioctls = "0.25.0"
 linux-loader = "0.13.2"
 mshv-bindings = "0.6.9"
 mshv-ioctls = "0.6.9"
 seccompiler = "0.5.0"
 vfio-bindings = { version = "0.6.2", default-features = false }
-vfio-ioctls = { version = "0.6.0", default-features = false }
+vfio-ioctls = { version = "0.7.0", default-features = false }
 vfio_user = { version = "0.1.3", default-features = false }
 vhost = { version = "0.16.0", default-features = false }
 vhost-user-backend = { version = "0.22.0", default-features = false }


### PR DESCRIPTION
Bump rust-vmm crates that don't require bumping vm-memory (which will
require broader porting).

Signed-off-by: Rob Bradford <rbradford@meta.com>
