### PR TITLE
arch: trim qualified paths

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -9,11 +9,13 @@
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt::Debug;
+use std::hash::BuildHasher;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::{cmp, fs, result, str};
 
 use byteorder::{BigEndian, ByteOrder};
+use fdt_parser::node::FdtNode;
 use hypervisor::arch::aarch64::gic::Vgic;
 use hypervisor::arch::aarch64::regs::{
     AARCH64_ARCH_TIMER_HYP_IRQ, AARCH64_ARCH_TIMER_PHYS_NONSECURE_IRQ,
@@ -205,7 +207,7 @@ pub fn get_cache_shared(cache_level: CacheLevel) -> bool {
 
 /// Creates the flattened device tree for this aarch64 VM.
 #[expect(clippy::too_many_arguments)]
-pub fn create_fdt<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
+pub fn create_fdt<T: DeviceInfoForFdt + Clone + Debug, S: BuildHasher>(
     guest_mem: &GuestMemoryMmap,
     cmdline: &str,
     vcpu_mpidr: &[u64],
@@ -879,7 +881,7 @@ fn create_fw_cfg_node<T: DeviceInfoForFdt + Clone + Debug>(
     Ok(())
 }
 
-fn create_devices_node<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
+fn create_devices_node<T: DeviceInfoForFdt + Clone + Debug, S: BuildHasher>(
     fdt: &mut FdtWriter,
     dev_info: &HashMap<(DeviceType, String), T, S>,
 ) -> FdtWriterResult<()> {
@@ -1145,7 +1147,7 @@ pub fn print_fdt(dtb: &[u8]) {
     }
 }
 
-fn print_node(node: fdt_parser::node::FdtNode<'_, '_>, n_spaces: usize) {
+fn print_node(node: FdtNode<'_, '_>, n_spaces: usize) {
     debug!("{:indent$}{}/", "", node.name, indent = n_spaces);
     for property in node.properties() {
         let name = property.name;

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -11,6 +11,7 @@ pub mod uefi;
 
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::hash::BuildHasher;
 use std::sync::{Arc, Mutex};
 
 use hypervisor::arch::aarch64::gic::Vgic;
@@ -122,7 +123,7 @@ pub fn arch_memory_regions() -> Vec<(GuestAddress, usize, RegionType)> {
 
 /// Configures the system and should be called once per vm before starting vcpu threads.
 #[expect(clippy::too_many_arguments)]
-pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
+pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: BuildHasher>(
     guest_mem: &GuestMemoryMmap,
     cmdline: &str,
     vcpu_mpidr: &[u64],

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -8,20 +8,18 @@
 //! Implements platform specific functionality.
 //! Supported platforms: x86_64, aarch64, riscv64.
 
-// TODO: Trim qualified paths in this crate, then drop this expectation.
-#![expect(clippy::absolute_paths)]
-
 use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{fmt, result};
 
-use serde::de::IntoDeserializer;
+use serde::de::{IntoDeserializer, value};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use vm_memory::bitmap::AtomicBitmap;
 
-type GuestMemoryMmap = vm_memory::GuestMemoryMmap<vm_memory::bitmap::AtomicBitmap>;
-type GuestRegionMmap = vm_memory::GuestRegionMmap<vm_memory::bitmap::AtomicBitmap>;
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
+type GuestRegionMmap = vm_memory::GuestRegionMmap<AtomicBitmap>;
 
 /// Type for returning error code.
 #[derive(Debug, Error)]
@@ -74,7 +72,7 @@ pub enum CpuProfile {
 
 // Note that this trait impl is architecture agnostic and may thus reside here.
 impl FromStr for CpuProfile {
-    type Err = serde::de::value::Error;
+    type Err = value::Error;
     fn from_str(s: &str) -> result::Result<Self, Self::Err> {
         Self::deserialize(s.into_deserializer())
     }

--- a/arch/src/x86_64/helpers.rs
+++ b/arch/src/x86_64/helpers.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use serde::{Deserialize, Deserializer, Serializer};
+use std::result;
+
+use serde::{Deserialize, Deserializer, Serializer, de};
 
 /// Serializes the given `input` as a hex string (starting with "0x").
 ///
@@ -12,17 +14,17 @@ use serde::{Deserialize, Deserializer, Serializer};
 pub(crate) fn serialize_u32_hex<S: Serializer>(
     input: &u32,
     serializer: S,
-) -> std::result::Result<S::Ok, S::Error> {
+) -> result::Result<S::Ok, S::Error> {
     serializer.serialize_str(&format!("{input:#x}"))
 }
 
 /// Deserializes a u32 from a hex string representation.
 pub(crate) fn deserialize_u32_hex<'de, D: Deserializer<'de>>(
     deserializer: D,
-) -> std::result::Result<u32, D::Error> {
+) -> result::Result<u32, D::Error> {
     let hex: &str = <&str>::deserialize(deserializer)?;
     u32::from_str_radix(hex.strip_prefix("0x").unwrap_or(""), 16).map_err(|_| {
-        <D::Error as serde::de::Error>::custom(format!("{hex} is not a hex encoded 32 bit integer"))
+        <D::Error as de::Error>::custom(format!("{hex} is not a hex encoded 32 bit integer"))
     })
 }
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -37,6 +37,7 @@ use vm_memory::{
     Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
     GuestMemoryRegion,
 };
+use vmm_sys_util::fam;
 
 use crate::x86_64::cpu_profile::cpuid_adjustments::MissingCpuidEntriesError;
 use crate::{CpuProfile, GuestMemoryMmap, InitramfsConfig, RegionType};
@@ -144,11 +145,11 @@ pub enum Error {
 
     /// Error populating CPUID with KVM HyperV emulation details
     #[error("Error populating CPUID with KVM HyperV emulation details")]
-    CpuidKvmHyperV(#[source] vmm_sys_util::fam::Error),
+    CpuidKvmHyperV(#[source] fam::Error),
 
     /// Error populating CPUID with CPU identification
     #[error("Error populating CPUID with CPU identification")]
-    CpuidIdentification(#[source] vmm_sys_util::fam::Error),
+    CpuidIdentification(#[source] fam::Error),
 
     /// Error checking CPUID compatibility
     #[error("Error checking CPUID compatibility")]
@@ -651,7 +652,7 @@ pub fn generate_common_cpuid(
         cpuid.retain(|c| c.function != i);
         // SAFETY: call cpuid with valid leaves
         #[allow(unused_unsafe)]
-        let leaf = unsafe { std::arch::x86_64::__cpuid(i) };
+        let leaf = unsafe { x86_64::__cpuid(i) };
         cpuid.push(CpuIdEntry {
             function: i,
             eax: leaf.eax,
@@ -783,10 +784,10 @@ fn required_common_cpuid_updates(
                     && entry.ecx == 0
                     && entry.edx == 0
                     // SAFETY: cpuid called with valid leaves
-                    && unsafe { std::arch::x86_64::__cpuid(0x8000_0000).eax } >= 0x8000_0005 =>
+                    && unsafe { x86_64::__cpuid(0x8000_0000).eax } >= 0x8000_0005 =>
             {
                 // SAFETY: cpuid called with valid leaves
-                let leaf = unsafe { std::arch::x86_64::__cpuid(0x8000_0005) };
+                let leaf = unsafe { x86_64::__cpuid(0x8000_0005) };
                 entry.eax = leaf.eax;
                 entry.ebx = leaf.ebx;
                 entry.ecx = leaf.ecx;
@@ -799,10 +800,10 @@ fn required_common_cpuid_updates(
                     && entry.ecx == 0
                     && entry.edx == 0
                     // SAFETY: cpuid called with valid leaves
-                    && unsafe { std::arch::x86_64::__cpuid(0x8000_0000).eax } >= 0x8000_0006 =>
+                    && unsafe { x86_64::__cpuid(0x8000_0000).eax } >= 0x8000_0006 =>
             {
                 // SAFETY: cpuid called with valid leaves
-                let leaf = unsafe { std::arch::x86_64::__cpuid(0x8000_0006) };
+                let leaf = unsafe { x86_64::__cpuid(0x8000_0006) };
                 entry.eax = leaf.eax;
                 entry.ebx = leaf.ebx;
                 entry.ecx = leaf.ecx;
@@ -971,9 +972,7 @@ pub fn configure_vcpu(
         // Need to check that the TSC doesn't vary with dynamic frequency
         #[allow(unused_unsafe)]
         // SAFETY: cpuid called with valid leaves
-        if unsafe { std::arch::x86_64::__cpuid(0x8000_0007) }.edx & (1u32 << INVARIANT_TSC_EDX_BIT)
-            > 0
-        {
+        if unsafe { x86_64::__cpuid(0x8000_0007) }.edx & (1u32 << INVARIANT_TSC_EDX_BIT) > 0 {
             CpuidPatch::set_cpuid_reg(&mut cpuid, 0x4000_0000, None, CpuidReg::EAX, 0x4000_0010);
             cpuid.retain(|c| c.function != 0x4000_0010);
             cpuid.push(CpuIdEntry {

--- a/arch/src/x86_64/mpspec.rs
+++ b/arch/src/x86_64/mpspec.rs
@@ -3,34 +3,37 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
+use std::mem;
+use std::os::raw;
+
 use vm_memory::ByteValued;
 
-pub const MP_PROCESSOR: ::std::os::raw::c_uint = 0;
-pub const MP_BUS: ::std::os::raw::c_uint = 1;
-pub const MP_IOAPIC: ::std::os::raw::c_uint = 2;
-pub const MP_INTSRC: ::std::os::raw::c_uint = 3;
-pub const MP_LINTSRC: ::std::os::raw::c_uint = 4;
-pub const CPU_ENABLED: ::std::os::raw::c_uint = 1;
-pub const CPU_BOOTPROCESSOR: ::std::os::raw::c_uint = 2;
-pub const MPC_APIC_USABLE: ::std::os::raw::c_uint = 1;
-pub const MP_IRQDIR_DEFAULT: ::std::os::raw::c_uint = 0;
+pub const MP_PROCESSOR: raw::c_uint = 0;
+pub const MP_BUS: raw::c_uint = 1;
+pub const MP_IOAPIC: raw::c_uint = 2;
+pub const MP_INTSRC: raw::c_uint = 3;
+pub const MP_LINTSRC: raw::c_uint = 4;
+pub const CPU_ENABLED: raw::c_uint = 1;
+pub const CPU_BOOTPROCESSOR: raw::c_uint = 2;
+pub const MPC_APIC_USABLE: raw::c_uint = 1;
+pub const MP_IRQDIR_DEFAULT: raw::c_uint = 0;
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mpf_intel {
-    pub signature: [::std::os::raw::c_uchar; 4usize],
-    pub physptr: ::std::os::raw::c_uint,
-    pub length: ::std::os::raw::c_uchar,
-    pub specification: ::std::os::raw::c_uchar,
-    pub checksum: ::std::os::raw::c_uchar,
-    pub feature1: ::std::os::raw::c_uchar,
-    pub feature2: ::std::os::raw::c_uchar,
-    pub feature3: ::std::os::raw::c_uchar,
-    pub feature4: ::std::os::raw::c_uchar,
-    pub feature5: ::std::os::raw::c_uchar,
+    pub signature: [raw::c_uchar; 4usize],
+    pub physptr: raw::c_uint,
+    pub length: raw::c_uchar,
+    pub specification: raw::c_uchar,
+    pub checksum: raw::c_uchar,
+    pub feature1: raw::c_uchar,
+    pub feature2: raw::c_uchar,
+    pub feature3: raw::c_uchar,
+    pub feature4: raw::c_uchar,
+    pub feature5: raw::c_uchar,
 }
 
-const _: () = assert!(::core::mem::size_of::<mpf_intel>() == 16);
+const _: () = assert!(mem::size_of::<mpf_intel>() == 16);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -40,24 +43,24 @@ unsafe impl ByteValued for mpf_intel {}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mpc_table {
-    pub signature: [::std::os::raw::c_uchar; 4usize],
-    pub length: ::std::os::raw::c_ushort,
-    pub spec: ::std::os::raw::c_uchar,
-    pub checksum: ::std::os::raw::c_uchar,
-    pub oem: [::std::os::raw::c_uchar; 8usize],
-    pub productid: [::std::os::raw::c_uchar; 12usize],
-    pub oemptr: ::std::os::raw::c_uint,
-    pub oemsize: ::std::os::raw::c_ushort,
-    pub oemcount: ::std::os::raw::c_ushort,
-    pub lapic: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
+    pub signature: [raw::c_uchar; 4usize],
+    pub length: raw::c_ushort,
+    pub spec: raw::c_uchar,
+    pub checksum: raw::c_uchar,
+    pub oem: [raw::c_uchar; 8usize],
+    pub productid: [raw::c_uchar; 12usize],
+    pub oemptr: raw::c_uint,
+    pub oemsize: raw::c_ushort,
+    pub oemcount: raw::c_ushort,
+    pub lapic: raw::c_uint,
+    pub reserved: raw::c_uint,
 }
 
 const _: () = {
-    assert!(::core::mem::size_of::<mpc_table>() == 4 + 2 + 1 + 1 + 8 + 12 + 4 + 2 + 2 + 4 + 4);
-    assert!(::core::mem::size_of::<::std::os::raw::c_uint>() == 4);
-    assert!(::core::mem::size_of::<::std::os::raw::c_ushort>() == 2);
-    assert!(::core::mem::size_of::<::std::os::raw::c_uchar>() == 1);
+    assert!(mem::size_of::<mpc_table>() == 4 + 2 + 1 + 1 + 8 + 12 + 4 + 2 + 2 + 4 + 4);
+    assert!(mem::size_of::<raw::c_uint>() == 4);
+    assert!(mem::size_of::<raw::c_ushort>() == 2);
+    assert!(mem::size_of::<raw::c_uchar>() == 1);
 };
 
 // SAFETY: all members of this struct are plain integers
@@ -69,16 +72,16 @@ unsafe impl ByteValued for mpc_table {}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mpc_cpu {
-    pub type_: ::std::os::raw::c_uchar,
-    pub apicid: ::std::os::raw::c_uchar,
-    pub apicver: ::std::os::raw::c_uchar,
-    pub cpuflag: ::std::os::raw::c_uchar,
-    pub cpufeature: ::std::os::raw::c_uint,
-    pub featureflag: ::std::os::raw::c_uint,
-    pub reserved: [::std::os::raw::c_uint; 2usize],
+    pub type_: raw::c_uchar,
+    pub apicid: raw::c_uchar,
+    pub apicver: raw::c_uchar,
+    pub cpuflag: raw::c_uchar,
+    pub cpufeature: raw::c_uint,
+    pub featureflag: raw::c_uint,
+    pub reserved: [raw::c_uint; 2usize],
 }
 
-const _: () = assert!(::core::mem::size_of::<mpc_cpu>() == 20);
+const _: () = assert!(mem::size_of::<mpc_cpu>() == 20);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -88,12 +91,12 @@ unsafe impl ByteValued for mpc_cpu {}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mpc_bus {
-    pub type_: ::std::os::raw::c_uchar,
-    pub busid: ::std::os::raw::c_uchar,
-    pub bustype: [::std::os::raw::c_uchar; 6usize],
+    pub type_: raw::c_uchar,
+    pub busid: raw::c_uchar,
+    pub bustype: [raw::c_uchar; 6usize],
 }
 
-const _: () = assert!(::core::mem::size_of::<mpc_bus>() == 8);
+const _: () = assert!(mem::size_of::<mpc_bus>() == 8);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -103,14 +106,14 @@ unsafe impl ByteValued for mpc_bus {}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mpc_ioapic {
-    pub type_: ::std::os::raw::c_uchar,
-    pub apicid: ::std::os::raw::c_uchar,
-    pub apicver: ::std::os::raw::c_uchar,
-    pub flags: ::std::os::raw::c_uchar,
-    pub apicaddr: ::std::os::raw::c_uint,
+    pub type_: raw::c_uchar,
+    pub apicid: raw::c_uchar,
+    pub apicver: raw::c_uchar,
+    pub flags: raw::c_uchar,
+    pub apicaddr: raw::c_uint,
 }
 
-const _: () = assert!(::core::mem::size_of::<mpc_ioapic>() == 8);
+const _: () = assert!(mem::size_of::<mpc_ioapic>() == 8);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -120,39 +123,39 @@ unsafe impl ByteValued for mpc_ioapic {}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mpc_intsrc {
-    pub type_: ::std::os::raw::c_uchar,
-    pub irqtype: ::std::os::raw::c_uchar,
-    pub irqflag: ::std::os::raw::c_ushort,
-    pub srcbus: ::std::os::raw::c_uchar,
-    pub srcbusirq: ::std::os::raw::c_uchar,
-    pub dstapic: ::std::os::raw::c_uchar,
-    pub dstirq: ::std::os::raw::c_uchar,
+    pub type_: raw::c_uchar,
+    pub irqtype: raw::c_uchar,
+    pub irqflag: raw::c_ushort,
+    pub srcbus: raw::c_uchar,
+    pub srcbusirq: raw::c_uchar,
+    pub dstapic: raw::c_uchar,
+    pub dstirq: raw::c_uchar,
 }
 
-const _: () = assert!(::core::mem::size_of::<mpc_intsrc>() == 8);
+const _: () = assert!(mem::size_of::<mpc_intsrc>() == 8);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
 // would be nowhere for them to exist.
 unsafe impl ByteValued for mpc_intsrc {}
 
-pub const MP_IRQ_SOURCE_TYPES_MP_INT: ::std::os::raw::c_uint = 0;
-pub const MP_IRQ_SOURCE_TYPES_MP_NMI: ::std::os::raw::c_uint = 1;
-pub const MP_IRQ_SOURCE_TYPES_MP_EXT_INT: ::std::os::raw::c_uint = 3;
+pub const MP_IRQ_SOURCE_TYPES_MP_INT: raw::c_uint = 0;
+pub const MP_IRQ_SOURCE_TYPES_MP_NMI: raw::c_uint = 1;
+pub const MP_IRQ_SOURCE_TYPES_MP_EXT_INT: raw::c_uint = 3;
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mpc_lintsrc {
-    pub type_: ::std::os::raw::c_uchar,
-    pub irqtype: ::std::os::raw::c_uchar,
-    pub irqflag: ::std::os::raw::c_ushort,
-    pub srcbusid: ::std::os::raw::c_uchar,
-    pub srcbusirq: ::std::os::raw::c_uchar,
-    pub destapic: ::std::os::raw::c_uchar,
-    pub destapiclint: ::std::os::raw::c_uchar,
+    pub type_: raw::c_uchar,
+    pub irqtype: raw::c_uchar,
+    pub irqflag: raw::c_ushort,
+    pub srcbusid: raw::c_uchar,
+    pub srcbusirq: raw::c_uchar,
+    pub destapic: raw::c_uchar,
+    pub destapiclint: raw::c_uchar,
 }
 
-const _: () = assert!(::core::mem::size_of::<mpc_lintsrc>() == 8);
+const _: () = assert!(mem::size_of::<mpc_lintsrc>() == 8);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -162,14 +165,14 @@ unsafe impl ByteValued for mpc_lintsrc {}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mpc_oemtable {
-    pub signature: [::std::os::raw::c_uchar; 4usize],
-    pub length: ::std::os::raw::c_ushort,
-    pub rev: ::std::os::raw::c_uchar,
-    pub checksum: ::std::os::raw::c_uchar,
-    pub mpc: [::std::os::raw::c_uchar; 8usize],
+    pub signature: [raw::c_uchar; 4usize],
+    pub length: raw::c_ushort,
+    pub rev: raw::c_uchar,
+    pub checksum: raw::c_uchar,
+    pub mpc: [raw::c_uchar; 8usize],
 }
 
-const _: () = assert!(::core::mem::size_of::<mpc_oemtable>() == 16);
+const _: () = assert!(mem::size_of::<mpc_oemtable>() == 16);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -452,7 +452,7 @@ pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Res
             .map_err(Error::WriteSmbiosEp)?;
     }
 
-    Ok(curptr.unchecked_offset_from(physptr) + std::mem::size_of::<Smbios30Entrypoint>() as u64)
+    Ok(curptr.unchecked_offset_from(physptr) + mem::size_of::<Smbios30Entrypoint>() as u64)
 }
 
 #[cfg(test)]

--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom};
-use std::mem;
 use std::str::FromStr;
+use std::{mem, slice};
 
 use log::{debug, info};
 use thiserror::Error;
@@ -163,7 +163,7 @@ pub fn parse_tdvf_sections(file: &mut File) -> Result<(Vec<TdvfSection>, bool), 
     let mut descriptor: TdvfDescriptor = Default::default();
     // SAFETY: we read exactly the size of the descriptor header
     file.read_exact(unsafe {
-        std::slice::from_raw_parts_mut(
+        slice::from_raw_parts_mut(
             (&raw mut descriptor).cast(),
             mem::size_of::<TdvfDescriptor>(),
         )
@@ -190,7 +190,7 @@ pub fn parse_tdvf_sections(file: &mut File) -> Result<(Vec<TdvfSection>, bool), 
 
     // SAFETY: we read exactly the advertised sections
     file.read_exact(unsafe {
-        std::slice::from_raw_parts_mut(
+        slice::from_raw_parts_mut(
             sections.as_mut_ptr().cast(),
             descriptor.num_sections as usize * mem::size_of::<TdvfSection>(),
         )
@@ -527,7 +527,7 @@ mod unit_tests {
     #[test]
     #[ignore]
     fn test_parse_tdvf_sections() {
-        let mut f = std::fs::File::open("tdvf.fd").unwrap();
+        let mut f = File::open("tdvf.fd").unwrap();
         let (sections, _) = parse_tdvf_sections(&mut f).unwrap();
         for section in sections {
             eprintln!("{section:x?}");


### PR DESCRIPTION
Part of #7670.

Import the modules used in the crate instead of spelling the
fully-qualified paths at every use site, and drop the now-unnecessary
crate-level `#![expect(clippy::absolute_paths)]`. The bulk is the
bindgen-generated `mpspec.rs` (`::std::os::raw::*` → `raw::*`,
`::core::mem::size_of` → `mem::size_of`). Other trims:

- `std::arch::x86_64::__cpuid` → `x86_64::__cpuid`, `vmm_sys_util::fam::Error` → `fam::Error`
- `std::result::Result` → `result::Result`, `serde::de::{Error, value::Error}` → relative
- `vm_memory::bitmap::AtomicBitmap` → `AtomicBitmap`, `::std::hash::BuildHasher` → `BuildHasher`, `fdt_parser::node::FdtNode` → `FdtNode`, `std::slice::from_raw_parts_mut` → `slice::…`

Verified clean on both aarch64 (native) and x86_64 (cross-check). Readability-only
change; no functional impact. Same approach as the most recently merged #8415, #8422, #8423.