### PR TITLE
vmm: Replace asserts for checks on ACPI device accesses

### DIFF
--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -45,10 +45,21 @@ impl AcpiShutdownDevice {
 impl BusDevice for AcpiShutdownDevice {
     // Spec has all fields as zero
     fn read(&mut self, _base: u64, _offset: u64, data: &mut [u8]) {
+        if data.len() != 1 {
+            warn!("Invalid sized read of ACPI shutdown device: {}", data.len());
+            return;
+        }
         data.fill(0);
     }
 
     fn write(&mut self, _base: u64, _offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        if data.len() != 1 {
+            warn!(
+                "Invalid sized write of ACPI shutdown device: {}",
+                data.len()
+            );
+            return None;
+        }
         if data[0] == 1 {
             info!("ACPI Reboot signalled");
             if let Err(e) = self.reset_evt.write(1) {
@@ -119,6 +130,10 @@ impl AcpiGedDevice {
 impl BusDevice for AcpiGedDevice {
     // Spec has all fields as zero
     fn read(&mut self, _base: u64, _offset: u64, data: &mut [u8]) {
+        if data.len() != 1 {
+            warn!("Invalid sized read of ACPI GED device: {}", data.len());
+            return;
+        }
         data[0] = self.notification_type.bits();
         self.notification_type = AcpiNotificationFlags::NO_DEVICES_CHANGED;
     }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -3221,11 +3221,20 @@ impl BusDevice for AcpiCpuHotplugController {
 
         match offset {
             Self::CPU_SELECTION_OFFSET => {
-                assert!(data.len() >= core::mem::size_of::<u32>());
-                data[0..core::mem::size_of::<u32>()]
-                    .copy_from_slice(&self.selected_cpu.to_le_bytes());
+                if data.len() != size_of::<u32>() {
+                    warn!(
+                        "Invalid sized read of CPU selection register: {}",
+                        data.len()
+                    );
+                    return;
+                }
+                data.copy_from_slice(&self.selected_cpu.to_le_bytes());
             }
             Self::CPU_STATUS_OFFSET => {
+                if data.len() != 1 {
+                    warn!("Invalid sized read of CPU status register: {}", data.len());
+                    return;
+                }
                 if self.selected_cpu < self.max_vcpus {
                     let state = &vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
                     if state.active() {
@@ -3250,11 +3259,20 @@ impl BusDevice for AcpiCpuHotplugController {
     fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         match offset {
             Self::CPU_SELECTION_OFFSET => {
-                assert!(data.len() >= core::mem::size_of::<u32>());
-                self.selected_cpu =
-                    u32::from_le_bytes(data[0..core::mem::size_of::<u32>()].try_into().unwrap());
+                if data.len() != size_of::<u32>() {
+                    warn!(
+                        "Invalid sized write of CPU selection register: {}",
+                        data.len()
+                    );
+                    return None;
+                }
+                self.selected_cpu = u32::from_le_bytes(data.try_into().unwrap());
             }
             Self::CPU_STATUS_OFFSET => {
+                if data.len() != 1 {
+                    warn!("Invalid sized write of CPU status register: {}", data.len());
+                    return None;
+                }
                 if self.selected_cpu < self.max_vcpus {
                     // This structure is not shared with the vCPU thread, therefore, holding the
                     // lock for the entire function doesn't cause any deadlock.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -6006,7 +6006,10 @@ impl BusDevice for DeviceManager {
     fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {
         match offset {
             PCIU_FIELD_OFFSET => {
-                assert!(data.len() == PCIU_FIELD_SIZE);
+                if data.len() != PCIU_FIELD_SIZE {
+                    warn!("Invalid sized read of PCIU register: {}", data.len());
+                    return;
+                }
                 data.copy_from_slice(
                     &self.pci_segments[self.selected_segment]
                         .pci_devices_up
@@ -6016,7 +6019,10 @@ impl BusDevice for DeviceManager {
                 self.pci_segments[self.selected_segment].pci_devices_up = 0;
             }
             PCID_FIELD_OFFSET => {
-                assert!(data.len() == PCID_FIELD_SIZE);
+                if data.len() != PCID_FIELD_SIZE {
+                    warn!("Invalid sized read of PCID register: {}", data.len());
+                    return;
+                }
                 data.copy_from_slice(
                     &self.pci_segments[self.selected_segment]
                         .pci_devices_down


### PR DESCRIPTION
Replace the asserts which will cause the VMM to exit (semi-cleanly via panic handler) with warnings. A correctly behaving guest will never trigger these as it should respect the ACPI definitions over how to access these registers.

- **devices: acpi: Reject mis-sized accesses to shutdown and GED devices**
- **vmm: device_manager: Reject mis-sized PCI hotplug register accesses**
- **vmm: cpu: Reject mis-sized ACPI CPU hotplug register accesses**
