### PR TITLE
seccomp: add SYS_fsync to vcpu thread seccomp filter

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -902,6 +902,7 @@ fn vcpu_thread_rules(
         ),
         (libc::SYS_fcntl, vec![]),
         (libc::SYS_fstat, vec![]),
+        (libc::SYS_fsync, vec![]),
         (libc::SYS_futex, vec![]),
         (libc::SYS_getcwd, vec![]),
         (libc::SYS_getrandom, vec![]),


### PR DESCRIPTION
Fix disk hot unplug failure caused by seccomp SIGSYS kill.

When performing disk hot unplug, the vcpu thread calls fsync() on the block device file descriptor to flush pending I/O. The seccomp filter previously blocked SYS_fsync, triggering SIGSYS and terminating the vcpu thread, which makes the hot unplug operation fail. This issue exists on both x86 and AArch64.

Strace log snippet captured during failure:
[pid 3118852] fsync(142) = 142
[pid 3118852] ---SIGSYS {si_signo=SIGSYS,si_code=SYS_SECCOMP,si_call_addr=0xffff9c931df8, si_syscall=__NR_fsync,si_arch=AUDIT_ARCH_AARCH64}

Add unrestricted SYS_fsync entry to vcpu thread syscall allowlist, consistent with existing file I/O syscalls such as fcntl and fstat.

Signed-off-by: yanjianqing <yanjianqing@kylinos.cn>