### PR TITLE
tests: trim qualified paths in integration_cvm

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -4,12 +4,14 @@
 use std::ffi::{CStr, CString};
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::net::{IpAddr, Ipv4Addr};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
 use std::string::String;
 use std::sync::mpsc;
-use std::thread;
 use std::time::Duration;
+use std::{panic, thread};
 
 use block::ImageType;
 use net_util::MacAddr;
@@ -37,7 +39,7 @@ pub(crate) fn _test_api_create_boot(target_api: &TargetApi, guest: &Guest) {
     let request_body = guest.api_create_body();
 
     let temp_config_path = guest.tmp_dir.as_path().join("config");
-    std::fs::write(&temp_config_path, request_body).unwrap();
+    fs::write(&temp_config_path, request_body).unwrap();
     let create_config = temp_config_path.as_os_str().to_str().unwrap();
 
     assert!(target_api.remote_command("create", Some(create_config),));
@@ -45,7 +47,7 @@ pub(crate) fn _test_api_create_boot(target_api: &TargetApi, guest: &Guest) {
     // Then boot it
     assert!(target_api.remote_command("boot", None));
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
         // Check that the VM booted as expected
         guest.validate_cpu_count(None);
@@ -76,10 +78,10 @@ pub(crate) fn _test_api_shutdown(target_api: &TargetApi, guest: &Guest) {
     let request_body = guest.api_create_body();
 
     let temp_config_path = guest.tmp_dir.as_path().join("config");
-    std::fs::write(&temp_config_path, request_body).unwrap();
+    fs::write(&temp_config_path, request_body).unwrap();
     let create_config = temp_config_path.as_os_str().to_str().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         assert!(target_api.remote_command("create", Some(create_config)));
 
         // Then boot it
@@ -136,10 +138,10 @@ pub(crate) fn _test_api_delete(target_api: &TargetApi, guest: &Guest) {
     let request_body = guest.api_create_body();
 
     let temp_config_path = guest.tmp_dir.as_path().join("config");
-    std::fs::write(&temp_config_path, request_body).unwrap();
+    fs::write(&temp_config_path, request_body).unwrap();
     let create_config = temp_config_path.as_os_str().to_str().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         assert!(target_api.remote_command("create", Some(create_config)));
 
         // Then boot it
@@ -199,7 +201,7 @@ pub(crate) fn _test_api_pause_resume(target_api: &TargetApi, guest: &Guest) {
     let request_body = guest.api_create_body();
 
     let temp_config_path = guest.tmp_dir.as_path().join("config");
-    std::fs::write(&temp_config_path, request_body).unwrap();
+    fs::write(&temp_config_path, request_body).unwrap();
     let create_config = temp_config_path.as_os_str().to_str().unwrap();
 
     assert!(target_api.remote_command("create", Some(create_config)));
@@ -207,7 +209,7 @@ pub(crate) fn _test_api_pause_resume(target_api: &TargetApi, guest: &Guest) {
     // Then boot it
     assert!(target_api.remote_command("boot", None));
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Check that the VM booted as expected
@@ -220,7 +222,7 @@ pub(crate) fn _test_api_pause_resume(target_api: &TargetApi, guest: &Guest) {
         // Check pausing again fails
         assert!(!target_api.remote_command("pause", None));
 
-        thread::sleep(std::time::Duration::new(2, 0));
+        thread::sleep(Duration::new(2, 0));
 
         // SSH into the VM should fail
         ssh_command_ip(
@@ -237,7 +239,7 @@ pub(crate) fn _test_api_pause_resume(target_api: &TargetApi, guest: &Guest) {
         // Check resuming again fails
         assert!(!target_api.remote_command("resume", None));
 
-        thread::sleep(std::time::Duration::new(2, 0));
+        thread::sleep(Duration::new(2, 0));
 
         // Now we should be able to SSH back in and get the right number of CPUs
         guest.validate_cpu_count(None);
@@ -250,7 +252,7 @@ pub(crate) fn _test_api_pause_resume(target_api: &TargetApi, guest: &Guest) {
 }
 
 pub(crate) fn _test_pty_interaction(pty_path: PathBuf) {
-    let mut cf = std::fs::OpenOptions::new()
+    let mut cf = fs::OpenOptions::new()
         .write(true)
         .read(true)
         .open(pty_path)
@@ -265,19 +267,19 @@ pub(crate) fn _test_pty_interaction(pty_path: PathBuf) {
     // before the console is up and we don't want
     // to try and write the next line before the
     // login process is ready.
-    thread::sleep(std::time::Duration::new(5, 0));
+    thread::sleep(Duration::new(5, 0));
     assert_eq!(cf.write(b"cloud\n").unwrap(), 6);
-    thread::sleep(std::time::Duration::new(2, 0));
+    thread::sleep(Duration::new(2, 0));
     assert_eq!(cf.write(b"cloud123\n").unwrap(), 9);
-    thread::sleep(std::time::Duration::new(2, 0));
+    thread::sleep(Duration::new(2, 0));
     assert_eq!(cf.write(b"echo test_pty_console\n").unwrap(), 22);
-    thread::sleep(std::time::Duration::new(2, 0));
+    thread::sleep(Duration::new(2, 0));
 
     let mut prev = String::new();
     // The console can stream continuously (e.g. journald forwarded to it), so
     // bound the wait: a missing marker must not loop until the harness timeout.
     for _ in 0..20 {
-        thread::sleep(std::time::Duration::new(2, 0));
+        thread::sleep(Duration::new(2, 0));
         // Drain everything available this round so a large replayed backlog
         // does not take one 2s tick per chunk to get through.
         loop {
@@ -329,7 +331,7 @@ pub(crate) fn test_cpu_topology(
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
         assert_eq!(
             guest.get_cpu_count().unwrap_or_default(),
@@ -458,7 +460,7 @@ pub(crate) fn _test_guest_numa_nodes(acpi: bool) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         guest.check_numa_common(
@@ -481,7 +483,7 @@ pub(crate) fn _test_guest_numa_nodes(acpi: bool) {
             // Resize to the maximum amount of CPUs and check each NUMA
             // node has been assigned the right CPUs set.
             resize_command(&api_socket, Some(12), None, None, None);
-            thread::sleep(std::time::Duration::new(5, 0));
+            thread::sleep(Duration::new(5, 0));
 
             guest.check_numa_common(
                 Some(&[3_840_000, 3_840_000, 3_840_000]),
@@ -512,7 +514,7 @@ pub(crate) fn _test_power_button(guest: &Guest) {
 
     let child = cmd.spawn().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
         assert!(remote_command(&api_socket, "power-button", None));
     });
@@ -580,8 +582,8 @@ pub(crate) fn test_vhost_user_net(
         .args(["--api-socket", &api_socket])
         .capture_output();
 
-    let mut daemon_child: std::process::Child;
-    let mut child: std::process::Child;
+    let mut daemon_child: Child;
+    let mut child: Child;
 
     if client_mode_daemon {
         child = ch_command.spawn().unwrap();
@@ -601,7 +603,7 @@ pub(crate) fn test_vhost_user_net(
         child = ch_command.spawn().unwrap();
     }
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         if let Some(tap_name) = tap {
@@ -692,7 +694,7 @@ pub(crate) fn test_vhost_user_net(
     handle_child_output(r, &output);
 }
 
-type PrepareBlkDaemon = dyn Fn(&TempDir, &str, usize, bool, bool) -> (std::process::Child, String);
+type PrepareBlkDaemon = dyn Fn(&TempDir, &str, usize, bool, bool) -> (Child, String);
 
 pub(crate) fn test_vhost_user_blk(
     num_queues: usize,
@@ -745,7 +747,7 @@ pub(crate) fn test_vhost_user_blk(
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Check both if /dev/vdc exists and if the block size is 16M.
@@ -887,7 +889,7 @@ pub(crate) fn test_boot_from_vhost_user_blk(
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Just check the VM booted correctly.
@@ -906,7 +908,7 @@ pub(crate) fn test_boot_from_vhost_user_blk(
 }
 
 pub(crate) fn _test_virtio_fs(
-    prepare_daemon: &dyn Fn(&TempDir, &str) -> (std::process::Child, String),
+    prepare_daemon: &dyn Fn(&TempDir, &str) -> (Child, String),
     hotplug: bool,
     use_generic_vhost_user: bool,
     pci_segment: Option<u16>,
@@ -984,7 +986,7 @@ pub(crate) fn _test_virtio_fs(
         "add-fs"
     };
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         if hotplug {
@@ -1073,12 +1075,12 @@ pub(crate) fn _test_virtio_fs(
         let _ = daemon_child.kill();
         let _ = daemon_child.wait();
         // Remove the stale socket so wait_for_virtiofsd_socket actually waits
-        let _ = std::fs::remove_file(&virtiofsd_socket_path);
+        let _ = fs::remove_file(&virtiofsd_socket_path);
 
         let (daemon_child, virtiofsd_socket_path) =
             prepare_daemon(&guest.tmp_dir, shared_dir.to_str().unwrap());
 
-        let r = std::panic::catch_unwind(|| {
+        let r = panic::catch_unwind(|| {
             // Wait for the daemon socket to be ready
             assert!(wait_until(Duration::from_secs(10), || Path::new(
                 &virtiofsd_socket_path
@@ -1158,7 +1160,7 @@ pub(crate) fn test_virtio_pmem(discard_writes: bool, specify_size: bool) {
     let pmem_temp_file = TempFile::new().unwrap();
     pmem_temp_file.as_file().set_len(128 << 20).unwrap();
 
-    std::process::Command::new("mkfs.ext4")
+    Command::new("mkfs.ext4")
         .arg(pmem_temp_file.as_path())
         .output()
         .expect("Expect creating disk image to succeed");
@@ -1188,7 +1190,7 @@ pub(crate) fn test_virtio_pmem(discard_writes: bool, specify_size: bool) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Check for the presence of /dev/pmem0
@@ -1241,7 +1243,7 @@ pub(crate) fn _test_virtio_vsock(guest: &Guest, hotplug: bool) {
 
     let mut child = cmd.capture_output().spawn().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         if hotplug {
@@ -1255,7 +1257,7 @@ pub(crate) fn _test_virtio_vsock(guest: &Guest, hotplug: bool) {
                 String::from_utf8_lossy(&cmd_output)
                     .contains("{\"id\":\"test0\",\"bdf\":\"0000:00:06.0\"}")
             );
-            thread::sleep(std::time::Duration::new(10, 0));
+            thread::sleep(Duration::new(10, 0));
             // Check adding a second one fails
             assert!(!remote_command(
                 &api_socket,
@@ -1305,7 +1307,7 @@ pub(crate) fn test_memory_mergeable(mergeable: bool) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest1.wait_vm_boot().unwrap();
     });
     if r.is_err() {
@@ -1331,7 +1333,7 @@ pub(crate) fn test_memory_mergeable(mergeable: bool) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest2.wait_vm_boot().unwrap();
         let ksm_ps_guest2 = get_ksm_pages_shared();
 
@@ -1398,7 +1400,7 @@ pub(crate) fn _test_virtio_iommu(_acpi: bool /* not needed on x86_64 */) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Verify the virtio-iommu device is present.
@@ -1602,7 +1604,7 @@ pub(crate) fn _test_simple_launch(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         guest.validate_cpu_count(None);
@@ -1663,7 +1665,7 @@ pub(crate) fn _test_multi_cpu(guest: &Guest) {
 
     let mut child = cmd.spawn().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         assert_eq!(guest.get_cpu_count().unwrap_or_default(), 2);
@@ -1705,7 +1707,7 @@ pub(crate) fn _test_cpu_affinity(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
         let pid = child.id();
         let taskset_vcpu0 = exec_host_command_output(format!("taskset -pc $(ps -T -p {pid} | grep vcpu0 | xargs | cut -f 2 -d \" \") | cut -f 6 -d \" \"").as_str());
@@ -1753,7 +1755,7 @@ pub(crate) fn _test_virtio_queue_affinity(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
         let pid = child.id();
         let taskset_q0 = exec_host_command_output(format!("taskset -pc $(ps -T -p {pid} | grep disk1_q0 | xargs | cut -f 2 -d \" \") | cut -f 6 -d \" \"").as_str());
@@ -1786,7 +1788,7 @@ pub(crate) fn _test_pci_msi(guest: &Guest) {
 
     let grep_cmd = format!("grep -c {} /proc/interrupts", get_msi_interrupt_pattern());
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         assert_eq!(
             guest
                 .ssh_command(&grep_cmd)
@@ -1822,7 +1824,7 @@ pub(crate) fn _test_virtio_net_ctrl_queue(guest: &Guest) {
     #[cfg(target_arch = "x86_64")]
     let iface = "ens4";
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         assert_eq!(
             guest
                 .ssh_command(
@@ -1896,7 +1898,7 @@ pub(crate) fn _test_pci_multiple_segments(
 
     let grep_cmd = "lspci | grep \"Host bridge\" | wc -l";
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         // There should be MAX_NUM_PCI_SEGMENTS PCI host bridges in the guest.
         assert_eq!(
             guest
@@ -1960,7 +1962,7 @@ pub(crate) fn _test_direct_kernel_boot(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         guest.validate_cpu_count(None);
@@ -2037,7 +2039,7 @@ pub(crate) fn _test_virtio_block(
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Check both if /dev/vdc exists and if the block size is 16M.
@@ -2103,7 +2105,7 @@ pub fn _test_virtio_block_dynamic_vhdx_expand(guest: &Guest) {
     let vhdx_path = vhdx_pathbuf.to_str().unwrap();
 
     // Generate a 100 MiB dynamic VHDX file
-    std::process::Command::new("qemu-img")
+    Command::new("qemu-img")
         .arg("create")
         .args(["-f", "vhdx"])
         .arg(vhdx_path)
@@ -2137,7 +2139,7 @@ pub fn _test_virtio_block_dynamic_vhdx_expand(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Check both if /dev/vdc exists and if the block size is 100 MiB.
@@ -2169,7 +2171,7 @@ pub fn _test_virtio_block_dynamic_vhdx_expand(guest: &Guest) {
 }
 
 fn vhdx_image_size(disk_name: &str) -> u64 {
-    std::fs::File::open(disk_name)
+    fs::File::open(disk_name)
         .unwrap()
         .seek(SeekFrom::End(0))
         .unwrap()
@@ -2187,7 +2189,7 @@ pub fn _test_split_irqchip(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         assert_eq!(
@@ -2228,7 +2230,7 @@ pub(crate) fn _test_dmi_serial_number(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         assert_eq!(
@@ -2259,7 +2261,7 @@ pub(crate) fn _test_dmi_uuid(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         assert_eq!(
@@ -2293,7 +2295,7 @@ pub(crate) fn _test_dmi_oem_strings(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         assert_eq!(
@@ -2354,7 +2356,7 @@ pub(crate) fn _test_dmi_system_and_chassis(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         for (_, dmidecode_field, expected) in fields {
@@ -2387,7 +2389,7 @@ pub(crate) fn _test_serial_off(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Test that there is no ttyS0
@@ -2424,7 +2426,7 @@ pub(crate) fn _test_multiple_network_interfaces(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         let tap_count = exec_host_command_output("ip link | grep -c mytap1");
@@ -2464,7 +2466,7 @@ pub(crate) fn _test_virtio_console(guest: &Guest) {
     let text = String::from("On a branch floating down river a cricket, singing.");
     let cmd = format!("echo {text} | sudo tee /dev/hvc0");
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         assert!(
@@ -2480,7 +2482,7 @@ pub(crate) fn _test_virtio_console(guest: &Guest) {
     let output = child.wait_with_output().unwrap();
     handle_child_output(r, &output);
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         assert!(String::from_utf8_lossy(&output.stdout).contains(&text));
     });
 
@@ -2507,17 +2509,17 @@ pub(crate) fn _test_console_file(guest: &Guest) {
 
     guest.ssh_command("sudo shutdown -h now").unwrap();
 
-    let _ = child.wait_timeout(std::time::Duration::from_secs(20));
+    let _ = child.wait_timeout(Duration::from_secs(20));
     kill_child(&mut child);
     let output = child.wait_with_output().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         // Check that the cloud-hypervisor binary actually terminated
         assert!(output.status.success());
 
         // Do this check after shutdown of the VM as an easy way to ensure
         // all writes are flushed to disk
-        let mut f = std::fs::File::open(console_path).unwrap();
+        let mut f = fs::File::open(console_path).unwrap();
         let mut buf = String::new();
         f.read_to_string(&mut buf).unwrap();
 
@@ -2543,7 +2545,7 @@ pub(crate) fn _test_direct_kernel_boot_noacpi(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         assert_eq!(guest.get_cpu_count().unwrap_or_default(), 1);
@@ -2571,7 +2573,7 @@ pub(crate) fn _test_pci_bar_reprogramming(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // 2 network interfaces + default localhost ==> 3 interfaces
@@ -2656,7 +2658,7 @@ pub(crate) fn _test_memory_overhead(guest: &Guest, guest_memory_size_kb: u32) {
         MAXIMUM_VMM_OVERHEAD_KB
     };
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         let overhead = get_vmm_overhead(child.id(), guest_memory_size_kb);
         eprintln!("Guest memory overhead: {overhead} vs {max_overhead}");
         assert!(overhead <= max_overhead);
@@ -2683,7 +2685,7 @@ pub(crate) fn _test_landlock(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Check /dev/vdc is not there
@@ -2747,7 +2749,7 @@ pub(crate) fn _test_disk_hotplug(guest: &Guest, landlock_enabled: bool) {
 
     let mut child = cmd.spawn().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Check /dev/vdc is not there
@@ -2891,7 +2893,7 @@ pub(crate) fn _test_virtio_block_topology(guest: &Guest, loop_dev: &str) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // MIN-IO column
@@ -2961,7 +2963,7 @@ pub(crate) fn _test_net_hotplug(
 
     guest.wait_vm_boot().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         // Add network
         let (cmd_success, cmd_output, _) = remote_command_w_output(
             &api_socket,
@@ -3110,7 +3112,7 @@ pub(crate) fn _test_counters(guest: &Guest) {
 
     let mut child = cmd.spawn().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         let orig_counters = get_counters(&api_socket);
@@ -3147,7 +3149,7 @@ pub(crate) fn _test_watchdog(guest: &Guest) {
 
     let mut child = cmd.spawn().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         let mut expected_reboot_count = 1;
@@ -3167,7 +3169,7 @@ pub(crate) fn _test_watchdog(guest: &Guest) {
         );
 
         // Allow some normal time to elapse to check we don't get spurious reboots
-        thread::sleep(std::time::Duration::new(40, 0));
+        thread::sleep(Duration::new(40, 0));
         // Check no reboot
         assert_eq!(get_reboot_count(guest), expected_reboot_count);
 
@@ -3224,7 +3226,7 @@ pub(crate) fn _test_pvpanic(guest: &Guest) {
 
     let mut child = cmd.spawn().unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Trigger guest a panic
@@ -3255,8 +3257,8 @@ pub(crate) fn _test_tap_from_fd(guest: &Guest) {
     use std::str::FromStr;
     let taps = net_util::open_tap(
         Some("chtap0"),
-        Some(std::net::IpAddr::V4(
-            std::net::Ipv4Addr::from_str(&guest.network.host_ip0).unwrap(),
+        Some(IpAddr::V4(
+            Ipv4Addr::from_str(&guest.network.host_ip0).unwrap(),
         )),
         None,
         &mut None,
@@ -3285,7 +3287,7 @@ pub(crate) fn _test_tap_from_fd(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         assert_eq!(
@@ -3432,7 +3434,7 @@ pub(crate) fn _test_macvtap(
     // The functional connectivity provided by the virtio-net device
     // gets tested through wait_vm_boot() as it expects to receive a
     // HTTP request, and through the SSH command as well.
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         assert_eq!(
@@ -3483,7 +3485,7 @@ pub(crate) fn _test_vdpa_block(guest: &Guest) {
         .spawn()
         .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
 
         // Check both if /dev/vdc exists and if the block size is 128M.

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -7,12 +7,12 @@ use std::io::{BufRead, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 #[cfg(not(feature = "mshv"))]
 use std::process::Stdio;
-use std::process::{Child, Command};
+use std::process::{Child, Command, Output};
 use std::string::String;
 use std::sync::mpsc;
 use std::sync::mpsc::Receiver;
 use std::time::{Duration, Instant};
-use std::{cmp, fs, io, thread};
+use std::{cmp, fs, io, panic, thread};
 
 use block::formats::qcow::internal::ImageType as QcowImageType;
 use test_infra::*;
@@ -112,10 +112,7 @@ pub(crate) fn wait_for_virtiofsd_socket(socket: &str) {
     }
 }
 
-pub(crate) fn prepare_virtiofsd(
-    tmp_dir: &TempDir,
-    shared_dir: &str,
-) -> (std::process::Child, String) {
+pub(crate) fn prepare_virtiofsd(tmp_dir: &TempDir, shared_dir: &str) -> (Child, String) {
     let mut workload_path = dirs::home_dir().unwrap();
     workload_path.push("workloads");
 
@@ -146,7 +143,7 @@ pub(crate) fn prepare_vubd(
     num_queues: usize,
     rdonly: bool,
     direct: bool,
-) -> (std::process::Child, String) {
+) -> (Child, String) {
     let mut workload_path = dirs::home_dir().unwrap();
     workload_path.push("workloads");
 
@@ -168,7 +165,7 @@ pub(crate) fn prepare_vubd(
         .spawn()
         .unwrap();
 
-    thread::sleep(std::time::Duration::new(10, 0));
+    thread::sleep(Duration::new(10, 0));
 
     (child, vubd_socket_path)
 }
@@ -184,7 +181,7 @@ pub(crate) fn temp_event_monitor_path(tmp_dir: &TempDir) -> String {
 // Creates the directory and returns the path.
 pub(crate) fn temp_snapshot_dir_path(tmp_dir: &TempDir) -> String {
     let snapshot_dir = String::from(tmp_dir.as_path().join("snapshot").to_str().unwrap());
-    std::fs::create_dir(&snapshot_dir).unwrap();
+    fs::create_dir(&snapshot_dir).unwrap();
     snapshot_dir
 }
 
@@ -212,7 +209,7 @@ pub(crate) fn prepare_vhost_user_net_daemon(
     mtu: Option<u16>,
     num_queues: usize,
     client_mode: bool,
-) -> (std::process::Command, String) {
+) -> (Command, String) {
     let vunet_socket_path = String::from(tmp_dir.as_path().join("vunet.sock").to_str().unwrap());
 
     // Start the daemon
@@ -234,7 +231,7 @@ pub(crate) fn prepare_vhost_user_net_daemon(
     (command, vunet_socket_path)
 }
 
-pub(crate) fn prepare_swtpm_daemon(tmp_dir: &TempDir) -> (std::process::Command, String) {
+pub(crate) fn prepare_swtpm_daemon(tmp_dir: &TempDir) -> (Command, String) {
     let swtpm_tpm_dir = String::from(tmp_dir.as_path().join("swtpm").to_str().unwrap());
     let swtpm_socket_path = String::from(
         tmp_dir
@@ -244,7 +241,7 @@ pub(crate) fn prepare_swtpm_daemon(tmp_dir: &TempDir) -> (std::process::Command,
             .to_str()
             .unwrap(),
     );
-    std::fs::create_dir(&swtpm_tpm_dir).unwrap();
+    fs::create_dir(&swtpm_tpm_dir).unwrap();
 
     let mut swtpm_command = Command::new("swtpm");
     let swtpm_args = [
@@ -298,7 +295,7 @@ pub(crate) fn resize_command(
             },
         ];
         // See: #5938
-        thread::sleep(std::time::Duration::new(1, 0));
+        thread::sleep(Duration::new(1, 0));
         assert!(check_latest_events_exact(&latest_events, event_path));
     }
 
@@ -393,7 +390,7 @@ pub(crate) fn setup_ovs_dpdk_guests(
     #[cfg(target_arch = "aarch64")]
     let guest_net_iface = "enp0s5";
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest1.wait_vm_boot().unwrap();
 
         guest1
@@ -438,7 +435,7 @@ pub(crate) fn setup_ovs_dpdk_guests(
                     .spawn()
                     .unwrap();
 
-    let r = std::panic::catch_unwind(|| {
+    let r = panic::catch_unwind(|| {
         guest2.wait_vm_boot().unwrap();
 
         guest2
@@ -660,14 +657,8 @@ pub(super) fn get_msi_interrupt_pattern() -> String {
     }
 }
 
-pub(super) type PrepareNetDaemon = dyn Fn(
-    &TempDir,
-    &str,
-    Option<&str>,
-    Option<u16>,
-    usize,
-    bool,
-) -> (std::process::Command, String);
+pub(super) type PrepareNetDaemon =
+    dyn Fn(&TempDir, &str, Option<&str>, Option<u16>, usize, bool) -> (Command, String);
 
 pub(super) fn get_ksm_pages_shared() -> u32 {
     fs::read_to_string("/sys/kernel/mm/ksm/pages_shared")
@@ -778,7 +769,7 @@ pub(crate) fn get_counters(api_socket: &str) -> Counters {
     }
 }
 
-pub(super) fn pty_read(mut pty: std::fs::File) -> Receiver<String> {
+pub(super) fn pty_read(mut pty: fs::File) -> Receiver<String> {
     let (tx, rx) = mpsc::channel::<String>();
     thread::spawn(move || {
         loop {
@@ -881,8 +872,8 @@ pub(crate) fn make_virtio_block_guest(factory: &GuestFactory, image_name: &str) 
 }
 
 pub(crate) fn compute_backing_checksum(
-    path_or_image_name: impl AsRef<std::path::Path>,
-) -> Option<(std::path::PathBuf, String, u32)> {
+    path_or_image_name: impl AsRef<Path>,
+) -> Option<(PathBuf, String, u32)> {
     let path = resolve_disk_path(path_or_image_name);
 
     let mut file = File::open(&path).ok()?;
@@ -896,11 +887,11 @@ pub(crate) fn compute_backing_checksum(
     let info = get_image_info(&path)?;
 
     let backing_file = info["backing-filename"].as_str()?;
-    let backing_path = if std::path::Path::new(backing_file).is_absolute() {
-        std::path::PathBuf::from(backing_file)
+    let backing_path = if Path::new(backing_file).is_absolute() {
+        PathBuf::from(backing_file)
     } else {
         path.parent()
-            .unwrap_or_else(|| std::path::Path::new("."))
+            .unwrap_or_else(|| Path::new("."))
             .join(backing_file)
     };
 
@@ -928,8 +919,8 @@ pub(crate) fn compute_backing_checksum(
 ///
 /// For QCOW2 v3 images, also verifies the dirty bit is cleared.
 pub(crate) fn disk_check_consistency(
-    path_or_image_name: impl AsRef<std::path::Path>,
-    initial_backing_checksum: Option<(std::path::PathBuf, String, u32)>,
+    path_or_image_name: impl AsRef<Path>,
+    initial_backing_checksum: Option<(PathBuf, String, u32)>,
 ) {
     let path = resolve_disk_path(path_or_image_name);
     let output = run_qemu_img(&path, &["check"], None);
@@ -968,12 +959,8 @@ pub(crate) fn disk_check_consistency(
     }
 }
 
-pub(crate) fn run_qemu_img(
-    path: &std::path::Path,
-    args: &[&str],
-    trailing_args: Option<&[&str]>,
-) -> std::process::Output {
-    let mut cmd = std::process::Command::new("qemu-img");
+pub(crate) fn run_qemu_img(path: &Path, args: &[&str], trailing_args: Option<&[&str]>) -> Output {
+    let mut cmd = Command::new("qemu-img");
     cmd.arg(args[0])
         .args(&args[1..])
         .arg(path.to_str().unwrap());
@@ -983,7 +970,7 @@ pub(crate) fn run_qemu_img(
     cmd.output().unwrap()
 }
 
-fn get_image_info(path: &std::path::Path) -> Option<serde_json::Value> {
+fn get_image_info(path: &Path) -> Option<serde_json::Value> {
     let output = run_qemu_img(path, &["info", "-U", "--output=json"], None);
 
     output.status.success().then_some(())?;
@@ -1032,7 +1019,7 @@ pub(crate) fn set_corrupt_flag(path: &Path, corrupt: bool) -> io::Result<()> {
     Ok(())
 }
 
-fn resolve_disk_path(path_or_image_name: impl AsRef<std::path::Path>) -> std::path::PathBuf {
+fn resolve_disk_path(path_or_image_name: impl AsRef<Path>) -> PathBuf {
     if path_or_image_name.as_ref().exists() {
         // A full path is provided
         path_or_image_name.as_ref().to_path_buf()
@@ -1044,7 +1031,7 @@ fn resolve_disk_path(path_or_image_name: impl AsRef<std::path::Path>) -> std::pa
     }
 }
 
-pub(crate) fn compute_file_checksum(reader: &mut dyn std::io::Read, size: u64) -> u32 {
+pub(crate) fn compute_file_checksum(reader: &mut dyn io::Read, size: u64) -> u32 {
     // Read first 16MB or entire data if smaller
     let read_size = cmp::min(size, 16 * 1024 * 1024) as usize;
 
@@ -1143,7 +1130,7 @@ pub(crate) fn start_live_migration(
         .spawn()
         .unwrap();
     // Give it '1s' to make sure the 'migration_socket' file is properly created
-    thread::sleep(std::time::Duration::new(1, 0));
+    thread::sleep(Duration::new(1, 0));
 
     if paused {
         // Test the migration of a paused VM.
@@ -1174,7 +1161,7 @@ pub(crate) fn start_live_migration(
 
     // The 'send-migration' command should be executed successfully within the given timeout
     let send_success = if let Some(status) = send_migration
-        .wait_timeout(std::time::Duration::from_secs(30))
+        .wait_timeout(Duration::from_secs(30))
         .unwrap()
     {
         status.success()
@@ -1196,7 +1183,7 @@ pub(crate) fn start_live_migration(
 
     // The 'receive-migration' command should be executed successfully within the given timeout
     let receive_success = if let Some(status) = receive_migration
-        .wait_timeout(std::time::Duration::from_secs(30))
+        .wait_timeout(Duration::from_secs(30))
         .unwrap()
     {
         status.success()

--- a/cloud-hypervisor/tests/integration_cvm.rs
+++ b/cloud-hypervisor/tests/integration_cvm.rs
@@ -4,8 +4,6 @@
 //
 #![cfg(any(devcli_testenv, clippy))]
 #![expect(clippy::undocumented_unsafe_blocks)]
-// TODO: Trim qualified paths in this crate, then drop this expectation.
-#![expect(clippy::absolute_paths)]
 // When enabling the `mshv` feature, we skip quite some tests and
 // hence have known dead-code. This annotation silences dead-code
 // related warnings for our quality workflow to pass.


### PR DESCRIPTION
Part of #7670.

Trim the fully-qualified absolute paths in the integration-test support code (`tests/common/utils.rs` and `tests/common/tests_wrappers.rs`, shared via `mod common;`) down to imported modules/items, and drop the now-unnecessary crate-level `#![expect(clippy::absolute_paths)]` from `tests/integration_cvm.rs`. Pure refactor — no behavioural change.

`integration_cvm.rs` itself had no qualified-path sites (it's all test-wrapper calls); the work is in the shared `common/` helpers. Trim style matches the existing convention in those files (bare `Command`/`Path`/`Duration`, `fs::`/`panic::`/`io::` keep the module cue).

`tests/integration.rs` keeps its own `#![expect]` for now — it still has many untrimmed sites of its own and will be a separate follow-up.

Verified with `cargo +nightly fmt` and `cargo clippy --all --all-targets --tests --examples -- -D warnings` on both aarch64 and x86_64 across the feature matrix.