### PR TITLE
main: trim qualified paths in lib

### DIFF
--- a/cloud-hypervisor/src/lib.rs
+++ b/cloud-hypervisor/src/lib.rs
@@ -2,10 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO: Trim qualified paths in this crate, then drop this expectation.
-#![expect(clippy::absolute_paths)]
-
 use std::error::Error;
+use std::iter;
 
 use log::error;
 
@@ -31,7 +29,7 @@ pub fn cli_print_error_chain<'a>(
         eprintln!("  {top_error}");
     } else {
         eprintln!("chain of errors:");
-        std::iter::successors(Some(top_error), |sub_error| {
+        iter::successors(Some(top_error), |sub_error| {
             // Dereference necessary to mitigate rustc compiler bug.
             // See <https://github.com/rust-lang/rust/issues/141673>
             (*sub_error).source()


### PR DESCRIPTION
Part of #7670.

Trim the single fully-qualified `std::iter::successors` path in the `cloud-hypervisor` library crate (`src/lib.rs`) to an imported module, and drop the now-unnecessary crate-level `#![expect(clippy::absolute_paths)]`. Pure refactor — no behavioural change.

First of several small PRs peeling the remaining `#![expect]` overrides off the `cloud-hypervisor` package one compilation unit at a time (lib, then the `ch-remote`/main binaries, then the integration tests).

Verified with `cargo +nightly fmt` and `cargo clippy -p cloud-hypervisor --lib -- -D warnings` on both aarch64 and x86_64.