### PR TITLE
devices: trim qualified paths

### DIFF
--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -9,8 +9,8 @@
 // Implementation of an intel 82093AA Input/Output Advanced Programmable Interrupt Controller
 // See https://pdos.csail.mit.edu/6.828/2016/readings/ia32/ioapic.pdf for a specification.
 
-use std::result;
 use std::sync::{Arc, Barrier};
+use std::{mem, result};
 
 use byteorder::{ByteOrder, LittleEndian};
 use log::{debug, error, trace, warn};
@@ -147,7 +147,7 @@ pub struct IoapicState {
 
 impl BusDevice for Ioapic {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
-        if data.len() != std::mem::size_of::<u32>() {
+        if data.len() != mem::size_of::<u32>() {
             warn!("Invalid read size on IOAPIC: {}", data.len());
             return;
         }
@@ -167,7 +167,7 @@ impl BusDevice for Ioapic {
     }
 
     fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
-        if data.len() != std::mem::size_of::<u32>() {
+        if data.len() != mem::size_of::<u32>() {
             warn!("Invalid write size on IOAPIC: {}", data.len());
             return None;
         }
@@ -442,7 +442,7 @@ impl Snapshottable for Ioapic {
         self.id.clone()
     }
 
-    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         Snapshot::new_from_state(&self.state())
     }
 }

--- a/devices/src/legacy/debug_port.rs
+++ b/devices/src/legacy/debug_port.rs
@@ -4,6 +4,7 @@
 //
 
 use std::fmt;
+use std::sync::{Arc, Barrier};
 use std::time::Instant;
 
 use log::{error, warn};
@@ -66,12 +67,7 @@ impl BusDevice for DebugPort {
         error!("Invalid read to debug port");
     }
 
-    fn write(
-        &mut self,
-        _base: u64,
-        _offset: u64,
-        data: &[u8],
-    ) -> Option<std::sync::Arc<std::sync::Barrier>> {
+    fn write(&mut self, _base: u64, _offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         let elapsed = self.timestamp.elapsed();
 
         let code = data[0];

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -7,9 +7,6 @@
 
 //! Emulates virtual and hardware devices.
 
-// TODO: Trim qualified paths in this crate, then drop this expectation.
-#![cfg_attr(target_arch = "x86_64", expect(clippy::absolute_paths))]
-
 pub mod acpi;
 #[cfg(target_arch = "riscv64")]
 pub mod aia;


### PR DESCRIPTION
Part of #7670.

Import the std modules used in the crate instead of spelling the
fully-qualified paths at every use site, and drop the now-unnecessary
`#[cfg_attr(target_arch = "x86_64", expect(clippy::absolute_paths))]`:

- `std::mem::size_of` → `mem::size_of` (ioapic)
- `std::result::Result<_, MigratableError>` → `result::Result<…>` (kept the `result::` cue alongside the local `Result` alias)
- `std::sync::Arc<std::sync::Barrier>` → `Arc<Barrier>` (debug_port)

The remaining sites were all x86_64-gated. Readability-only change; no
functional impact. Same approach as the most recently merged #8414, #8415, #8422.