### PR TITLE
misc: use prelude size_of

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -21,7 +21,6 @@ mod mptable;
 mod smbios;
 
 use std::arch::x86_64;
-use std::mem;
 
 use helpers::{deserialize_u32_hex, serialize_u32_hex};
 use hypervisor::arch::x86::{CPUID_FLAG_VALID_INDEX, CpuIdEntry};
@@ -1259,7 +1258,7 @@ fn configure_pvh(
     guest_mem
         .checked_offset(
             memmap_start_addr,
-            mem::size_of::<hvm_memmap_table_entry>() * start_info.memmap_entries as usize,
+            size_of::<hvm_memmap_table_entry>() * start_info.memmap_entries as usize,
         )
         .ok_or(super::Error::MemmapTablePastRamEnd)?;
 
@@ -1269,7 +1268,7 @@ fn configure_pvh(
             .write_obj(memmap_entry, memmap_start_addr)
             .map_err(super::Error::MemmapTableSetup)?;
         memmap_start_addr =
-            memmap_start_addr.unchecked_add(mem::size_of::<hvm_memmap_table_entry>() as u64);
+            memmap_start_addr.unchecked_add(size_of::<hvm_memmap_table_entry>() as u64);
     }
 
     // The hvm_start_info struct itself must be stored at PVH_START_INFO
@@ -1278,7 +1277,7 @@ fn configure_pvh(
     let start_info_addr = layout::PVH_INFO_START;
 
     guest_mem
-        .checked_offset(start_info_addr, mem::size_of::<hvm_start_info>())
+        .checked_offset(start_info_addr, size_of::<hvm_start_info>())
         .ok_or(super::Error::StartInfoPastRamEnd)?;
 
     // Write the start_info struct to guest memory.
@@ -1357,7 +1356,7 @@ fn configure_32bit_entry(
 
     let zero_page_addr = layout::ZERO_PAGE_START;
     guest_mem
-        .checked_offset(zero_page_addr, mem::size_of::<boot_params>())
+        .checked_offset(zero_page_addr, size_of::<boot_params>())
         .ok_or(super::Error::ZeroPagePastRamEnd)?;
     guest_mem
         .write_obj(params, zero_page_addr)

--- a/arch/src/x86_64/mpspec.rs
+++ b/arch/src/x86_64/mpspec.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
-use std::mem;
 use std::os::raw;
 
 use vm_memory::ByteValued;
@@ -33,7 +32,7 @@ pub struct mpf_intel {
     pub feature5: raw::c_uchar,
 }
 
-const _: () = assert!(mem::size_of::<mpf_intel>() == 16);
+const _: () = assert!(size_of::<mpf_intel>() == 16);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -57,10 +56,10 @@ pub struct mpc_table {
 }
 
 const _: () = {
-    assert!(mem::size_of::<mpc_table>() == 4 + 2 + 1 + 1 + 8 + 12 + 4 + 2 + 2 + 4 + 4);
-    assert!(mem::size_of::<raw::c_uint>() == 4);
-    assert!(mem::size_of::<raw::c_ushort>() == 2);
-    assert!(mem::size_of::<raw::c_uchar>() == 1);
+    assert!(size_of::<mpc_table>() == 4 + 2 + 1 + 1 + 8 + 12 + 4 + 2 + 2 + 4 + 4);
+    assert!(size_of::<raw::c_uint>() == 4);
+    assert!(size_of::<raw::c_ushort>() == 2);
+    assert!(size_of::<raw::c_uchar>() == 1);
 };
 
 // SAFETY: all members of this struct are plain integers
@@ -81,7 +80,7 @@ pub struct mpc_cpu {
     pub reserved: [raw::c_uint; 2usize],
 }
 
-const _: () = assert!(mem::size_of::<mpc_cpu>() == 20);
+const _: () = assert!(size_of::<mpc_cpu>() == 20);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -96,7 +95,7 @@ pub struct mpc_bus {
     pub bustype: [raw::c_uchar; 6usize],
 }
 
-const _: () = assert!(mem::size_of::<mpc_bus>() == 8);
+const _: () = assert!(size_of::<mpc_bus>() == 8);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -113,7 +112,7 @@ pub struct mpc_ioapic {
     pub apicaddr: raw::c_uint,
 }
 
-const _: () = assert!(mem::size_of::<mpc_ioapic>() == 8);
+const _: () = assert!(size_of::<mpc_ioapic>() == 8);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -132,7 +131,7 @@ pub struct mpc_intsrc {
     pub dstirq: raw::c_uchar,
 }
 
-const _: () = assert!(mem::size_of::<mpc_intsrc>() == 8);
+const _: () = assert!(size_of::<mpc_intsrc>() == 8);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -155,7 +154,7 @@ pub struct mpc_lintsrc {
     pub destapiclint: raw::c_uchar,
 }
 
-const _: () = assert!(mem::size_of::<mpc_lintsrc>() == 8);
+const _: () = assert!(size_of::<mpc_lintsrc>() == 8);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there
@@ -172,7 +171,7 @@ pub struct mpc_oemtable {
     pub mpc: [raw::c_uchar; 8usize],
 }
 
-const _: () = assert!(mem::size_of::<mpc_oemtable>() == 16);
+const _: () = assert!(size_of::<mpc_oemtable>() == 16);
 // SAFETY: all members of this struct are plain integers
 // and the sum of their sizes is the size of the struct, so
 // padding and reserved values are not possible as there

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
-use std::{mem, result, slice};
+use std::{result, slice};
 
 use libc::c_uchar;
 use log::{info, warn};
@@ -103,7 +103,7 @@ const CPU_FEATURE_FPU: u32 = 0x001;
 fn compute_checksum<T: Copy + ByteValued>(v: &T) -> u8 {
     let v: *const T = v;
     // SAFETY: we are only reading the bytes within the size of the `T` reference `v`.
-    let v_slice = unsafe { slice::from_raw_parts(v.cast(), mem::size_of::<T>()) };
+    let v_slice = unsafe { slice::from_raw_parts(v.cast(), size_of::<T>()) };
     let mut checksum: u8 = 0;
     for i in v_slice.iter() {
         checksum = checksum.wrapping_add(*i);
@@ -117,13 +117,13 @@ fn mpf_intel_compute_checksum(v: &mpspec::mpf_intel) -> u8 {
 }
 
 fn compute_mp_size(num_cpus: u32) -> usize {
-    mem::size_of::<MpfIntelWrapper>()
-        + mem::size_of::<MpcTableWrapper>()
-        + mem::size_of::<MpcCpuWrapper>() * (num_cpus as usize)
-        + mem::size_of::<MpcIoapicWrapper>()
-        + mem::size_of::<MpcBusWrapper>()
-        + mem::size_of::<MpcIntsrcWrapper>() * 16
-        + mem::size_of::<MpcLintsrcWrapper>() * 2
+    size_of::<MpfIntelWrapper>()
+        + size_of::<MpcTableWrapper>()
+        + size_of::<MpcCpuWrapper>() * (num_cpus as usize)
+        + size_of::<MpcIoapicWrapper>()
+        + size_of::<MpcBusWrapper>()
+        + size_of::<MpcIntsrcWrapper>() * 16
+        + size_of::<MpcLintsrcWrapper>() * 2
 }
 
 /// Performs setup of the MP table for the given `num_cpus`.
@@ -170,7 +170,7 @@ pub fn setup_mptable(
 
     {
         let mut mpf_intel = MpfIntelWrapper(mpspec::mpf_intel::default());
-        let size = mem::size_of::<MpfIntelWrapper>() as u64;
+        let size = size_of::<MpfIntelWrapper>() as u64;
         mpf_intel.0.signature = *SMP_MAGIC_IDENT;
         mpf_intel.0.length = 1;
         mpf_intel.0.specification = 4;
@@ -184,10 +184,10 @@ pub fn setup_mptable(
     // We set the location of the mpc_table here but we can't fill it out until we have the length
     // of the entire table later.
     let table_base = base_mp;
-    base_mp = base_mp.unchecked_add(mem::size_of::<MpcTableWrapper>() as u64);
+    base_mp = base_mp.unchecked_add(size_of::<MpcTableWrapper>() as u64);
 
     {
-        let size = mem::size_of::<MpcCpuWrapper>();
+        let size = size_of::<MpcCpuWrapper>();
         for cpu_id in 0..num_cpus {
             let mut mpc_cpu = MpcCpuWrapper(mpspec::mpc_cpu::default());
             mpc_cpu.0.type_ = mpspec::MP_PROCESSOR as u8;
@@ -208,7 +208,7 @@ pub fn setup_mptable(
         }
     }
     {
-        let size = mem::size_of::<MpcBusWrapper>();
+        let size = size_of::<MpcBusWrapper>();
         let mut mpc_bus = MpcBusWrapper(mpspec::mpc_bus::default());
         mpc_bus.0.type_ = mpspec::MP_BUS as u8;
         mpc_bus.0.busid = 0;
@@ -219,7 +219,7 @@ pub fn setup_mptable(
         checksum = checksum.wrapping_add(compute_checksum(&mpc_bus.0));
     }
     {
-        let size = mem::size_of::<MpcIoapicWrapper>();
+        let size = size_of::<MpcIoapicWrapper>();
         let mut mpc_ioapic = MpcIoapicWrapper(mpspec::mpc_ioapic::default());
         mpc_ioapic.0.type_ = mpspec::MP_IOAPIC as u8;
         mpc_ioapic.0.apicid = ioapicid;
@@ -233,7 +233,7 @@ pub fn setup_mptable(
     }
     // Per kvm_setup_default_irq_routing() in kernel
     for i in 0..16 {
-        let size = mem::size_of::<MpcIntsrcWrapper>();
+        let size = size_of::<MpcIntsrcWrapper>();
         let mut mpc_intsrc = MpcIntsrcWrapper(mpspec::mpc_intsrc::default());
         mpc_intsrc.0.type_ = mpspec::MP_INTSRC as u8;
         mpc_intsrc.0.irqtype = mpspec::MP_IRQ_SOURCE_TYPES_MP_INT as u8;
@@ -248,7 +248,7 @@ pub fn setup_mptable(
         checksum = checksum.wrapping_add(compute_checksum(&mpc_intsrc.0));
     }
     {
-        let size = mem::size_of::<MpcLintsrcWrapper>();
+        let size = size_of::<MpcLintsrcWrapper>();
         let mut mpc_lintsrc = MpcLintsrcWrapper(mpspec::mpc_lintsrc::default());
         mpc_lintsrc.0.type_ = mpspec::MP_LINTSRC as u8;
         mpc_lintsrc.0.irqtype = mpspec::MP_IRQ_SOURCE_TYPES_MP_EXT_INT as u8;
@@ -263,7 +263,7 @@ pub fn setup_mptable(
         checksum = checksum.wrapping_add(compute_checksum(&mpc_lintsrc.0));
     }
     {
-        let size = mem::size_of::<MpcLintsrcWrapper>();
+        let size = size_of::<MpcLintsrcWrapper>();
         let mut mpc_lintsrc = MpcLintsrcWrapper(mpspec::mpc_lintsrc::default());
         mpc_lintsrc.0.type_ = mpspec::MP_LINTSRC as u8;
         mpc_lintsrc.0.irqtype = mpspec::MP_IRQ_SOURCE_TYPES_MP_NMI as u8;
@@ -308,11 +308,11 @@ mod unit_tests {
 
     fn table_entry_size(type_: u8) -> usize {
         match type_ as u32 {
-            mpspec::MP_PROCESSOR => mem::size_of::<MpcCpuWrapper>(),
-            mpspec::MP_BUS => mem::size_of::<MpcBusWrapper>(),
-            mpspec::MP_IOAPIC => mem::size_of::<MpcIoapicWrapper>(),
-            mpspec::MP_INTSRC => mem::size_of::<MpcIntsrcWrapper>(),
-            mpspec::MP_LINTSRC => mem::size_of::<MpcLintsrcWrapper>(),
+            mpspec::MP_PROCESSOR => size_of::<MpcCpuWrapper>(),
+            mpspec::MP_BUS => size_of::<MpcBusWrapper>(),
+            mpspec::MP_IOAPIC => size_of::<MpcIoapicWrapper>(),
+            mpspec::MP_INTSRC => size_of::<MpcIntsrcWrapper>(),
+            mpspec::MP_LINTSRC => size_of::<MpcLintsrcWrapper>(),
             _ => panic!("unrecognized mpc table entry type: {type_}"),
         }
     }
@@ -405,7 +405,7 @@ mod unit_tests {
                 .unwrap();
 
             let mut entry_offset = mpc_offset
-                .checked_add(mem::size_of::<MpcTableWrapper>() as GuestUsize)
+                .checked_add(size_of::<MpcTableWrapper>() as GuestUsize)
                 .unwrap();
             let mut cpu_count = 0;
             while entry_offset < mpc_end {

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -6,7 +6,7 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
-use std::{mem, result};
+use std::result;
 
 use hypervisor::arch::x86::gdt::{gdt_entry, segment_from_gdt};
 use hypervisor::arch::x86::regs::CR0_PE;
@@ -134,7 +134,7 @@ fn write_gdt_table(table: &[u64], guest_mem: &GuestMemoryMmap) -> Result<()> {
     let boot_gdt_addr = BOOT_GDT_START;
     for (index, entry) in table.iter().enumerate() {
         let addr = guest_mem
-            .checked_offset(boot_gdt_addr, index * mem::size_of::<u64>())
+            .checked_offset(boot_gdt_addr, index * size_of::<u64>())
             .ok_or(Error::CheckGdtAddr)?;
         guest_mem.write_obj(*entry, addr).map_err(Error::WriteGdt)?;
     }
@@ -170,11 +170,11 @@ pub fn configure_segments_and_sregs(
     // Write segments
     write_gdt_table(&gdt_table[..], mem)?;
     sregs.gdt.base = BOOT_GDT_START.raw_value();
-    sregs.gdt.limit = mem::size_of_val(&gdt_table) as u16 - 1;
+    sregs.gdt.limit = size_of_val(&gdt_table) as u16 - 1;
 
     write_idt_value(0, mem)?;
     sregs.idt.base = BOOT_IDT_START.raw_value();
-    sregs.idt.limit = mem::size_of::<u64>() as u16 - 1;
+    sregs.idt.limit = size_of::<u64>() as u16 - 1;
 
     sregs.cs = code_seg;
     sregs.ds = data_seg;

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::{mem, result, slice};
+use std::{result, slice};
 
 use thiserror::Error;
 use uuid::Uuid;
@@ -90,7 +90,7 @@ impl SmbiosConfig {
 fn compute_checksum<T: Copy>(v: &T) -> u8 {
     let v: *const T = v;
     // SAFETY: we are only reading the bytes within the size of the `T` reference `v`.
-    let v_slice = unsafe { slice::from_raw_parts(v.cast(), mem::size_of::<T>()) };
+    let v_slice = unsafe { slice::from_raw_parts(v.cast(), size_of::<T>()) };
     let mut checksum: u8 = 0;
     for i in v_slice.iter() {
         checksum = checksum.wrapping_add(*i);
@@ -209,7 +209,7 @@ fn write_and_incr<T: ByteValued>(
 ) -> Result<GuestAddress> {
     mem.write_obj(val, curptr).map_err(Error::WriteData)?;
     curptr = curptr
-        .checked_add(mem::size_of::<T>() as u64)
+        .checked_add(size_of::<T>() as u64)
         .ok_or(Error::NotEnoughMemory)?;
     Ok(curptr)
 }
@@ -310,7 +310,7 @@ fn write_type1_system(
 
     let sys = SmbiosSysInfo {
         r#type: SYSTEM_INFORMATION,
-        length: mem::size_of::<SmbiosSysInfo>() as u8,
+        length: size_of::<SmbiosSysInfo>() as u8,
         handle: *handle,
         manufacturer: manufacturer_idx,
         product_name: product_idx,
@@ -347,7 +347,7 @@ fn write_type3_chassis(
 
     let ch = SmbiosChassis {
         r#type: SYSTEM_ENCLOSURE,
-        length: mem::size_of::<SmbiosChassis>() as u8,
+        length: size_of::<SmbiosChassis>() as u8,
         handle: *handle,
         manufacturer: 0,
         chassis_type: CHASSIS_TYPE_UNKNOWN,
@@ -374,7 +374,7 @@ pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Res
     let chassis = smbios.and_then(|cfg| cfg.chassis.as_ref());
     let oem_strings: &[String] = smbios.map_or(&[], |cfg| &cfg.oem_strings);
     let physptr = GuestAddress(SMBIOS_START)
-        .checked_add(mem::size_of::<Smbios30Entrypoint>() as u64)
+        .checked_add(size_of::<Smbios30Entrypoint>() as u64)
         .ok_or(Error::NotEnoughMemory)?;
     let mut curptr = physptr;
     let mut handle = 0;
@@ -383,7 +383,7 @@ pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Res
         handle += 1;
         let smbios_biosinfo = SmbiosBiosInfo {
             r#type: BIOS_INFORMATION,
-            length: mem::size_of::<SmbiosBiosInfo>() as u8,
+            length: size_of::<SmbiosBiosInfo>() as u8,
             handle,
             vendor: 1,  // First string written in this section
             version: 2, // Second string written in this section
@@ -408,7 +408,7 @@ pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Res
 
         let smbios_oemstrings = SmbiosOemStrings {
             r#type: OEM_STRINGS,
-            length: mem::size_of::<SmbiosOemStrings>() as u8,
+            length: size_of::<SmbiosOemStrings>() as u8,
             handle,
             count: oem_strings.len() as u8,
         };
@@ -426,7 +426,7 @@ pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Res
         handle += 1;
         let smbios_end = SmbiosEndOfTable {
             r#type: END_OF_TABLE,
-            length: mem::size_of::<SmbiosEndOfTable>() as u8,
+            length: size_of::<SmbiosEndOfTable>() as u8,
             handle,
         };
         curptr = write_and_incr(mem, smbios_end, curptr)?;
@@ -437,7 +437,7 @@ pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Res
     {
         let mut smbios_ep = Smbios30Entrypoint {
             signature: *SM3_MAGIC_IDENT,
-            length: mem::size_of::<Smbios30Entrypoint>() as u8,
+            length: size_of::<Smbios30Entrypoint>() as u8,
             // SMBIOS rev 3.2.0
             majorver: 0x03,
             minorver: 0x02,
@@ -452,7 +452,7 @@ pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Res
             .map_err(Error::WriteSmbiosEp)?;
     }
 
-    Ok(curptr.unchecked_offset_from(physptr) + mem::size_of::<Smbios30Entrypoint>() as u64)
+    Ok(curptr.unchecked_offset_from(physptr) + size_of::<Smbios30Entrypoint>() as u64)
 }
 
 #[cfg(test)]
@@ -509,17 +509,17 @@ mod unit_tests {
     #[test]
     fn entrypoint_struct_size() {
         assert_eq!(
-            mem::size_of::<Smbios30Entrypoint>(),
+            size_of::<Smbios30Entrypoint>(),
             0x18usize,
             concat!("Size of: ", stringify!(Smbios30Entrypoint))
         );
         assert_eq!(
-            mem::size_of::<SmbiosBiosInfo>(),
+            size_of::<SmbiosBiosInfo>(),
             0x14usize,
             concat!("Size of: ", stringify!(SmbiosBiosInfo))
         );
         assert_eq!(
-            mem::size_of::<SmbiosSysInfo>(),
+            size_of::<SmbiosSysInfo>(),
             0x1busize,
             concat!("Size of: ", stringify!(SmbiosSysInfo))
         );
@@ -699,7 +699,7 @@ mod unit_tests {
     fn smbios_write_fails_with_too_small_memory() {
         let mem = GuestMemoryMmap::from_ranges(&[(
             GuestAddress(SMBIOS_START),
-            mem::size_of::<Smbios30Entrypoint>(),
+            size_of::<Smbios30Entrypoint>(),
         )])
         .unwrap();
 

--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom};
+use std::slice;
 use std::str::FromStr;
-use std::{mem, slice};
 
 use log::{debug, info};
 use thiserror::Error;
@@ -163,10 +163,7 @@ pub fn parse_tdvf_sections(file: &mut File) -> Result<(Vec<TdvfSection>, bool), 
     let mut descriptor: TdvfDescriptor = Default::default();
     // SAFETY: we read exactly the size of the descriptor header
     file.read_exact(unsafe {
-        slice::from_raw_parts_mut(
-            (&raw mut descriptor).cast(),
-            mem::size_of::<TdvfDescriptor>(),
-        )
+        slice::from_raw_parts_mut((&raw mut descriptor).cast(), size_of::<TdvfDescriptor>())
     })
     .map_err(TdvfError::ReadDescriptor)?;
 
@@ -175,8 +172,7 @@ pub fn parse_tdvf_sections(file: &mut File) -> Result<(Vec<TdvfSection>, bool), 
     }
 
     if descriptor.length as usize
-        != mem::size_of::<TdvfDescriptor>()
-            + mem::size_of::<TdvfSection>() * descriptor.num_sections as usize
+        != size_of::<TdvfDescriptor>() + size_of::<TdvfSection>() * descriptor.num_sections as usize
     {
         return Err(TdvfError::InvalidDescriptorSize);
     }
@@ -192,7 +188,7 @@ pub fn parse_tdvf_sections(file: &mut File) -> Result<(Vec<TdvfSection>, bool), 
     file.read_exact(unsafe {
         slice::from_raw_parts_mut(
             sections.as_mut_ptr().cast(),
-            descriptor.num_sections as usize * mem::size_of::<TdvfSection>(),
+            descriptor.num_sections as usize * size_of::<TdvfSection>(),
         )
     })
     .map_err(TdvfError::ReadDescriptor)?;
@@ -306,7 +302,7 @@ fn align_hob(v: u64) -> u64 {
 
 impl TdHob {
     fn update_offset<T>(&mut self) {
-        self.current_offset = align_hob(self.current_offset + mem::size_of::<T>() as u64);
+        self.current_offset = align_hob(self.current_offset + size_of::<T>() as u64);
     }
 
     pub fn start(offset: u64) -> TdHob {
@@ -323,7 +319,7 @@ impl TdHob {
         // Write end
         let end = HobHeader {
             r#type: HobType::EndOfHobList,
-            length: mem::size_of::<HobHeader>() as u16,
+            length: size_of::<HobHeader>() as u16,
             reserved: 0,
         };
         info!("Writing HOB end {:x} {:x?}", self.current_offset, end);
@@ -336,7 +332,7 @@ impl TdHob {
         let handoff = HobHandoffInfoTable {
             header: HobHeader {
                 r#type: HobType::Handoff,
-                length: mem::size_of::<HobHandoffInfoTable>() as u16,
+                length: size_of::<HobHandoffInfoTable>() as u16,
                 reserved: 0,
             },
             version: 0x9,
@@ -363,7 +359,7 @@ impl TdHob {
         let resource_descriptor = HobResourceDescriptor {
             header: HobHeader {
                 r#type: HobType::ResourceDescriptor,
-                length: mem::size_of::<HobResourceDescriptor>() as u16,
+                length: size_of::<HobResourceDescriptor>() as u16,
                 reserved: 0,
             },
             owner: EfiGuid::default(),
@@ -440,8 +436,7 @@ impl TdHob {
         // We already know the HobGuidType size is 8 bytes multiple, but we
         // need the total size to be 8 bytes multiple. That is why the ACPI
         // table size must be 8 bytes multiple as well.
-        let length =
-            mem::size_of::<HobGuidType>() as u16 + align_hob(table_content.len() as u64) as u16;
+        let length = size_of::<HobGuidType>() as u16 + align_hob(table_content.len() as u64) as u16;
         let hob_guid_type = HobGuidType {
             header: HobHeader {
                 r#type: HobType::GuidExtension,
@@ -463,7 +458,7 @@ impl TdHob {
         );
         mem.write_obj(hob_guid_type, GuestAddress(self.current_offset))
             .map_err(TdvfError::GuestMemoryWriteHob)?;
-        let current_offset = self.current_offset + mem::size_of::<HobGuidType>() as u64;
+        let current_offset = self.current_offset + size_of::<HobGuidType>() as u64;
 
         // In case the table is quite large, let's make sure we can handle
         // retrying until everything has been correctly copied.
@@ -494,7 +489,7 @@ impl TdHob {
             guid_type: HobGuidType {
                 header: HobHeader {
                     r#type: HobType::GuidExtension,
-                    length: mem::size_of::<TdPayload>() as u16,
+                    length: size_of::<TdPayload>() as u16,
                     reserved: 0,
                 },
                 // HOB_PAYLOAD_INFO_GUID

--- a/block/src/formats/qcow/internal/header.rs
+++ b/block/src/formats/qcow/internal/header.rs
@@ -10,7 +10,6 @@
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::mem::size_of;
 use std::str::FromStr;
 
 use bitflags::bitflags;

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -17,7 +17,6 @@ use std::cmp::{max, min};
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::fs::{OpenOptions, read_link};
 use std::io::{self, Seek, SeekFrom};
-use std::mem::size_of;
 use std::os::fd::AsRawFd;
 use std::path::Path;
 use std::{result, str};

--- a/block/src/formats/qcow/internal/qcow_raw_file.rs
+++ b/block/src/formats/qcow/internal/qcow_raw_file.rs
@@ -6,7 +6,6 @@
 
 use std::fmt::Debug;
 use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
-use std::mem::size_of;
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -364,14 +363,13 @@ impl AsFd for QcowRawFile {
 #[cfg(test)]
 mod unit_tests {
     use std::io::{Read, Seek, SeekFrom};
-    use std::mem;
 
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
 
     fn be_bytes(entries: &[u64]) -> Vec<u8> {
-        let mut v = Vec::with_capacity(mem::size_of_val(entries));
+        let mut v = Vec::with_capacity(size_of_val(entries));
         for e in entries {
             v.extend_from_slice(&e.to_be_bytes());
         }

--- a/block/src/formats/vhdx/internal/bat.rs
+++ b/block/src/formats/vhdx/internal/bat.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::mem::size_of;
 use std::os::unix::fs::FileExt;
 use std::{io, result};
 

--- a/block/src/formats/vhdx/internal/header.rs
+++ b/block/src/formats/vhdx/internal/header.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::btree_map::BTreeMap;
-use std::mem::size_of;
 use std::os::unix::fs::FileExt;
 use std::{io, result, slice};
 

--- a/block/src/formats/vhdx/internal/metadata.rs
+++ b/block/src/formats/vhdx/internal/metadata.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::mem::size_of;
 use std::os::unix::fs::FileExt;
 use std::{io, result};
 

--- a/block/src/io/request.rs
+++ b/block/src/io/request.rs
@@ -41,7 +41,7 @@ pub const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;
 /// Maximum number of segments per DISCARD or WRITE_ZEROES request.
 pub const MAX_DISCARD_WRITE_ZEROES_SEG: u32 = 1;
 /// Size and field offsets within `struct virtio_blk_discard_write_zeroes`.
-const DISCARD_WZ_SEG_SIZE: u32 = mem::size_of::<virtio_blk_discard_write_zeroes>() as u32;
+const DISCARD_WZ_SEG_SIZE: u32 = size_of::<virtio_blk_discard_write_zeroes>() as u32;
 const DISCARD_WZ_MAX_PAYLOAD: u32 = DISCARD_WZ_SEG_SIZE * MAX_DISCARD_WRITE_ZEROES_SEG;
 const DISCARD_WZ_SECTOR_OFFSET: u64 =
     mem::offset_of!(virtio_blk_discard_write_zeroes, sector) as u64;
@@ -504,7 +504,7 @@ impl Request {
         for &(data_addr, data_len) in &self.data_descriptors {
             let _: u32 = data_len;
             const _: () = assert!(
-                mem::size_of::<u32>() <= mem::size_of::<usize>(),
+                size_of::<u32>() <= size_of::<usize>(),
                 "unsupported platform"
             );
             if data_len == 0 {

--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -6,7 +6,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::time::{Duration, Instant};
-use std::{io, mem, thread};
+use std::{io, thread};
 
 use acpi_tables::{Aml, AmlSink, aml};
 use log::{error, info, warn};
@@ -250,7 +250,7 @@ impl Default for AcpiPmTimerDevice {
 
 impl BusDevice for AcpiPmTimerDevice {
     fn read(&mut self, _base: u64, _offset: u64, data: &mut [u8]) {
-        if data.len() != mem::size_of::<u32>() {
+        if data.len() != size_of::<u32>() {
             warn!("Invalid sized read of PM timer: {}", data.len());
             return;
         }

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -9,8 +9,8 @@
 // Implementation of an intel 82093AA Input/Output Advanced Programmable Interrupt Controller
 // See https://pdos.csail.mit.edu/6.828/2016/readings/ia32/ioapic.pdf for a specification.
 
+use std::result;
 use std::sync::{Arc, Barrier};
-use std::{mem, result};
 
 use byteorder::{ByteOrder, LittleEndian};
 use log::{debug, error, trace, warn};
@@ -147,7 +147,7 @@ pub struct IoapicState {
 
 impl BusDevice for Ioapic {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
-        if data.len() != mem::size_of::<u32>() {
+        if data.len() != size_of::<u32>() {
             warn!("Invalid read size on IOAPIC: {}", data.len());
             return;
         }
@@ -167,7 +167,7 @@ impl BusDevice for Ioapic {
     }
 
     fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
-        if data.len() != mem::size_of::<u32>() {
+        if data.len() != size_of::<u32>() {
             warn!("Invalid write size on IOAPIC: {}", data.len());
             return None;
         }

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -21,7 +21,7 @@ use vm_device::BusDevice;
 
 use crate::{read_le_u32, write_le_u32};
 
-// As you can see in https://static.docs.arm.com/ddi0224/c/real_time_clock_pl031_r1p3_technical_reference_manual_DDI0224C.pdf
+// As you can see in https://developer.arm.com/documentation/ddi0224/c/
 // at section 3.2 Summary of RTC registers, the total size occupied by this device is 0x000 -> 0xFFC + 4 = 0x1000.
 // From 0x0 to 0x1C we have following registers:
 const RTCDR: u64 = 0x0; // Data Register.

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -452,7 +452,7 @@ mod unit_tests {
                     ),
                 ];
 
-                let type_size = std::mem::size_of::<$data_type>();
+                let type_size = size_of::<$data_type>();
                 for (test_val, v_arr) in &test_cases {
                     let v = *test_val as $data_type;
                     let cmp_iter: Box<dyn Iterator<Item = _>> = if $is_be {

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -48,7 +48,7 @@ bitflags! {
 macro_rules! generate_read_fn {
     ($fn_name: ident, $data_type: ty, $byte_type: ty, $type_size: expr, $endian_type: ident) => {
         pub fn $fn_name(input: &[$byte_type]) -> $data_type {
-            assert!($type_size == std::mem::size_of::<$data_type>());
+            assert!($type_size == size_of::<$data_type>());
             let mut array = [0u8; $type_size];
             for (byte, read) in array.iter_mut().zip(input.iter().cloned()) {
                 *byte = read as u8;

--- a/devices/src/pvmemcontrol.rs
+++ b/devices/src/pvmemcontrol.rs
@@ -108,8 +108,8 @@ struct PvmemcontrolTransport {
     command: PvmemcontrolTransportCommand,
 }
 
-const PVMEMCONTROL_DEVICE_MMIO_SIZE: u64 = mem::size_of::<PvmemcontrolTransport>() as u64;
-const PVMEMCONTROL_DEVICE_MMIO_ALIGN: u64 = mem::align_of::<PvmemcontrolTransport>() as u64;
+const PVMEMCONTROL_DEVICE_MMIO_SIZE: u64 = size_of::<PvmemcontrolTransport>() as u64;
+const PVMEMCONTROL_DEVICE_MMIO_ALIGN: u64 = align_of::<PvmemcontrolTransport>() as u64;
 
 impl PvmemcontrolTransport {
     fn ack() -> Self {
@@ -293,7 +293,7 @@ impl PvmemcontrolDevice {
         let buf_phys_addr = GuestAddress(buf_phys_addr.into());
         if !guest_memory.memory().check_range(
             buf_phys_addr,
-            mem::size_of::<PvmemcontrolResp>().max(mem::size_of::<PvmemcontrolReq>()),
+            size_of::<PvmemcontrolResp>().max(size_of::<PvmemcontrolReq>()),
         ) {
             warn!("guest sent invalid phys addr {:#x}", buf_phys_addr.0);
             return PvmemcontrolDevice::new(

--- a/fuzz/fuzz_targets/qcow.rs
+++ b/fuzz/fuzz_targets/qcow.rs
@@ -8,7 +8,6 @@
 use std::ffi;
 use std::fs::File;
 use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
-use std::mem::size_of;
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::sync::Arc;
 

--- a/hypervisor/src/arch/aarch64/gic.rs
+++ b/hypervisor/src/arch/aarch64/gic.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::any::Any;
-use std::{mem, result};
+use std::result;
 
 use serde::de::Error as SerdeError;
 use serde::{Deserialize, Serialize};
@@ -67,7 +67,7 @@ impl<'de> Deserialize<'de> for GicState {
         }
 
         const {
-            assert!(mem::size_of::<GicStateDefaultDeserialize>() == mem::size_of::<GicState>());
+            assert!(size_of::<GicStateDefaultDeserialize>() == size_of::<GicState>());
         };
 
         let value: serde_json::Value = Deserialize::deserialize(deserializer)?;

--- a/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
@@ -54,12 +54,12 @@ macro_rules! cmp_rm_r {
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
         ) -> Result<(), EmulationError<Exception>> {
-            let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
+            let op0_value = get_op(&insn, 0, size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
-            let op1_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
+            let op1_value = get_op(&insn, 1, size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
-            let cpazso = calc_rflags_cpazso(op0_value, op1_value, std::mem::size_of::<$bound>());
+            let cpazso = calc_rflags_cpazso(op0_value, op1_value, size_of::<$bound>());
 
             state.set_flags((state.flags() & !FLAGS_MASK) | cpazso);
 
@@ -76,12 +76,12 @@ macro_rules! cmp_r_rm {
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
         ) -> Result<(), EmulationError<Exception>> {
-            let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
+            let op0_value = get_op(&insn, 0, size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
-            let op1_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
+            let op1_value = get_op(&insn, 1, size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
-            let cpazso = calc_rflags_cpazso(op0_value, op1_value, std::mem::size_of::<$bound>());
+            let cpazso = calc_rflags_cpazso(op0_value, op1_value, size_of::<$bound>());
 
             state.set_flags((state.flags() & !FLAGS_MASK) | cpazso);
 
@@ -98,12 +98,12 @@ macro_rules! cmp_rm_imm {
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
         ) -> Result<(), EmulationError<Exception>> {
-            let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
+            let op0_value = get_op(&insn, 0, size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
-            let op1_value = get_op(&insn, 1, std::mem::size_of::<$imm>(), state, platform)
+            let op1_value = get_op(&insn, 1, size_of::<$imm>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
-            let cpazso = calc_rflags_cpazso(op0_value, op1_value, std::mem::size_of::<$bound>());
+            let cpazso = calc_rflags_cpazso(op0_value, op1_value, size_of::<$bound>());
 
             state.set_flags((state.flags() & !FLAGS_MASK) | cpazso);
 

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -22,13 +22,13 @@ macro_rules! mov_rm_r {
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
         ) -> Result<(), EmulationError<Exception>> {
-            let src_reg_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
+            let src_reg_value = get_op(&insn, 1, size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
             set_op(
                 &insn,
                 0,
-                std::mem::size_of::<$bound>(),
+                size_of::<$bound>(),
                 state,
                 platform,
                 src_reg_value,
@@ -48,18 +48,11 @@ macro_rules! mov_rm_imm {
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
         ) -> Result<(), EmulationError<Exception>> {
-            let imm = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
+            let imm = get_op(&insn, 1, size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
-            set_op(
-                &insn,
-                0,
-                std::mem::size_of::<$bound>(),
-                state,
-                platform,
-                imm,
-            )
-            .map_err(EmulationError::PlatformEmulationError)?;
+            set_op(&insn, 0, size_of::<$bound>(), state, platform, imm)
+                .map_err(EmulationError::PlatformEmulationError)?;
 
             Ok(())
         }
@@ -74,19 +67,13 @@ macro_rules! movzx {
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
         ) -> Result<(), EmulationError<Exception>> {
-            let src_value = get_op(
-                &insn,
-                1,
-                std::mem::size_of::<$src_op_size>(),
-                state,
-                platform,
-            )
-            .map_err(EmulationError::PlatformEmulationError)?;
+            let src_value = get_op(&insn, 1, size_of::<$src_op_size>(), state, platform)
+                .map_err(EmulationError::PlatformEmulationError)?;
 
             set_op(
                 &insn,
                 0,
-                std::mem::size_of::<$dest_op_size>(),
+                size_of::<$dest_op_size>(),
                 state,
                 platform,
                 src_value,
@@ -113,18 +100,11 @@ macro_rules! mov_r_imm {
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
         ) -> Result<(), EmulationError<Exception>> {
-            let imm = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
+            let imm = get_op(&insn, 1, size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
-            set_op(
-                &insn,
-                0,
-                std::mem::size_of::<$bound>(),
-                state,
-                platform,
-                imm,
-            )
-            .map_err(EmulationError::PlatformEmulationError)?;
+            set_op(&insn, 0, size_of::<$bound>(), state, platform, imm)
+                .map_err(EmulationError::PlatformEmulationError)?;
 
             Ok(())
         }

--- a/hypervisor/src/arch/x86/emulator/instructions/movs.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/movs.rs
@@ -39,7 +39,7 @@ macro_rules! movs {
                 .map_err(|e| EmulationError::InvalidOperand(anyhow!(e)))?;
 
             let backwards = string_op_backwards(state.flags());
-            let len = std::mem::size_of::<$bound>();
+            let len = size_of::<$bound>();
 
             while count > 0 {
                 let mut memory: [u8; 8] = [0; 8];

--- a/hypervisor/src/arch/x86/emulator/instructions/or.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/or.rs
@@ -20,23 +20,16 @@ macro_rules! or_rm_r {
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
         ) -> Result<(), EmulationError<Exception>> {
-            let src_reg_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
+            let src_reg_value = get_op(&insn, 1, size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
-            let dst_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
+            let dst_value = get_op(&insn, 0, size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
             let result = src_reg_value | dst_value;
 
-            set_op(
-                &insn,
-                0,
-                std::mem::size_of::<$bound>(),
-                state,
-                platform,
-                result,
-            )
-            .map_err(EmulationError::PlatformEmulationError)?;
+            set_op(&insn, 0, size_of::<$bound>(), state, platform, result)
+                .map_err(EmulationError::PlatformEmulationError)?;
 
             Ok(())
         }

--- a/hypervisor/src/arch/x86/emulator/instructions/stos.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/stos.rs
@@ -40,7 +40,7 @@ macro_rules! stos {
                 .map_err(|e| EmulationError::InvalidOperand(anyhow!(e)))?;
 
             let backwards = string_op_backwards(state.flags());
-            let len = std::mem::size_of::<$bound>();
+            let len = size_of::<$bound>();
             let rax_bytes = rax.to_le_bytes();
 
             while count > 0 {

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -53,7 +53,7 @@ macro_rules! arm64_core_reg_id {
         KVM_REG_ARM64 as u64
             | u64::from(KVM_REG_ARM_CORE)
             | $size
-            | (($offset / mem::size_of::<u32>()) as u64)
+            | (($offset / size_of::<u32>()) as u64)
     };
 }
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -36,7 +36,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 #[cfg(target_arch = "aarch64")]
 use std::time::{SystemTime, UNIX_EPOCH};
-use std::{fs, io, mem, result};
+use std::{fs, io, result};
 
 #[cfg(target_arch = "x86_64")]
 use anyhow::Context;
@@ -1108,7 +1108,7 @@ impl vm::Vm for KvmVm {
             flags |= KVM_MEM_LOG_DIRTY_PAGES;
         }
 
-        const _: () = assert!(mem::size_of::<usize>() <= mem::size_of::<u64>());
+        const _: () = assert!(size_of::<usize>() <= size_of::<u64>());
 
         // Create a per-region guest_memfd when supported.
         // Each region gets its own fd sized exactly to memory_size
@@ -1222,7 +1222,7 @@ impl vm::Vm for KvmVm {
             flags |= KVM_MEM_LOG_DIRTY_PAGES;
         }
 
-        const _: () = assert!(mem::size_of::<usize>() <= mem::size_of::<u64>());
+        const _: () = assert!(size_of::<usize>() <= size_of::<u64>());
 
         let mut region = kvm_userspace_memory_region2 {
             slot,
@@ -2022,7 +2022,7 @@ impl cpu::Vcpu for KvmVcpu {
                 .get_one_reg(arm64_core_reg_id!(KVM_REG_SIZE_U64, off), &mut bytes)
                 .map_err(|e| cpu::HypervisorCpuError::GetAarchCoreRegister(e.into()))?;
             state.regs.regs[i] = u64::from_le_bytes(bytes);
-            off += mem::size_of::<u64>();
+            off += size_of::<u64>();
         }
 
         // We are now entering the "Other register" section of the ARMv8-a architecture.
@@ -2075,7 +2075,7 @@ impl cpu::Vcpu for KvmVcpu {
                 .get_one_reg(arm64_core_reg_id!(KVM_REG_SIZE_U64, off), &mut bytes)
                 .map_err(|e| cpu::HypervisorCpuError::GetAarchCoreRegister(e.into()))?;
             state.spsr[i] = u64::from_le_bytes(bytes);
-            off += mem::size_of::<u64>();
+            off += size_of::<u64>();
         }
 
         Ok(state.into())
@@ -2177,7 +2177,7 @@ impl cpu::Vcpu for KvmVcpu {
                     &kvm_regs_state.regs.regs[i].to_le_bytes(),
                 )
                 .map_err(|e| cpu::HypervisorCpuError::SetAarchCoreRegister(e.into()))?;
-            off += mem::size_of::<u64>();
+            off += size_of::<u64>();
         }
 
         let off = offset_of!(user_pt_regs, sp);
@@ -2228,7 +2228,7 @@ impl cpu::Vcpu for KvmVcpu {
                     &kvm_regs_state.spsr[i].to_le_bytes(),
                 )
                 .map_err(|e| cpu::HypervisorCpuError::SetAarchCoreRegister(e.into()))?;
-            off += mem::size_of::<u64>();
+            off += size_of::<u64>();
         }
 
         Ok(())
@@ -3723,7 +3723,7 @@ impl KvmVcpu {
                 .get_one_reg(arm64_core_reg_id!(KVM_REG_SIZE_U128, off), &mut bytes)
                 .map_err(|e| cpu::HypervisorCpuError::GetAarchCoreRegister(e.into()))?;
             regs.fp_regs.vregs[i] = u128::from_le_bytes(bytes);
-            off += mem::size_of::<u128>();
+            off += size_of::<u128>();
         }
 
         // Floating-point Status Register
@@ -3756,7 +3756,7 @@ impl KvmVcpu {
                     &regs.fp_regs.vregs[i].to_le_bytes(),
                 )
                 .map_err(|e| cpu::HypervisorCpuError::SetAarchCoreRegister(e.into()))?;
-            off += mem::size_of::<u128>();
+            off += size_of::<u128>();
         }
 
         // Floating-point Status Register

--- a/hypervisor/src/kvm/riscv64/mod.rs
+++ b/hypervisor/src/kvm/riscv64/mod.rs
@@ -74,7 +74,7 @@ macro_rules! riscv64_reg_id {
         kvm_bindings::KVM_REG_RISCV as u64
             | u64::from($reg_type)
             | u64::from(kvm_bindings::KVM_REG_SIZE_U64)
-            | (($offset / std::mem::size_of::<u64>()) as u64)
+            | (($offset / size_of::<u64>()) as u64)
     };
 }
 

--- a/hypervisor/src/kvm/x86_64/sev.rs
+++ b/hypervisor/src/kvm/x86_64/sev.rs
@@ -291,7 +291,6 @@ impl SevFd {
 
 #[cfg(test)]
 mod tests {
-    use core::mem::size_of;
 
     use super::*;
 

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -116,7 +116,6 @@ fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
 // for `Foo`, a `Vec<Foo>` is created. Only the first element of `Vec<Foo>` would actually be used
 // as a `Foo`. The remaining memory in the `Vec<Foo>` is for `entries`, which must be contiguous
 // with `Foo`. This function is used to make the `Vec<Foo>` with enough space for `count` entries.
-use std::mem::size_of;
 pub fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
     let element_space = count * size_of::<F>();
     let vec_size_bytes = size_of::<T>() + element_space;

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -102,7 +102,7 @@ fn create_unix_socket() -> Result<net::UdpSocket> {
 }
 
 fn vnet_hdr_len() -> usize {
-    mem::size_of::<virtio_net_hdr_v1>()
+    size_of::<virtio_net_hdr_v1>()
 }
 
 pub fn register_listener(

--- a/tpm/src/emulator.rs
+++ b/tpm/src/emulator.rs
@@ -156,8 +156,7 @@ impl Emulator {
         }
         self.control_socket.set_msgfd(fds[1]);
         debug!("data fd to be configured in swtpm = {:?}", fds[1]);
-        if let Err(e) =
-            self.run_control_cmd(Commands::CmdSetDatafd, &mut res, 0, mem::size_of::<u32>())
+        if let Err(e) = self.run_control_cmd(Commands::CmdSetDatafd, &mut res, 0, size_of::<u32>())
         {
             // SAFETY: FFI calls and return values of the unsafe calls are checked
             unsafe {
@@ -199,7 +198,7 @@ impl Emulator {
                 libc::SOL_SOCKET,
                 libc::SO_RCVTIMEO,
                 (&raw const tv).cast(),
-                mem::size_of::<libc::timeval>() as u32,
+                size_of::<libc::timeval>() as u32,
             );
             if ret == -1 {
                 return Err(Error::PrepareDataFd(anyhow!(
@@ -216,12 +215,7 @@ impl Emulator {
     ///
     fn probe_caps(&mut self) -> Result<()> {
         let mut caps: u64 = 0;
-        self.run_control_cmd(
-            Commands::CmdGetCapability,
-            &mut caps,
-            0,
-            mem::size_of::<u64>(),
-        )?;
+        self.run_control_cmd(Commands::CmdGetCapability, &mut caps, 0, size_of::<u64>())?;
         self.caps = caps;
         Ok(())
     }
@@ -262,7 +256,7 @@ impl Emulator {
         debug!("Control Cmd to send : {cmd:02X?}");
 
         let cmd_no = (cmd as u32).to_be_bytes();
-        let n = mem::size_of::<u32>() + msg_len_in;
+        let n = size_of::<u32>() + msg_len_in;
 
         let converted_req = msg.ptm_to_request();
         debug!("converted request: {converted_req:02X?}");
@@ -305,7 +299,7 @@ impl Emulator {
         // 0x0A). In that case we must not block waiting for more bytes, so we
         // first read the 4-byte result code, and only read the remainder of
         // `msg_len_out` if the command succeeded.
-        let result_len = mem::size_of::<u32>();
+        let result_len = size_of::<u32>();
         self.control_socket
             .read_exact(&mut output, result_len)
             .map_err(|e| {
@@ -378,7 +372,7 @@ impl Emulator {
             Commands::CmdGetTpmEstablished,
             &mut est,
             0,
-            2 * mem::size_of::<u32>(),
+            2 * size_of::<u32>(),
         ) {
             error!("Failed to run CmdGetTpmEstablished Control Cmd. Error: {e:?}");
             return false;
@@ -394,7 +388,7 @@ impl Emulator {
     pub fn deliver_request(&mut self, cmd: &mut BackendCmd) -> Result<()> {
         // SAFETY: type "sockaddr_storage" is valid with an all-zero byte-pattern value
         let mut addr: sockaddr_storage = unsafe { mem::zeroed() };
-        let mut len = mem::size_of::<sockaddr_storage>() as socklen_t;
+        let mut len = size_of::<sockaddr_storage>() as socklen_t;
         let isselftest = is_selftest(&cmd.buffer[0..cmd.input_len]);
 
         debug!(
@@ -469,12 +463,7 @@ impl Emulator {
                 "Emulator does not implement 'Cancel Command' Capability"
             )));
         }
-        self.run_control_cmd(
-            Commands::CmdCancelTpmCmd,
-            &mut res,
-            0,
-            mem::size_of::<u32>(),
-        )?;
+        self.run_control_cmd(Commands::CmdCancelTpmCmd, &mut res, 0, size_of::<u32>())?;
         Ok(())
     }
 
@@ -487,8 +476,8 @@ impl Emulator {
         self.run_control_cmd(
             Commands::CmdSetBufferSize,
             &mut psbs,
-            mem::size_of::<u32>(),
-            4 * mem::size_of::<u32>(),
+            size_of::<u32>(),
+            4 * size_of::<u32>(),
         )?;
 
         Ok(psbs.get_bufsize() as usize)
@@ -505,8 +494,8 @@ impl Emulator {
         self.run_control_cmd(
             Commands::CmdInit,
             &mut init,
-            mem::size_of::<u32>(),
-            mem::size_of::<u32>(),
+            size_of::<u32>(),
+            size_of::<u32>(),
         )?;
 
         self.tpm2_startup_clear()?;
@@ -536,7 +525,7 @@ impl Emulator {
     fn stop_tpm(&mut self) -> Result<()> {
         let mut res: PtmResult = 0;
 
-        self.run_control_cmd(Commands::CmdStop, &mut res, 0, mem::size_of::<u32>())?;
+        self.run_control_cmd(Commands::CmdStop, &mut res, 0, size_of::<u32>())?;
 
         Ok(())
     }

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 use std::io::{self, Write};
-use std::mem::size_of;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier};

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -666,8 +666,7 @@ impl BlockEpollHandler {
         if let Some(cpuset) = cpuset.as_ref() {
             let cpuset: *const libc::cpu_set_t = cpuset;
             // SAFETY: FFI call with correct arguments
-            let ret =
-                unsafe { libc::sched_setaffinity(0, mem::size_of::<libc::cpu_set_t>(), cpuset) };
+            let ret = unsafe { libc::sched_setaffinity(0, size_of::<libc::cpu_set_t>(), cpuset) };
 
             if ret != 0 {
                 error!(
@@ -1148,7 +1147,7 @@ impl VirtioDevice for Block {
         // The "writeback" field is the only mutable field
         let writeback_offset =
             (&raw const self.config.writeback as u64) - (&raw const self.config as u64);
-        if offset != writeback_offset || data.len() != mem::size_of_val(&self.config.writeback) {
+        if offset != writeback_offset || data.len() != size_of_val(&self.config.writeback) {
             error!(
                 "Attempt to write to read-only field: offset {:x} length {}",
                 offset,

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -3,11 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::collections::BTreeMap;
-use std::mem::size_of;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex, RwLock};
-use std::{io, mem, result};
+use std::{io, result};
 
 use anyhow::anyhow;
 use event_monitor::event;
@@ -1274,7 +1273,7 @@ impl VirtioDevice for Iommu {
         // The "bypass" field is the only mutable field
         let bypass_offset =
             (&raw const self.config.bypass as u64) - (&raw const self.config as u64);
-        if offset != bypass_offset || data.len() != mem::size_of_val(&self.config.bypass) {
+        if offset != bypass_offset || data.len() != size_of_val(&self.config.bypass) {
             error!(
                 "Attempt to write to read-only field: offset {:x} length {}",
                 offset,

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
-use std::mem::size_of;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier, Mutex};

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::fs::File;
-use std::mem::size_of;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier};

--- a/virtio-devices/src/rtc.rs
+++ b/virtio-devices/src/rtc.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 
-use std::mem::size_of;
 use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::AtomicBool;

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -8,11 +8,10 @@
 
 use std::any::Any;
 use std::io::Write;
-use std::mem::size_of;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
-use std::{cmp, io, mem, result};
+use std::{cmp, io, result};
 
 use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
@@ -91,7 +90,7 @@ const VIRTIO_PCI_CAP_LEN_OFFSET: u8 = 2;
 impl VirtioPciCap {
     pub fn new(cfg_type: PciCapabilityType, pci_bar: u8, offset: u32, length: u32) -> Self {
         VirtioPciCap {
-            cap_len: (mem::size_of::<VirtioPciCap>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET,
+            cap_len: (size_of::<VirtioPciCap>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET,
             cfg_type: cfg_type as u8,
             pci_bar,
             id: 0,
@@ -131,7 +130,7 @@ impl VirtioPciNotifyCap {
     ) -> Self {
         VirtioPciNotifyCap {
             cap: VirtioPciCap {
-                cap_len: (mem::size_of::<VirtioPciNotifyCap>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET,
+                cap_len: (size_of::<VirtioPciNotifyCap>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET,
                 cfg_type: cfg_type as u8,
                 pci_bar,
                 id: 0,
@@ -168,7 +167,7 @@ impl VirtioPciCap64 {
     pub fn new(cfg_type: PciCapabilityType, pci_bar: u8, id: u8, offset: u64, length: u64) -> Self {
         VirtioPciCap64 {
             cap: VirtioPciCap {
-                cap_len: (mem::size_of::<VirtioPciCap64>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET,
+                cap_len: (size_of::<VirtioPciCap64>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET,
                 cfg_type: cfg_type as u8,
                 pci_bar,
                 id,
@@ -776,7 +775,7 @@ impl VirtioPciDevice {
             return;
         }
 
-        if offset < mem::size_of::<VirtioPciCap>() {
+        if offset < size_of::<VirtioPciCap>() {
             if let Some(end) = offset.checked_add(data_len) {
                 // This write can't fail, offset and end are checked against config_len.
                 data.write_all(&cap_slice[offset..cmp::min(end, cap_len)])
@@ -799,7 +798,7 @@ impl VirtioPciDevice {
             return None;
         }
 
-        if offset < mem::size_of::<VirtioPciCap>() {
+        if offset < size_of::<VirtioPciCap>() {
             let (_, right) = cap_slice.split_at_mut(offset);
             right[..data_len].copy_from_slice(data);
             None

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::{io, mem, result};
+use std::{io, result};
 
 use anyhow::anyhow;
 use event_monitor::event;
@@ -253,7 +253,7 @@ impl Vdpa {
                     .desc_table()
                     .translate_gpa(
                         self.common.access_platform().as_deref(),
-                        queue_size as usize * mem::size_of::<RawDescriptor>(),
+                        queue_size as usize * size_of::<RawDescriptor>(),
                     )
                     .map_err(Error::TranslateAddress)?,
                 used_ring_addr: queue

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -1,9 +1,9 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::result;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier, Mutex};
-use std::{mem, result};
 
 use block::VirtioBlockConfig;
 use log::{error, info};
@@ -138,7 +138,7 @@ impl Blk {
                 return Err(Error::BadQueueNum);
             }
 
-            let config_len = mem::size_of::<VirtioBlockConfig>();
+            let config_len = size_of::<VirtioBlockConfig>();
             let config_space: Vec<u8> = vec![0u8; config_len];
             let (_, config_space) = vu
                 .socket_handle()
@@ -237,7 +237,7 @@ impl VirtioDevice for Blk {
         // The "writeback" field is the only mutable field
         let writeback_offset =
             (&raw const self.config.writeback as u64) - (&raw const self.config as u64);
-        if offset != writeback_offset || data.len() != mem::size_of_val(&self.config.writeback) {
+        if offset != writeback_offset || data.len() != size_of_val(&self.config.writeback) {
             error!(
                 "Attempt to write to read-only field: offset {:x} length {}",
                 offset,

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -8,7 +8,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
-use std::{ffi, fs, io, mem, slice};
+use std::{ffi, fs, io, slice};
 
 use log::{error, info};
 use vhost::vhost_kern::vhost_binding::VHOST_VRING_F_LOG;
@@ -228,7 +228,7 @@ impl VhostUserHandle {
                 desc_table_addr: get_host_address_range(
                     mem,
                     GuestAddress(queue.desc_table()),
-                    actual_size * mem::size_of::<RawDescriptor>(),
+                    actual_size * size_of::<RawDescriptor>(),
                 )
                 .ok_or(Error::DescriptorTableAddress)? as u64,
                 // The used ring is {flags: u16; idx: u16; virtq_used_elem [{id: u16, len: u16}; actual_size]},

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -87,9 +87,8 @@
 //! to newer ones.
 
 use std::io::{Read, Write};
-use std::mem::size_of;
 use std::ops::RangeInclusive;
-use std::{mem, slice};
+use std::slice;
 
 use anyhow::anyhow;
 use itertools::Itertools;
@@ -577,7 +576,7 @@ impl MemoryRangeTable {
     }
 
     pub fn length(&self) -> u64 {
-        (mem::size_of::<MemoryRange>() * self.data.len()) as u64
+        (size_of::<MemoryRange>() * self.data.len()) as u64
     }
 
     pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -10,7 +10,6 @@
 
 pub mod testing {
     use std::marker::PhantomData;
-    use std::mem;
 
     use virtio_queue::desc::split::VirtqUsedElem;
     use virtio_queue::{Queue, QueueT};
@@ -62,13 +61,11 @@ pub mod testing {
         // This function returns a place in memory which holds a value of type U, and starts
         // immediately after the end of self (which is location + sizeof(T)).
         fn next_place<U>(&self) -> SomeplaceInMemory<'a, U> {
-            self.map_offset::<U>(mem::size_of::<T>() as u64)
+            self.map_offset::<U>(size_of::<T>() as u64)
         }
 
         fn end(&self) -> GuestAddress {
-            self.location
-                .checked_add(mem::size_of::<T>() as u64)
-                .unwrap()
+            self.location.checked_add(size_of::<T>() as u64).unwrap()
         }
     }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -3498,7 +3498,7 @@ mod unit_tests {
 #[cfg(test)]
 mod unit_tests {
     #[cfg(feature = "kvm")]
-    use std::{mem, mem::offset_of};
+    use std::mem::offset_of;
 
     use arch::layout;
     use hypervisor::arch::aarch64::regs::MPIDR_EL1;

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 use std::ffi::CString;
 #[cfg(feature = "kvm")]
 use std::iter;
-use std::mem::size_of;
 use std::sync::{Arc, Mutex};
 use std::{ffi, io};
 

--- a/vmm/src/sev.rs
+++ b/vmm/src/sev.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use core::mem::size_of;
 use std::ffi::CString;
 use std::fs::File;
 use std::io::{self, Cursor, Read, Seek, SeekFrom};

--- a/vmm/src/uffd.rs
+++ b/vmm/src/uffd.rs
@@ -13,11 +13,11 @@
 //! original memory mapping, so it remains compatible with VFIO device
 //! passthrough and shared-memory-backed guest RAM.
 
+use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Error, Read};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::fs::FileExt;
-use std::{fmt, mem};
 
 use vm_migration::protocol::{MemoryRange, Request, Response, Status};
 
@@ -65,7 +65,7 @@ pub(crate) struct UffdMsg {
     _pad: [u8; 8],
 }
 
-const _: () = assert!(mem::size_of::<UffdMsg>() == 32);
+const _: () = assert!(size_of::<UffdMsg>() == 32);
 
 /// Try to obtain a userfaultfd via /dev/userfaultfd (Linux 6.1+).
 ///

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -16,8 +16,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Seek, SeekFrom, Write};
-#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
-use std::mem::size_of;
 use std::num::Wrapping;
 use std::ops::Deref;
 use std::os::unix::net::UnixStream;


### PR DESCRIPTION
`size_of` is part of `std::prelude` since Rust 1.80 (along with `size_of_val`, `align_of`, `align_of_val`), and the workspace MSRV is 1.89, so qualifying it (`mem::size_of`, `std::mem::size_of`, `core::mem::size_of`) is unnecessary noise.

This converts every qualified `size_of` call-site to the bare prelude form across the workspace and drops the now-redundant `use std::mem::size_of;` imports — keeping `use std::mem;` only where it still serves non-prelude items (`transmute`, `swap`, `replace`, `take`, `zeroed`, `MaybeUninit`, `offset_of!`). `size_of` is the only one of the four prelude memory intrinsics currently used in the tree.

Pure refactor — no behavioural change. Follow-up to the `clippy::absolute_paths` cleanup (#7670), as discussed in #8444.

Verified with `cargo +nightly fmt` and `cargo clippy --all --all-targets --tests --examples -- -D warnings` on both aarch64 and x86_64 across the CI feature matrix.