### PR TITLE
virtio-devices: block: Reuse descriptor chain's memory for queue enable

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -317,7 +317,7 @@ impl BlockEpollHandler {
                     .add_used(desc_chain.memory(), desc_chain.head_index(), 1)
                     .map_err(Error::QueueAddUsed)?;
                 queue
-                    .enable_notification(self.mem.memory().deref())
+                    .enable_notification(desc_chain.memory())
                     .map_err(Error::QueueEnableNotification)?;
                 continue;
             }
@@ -404,7 +404,7 @@ impl BlockEpollHandler {
                     .add_used(desc_chain.memory(), desc_chain.head_index(), len)
                     .map_err(Error::QueueAddUsed)?;
                 queue
-                    .enable_notification(self.mem.memory().deref())
+                    .enable_notification(desc_chain.memory())
                     .map_err(Error::QueueEnableNotification)?;
             }
         }


### PR DESCRIPTION
The two synchronous completion paths add the head to the used ring with `desc_chain.memory()` but reload `self.mem.memory()` to reenable notifications. Keep both on the snapshot the chain was parsed from so the used ring update and the notification reenable always act on one guest memory view rather than two independent atomic loads.