### PR TITLE
Silence some log messages (info! to debug!)

### DIFF
--- a/virtio-devices/src/epoll_helper.rs
+++ b/virtio-devices/src/epoll_helper.rs
@@ -14,7 +14,7 @@ use std::sync::Barrier;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{io, result, thread};
 
-use log::info;
+use log::debug;
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -212,11 +212,11 @@ impl EpollHelper {
 
                 match ev_type {
                     EPOLL_HELPER_EVENT_KILL => {
-                        info!("KILL_EVENT received, stopping epoll loop");
+                        debug!("KILL_EVENT received, stopping epoll loop");
                         return Ok(());
                     }
                     EPOLL_HELPER_EVENT_PAUSE => {
-                        info!("PAUSE_EVENT received, pausing epoll loop");
+                        debug!("PAUSE_EVENT received, pausing epoll loop");
 
                         // Acknowledge the pause is effective by using the
                         // paused_sync barrier.
@@ -284,11 +284,11 @@ impl EpollHelper {
 
                 match ev_type {
                     EPOLL_HELPER_EVENT_KILL => {
-                        info!("KILL_EVENT received, stopping epoll loop");
+                        debug!("KILL_EVENT received, stopping epoll loop");
                         return Ok(());
                     }
                     EPOLL_HELPER_EVENT_PAUSE => {
-                        info!("PAUSE_EVENT received, pausing epoll loop");
+                        debug!("PAUSE_EVENT received, pausing epoll loop");
 
                         // Acknowledge the pause is effective by using the
                         // paused_sync barrier.

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -290,7 +290,7 @@ impl NetEpollHandler {
         {
             helper.add_event(self.net.tap.as_raw_fd(), RX_TAP_EVENT)?;
             self.net.rx_tap_listening = true;
-            info!("Listener registered at start");
+            debug!("Listener registered at start");
         }
 
         // The NetQueuePair needs the epoll fd.

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -58,12 +58,7 @@ use hypervisor::{CpuState, HypervisorCpuError, VmExit, VmOps};
 use libc::{c_void, siginfo_t};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use linux_loader::elf::Elf64_Nhdr;
-#[cfg(any(
-    target_arch = "aarch64",
-    all(target_arch = "x86_64", feature = "guest_debug")
-))]
-use log::debug;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use seccompiler::{SeccompAction, apply_filter};
 use thiserror::Error;
 use tracer::trace_scoped;
@@ -979,7 +974,7 @@ impl CpuManager {
         cpu_id: u32,
         snapshot: Option<&Snapshot>,
     ) -> Result<Arc<Mutex<Vcpu>>> {
-        info!("Creating vCPU: cpu_id = {cpu_id}");
+        debug!("Creating vCPU: cpu_id = {cpu_id}");
 
         #[cfg(target_arch = "x86_64")]
         let topology = self.get_vcpu_topology();
@@ -1229,7 +1224,7 @@ impl CpuManager {
         #[cfg(target_arch = "x86_64")]
         let interrupt_controller_clone = self.interrupt_controller.as_ref().cloned();
 
-        info!("Starting vCPU: cpu_id = {vcpu_id}");
+        debug!("Starting vCPU: cpu_id = {vcpu_id}");
 
         let handle = Some(
             thread::Builder::new()

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -585,7 +585,6 @@ impl SendAdditionalConnections {
         worker_error: &AtomicBool,
         notify_tx: &Sender<SendMemoryThreadNotify>,
     ) -> Result<(), MigratableError> {
-        info!("Spawned thread to send VM memory.");
         loop {
             // Every memory sending thread receives messages from the main thread through this
             // channel. The lock is necessary to synchronize the multiple consumers. If the


### PR DESCRIPTION
We have larger cloud deployments and analyzed the logs. Let's silence
some messages that generally provide little value on the `info!` level.

I think the changes should be fairly uncontroversial.
