### PR TITLE
pci: msix: Reject mis-sized MSI-X table and PBA reads

### DIFF
--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -268,7 +268,14 @@ impl MsixConfig {
     }
 
     pub fn read_table(&self, offset: u64, data: &mut [u8]) {
-        assert!(data.len() == 4 || data.len() == 8);
+        if data.len() != 4 && data.len() != 8 {
+            error!(
+                "invalid MSI-X table read size: {} (allowed: 4 or 8)",
+                data.len()
+            );
+            data.fill(0xff);
+            return;
+        }
 
         let index: usize = (offset / MSIX_TABLE_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_TABLE_ENTRIES_MODULO;
@@ -423,7 +430,14 @@ impl MsixConfig {
     }
 
     pub fn read_pba(&mut self, offset: u64, data: &mut [u8]) {
-        assert!(data.len() == 4 || data.len() == 8);
+        if data.len() != 4 && data.len() != 8 {
+            error!(
+                "invalid MSI-X PBA read size: {} (allowed: 4 or 8)",
+                data.len()
+            );
+            data.fill(0xff);
+            return;
+        }
 
         let index: usize = (offset / MSIX_PBA_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_PBA_ENTRIES_MODULO;


### PR DESCRIPTION
Replace assertions for incorrect access sizes with logged errors. The
write_table() method already handled it like this and this commit
extends the same pattern to read_table() and read_pba().

Signed-off-by: Rob Bradford <rbradford@meta.com>
