### PR TITLE
vmm: migration: add seccomp rules for migration threads

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -65,7 +65,9 @@ use crate::migration::get_vm_snapshot;
 use crate::migration::transport::{
     self, ReceiveAdditionalConnections, ReceiveListener, SendAdditionalConnections, SocketStream,
 };
-use crate::migration::worker::{MigrationWorker, MigrationWorkerHandle, MigrationWorkerResult};
+use crate::migration::worker::{
+    MigrationSeccompFilters, MigrationWorker, MigrationWorkerHandle, MigrationWorkerResult,
+};
 use crate::migration::{recv_vm_config, recv_vm_state};
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::vm::{Error as VmError, Vm, VmState};
@@ -1548,7 +1550,7 @@ impl Vmm {
         hypervisor: &dyn hypervisor::Hypervisor,
         send_data_migration: &VmSendMigrationData,
         initial_vm_state: VmState,
-        seccomp_action: &SeccompAction,
+        seccomp_filters: &MigrationSeccompFilters,
     ) -> result::Result<(), MigratableError> {
         // State machine that is updated with more context as we progress.
         let mut ctx = OngoingMigrationContext::new();
@@ -1684,15 +1686,17 @@ impl Vmm {
                 send_data_migration.tls_dir.as_deref(),
             )?;
             let guest_memory = vm.guest_memory();
-            // Build the seccomp filter on the parent thread so any failure aborts
-            // the migration before the serve thread is spawned.
-            let seccomp_filter =
-                get_seccomp_filter(seccomp_action, Thread::MigrateSendPostcopy, None)
-                    .context("creating postcopy serve seccomp filter")
-                    .map_err(MigratableError::MigrateSend)?;
+
+            let seccomp_filters_clone = seccomp_filters.clone();
             let handle = thread::Builder::new()
                 .name("migrate-send-postcopy".to_owned())
-                .spawn(move || Self::serve_postcopy(seccomp_filter, fault_stream, guest_memory))
+                .spawn(move || {
+                    Self::serve_postcopy(
+                        &seccomp_filters_clone.postcopy_server,
+                        fault_stream,
+                        guest_memory,
+                    )
+                })
                 .context("spawning postcopy serve thread")
                 .map_err(MigratableError::MigrateSend)?;
             Some(handle)
@@ -1773,7 +1777,7 @@ impl Vmm {
         reason = "runs on a dedicated thread and must own its arguments"
     )]
     fn serve_postcopy(
-        seccomp_filter: BpfProgram,
+        seccomp_filter: &BpfProgram,
         mut socket: SocketStream,
         guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> result::Result<(), MigratableError> {
@@ -1781,7 +1785,7 @@ impl Vmm {
         // seccomp is disabled (SeccompAction::Allow), in which case there is
         // nothing to apply.
         if !seccomp_filter.is_empty() {
-            apply_filter(&seccomp_filter)
+            apply_filter(seccomp_filter)
                 .context("applying postcopy serve seccomp filter")
                 .map_err(MigratableError::MigrateSend)?;
         }
@@ -3144,6 +3148,21 @@ impl RequestHandler for Vmm {
             .with_context(|| "Failed to clone check_migration_evt FD")
             .map_err(MigratableError::MigrateSend)?;
 
+        // We are creating all seccomp filters beforehand, as:
+        // - this simplifies the code (especially error propagation)
+        // - the overhead is negligible
+        let seccomp_filters = {
+            let postcopy_server =
+                get_seccomp_filter(&self.seccomp_action, Thread::MigrateSendPostcopy, None)
+                    .map_err(|e| {
+                        MigratableError::MigrateSend(anyhow!(
+                            "creating postcopy serve seccomp filter: {e}"
+                        ))
+                    })?;
+
+            MigrationSeccompFilters { postcopy_server }
+        };
+
         // Take VM ownership. This also means that API events can no longer
         // change the VM (e.g. net device hotplug).
         let vm = self
@@ -3160,7 +3179,7 @@ impl RequestHandler for Vmm {
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             self.hypervisor.clone(),
             initial_vm_state,
-            self.seccomp_action.clone(),
+            seccomp_filters,
         ) {
             Ok(handle) => {
                 self.vm = VmOwnership::Migration {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3152,6 +3152,13 @@ impl RequestHandler for Vmm {
         // - this simplifies the code (especially error propagation)
         // - the overhead is negligible
         let seccomp_filters = {
+            let worker = get_seccomp_filter(&self.seccomp_action, Thread::MigrationWorker, None)
+                .map_err(|e| {
+                    MigratableError::MigrateSend(anyhow!(
+                        "Error creating migration seccomp filter: {e}"
+                    ))
+                })?;
+
             let postcopy_server =
                 get_seccomp_filter(&self.seccomp_action, Thread::MigrateSendPostcopy, None)
                     .map_err(|e| {
@@ -3160,7 +3167,10 @@ impl RequestHandler for Vmm {
                         ))
                     })?;
 
-            MigrationSeccompFilters { postcopy_server }
+            MigrationSeccompFilters {
+                worker,
+                postcopy_server,
+            }
         };
 
         // Take VM ownership. This also means that API events can no longer

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -980,7 +980,12 @@ impl Vmm {
                 // The accept thread hands the page fault connection back via this channel.
                 let (fault_tx, fault_rx) = channel();
                 let connections = listener.try_clone().and_then(|l| {
-                    ReceiveAdditionalConnections::new(l, guest_memory.clone(), fault_tx)
+                    ReceiveAdditionalConnections::new(
+                        l,
+                        guest_memory.clone(),
+                        fault_tx,
+                        &self.seccomp_action,
+                    )
                 })?;
                 Ok(ReceiveMigrationConfiguredData {
                     memory_manager,
@@ -1652,6 +1657,7 @@ impl Vmm {
                 send_data_migration.connections,
                 send_data_migration.tls_dir.as_deref(),
                 &vm.guest_memory(),
+                &seccomp_filters.tcp_worker,
             )?;
 
             Self::do_memory_migration(
@@ -3159,6 +3165,16 @@ impl RequestHandler for Vmm {
                     ))
                 })?;
 
+            let tcp_worker =
+                get_seccomp_filter(&self.seccomp_action, Thread::MigrationTcpWorker, None)
+                    .map_err(|e| {
+                        MigratableError::MigrateSend(anyhow!(
+                            "Error creating migration TCP worker seccomp filter: {e}"
+                        ))
+                    })?;
+
+            // Build the seccomp filter on the parent thread so any failure aborts
+            // the migration before the serve thread is spawned.
             let postcopy_server =
                 get_seccomp_filter(&self.seccomp_action, Thread::MigrateSendPostcopy, None)
                     .map_err(|e| {
@@ -3169,6 +3185,7 @@ impl RequestHandler for Vmm {
 
             MigrationSeccompFilters {
                 worker,
+                tcp_worker,
                 postcopy_server,
             }
         };

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -18,6 +18,7 @@ use std::{mem, thread};
 
 use anyhow::{Context, anyhow};
 use log::{debug, error, info, warn};
+use seccompiler::{BpfProgram, SeccompAction, apply_filter};
 use serde_json;
 use thiserror::Error;
 use vm_memory::bitmap::BitmapSlice;
@@ -30,6 +31,7 @@ use vm_migration::tls::{TlsServerConfig, TlsStream};
 use vm_migration::{MigratableError, Snapshot};
 use vmm_sys_util::eventfd::EventFd;
 
+use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::sync_utils::Gate;
 use crate::{GuestMemoryMmap, VmMigrationConfig};
 
@@ -308,6 +310,7 @@ impl ReceiveAdditionalConnections {
         listener: ReceiveListener,
         guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
         fault_tx: Sender<SocketStream>,
+        seccomp_action: &SeccompAction,
     ) -> Result<Self, MigratableError> {
         let event_fd = EventFd::new(0)
             .context("Error creating terminate fd")
@@ -318,10 +321,26 @@ impl ReceiveAdditionalConnections {
             .context("Error cloning terminate fd")
             .map_err(MigratableError::MigrateReceive)?;
 
+        let seccomp_filter = get_seccomp_filter(seccomp_action, Thread::MigrationTcpWorker, None)
+            .context("Error creating migration TCP worker seccomp filter")
+            .map_err(MigratableError::MigrateReceive)?;
+
         let accept_thread = thread::Builder::new()
             .name("migrate-receive-accept-connections".to_owned())
             .spawn(move || {
-                Self::accept_connections(listener, &terminate_fd, &guest_memory, &fault_tx)
+                if !seccomp_filter.is_empty() {
+                    apply_filter(&seccomp_filter)
+                        .context("Error applying migration TCP worker seccomp filter")
+                        .map_err(MigratableError::MigrateReceive)?;
+                }
+
+                Self::accept_connections(
+                    listener,
+                    &terminate_fd,
+                    &guest_memory,
+                    &fault_tx,
+                    &seccomp_filter,
+                )
             })
             .context("Error creating connection accept thread")
             .map_err(MigratableError::MigrateReceive)?;
@@ -348,6 +367,7 @@ impl ReceiveAdditionalConnections {
         terminate_fd: &EventFd,
         guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
         fault_tx: &Sender<SocketStream>,
+        seccomp_filter: &BpfProgram,
     ) -> Result<(), MigratableError> {
         let mut threads = Vec::new();
         let first_err = Self::accept_connections_loop(
@@ -356,6 +376,7 @@ impl ReceiveAdditionalConnections {
             guest_memory,
             fault_tx,
             &mut threads,
+            seccomp_filter,
         );
 
         if first_err.is_err() {
@@ -380,6 +401,7 @@ impl ReceiveAdditionalConnections {
         guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
         fault_tx: &Sender<SocketStream>,
         threads: &mut Vec<thread::JoinHandle<Result<(), MigratableError>>>,
+        seccomp_filter: &BpfProgram,
     ) -> Result<(), MigratableError> {
         loop {
             let socket = listener.abortable_accept(terminate_fd)?;
@@ -402,6 +424,7 @@ impl ReceiveAdditionalConnections {
                 threads.len(),
                 terminate_fd,
                 guest_memory.clone(),
+                seccomp_filter,
             )?;
             threads.push(thread);
         }
@@ -456,15 +479,24 @@ impl ReceiveAdditionalConnections {
         index: usize,
         terminate_fd: &EventFd,
         guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
+        seccomp_filter: &BpfProgram,
     ) -> Result<thread::JoinHandle<Result<(), MigratableError>>, MigratableError> {
         let terminate_fd = terminate_fd
             .try_clone()
             .context("Error cloning terminate fd")
             .map_err(MigratableError::MigrateReceive)?;
 
+        let seccomp_filter_t = seccomp_filter.clone();
         thread::Builder::new()
             .name(format!("migrate-receive-memory-{index}"))
-            .spawn(move || Self::worker_receive_memory(&mut socket, &terminate_fd, &guest_memory))
+            .spawn(move || {
+                if !seccomp_filter_t.is_empty() {
+                    apply_filter(&seccomp_filter_t)
+                        .context("Error applying migration TCP worker seccomp filter")
+                        .map_err(MigratableError::MigrateReceive)?;
+                }
+                Self::worker_receive_memory(&mut socket, &terminate_fd, &guest_memory)
+            })
             .map_err(|e| {
                 error!("Error spawning receive-memory thread: {e}");
                 MigratableError::MigrateReceive(
@@ -652,6 +684,7 @@ impl SendAdditionalConnections {
         connections: NonZeroU32,
         tls_dir: Option<&Path>,
         guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
+        seccomp_filter: &BpfProgram,
     ) -> Result<Self, MigratableError> {
         let mut threads = Vec::new();
         let configured_connections = connections.get();
@@ -683,10 +716,17 @@ impl SendAdditionalConnections {
             let message_rx = message_rx.clone();
             let worker_error = worker_error.clone();
             let notify_tx = notify_tx.clone();
+            let seccomp_filter = seccomp_filter.clone();
 
             let thread = thread::Builder::new()
                 .name(format!("migrate-send-memory-{n}"))
                 .spawn(move || {
+                    if !seccomp_filter.is_empty() {
+                        apply_filter(&seccomp_filter)
+                            .context("Error applying migration TCP worker seccomp filter")
+                            .map_err(MigratableError::MigrateReceive)?;
+                    }
+
                     Self::worker_send_memory(
                         &mut socket,
                         &guest_memory,

--- a/vmm/src/migration/worker.rs
+++ b/vmm/src/migration/worker.rs
@@ -72,6 +72,7 @@ impl Drop for MigrationWorkerHandle {
 #[derive(Clone, Debug)]
 pub struct MigrationSeccompFilters {
     pub worker: BpfProgram,
+    pub tcp_worker: BpfProgram,
     pub postcopy_server: BpfProgram,
 }
 

--- a/vmm/src/migration/worker.rs
+++ b/vmm/src/migration/worker.rs
@@ -21,7 +21,7 @@ use std::{io, thread};
 
 use event_monitor::event;
 use log::warn;
-use seccompiler::SeccompAction;
+use seccompiler::BpfProgram;
 use vm_migration::MigratableError;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -68,6 +68,11 @@ impl Drop for MigrationWorkerHandle {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct MigrationSeccompFilters {
+    pub postcopy_server: BpfProgram,
+}
+
 pub struct MigrationWorker {
     // Keep the VM out of the thread closure until spawning succeeds.
     vm_receiver: Receiver<Vm>,
@@ -76,7 +81,7 @@ pub struct MigrationWorker {
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
     initial_vm_state: VmState,
-    seccomp_action: SeccompAction,
+    seccomp_filters: MigrationSeccompFilters,
 }
 
 impl MigrationWorker {
@@ -92,7 +97,7 @@ impl MigrationWorker {
             self.hypervisor.as_ref(),
             &self.config,
             self.initial_vm_state,
-            &self.seccomp_action,
+            &self.seccomp_filters,
         )
         .inspect(|_| event!("vm", "migration-finished"))
         .inspect_err(|_| event!("vm", "migration-failed"));
@@ -119,7 +124,7 @@ impl MigrationWorker {
             dyn hypervisor::Hypervisor,
         >,
         initial_vm_state: VmState,
-        seccomp_action: SeccompAction,
+        seccomp_filters: MigrationSeccompFilters,
     ) -> Result<MigrationWorkerHandle, MigrationWorkerSpawnError> {
         let (vm_sender, vm_receiver) = mpsc::sync_channel(0);
         let worker = MigrationWorker {
@@ -129,7 +134,7 @@ impl MigrationWorker {
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             hypervisor,
             initial_vm_state,
-            seccomp_action,
+            seccomp_filters,
         };
 
         let inner_handle = match thread::Builder::new()

--- a/vmm/src/migration/worker.rs
+++ b/vmm/src/migration/worker.rs
@@ -19,9 +19,10 @@ use std::sync::mpsc::{self, Receiver};
 use std::thread::JoinHandle;
 use std::{io, thread};
 
+use anyhow::anyhow;
 use event_monitor::event;
 use log::warn;
-use seccompiler::BpfProgram;
+use seccompiler::{BpfProgram, apply_filter};
 use vm_migration::MigratableError;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -70,6 +71,7 @@ impl Drop for MigrationWorkerHandle {
 
 #[derive(Clone, Debug)]
 pub struct MigrationSeccompFilters {
+    pub worker: BpfProgram,
     pub postcopy_server: BpfProgram,
 }
 
@@ -88,26 +90,41 @@ impl MigrationWorker {
     /// Drives the migration from its start to its end (success, cancellation,
     /// failure)
     fn run(self) -> MigrationWorkerResult {
+        let seccomp_res = if self.seccomp_filters.worker.is_empty() {
+            Ok(())
+        } else {
+            apply_filter(&self.seccomp_filters.worker).map_err(|e| {
+                MigratableError::MigrateSend(anyhow!(
+                    "Error applying migration seccomp filter: {e}"
+                ))
+            })
+        };
+
         let mut vm = self.vm_receiver.recv().expect("VMM should send VM");
 
-        event!("vm", "migration-started");
-        let res = Vmm::send_migration(
-            &mut vm,
-            #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-            self.hypervisor.as_ref(),
-            &self.config,
-            self.initial_vm_state,
-            &self.seccomp_filters,
-        )
-        .inspect(|_| event!("vm", "migration-finished"))
-        .inspect_err(|_| event!("vm", "migration-failed"));
+        // We can't propagate errors early because of the complex return type,
+        // therefore we chain the results together.
+        let migration_result = seccomp_res
+            .and_then(|()| {
+                event!("vm", "migration-started");
+                Vmm::send_migration(
+                    &mut vm,
+                    #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+                    self.hypervisor.as_ref(),
+                    &self.config,
+                    self.initial_vm_state,
+                    &self.seccomp_filters,
+                )
+            })
+            .inspect(|_| event!("vm", "migration-finished"))
+            .inspect_err(|_| event!("vm", "migration-failed"));
 
         // Notify VMM thread to check migration result.
         self.check_migration_evt.write(1).unwrap();
 
         MigrationWorkerResult {
             vm,
-            migration_result: res,
+            migration_result,
             initial_vm_state: self.initial_vm_state,
         }
     }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -39,6 +39,7 @@ pub enum Thread {
     #[cfg(feature = "dbus_api")]
     DBusApi,
     EventMonitor,
+    MigrationWorker,
     SignalHandler,
     Vcpu,
     Vmm,
@@ -1063,6 +1064,66 @@ fn event_monitor_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendE
     ])
 }
 
+fn migration_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
+    Ok(vec![
+        (libc::SYS_accept4, vec![]),
+        (libc::SYS_brk, vec![]),
+        (libc::SYS_clock_gettime, vec![]),
+        (libc::SYS_clock_nanosleep, vec![]),
+        (libc::SYS_clone, vec![]),
+        (libc::SYS_clone3, vec![]),
+        (libc::SYS_close, vec![]),
+        (libc::SYS_connect, vec![]),
+        (libc::SYS_exit, vec![]),
+        (libc::SYS_exit_group, vec![]),
+        (libc::SYS_fcntl, vec![]),
+        (libc::SYS_fstat, vec![]),
+        (libc::SYS_ftruncate, vec![]),
+        (libc::SYS_futex, vec![]),
+        (libc::SYS_getpid, vec![]),
+        (libc::SYS_getrandom, vec![]),
+        (libc::SYS_gettid, vec![]),
+        (libc::SYS_ioctl, vec![]),
+        (libc::SYS_lseek, vec![]),
+        (libc::SYS_madvise, vec![]),
+        (libc::SYS_memfd_create, vec![]),
+        (libc::SYS_mmap, vec![]),
+        (libc::SYS_mprotect, vec![]),
+        (libc::SYS_mremap, vec![]),
+        (libc::SYS_munmap, vec![]),
+        (libc::SYS_nanosleep, vec![]),
+        (libc::SYS_openat, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_poll, vec![]),
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+        (libc::SYS_ppoll, vec![]),
+        (libc::SYS_prctl, vec![]),
+        (libc::SYS_read, vec![]),
+        (libc::SYS_readv, vec![]),
+        (libc::SYS_tkill, vec![]),
+        (libc::SYS_recvfrom, vec![]),
+        (libc::SYS_recvmsg, vec![]),
+        (libc::SYS_rseq, vec![]),
+        (libc::SYS_rt_sigprocmask, vec![]),
+        (libc::SYS_rt_sigreturn, vec![]),
+        (libc::SYS_sched_getaffinity, vec![]),
+        (libc::SYS_sched_yield, vec![]),
+        (libc::SYS_seccomp, vec![]),
+        (libc::SYS_sendmsg, vec![]),
+        (libc::SYS_setsockopt, vec![]),
+        (libc::SYS_sendto, vec![]),
+        (libc::SYS_set_robust_list, vec![]),
+        (libc::SYS_sigaltstack, vec![]),
+        (libc::SYS_socket, vec![]),
+        (libc::SYS_socketpair, vec![]),
+        (libc::SYS_statx, vec![]),
+        (libc::SYS_tgkill, vec![]),
+        (libc::SYS_timerfd_settime, vec![]),
+        (libc::SYS_write, vec![]),
+        (libc::SYS_writev, vec![]),
+    ])
+}
+
 fn serial_manager_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
     Ok(vec![
         (libc::SYS_accept4, vec![]),
@@ -1131,6 +1192,7 @@ fn get_seccomp_rules(
         #[cfg(feature = "dbus_api")]
         Thread::DBusApi => dbus_api_thread_rules()?,
         Thread::EventMonitor => event_monitor_thread_rules()?,
+        Thread::MigrationWorker => migration_thread_rules()?,
         Thread::SerialManager => serial_manager_thread_rules()?,
         Thread::SignalHandler => signal_handler_thread_rules()?,
         Thread::Vcpu => vcpu_thread_rules(

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -39,7 +39,11 @@ pub enum Thread {
     #[cfg(feature = "dbus_api")]
     DBusApi,
     EventMonitor,
+    /// Thread handling the migration on the sending side.
     MigrationWorker,
+    /// Key used for the TCP workers for send and receive, as well as the accept
+    /// thread on the receiver side.
+    MigrationTcpWorker,
     SignalHandler,
     Vcpu,
     Vmm,
@@ -1124,6 +1128,52 @@ fn migration_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError
     ])
 }
 
+fn migration_tcp_worker_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
+    Ok(vec![
+        (libc::SYS_accept4, vec![]),
+        (libc::SYS_brk, vec![]),
+        (libc::SYS_clock_gettime, vec![]),
+        (libc::SYS_clone, vec![]),
+        (libc::SYS_clone3, vec![]),
+        (libc::SYS_close, vec![]),
+        (libc::SYS_exit, vec![]),
+        (libc::SYS_exit_group, vec![]),
+        (libc::SYS_fcntl, vec![]),
+        (libc::SYS_futex, vec![]),
+        (libc::SYS_getrandom, vec![]),
+        (libc::SYS_gettid, vec![]),
+        (libc::SYS_madvise, vec![]),
+        (libc::SYS_mmap, vec![]),
+        (libc::SYS_mprotect, vec![]),
+        (libc::SYS_munmap, vec![]),
+        (libc::SYS_openat, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_poll, vec![]),
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+        (libc::SYS_ppoll, vec![]),
+        (libc::SYS_prctl, vec![]),
+        (libc::SYS_pwrite64, vec![]),
+        (libc::SYS_read, vec![]),
+        (libc::SYS_readv, vec![]),
+        (libc::SYS_recvfrom, vec![]),
+        (libc::SYS_recvmsg, vec![]),
+        (libc::SYS_rseq, vec![]),
+        (libc::SYS_rt_sigprocmask, vec![]),
+        (libc::SYS_rt_sigreturn, vec![]),
+        (libc::SYS_sched_getaffinity, vec![]),
+        (libc::SYS_sched_yield, vec![]),
+        // We are already inheriting seccomp from the parent thread.
+        (libc::SYS_seccomp, vec![]),
+        (libc::SYS_sendmsg, vec![]),
+        (libc::SYS_sendto, vec![]),
+        (libc::SYS_set_robust_list, vec![]),
+        (libc::SYS_setsockopt, vec![]),
+        (libc::SYS_sigaltstack, vec![]),
+        (libc::SYS_write, vec![]),
+        (libc::SYS_writev, vec![]),
+    ])
+}
+
 fn serial_manager_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
     Ok(vec![
         (libc::SYS_accept4, vec![]),
@@ -1193,6 +1243,7 @@ fn get_seccomp_rules(
         Thread::DBusApi => dbus_api_thread_rules()?,
         Thread::EventMonitor => event_monitor_thread_rules()?,
         Thread::MigrationWorker => migration_thread_rules()?,
+        Thread::MigrationTcpWorker => migration_tcp_worker_thread_rules()?,
         Thread::SerialManager => serial_manager_thread_rules()?,
         Thread::SignalHandler => signal_handler_thread_rules()?,
         Thread::Vcpu => vcpu_thread_rules(


### PR DESCRIPTION
Add missing seccomp rules for migration threads.

As always with seccomp: I am unsure if 100% of possible syscalls (from all possible code paths) are covered. We'll see.

Split-out from #8021