### PR TITLE
build: Deny clippy::absolute_paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ style = "deny"
 suspicious = "deny"
 
 # Individual Lints
+absolute_paths = "deny"
 assertions_on_result_states = "deny"
 if_not_else = "deny"
 manual_string_new = "deny"

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -8,6 +8,9 @@
 //! Implements platform specific functionality.
 //! Supported platforms: x86_64, aarch64, riscv64.
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
+
 use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::sync::Arc;

--- a/block/src/formats/vhdx/internal/mod.rs
+++ b/block/src/formats/vhdx/internal/mod.rs
@@ -256,6 +256,8 @@ pub(crate) fn uuid_from_guid(buf: &[u8]) -> Uuid {
 }
 
 #[cfg(test)]
+// TODO: Trim qualified paths in these tests, then drop this expectation.
+#[expect(clippy::absolute_paths)]
 mod tests {
     use std::process::Command;
 

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
+
 #[cfg(test)]
 #[path = "../test_util.rs"]
 mod test_util;

--- a/cloud-hypervisor/src/lib.rs
+++ b/cloud-hypervisor/src/lib.rs
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
+
 use std::error::Error;
 
 use log::error;

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
+
 mod logger;
 #[cfg(test)]
 mod test_util;

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -4,6 +4,8 @@
 //
 #![cfg(any(devcli_testenv, clippy))]
 #![allow(clippy::undocumented_unsafe_blocks)]
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
 // When enabling the `mshv` feature, we skip quite some tests and
 // hence have known dead-code. This annotation silences dead-code
 // related warnings for our quality workflow to pass.

--- a/cloud-hypervisor/tests/integration_cvm.rs
+++ b/cloud-hypervisor/tests/integration_cvm.rs
@@ -4,6 +4,8 @@
 //
 #![cfg(any(devcli_testenv, clippy))]
 #![allow(clippy::undocumented_unsafe_blocks)]
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
 // When enabling the `mshv` feature, we skip quite some tests and
 // hence have known dead-code. This annotation silences dead-code
 // related warnings for our quality workflow to pass.

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -7,6 +7,9 @@
 
 //! Emulates virtual and hardware devices.
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![cfg_attr(target_arch = "x86_64", expect(clippy::absolute_paths))]
+
 pub mod acpi;
 #[cfg(target_arch = "riscv64")]
 pub mod aia;

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -21,6 +21,9 @@
 //! - riscv64 (experimental)
 //!
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
+
 /// Architecture specific definitions
 #[macro_use]
 pub mod arch;

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
+
 // Custom harness to run performance tests
 mod micro_bench_block;
 mod performance_tests;

--- a/serial_buffer/src/lib.rs
+++ b/serial_buffer/src/lib.rs
@@ -116,6 +116,8 @@ impl Write for SerialBuffer {
 }
 
 #[cfg(test)]
+// TODO: Trim qualified paths in these tests, then drop this expectation.
+#[expect(clippy::absolute_paths)]
 mod tests {
     use std::io::Write;
     use std::sync::atomic::{AtomicBool, Ordering};

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -4,6 +4,8 @@
 //
 
 #![allow(clippy::undocumented_unsafe_blocks)]
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
 
 use std::collections::HashMap;
 use std::ffi::OsStr;

--- a/tpm/src/lib.rs
+++ b/tpm/src/lib.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
+
 pub mod emulator;
 pub mod socket;
 

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -10,6 +10,9 @@
 
 //! Implements virtio devices, queues, and transport mechanisms.
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
+
 use std::io;
 use std::sync::atomic::{AtomicU8, Ordering};
 

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
+
 use std::collections::BTreeMap;
 use std::{io, result};
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// TODO: Trim qualified paths in this crate, then drop this expectation.
+#![expect(clippy::absolute_paths)]
+
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write, stdout};


### PR DESCRIPTION
Removal of absolute paths is currently in progress - to avoid regressing those changes add a clippy deny add the workspace level and at the crate level override with #[expect(clippy::absolute_paths)]

See: #7670