### PR TITLE
treewide: reevaluate #[allow] attributes

### DIFF
--- a/block/src/formats/qcow/worker/async_uring.rs
+++ b/block/src/formats/qcow/worker/async_uring.rs
@@ -321,7 +321,7 @@ impl QcowAsync {
     /// Returns `Some(host_offset)` if the entire read falls within a single
     /// allocated cluster (fast path). Otherwise handles the read
     /// synchronously via `scatter_read_sync` and returns `None`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn resolve_read(
         metadata: &QcowMetadata,
         data_file: &QcowRawFile,

--- a/block/src/io/fcntl.rs
+++ b/block/src/io/fcntl.rs
@@ -34,7 +34,7 @@ pub enum LockError {
 }
 
 /// Commands for use with [`fcntl`].
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 enum FcntlArg<'a> {
     /// Set an OFD lock from the given lock description.
     F_OFD_SETLK(&'a libc::flock),

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -1232,7 +1232,7 @@ fn main() {
 
     if let Err(top_error) = target_api.do_command(&matches) {
         // Helper to join strings with a newline.
-        #[allow(clippy::needless_pass_by_value)]
+        #[expect(clippy::needless_pass_by_value)]
         fn join_strs(mut acc: String, next: String) -> String {
             if !acc.is_empty() {
                 acc.push('\n');

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #![cfg(any(devcli_testenv, clippy))]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![expect(clippy::undocumented_unsafe_blocks)]
 // TODO: Trim qualified paths in this crate, then drop this expectation.
 #![expect(clippy::absolute_paths)]
 // When enabling the `mshv` feature, we skip quite some tests and

--- a/cloud-hypervisor/tests/integration_cvm.rs
+++ b/cloud-hypervisor/tests/integration_cvm.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #![cfg(any(devcli_testenv, clippy))]
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![expect(clippy::undocumented_unsafe_blocks)]
 // TODO: Trim qualified paths in this crate, then drop this expectation.
 #![expect(clippy::absolute_paths)]
 // When enabling the `mshv` feature, we skip quite some tests and

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
         v / (1_000_000_000_f64)
     }
 
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn Bps_to_MiBps(v: f64) -> f64 {
         v / (1 << 20) as f64
     }

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#![allow(clippy::undocumented_unsafe_blocks)]
+#![expect(clippy::undocumented_unsafe_blocks)]
 // TODO: Trim qualified paths in this crate, then drop this expectation.
 #![expect(clippy::absolute_paths)]
 
@@ -721,7 +721,7 @@ pub fn rate_limited_copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::
     Err(io::Error::last_os_error())
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 pub fn handle_child_output(
     r: Result<(), std::boxed::Box<dyn std::any::Any + std::marker::Send>>,
     output: &std::process::Output,

--- a/tracer/src/tracer.rs
+++ b/tracer/src/tracer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#![allow(static_mut_refs)]
+#![expect(static_mut_refs)]
 
 use std::cell::OnceCell;
 use std::collections::HashMap;

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -119,7 +119,7 @@ pub struct VhostUserNetBackend {
 }
 
 impl VhostUserNetBackend {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         ip_addr: IpAddr,
         host_mac: MacAddr,


### PR DESCRIPTION
Closes #8326. Final batch, following #8363, #8373, and #8382.

Covers the remaining crates - `block`, `cloud-hypervisor`,
`performance-metrics`, `test_infra`, `tracer`, `vhost_user_net`,
`vm-allocator` - one commit per crate. Each `#[allow]` was converted to
`#[expect]` after confirming its lint still fires (including the
`undocumented_unsafe_blocks` allows in the integration test files).

Verified across x86_64 and aarch64, under kvm/mshv and `--all-features`
where relevant.

Deliberately left as `#[allow]`:
- `net_util` `unnecessary_cast` - conditional on `c_char` signedness.
- `test_infra` `unknown_lints` + `zombie_processes` -  forward-compat for
  older clippy versions.