### PR TITLE
performance-metrics: trim qualified paths

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -3,19 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// TODO: Trim qualified paths in this crate, then drop this expectation.
-#![expect(clippy::absolute_paths)]
-
 // Custom harness to run performance tests
 mod micro_bench_block;
 mod performance_tests;
 mod util;
 
-use std::process::Command;
+use std::process::{self, Command};
 use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::time::Duration;
-use std::{env, fmt, thread};
+use std::{env, fmt, fs, io, panic, path, str, thread};
 
 use clap::{Arg, ArgAction, Command as ClapCommand};
 use performance_tests::*;
@@ -151,7 +148,7 @@ pub enum ImageFormat {
     Vhdx,
 }
 
-impl std::str::FromStr for ImageFormat {
+impl str::FromStr for ImageFormat {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -1733,7 +1730,7 @@ fn run_test_with_timeout(
                 test.name, test.control, overrides
             );
 
-            let output = match std::panic::catch_unwind(|| test.run(&overrides)) {
+            let output = match panic::catch_unwind(|| test.run(&overrides)) {
                 Ok(test_result) => {
                     println!(
                         "Test '{}' .. ok: mean = {}, std_dev = {}",
@@ -1914,7 +1911,7 @@ fn main() {
     {
         if overrides.vm_type == GuestVmType::Confidential {
             eprintln!("Confidential VM is currently not supported on Arm64");
-            std::process::exit(1);
+            process::exit(1);
         }
     }
 
@@ -1943,7 +1940,7 @@ fn main() {
                         .push(PerformanceTestResult::failed(test.name));
                 } else {
                     eprintln!("Aborting test due to error: '{e:?}'");
-                    std::process::exit(1);
+                    process::exit(1);
                 }
             }
         }
@@ -1953,18 +1950,18 @@ fn main() {
         cleanup_tests();
     }
 
-    let mut report_file: Box<dyn std::io::Write + Send> =
+    let mut report_file: Box<dyn io::Write + Send> =
         if let Some(file) = cmd_arguments.get_one::<String>("report-file") {
             Box::new(
-                std::fs::File::create(std::path::Path::new(file))
+                fs::File::create(path::Path::new(file))
                     .map_err(|e| {
                         eprintln!("Error opening report file: {file}: {e}");
-                        std::process::exit(1);
+                        process::exit(1);
                     })
                     .unwrap(),
             )
         } else {
-            Box::new(std::io::stdout())
+            Box::new(io::stdout())
         };
 
     report_file
@@ -1975,11 +1972,11 @@ fn main() {
         )
         .map_err(|e| {
             eprintln!("Error writing report file: {e}");
-            std::process::exit(1);
+            process::exit(1);
         })
         .unwrap();
 
     if has_failure {
-        std::process::exit(1);
+        process::exit(1);
     }
 }

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -6,7 +6,7 @@
 // Performance tests
 
 use std::time::Duration;
-use std::{fs, thread};
+use std::{fs, panic, thread};
 
 use test_infra::{Error as InfraError, *};
 use thiserror::Error;
@@ -156,7 +156,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
         measure_virtio_net_throughput(test_timeout, num_queues / 2, &guest, rx, bandwidth).unwrap()
     });
@@ -196,7 +196,7 @@ pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // 'ethr' tool will measure the latency multiple times with provided test time
@@ -217,7 +217,7 @@ pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
 }
 
 fn parse_boot_time_output(output: &[u8]) -> Result<f64, Error> {
-    std::panic::catch_unwind(|| {
+    panic::catch_unwind(|| {
         let l: Vec<String> = String::from_utf8_lossy(output)
             .lines()
             .filter(|l| l.contains("Debug I/O port: Kernel code"))
@@ -320,7 +320,7 @@ fn measure_boot_time(cmd: &mut GuestCommand, test_timeout: u32) -> Result<f64, E
 }
 
 pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = performance_test_new_guest(Box::new(jammy), control);
         let mut cmd = GuestCommand::new(&guest);
@@ -344,7 +344,7 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
 }
 
 pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = performance_test_new_guest(Box::new(jammy), control);
         let mut cmd = GuestCommand::new(&guest);
@@ -435,7 +435,7 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         let fio_command = format!(
@@ -523,7 +523,7 @@ fn measure_restore_time(
 }
 
 pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = performance_test_new_guest(Box::new(jammy), control);
         let api_socket_source = String::from(
@@ -548,7 +548,7 @@ pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
 
         thread::sleep(Duration::new((control.test_timeout / 2) as u64, 0));
         let snapshot_dir = String::from(guest.tmp_dir.as_path().join("snapshot").to_str().unwrap());
-        std::fs::create_dir(&snapshot_dir).unwrap();
+        fs::create_dir(&snapshot_dir).unwrap();
         assert!(remote_command(&api_socket_source, "pause", None));
         assert!(remote_command(
             &api_socket_source,


### PR DESCRIPTION
Part of #7670.

Import the std modules used in the crate instead of spelling the
fully-qualified paths at every use site, and drop the now-unnecessary
crate-level `#![expect(clippy::absolute_paths)]`:

- `std::panic::catch_unwind` → `panic::catch_unwind`
- `std::process::exit` → `process::exit` (via `use std::process::{self, Command}`)
- `std::io::{Write, stdout}` → `io::…`, `std::fs::File::create(std::path::Path::new(..))` → `fs::…(path::…)`, `std::fs::create_dir` → `fs::create_dir`
- `impl std::str::FromStr` → `impl str::FromStr`

Readability-only change; no functional impact. Latest in the series of
per-crate cleanups for #7670 — same approach as the most recently merged
#8397, #8398, #8399.