### PR TITLE
tpm: trim qualified paths

### DIFF
--- a/tpm/src/emulator.rs
+++ b/tpm/src/emulator.rs
@@ -5,7 +5,7 @@
 
 use std::os::unix::io::RawFd;
 use std::path::Path;
-use std::{mem, ptr};
+use std::{io, mem, ptr};
 
 use anyhow::anyhow;
 use libc::{sockaddr_storage, socklen_t};
@@ -150,7 +150,7 @@ impl Emulator {
             if ret == -1 {
                 return Err(Error::PrepareDataFd(anyhow!(
                     "Failed to prepare data fd for tpm emulator. Error Code {:?}",
-                    std::io::Error::last_os_error()
+                    io::Error::last_os_error()
                 )));
             }
         }
@@ -164,13 +164,13 @@ impl Emulator {
                 if libc::close(fds[0]) == -1 {
                     error!(
                         "Failed to close TPM data fd after CmdSetDatafd failure: {:?}",
-                        std::io::Error::last_os_error()
+                        io::Error::last_os_error()
                     );
                 }
                 if libc::close(fds[1]) == -1 {
                     error!(
                         "Failed to close TPM swtpm fd after CmdSetDatafd failure: {:?}",
-                        std::io::Error::last_os_error()
+                        io::Error::last_os_error()
                     );
                 }
             }
@@ -181,7 +181,7 @@ impl Emulator {
             if libc::close(fds[1]) == -1 {
                 error!(
                     "Failed to close local TPM swtpm fd: {:?}",
-                    std::io::Error::last_os_error()
+                    io::Error::last_os_error()
                 );
             }
         }
@@ -199,12 +199,12 @@ impl Emulator {
                 libc::SOL_SOCKET,
                 libc::SO_RCVTIMEO,
                 (&raw const tv).cast(),
-                std::mem::size_of::<libc::timeval>() as u32,
+                mem::size_of::<libc::timeval>() as u32,
             );
             if ret == -1 {
                 return Err(Error::PrepareDataFd(anyhow!(
                     "Failed to set receive timeout on data fd socket. Error Code {:?}",
-                    std::io::Error::last_os_error()
+                    io::Error::last_os_error()
                 )));
             }
         }
@@ -422,7 +422,7 @@ impl Emulator {
             if ret == -1 {
                 return Err(Error::SendReceive(anyhow!(
                     "Failed to send tpm command over Data FD. Error Code {:?}",
-                    std::io::Error::last_os_error()
+                    io::Error::last_os_error()
                 )));
             }
         }
@@ -441,7 +441,7 @@ impl Emulator {
             if ret == -1 {
                 return Err(Error::SendReceive(anyhow!(
                     "Failed to receive response for tpm command over Data FD. Error Code {:?}",
-                    std::io::Error::last_os_error()
+                    io::Error::last_os_error()
                 )));
             }
             output_len = ret as usize;
@@ -554,7 +554,7 @@ impl Drop for Emulator {
                 if libc::close(self.data_fd) == -1 {
                     error!(
                         "Failed to close TPM data fd: {:?}",
-                        std::io::Error::last_os_error()
+                        io::Error::last_os_error()
                     );
                 }
             }

--- a/tpm/src/lib.rs
+++ b/tpm/src/lib.rs
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// TODO: Trim qualified paths in this crate, then drop this expectation.
-#![expect(clippy::absolute_paths)]
-
 pub mod emulator;
 pub mod socket;
 


### PR DESCRIPTION
Part of #7670.

Import the std modules used in the crate instead of spelling the
fully-qualified paths at every use site, and drop the now-unnecessary
crate-level `#![expect(clippy::absolute_paths)]`:

- `std::io::Error::last_os_error()` → `io::Error::last_os_error()` (the syscall error handling in `emulator.rs`)
- `std::mem::size_of::<libc::timeval>()` → `mem::size_of::<…>()`

Readability-only change; no functional impact. Latest in the series of
per-crate cleanups for #7670 — same approach as the most recently merged
#8397, #8398, #8399.