### PR TITLE
block: Remove redundant BlockBackend trait

### DIFF
--- a/block/src/aligned_file.rs
+++ b/block/src/aligned_file.rs
@@ -7,14 +7,13 @@ use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::fs::FileExt;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::result;
 
 use vmm_sys_util::file_traits::FileSync;
 use vmm_sys_util::seek_hole::SeekHole;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
 use crate::aligned_buffer::AlignedBuffer;
-use crate::{BlockBackend, SECTOR_SIZE, probe_direct_alignment, query_device_size};
+use crate::{SECTOR_SIZE, probe_direct_alignment, query_device_size};
 
 /// True when `buf_ptr`/`len`/`offset` already satisfy `alignment`
 /// (`alignment == 0` means no O_DIRECT, so everything is "aligned").
@@ -222,20 +221,6 @@ impl SeekHole for AlignedFile {
             }
             Err(e) => Err(e),
         }
-    }
-}
-
-impl BlockBackend for AlignedFile {
-    fn logical_size(&self) -> result::Result<u64, crate::Error> {
-        Ok(query_device_size(&self.file)
-            .map_err(crate::Error::RawFileError)?
-            .0)
-    }
-
-    fn physical_size(&self) -> result::Result<u64, crate::Error> {
-        Ok(query_device_size(&self.file)
-            .map_err(crate::Error::RawFileError)?
-            .1)
     }
 }
 

--- a/block/src/formats/vhd/internal/fixed.rs
+++ b/block/src/formats/vhd/internal/fixed.rs
@@ -3,17 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs::File;
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use super::footer::VhdFooter;
-use crate::BlockBackend;
 
 #[derive(Debug)]
 pub struct FixedVhd {
     file: File,
     size: u64,
-    position: u64,
 }
 
 impl FixedVhd {
@@ -23,7 +21,6 @@ impl FixedVhd {
         Ok(Self {
             file,
             size: footer.current_size(),
-            position: 0,
         })
     }
 
@@ -38,53 +35,13 @@ impl AsRawFd for FixedVhd {
     }
 }
 
-impl Read for FixedVhd {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match self.file.read(buf) {
-            Ok(r) => {
-                self.position = self.position.checked_add(r.try_into().unwrap()).unwrap();
-                Ok(r)
-            }
-            Err(e) => Err(e),
-        }
-    }
-}
-
-impl Write for FixedVhd {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match self.file.write(buf) {
-            Ok(r) => {
-                self.position = self.position.checked_add(r.try_into().unwrap()).unwrap();
-                Ok(r)
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.file.sync_all()
-    }
-}
-
-impl Seek for FixedVhd {
-    fn seek(&mut self, newpos: SeekFrom) -> io::Result<u64> {
-        match self.file.seek(newpos) {
-            Ok(pos) => {
-                self.position = pos;
-                Ok(pos)
-            }
-            Err(e) => Err(e),
-        }
-    }
-}
-
-impl BlockBackend for FixedVhd {
-    fn logical_size(&self) -> Result<u64, crate::Error> {
+impl FixedVhd {
+    pub(crate) fn logical_size(&self) -> Result<u64, crate::Error> {
         Ok(self.size)
     }
 
     /// Returns the physical size of the underlying file.
-    fn physical_size(&self) -> Result<u64, crate::Error> {
+    pub(crate) fn physical_size(&self) -> Result<u64, crate::Error> {
         self.file
             .metadata()
             .map(|m| m.len())
@@ -97,7 +54,6 @@ impl Clone for FixedVhd {
         Self {
             file: self.file.try_clone().expect("FixedVhd cloning failed"),
             size: self.size,
-            position: self.position,
         }
     }
 }

--- a/block/src/formats/vhd/mod.rs
+++ b/block/src/formats/vhd/mod.rs
@@ -26,7 +26,7 @@ use self::worker::sync::FixedVhdSync;
 use crate::async_io::{AsyncIo, BorrowedDiskFd, DiskFileError};
 use crate::disk_file::DiskSize;
 use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
-use crate::{AlignedFile, BlockBackend, DiskTopology, Error, disk_file};
+use crate::{AlignedFile, DiskTopology, Error, disk_file};
 
 #[derive(Debug)]
 pub struct VhdDisk {

--- a/block/src/formats/vhdx/internal/mod.rs
+++ b/block/src/formats/vhdx/internal/mod.rs
@@ -19,7 +19,6 @@ use self::bat::{BatEntry, VhdxBatError};
 use self::header::{RegionInfo, RegionTableEntry, VhdxHeader, VhdxHeaderError};
 use self::io::VhdxIoError;
 use self::metadata::{DiskSpec, VhdxMetadataError};
-use crate::BlockBackend;
 use crate::aligned_file::AlignedFile;
 
 mod bat;
@@ -207,12 +206,8 @@ impl Seek for Vhdx {
     }
 }
 
-impl BlockBackend for Vhdx {
-    fn logical_size(&self) -> result::Result<u64, crate::Error> {
-        Ok(self.virtual_disk_size())
-    }
-
-    fn physical_size(&self) -> result::Result<u64, crate::Error> {
+impl Vhdx {
+    pub(crate) fn physical_size(&self) -> result::Result<u64, crate::Error> {
         self.aligned
             .file()
             .metadata()

--- a/block/src/formats/vhdx/mod.rs
+++ b/block/src/formats/vhdx/mod.rs
@@ -22,7 +22,7 @@ pub use internal::{Vhdx, VhdxError};
 use self::worker::sync::VhdxSync;
 use crate::async_io::{AsyncIo, BorrowedDiskFd, DiskFileError};
 use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
-use crate::{BlockBackend, Error, disk_file};
+use crate::{Error, disk_file};
 
 #[derive(Debug)]
 pub struct VhdxDisk {

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -21,7 +21,7 @@ mod sparse;
 use std::alloc::{Layout, alloc_zeroed};
 use std::fmt::{self, Debug};
 use std::fs::{File, OpenOptions};
-use std::io::{self, Read, Seek, Write};
+use std::io::{self, Read};
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::fs::FileTypeExt;
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -75,8 +75,6 @@ pub enum Error {
     InvalidOffset,
     #[error("Failure in qcow")]
     QcowError(#[source] qcow::Error),
-    #[error("Failure in raw file")]
-    RawFileError(#[source] io::Error),
     #[error("The requested operation does not support multiple descriptors")]
     TooManyDescriptors,
     #[error("Request contains too many segments ({0}, max {MAX_DISCARD_WRITE_ZEROES_SEG})")]
@@ -576,17 +574,6 @@ pub fn detect_image_type(f: &mut File) -> BlockResult<ImageType> {
     };
 
     Ok(image_type)
-}
-
-pub trait BlockBackend: Read + Write + Seek + Send + Debug {
-    /// Returns the logical disk size a guest will see.
-    ///
-    /// For raw formats, this is equal to [`Self::physical_size`]. For file formats
-    /// that wrap disk images in a container (e.g. QCOW2), this refers to the
-    /// effective size that the guest will see.
-    fn logical_size(&self) -> Result<u64, Error>;
-    /// Returns the physical size of the underlying file.
-    fn physical_size(&self) -> Result<u64, Error>;
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
`BlockBackend` predated the `disk_file` trait family and only carried `logical_size` and `physical_size`, which the disk backends expose through the `disk_file` traits `DiskSize` and `PhysicalSize`.

It added no polymorphism while its `Read`, `Write` and `Seek` supertraits forced an unused cursor. Dropping the trait removes the dead code it was keeping alive.