### PR TITLE
build: Disable rate-limiter job on MQ

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -711,22 +711,23 @@ jobs:
       - name: Run Windows guest integration tests for musl
         timeout-minutes: 15
         run: scripts/dev_cli.sh tests --integration-windows --libc musl
-  integration-rate-limiter:
-    name: integration-rate-limiter
-    needs: [preflight, dco, quality, build]
-    if: >-
-      github.event_name == 'merge_group' && needs.preflight.outputs.full == 'true' && needs.dco.result == 'success' && needs.quality.result == 'success' && needs.build.result == 'success'
-    runs-on: bare-metal-9950x
-    env:
-      AUTH_DOWNLOAD_TOKEN: ${{ secrets.AUTH_DOWNLOAD_TOKEN }}
-    steps:
-      - name: Code checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Run rate-limiter integration tests
-        timeout-minutes: 20
-        run: scripts/dev_cli.sh tests --integration-rate-limiter
+  # Rate-limiter host is not available
+  # integration-rate-limiter:
+  #   name: integration-rate-limiter
+  #   needs: [preflight, dco, quality, build]
+  #   if: >-
+  #     github.event_name == 'merge_group' && needs.preflight.outputs.full == 'true' && needs.dco.result == 'success' && needs.quality.result == 'success' && needs.build.result == 'success'
+  #   runs-on: bare-metal-9950x
+  #   env:
+  #     AUTH_DOWNLOAD_TOKEN: ${{ secrets.AUTH_DOWNLOAD_TOKEN }}
+  #   steps:
+  #     - name: Code checkout
+  #       uses: actions/checkout@v6
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Run rate-limiter integration tests
+  #       timeout-minutes: 20
+  #       run: scripts/dev_cli.sh tests --integration-rate-limiter
   integration-sev-snp:
     name: integration-sev-snp
     needs: [preflight, dco, quality, build]
@@ -756,6 +757,23 @@ jobs:
       - name: Run CVM (SEV-SNP) integration tests
         timeout-minutes: 20
         run: scripts/dev_cli.sh tests --integration-cvm --hypervisor kvm
+  # Rate-limiter host is not available
+  # integration-rate-limiter:
+  #   name: integration-rate-limiter
+  #   needs: [preflight, dco, quality, build]
+  #   if: >-
+  #     github.event_name == 'merge_group' && needs.preflight.outputs.full == 'true' && needs.dco.result == 'success' && needs.quality.result == 'success' && needs.build.result == 'success'
+  #   runs-on: bare-metal-9950x
+  #   env:
+  #     AUTH_DOWNLOAD_TOKEN: ${{ secrets.AUTH_DOWNLOAD_TOKEN }}
+  #   steps:
+  #     - name: Code checkout
+  #       uses: actions/checkout@v6
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Run rate-limiter integration tests
+  #       timeout-minutes: 20
+  #       run: scripts/dev_cli.sh tests --integration-rate-limiter
   # The single required-status check. Branch protection requires this one job.
   all-green:
     name: all-green


### PR DESCRIPTION
This is not a blocking job but the worker is no longer handling the jobs
so it remains pending indefinitely.

Signed-off-by: Rob Bradford <rbradford@meta.com>
