### PR TITLE
vmm/devices: Add GuestEvent legacy device for lifecycle notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ dependencies = [
  "bitflags 2.13.0",
  "byteorder",
  "event_monitor",
+ "flume",
  "hypervisor",
  "libc",
  "linux-loader",

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -803,6 +803,18 @@ fn create_serial_node<T: DeviceInfoForFdt + Clone + Debug>(
     Ok(())
 }
 
+fn create_guest_event_node<T: DeviceInfoForFdt + Clone + Debug>(
+    fdt: &mut FdtWriter,
+    dev_info: &T,
+) -> FdtWriterResult<()> {
+    let reg_prop = [dev_info.addr(), dev_info.length()];
+    let node = fdt.begin_node(&format!("guest-event@{:x}", dev_info.addr()))?;
+    fdt.property_string("compatible", "guest-event")?;
+    fdt.property_array_u64("reg", &reg_prop)?;
+    fdt.end_node(node)?;
+    Ok(())
+}
+
 fn create_rtc_node<T: DeviceInfoForFdt + Clone + Debug>(
     fdt: &mut FdtWriter,
     dev_info: &T,
@@ -891,6 +903,7 @@ fn create_devices_node<T: DeviceInfoForFdt + Clone + Debug, S: BuildHasher>(
     for ((device_type, _device_id), info) in dev_info {
         match device_type {
             DeviceType::Gpio => create_gpio_node(fdt, info)?,
+            DeviceType::GuestEvent => create_guest_event_node(fdt, info)?,
             DeviceType::Rtc => create_rtc_node(fdt, info)?,
             DeviceType::Serial => create_serial_node(fdt, info)?,
             DeviceType::Virtio(_) => {

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -76,6 +76,7 @@ pub const GIC_V3_ITS_SIZE: u64 = 0x02_0000;
 pub const LEGACY_SERIAL_MAPPED_IO_START: GuestAddress = MAPPED_IO_START;
 pub const LEGACY_RTC_MAPPED_IO_START: GuestAddress = GuestAddress(0x0901_0000);
 pub const LEGACY_GPIO_MAPPED_IO_START: GuestAddress = GuestAddress(0x0902_0000);
+pub const LEGACY_GUEST_EVENT_MAPPED_IO_START: GuestAddress = GuestAddress(0x0903_0000);
 
 /// Space 0x0905_0000 ~ 0x0906_0000 is reserved for pcie io address
 pub const MEM_PCI_IO_START: GuestAddress = GuestAddress(0x0905_0000);

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -176,6 +176,9 @@ pub enum DeviceType {
     /// Device Type: fw_cfg.
     #[cfg(feature = "fw_cfg")]
     FwCfg,
+    /// Device Type: GuestEvent.
+    #[cfg(target_arch = "aarch64")]
+    GuestEvent,
 }
 
 /// Default (smallest) memory page size for the supported architectures.

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -391,6 +391,12 @@ fn get_cli_options_sorted(
             .num_args(0)
             .action(ArgAction::SetTrue)
             .group("vm-config"),
+        Arg::new("guest-events")
+            .long("guest-events")
+            .help("Enable guest events device")
+            .num_args(0)
+            .action(ArgAction::SetTrue)
+            .group("vm-config"),
         Arg::new("rate-limit-group")
             .long("rate-limit-group")
             .help(RateLimiterGroupConfig::SYNTAX)
@@ -1060,6 +1066,7 @@ mod unit_tests {
             vdpa: None,
             vsock: None,
             pvpanic: false,
+            guest_events: false,
             #[cfg(feature = "pvmemcontrol")]
             pvmemcontrol: None,
             iommu: false,

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -40,6 +40,9 @@ zerocopy = { version = "0.8.50", features = [
   "derive",
 ], optional = true }
 
+[dev-dependencies]
+flume = { workspace = true }
+
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 arch = { path = "../arch" }
 
@@ -52,3 +55,4 @@ pvmemcontrol = []
 
 [lints]
 workspace = true
+

--- a/devices/src/legacy/guest_event.rs
+++ b/devices/src/legacy/guest_event.rs
@@ -1,0 +1,82 @@
+// Copyright © 2026 Cloud Hypervisor Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::sync::{Arc, Barrier};
+use event_monitor::event;
+use vm_device::BusDevice;
+
+const EVENT_START: u8 = 0x01;
+const EVENT_PANIC: u8 = 0x04;
+const EVENT_INIT_READY: u8 = 0x08;
+
+#[derive(Default)]
+pub struct GuestEventDevice;
+
+impl GuestEventDevice {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl BusDevice for GuestEventDevice {
+    fn read(&mut self, _base: u64, _offset: u64, _data: &mut [u8]) {}
+
+    fn write(&mut self, _base: u64, _offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        if data.is_empty() {
+            return None;
+        }
+        match data[0] {
+            EVENT_START => event!("guest", "sys_start", "source", "guest_event_device"),
+            EVENT_INIT_READY => event!("guest", "init_ready", "source", "guest_event_device"),
+            EVENT_PANIC => event!("guest", "panic", "source", "guest_event_device"),
+            _ => {} // Ignore unknown signals
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+
+    static MONITOR_RX: OnceLock<Mutex<flume::Receiver<String>>> = OnceLock::new();
+
+    fn get_monitor_rx() -> &'static Mutex<flume::Receiver<String>> {
+        MONITOR_RX.get_or_init(|| {
+            let monitor = event_monitor::set_monitor(None).unwrap();
+            Mutex::new(monitor.rx)
+        })
+    }
+
+    #[test]
+    fn test_guest_event_device() {
+        let rx_lock = get_monitor_rx();
+        let rx = rx_lock.lock().unwrap();
+        let mut device = GuestEventDevice::new();
+
+        // Write EVENT_START
+        device.write(0, 0, &[EVENT_START]);
+        if let Ok(msg) = rx.recv() {
+            assert!(msg.contains(r#""source":"guest""#) || msg.contains(r#""source": "guest""#), "msg was: {msg}");
+            assert!(msg.contains(r#""event":"sys_start""#) || msg.contains(r#""event": "sys_start""#), "msg was: {msg}");
+        }
+
+        // Write EVENT_INIT_READY
+        device.write(0, 0, &[EVENT_INIT_READY]);
+        if let Ok(msg) = rx.recv() {
+            assert!(msg.contains(r#""source":"guest""#) || msg.contains(r#""source": "guest""#), "msg was: {msg}");
+            assert!(msg.contains(r#""event":"init_ready""#) || msg.contains(r#""event": "init_ready""#), "msg was: {msg}");
+        }
+
+        // Write EVENT_PANIC
+        device.write(0, 0, &[EVENT_PANIC]);
+        if let Ok(msg) = rx.recv() {
+            assert!(msg.contains(r#""source":"guest""#) || msg.contains(r#""source": "guest""#), "msg was: {msg}");
+            assert!(msg.contains(r#""event":"panic""#) || msg.contains(r#""event": "panic""#), "msg was: {msg}");
+        }
+    }
+}

--- a/devices/src/legacy/mod.rs
+++ b/devices/src/legacy/mod.rs
@@ -38,3 +38,5 @@ pub use self::rtc_pl031::Rtc;
 pub use self::serial::Serial;
 #[cfg(target_arch = "aarch64")]
 pub use self::uart_pl011::Pl011;
+pub mod guest_event;
+pub use self::guest_event::GuestEventDevice;

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -486,6 +486,7 @@ pub struct VmParams<'a> {
     #[cfg(feature = "pvmemcontrol")]
     pub pvmemcontrol: bool,
     pub pvpanic: bool,
+    pub guest_events: bool,
     pub numa: Option<Vec<&'a str>>,
     pub watchdog: bool,
     pub rtc: Option<&'a str>,
@@ -555,6 +556,7 @@ impl<'a> VmParams<'a> {
         #[cfg(feature = "pvmemcontrol")]
         let pvmemcontrol = args.get_flag("pvmemcontrol");
         let pvpanic = args.get_flag("pvpanic");
+        let guest_events = args.get_flag("guest-events");
         let numa: Option<Vec<&str>> = args
             .get_many::<String>("numa")
             .map(|x| x.map(|y| y as &str).collect());
@@ -607,6 +609,7 @@ impl<'a> VmParams<'a> {
             #[cfg(feature = "pvmemcontrol")]
             pvmemcontrol,
             pvpanic,
+            guest_events,
             numa,
             watchdog,
             rtc,
@@ -3673,6 +3676,7 @@ impl VmConfig {
             #[cfg(feature = "pvmemcontrol")]
             pvmemcontrol,
             pvpanic: vm_params.pvpanic,
+            guest_events: vm_params.guest_events,
             iommu: false, // updated in VmConfig::validate()
             numa,
             watchdog: vm_params.watchdog,
@@ -5154,6 +5158,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             #[cfg(feature = "pvmemcontrol")]
             pvmemcontrol: None,
             pvpanic: false,
+            guest_events: false,
             iommu: false,
             numa: None,
             watchdog: false,
@@ -5410,6 +5415,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             #[cfg(feature = "pvmemcontrol")]
             pvmemcontrol: None,
             pvpanic: false,
+            guest_events: false,
             iommu: false,
             numa: None,
             watchdog: false,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2106,6 +2106,16 @@ impl DeviceManager {
             .insert(debug_port, 0x80, 0x1)
             .map_err(DeviceManagerError::BusError)?;
 
+        if self.config.lock().unwrap().guest_events {
+            let guest_event_device = Arc::new(Mutex::new(devices::legacy::GuestEventDevice::new()));
+            self.bus_devices
+                .push(Arc::clone(&guest_event_device) as Arc<dyn BusDeviceSync>);
+            self.address_manager
+                .io_bus
+                .insert(guest_event_device, 0x680, 0x1)
+                .map_err(DeviceManagerError::BusError)?;
+        }
+
         Ok(())
     }
 
@@ -2192,6 +2202,25 @@ impl DeviceManager {
             .lock()
             .unwrap()
             .insert(id.clone(), device_node!(id, gpio_device));
+
+        if self.config.lock().unwrap().guest_events {
+            let guest_event_device = Arc::new(Mutex::new(devices::legacy::GuestEventDevice::new()));
+            self.bus_devices
+                .push(Arc::clone(&guest_event_device) as Arc<dyn BusDeviceSync>);
+            let addr = arch::layout::LEGACY_GUEST_EVENT_MAPPED_IO_START;
+            self.address_manager
+                .mmio_bus
+                .insert(guest_event_device, addr.0, MMIO_LEN)
+                .map_err(DeviceManagerError::BusError)?;
+            self.id_to_dev_info.insert(
+                (DeviceType::GuestEvent, "guest-event".to_string()),
+                MmioDeviceInfo {
+                    addr: addr.0,
+                    len: MMIO_LEN,
+                    irq: 0,
+                },
+            );
+        }
 
         Ok(())
     }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -758,7 +758,6 @@ impl Vmm {
 
         for signal in signals.forever() {
             match signal {
-                #[expect(clippy::collapsible_match)]
                 SIGTERM | SIGINT => {
                     if exit_evt.write(1).is_err() {
                         // Resetting the terminal is usually done as the VMM exits
@@ -2901,6 +2900,7 @@ mod unit_tests {
             #[cfg(feature = "pvmemcontrol")]
             pvmemcontrol: None,
             pvpanic: false,
+            guest_events: false,
             iommu: false,
             numa: None,
             watchdog: false,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -1183,6 +1183,8 @@ pub struct VmConfig {
     #[serde(default)]
     pub pvpanic: bool,
     #[serde(default)]
+    pub guest_events: bool,
+    #[serde(default)]
     pub iommu: bool,
     pub numa: Option<Box<[NumaConfig]>>,
     #[serde(default)]


### PR DESCRIPTION
### **Description**
**Motivation:**
Currently, when the `/sbin/init` process starts inside the guest OS, external management programs (like `kata-runtime`) need to perceive whether the guest environment is fully ready. Existing solutions often rely on an inefficient polling mechanism (e.g., continuously checking vsock connectivity or a serial port). This not only introduces unnecessary CPU overhead but also delays the perception of the VM boot timeline.

**Solution:**
This PR introduces a lightweight, event-triggered notification mechanism. By adding a stateless legacy device (`GuestEventDevice`), the guest OS can now proactively signal its lifecycle states directly to the host infrastructure.

**Implementation Details:**
- **Stateless Device:** Implemented `GuestEventDevice` which translates specific single-byte writes into corresponding hypervisor JSON events (`sys_start`, `init_ready`, `panic`) emitted to the `event_monitor`. The event source is explicitly marked as `"guest"`.
- **x86_64 Support:** Wired the device to the PIO bus at port `0x680` (1 byte length).
- **AArch64 Support:** Mapped the device to the MMIO bus at `0x09030000`. Also added the corresponding `GuestEvent` device type and registered it to the Device Tree (FDT) as `compatible = "guest-event"`.
- **Configuration:** The feature is opt-in and exposed via a new CLI argument `--guest-events`.

Guest Side Usage (How the init process emits events): The /sbin/init process (or kata-agent) running inside the guest can trigger these events using standard I/O write operations. No special kernel driver is required:

On x86_64 (via PIO port):
```c
// equivalent to shell: devmem 0x09030000 8 0x08
// Example in C: Emit EVENT_INIT_READY (0x08)
outb(0x08, 0x680);
```
On AArch64 (via MMIO):
 ```c
// equivalent to shell: printf '\x08' | dd of=/dev/port bs=1 seek=$((0x680))
// Example in C: Emit EVENT_INIT_READY (0x08)
uint8_t *guest_event_addr = mmap(NULL, 1, PROT_WRITE, MAP_SHARED, mem_fd, 0x09030000);
*guest_event_addr = 0x08;
```
**Impact:**
This enables management planes like `kata-runtime` to seamlessly switch from a polling-based architecture to an event-driven architecture, significantly reducing boot latency and host overhead.
