### PR TITLE
block: trim qualified paths in vhdx tests

### DIFF
--- a/block/src/formats/vhdx/internal/mod.rs
+++ b/block/src/formats/vhdx/internal/mod.rs
@@ -256,9 +256,8 @@ pub(crate) fn uuid_from_guid(buf: &[u8]) -> Uuid {
 }
 
 #[cfg(test)]
-// TODO: Trim qualified paths in these tests, then drop this expectation.
-#[expect(clippy::absolute_paths)]
 mod tests {
+    use std::fs;
     use std::process::Command;
 
     use vmm_sys_util::tempfile::TempFile;
@@ -291,7 +290,7 @@ mod tests {
             return;
         };
 
-        let file = std::fs::OpenOptions::new()
+        let file = fs::OpenOptions::new()
             .read(true)
             .write(true)
             .open(tf.as_path())


### PR DESCRIPTION
Part of #7670.

Trim the last fully-qualified path in `block` — a single `std::fs::OpenOptions`
in the vhdx `internal` test module — and drop the now-unnecessary
`#[expect(clippy::absolute_paths)]` on that test module:

- `std::fs::OpenOptions::new()` → `fs::OpenOptions::new()` (added `use std::fs;` to the test module)

With this, `block` is fully `absolute_paths`-clean (the io-shadow in
`vhdx/internal` was already handled with `IoError` aliases in #8387).
Readability-only change; no functional impact. Same approach as the most
recently merged #8397, #8398, #8399.