### PR TITLE
vmm: Emit complete ACPI S5 sleep package

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -5853,7 +5853,7 @@ impl Aml for DeviceManager {
             .to_aml_bytes(sink);
         }
 
-        aml::Name::new("_S5_".into(), &aml::Package::new(vec![&5u8])).to_aml_bytes(sink);
+        create_s5_sleep_state(sink);
 
         aml::Device::new(
             "_SB_.PWRB".into(),
@@ -5877,6 +5877,17 @@ impl Aml for DeviceManager {
             .unwrap()
             .to_aml_bytes(sink);
     }
+}
+
+fn create_s5_sleep_state(sink: &mut dyn acpi_tables::AmlSink) {
+    // More information about the sleep state structure can be found here:
+    // https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/07_Power_and_Performance_Mgmt/oem-supplied-system-level-control-methods.html#sx-system-states
+
+    aml::Name::new(
+        "_S5_".into(),
+        &aml::Package::new(vec![&5u8, &5u8, &0u8, &0u8]),
+    )
+    .to_aml_bytes(sink);
 }
 
 impl Pausable for DeviceManager {
@@ -6127,6 +6138,20 @@ impl Drop for DeviceManager {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+
+    #[test]
+    fn test_s5_sleep_state_uses_complete_package() {
+        let mut bytes = Vec::new();
+
+        create_s5_sleep_state(&mut bytes);
+
+        assert_eq!(
+            bytes,
+            vec![
+                0x08, b'_', b'S', b'5', b'_', 0x12, 0x08, 0x04, 0x0a, 0x05, 0x0a, 0x05, 0x00, 0x00,
+            ]
+        );
+    }
 
     #[test]
     fn test_hotplugged_block_devices_use_64bit_bars() {


### PR DESCRIPTION
OpenBSD expects the ACPI _S5_ object to provide both sleep type values. The single-value package made acpi_init_states() parse an invalid object and fault during early ACPI setup with:

```
    acpi0: sleep statesfatal protection fault in supervisor mode
    trap type 4 code 0 rip ffffffff814af264 cs 8 rflags 10282 cr2 0 cpl e rsp ffffffff81a06a30
    gsbase 0xffffffff81755ff0  kgsbase 0x0
    panic: trap type 4, code=0, pc=ffffffff814af264
    Starting stack trace...
    panic(ffffffff81a06980,4,ffffffff81a06a58,ffffffff81756ae0,ffffffff81a06960,ffffffff81a068e0) at panic+0x12e
    ...
    acpi_init_states(1,ffff800000232400,ffff800000232470,0,ef0d316e102be1f4,5f35535f) at acpi_init_states+0xd5
    ...
    cpu_configure(8,1001000,ffffffff814f3859,ffffffff81a06f20,8,1001000) at cpu_configure+0x29
    main(1001000,ef0d316e102be1f4,ffffffff812e8b2f,ffffffff81a06f40,8,1001000) at main+0x3af
    end trace frame: 0x0, count: 244
    End of stack trace.
```

Advertise S5 as the conventional four-element package as described in the ACPI spec [1]. Cover the generated AML bytes with a unit test.

In AML, the package now looks like this:

```
Name (_S5, Package () {
  0x05, 0x05, 0x00, 0x00
})
```

Before the fix, the package looked like this:


```
Name (_S5, Package () {
  0x05
})
```

This is the first part of fixing OpenBSD boot. The kernel now now progresses above this check, but will get stuck eventually later on due to missing PIT for timer calibration. This is another issue though.

[1] https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/07_Power_and_Performance_Mgmt/oem-supplied-system-level-control-methods.html#sx-system-states
