### PR TITLE
Keep ReceiveAdditionalConnections maintainable (Rustdoc and Code Splitting)

### DIFF
--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -349,79 +349,14 @@ impl ReceiveAdditionalConnections {
         guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
         fault_tx: &Sender<SocketStream>,
     ) -> Result<(), MigratableError> {
-        let mut threads: Vec<thread::JoinHandle<Result<(), MigratableError>>> = Vec::new();
-        let mut first_err = loop {
-            let socket = match listener.abortable_accept(terminate_fd) {
-                Ok(socket) => socket,
-                Err(e) => break Err(e),
-            };
-            let Some(mut socket) = socket else {
-                break Ok(());
-            };
-
-            if threads.len() >= MAX_MIGRATION_CONNECTIONS as usize {
-                break Err(MigratableError::MigrateReceive(anyhow!(
-                    "Received more than {MAX_MIGRATION_CONNECTIONS} additional migration connections."
-                )));
-            }
-
-            // Read the role header with a timeout so a stalled peer can't block
-            // acceptance of other connections.
-            socket
-                .set_read_timeout(Some(Duration::from_secs(10)))
-                .map_err(MigratableError::MigrateSocket)?;
-            let role = match ConnectionRole::read_from(&mut socket) {
-                Ok(role) => role,
-                Err(e) => {
-                    warn!("Dropping connection: failed to read connection role: {e}");
-                    continue;
-                }
-            };
-            socket
-                .set_read_timeout(None)
-                .map_err(MigratableError::MigrateSocket)?;
-
-            match role {
-                ConnectionRole::Invalid => {
-                    warn!("Dropping connection: invalid connection role");
-                    continue;
-                }
-                ConnectionRole::Fault => {
-                    // Hand the fault connection to the main thread. No memory worker for it.
-                    if let Err(e) = fault_tx.send(socket) {
-                        break Err(MigratableError::MigrateReceive(anyhow!(
-                            "Failed to hand off fault connection: {e}"
-                        )));
-                    }
-                    continue;
-                }
-                ConnectionRole::PrecopyMemory => {}
-            }
-
-            let guest_memory = guest_memory.clone();
-            let terminate_fd = match terminate_fd
-                .try_clone()
-                .context("Error cloning terminate fd")
-                .map_err(MigratableError::MigrateReceive)
-            {
-                Ok(terminate_fd) => terminate_fd,
-                Err(e) => break Err(e),
-            };
-
-            match thread::Builder::new()
-                .name(format!("migrate-receive-memory-{}", threads.len()).to_owned())
-                .spawn(move || {
-                    Self::worker_receive_memory(&mut socket, &terminate_fd, &guest_memory)
-                }) {
-                Ok(t) => threads.push(t),
-                Err(e) => {
-                    error!("Error spawning receive-memory thread: {e}");
-                    break Err(MigratableError::MigrateReceive(
-                        anyhow!(e).context("Error spawning receive-memory thread"),
-                    ));
-                }
-            }
-        };
+        let mut threads = Vec::new();
+        let first_err = Self::accept_connections_loop(
+            &mut listener,
+            terminate_fd,
+            guest_memory,
+            fault_tx,
+            &mut threads,
+        );
 
         if first_err.is_err() {
             warn!("Signaling termination due to an error while accepting connections.");
@@ -430,7 +365,118 @@ impl ReceiveAdditionalConnections {
 
         info!("Stopped accepting additional connections. Cleaning up threads.");
 
-        // We only return the first error we encounter here.
+        Self::join_memory_threads(threads, first_err)
+    }
+
+    /// Runs the accept loop and spawns workers for memory connections.
+    ///
+    /// This accepts at most [`MAX_MIGRATION_CONNECTIONS`] precopy memory
+    /// connections, depending on how many additional connections the migration
+    /// sender opens. Fault connections (postcopy) are handed off to the main
+    /// migration thread and do not spawn workers.
+    fn accept_connections_loop(
+        listener: &mut ReceiveListener,
+        terminate_fd: &EventFd,
+        guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
+        fault_tx: &Sender<SocketStream>,
+        threads: &mut Vec<thread::JoinHandle<Result<(), MigratableError>>>,
+    ) -> Result<(), MigratableError> {
+        loop {
+            let socket = listener.abortable_accept(terminate_fd)?;
+            let Some(socket) = socket else {
+                return Ok(());
+            };
+
+            if threads.len() >= MAX_MIGRATION_CONNECTIONS as usize {
+                return Err(MigratableError::MigrateReceive(anyhow!(
+                    "Received more than {MAX_MIGRATION_CONNECTIONS} additional migration connections."
+                )));
+            }
+
+            let Some(socket) = Self::handle_accepted_connection(socket, fault_tx)? else {
+                continue;
+            };
+
+            let thread = Self::spawn_memory_worker(
+                socket,
+                threads.len(),
+                terminate_fd,
+                guest_memory.clone(),
+            )?;
+            threads.push(thread);
+        }
+    }
+
+    /// Classifies a newly accepted auxiliary socket.
+    ///
+    /// Returns `Some(socket)` for precopy memory connections. Invalid sockets
+    /// are dropped, and fault sockets (postcopy) are handed to the main
+    /// migration thread.
+    fn handle_accepted_connection(
+        mut socket: SocketStream,
+        fault_tx: &Sender<SocketStream>,
+    ) -> Result<Option<SocketStream>, MigratableError> {
+        // Timeout the role header so one stalled peer cannot block the accept
+        // thread from handling other connections.
+        socket
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .map_err(MigratableError::MigrateSocket)?;
+
+        let role = match ConnectionRole::read_from(&mut socket) {
+            Ok(role) => role,
+            Err(e) => {
+                warn!("Dropping connection: failed to read connection role: {e}");
+                return Ok(None);
+            }
+        };
+
+        socket
+            .set_read_timeout(None)
+            .map_err(MigratableError::MigrateSocket)?;
+
+        match role {
+            ConnectionRole::Invalid => {
+                warn!("Dropping connection: invalid connection role");
+                Ok(None)
+            }
+            ConnectionRole::Fault => {
+                fault_tx.send(socket).map_err(|e| {
+                    MigratableError::MigrateReceive(anyhow!(
+                        "Failed to hand off fault connection: {e}"
+                    ))
+                })?;
+                Ok(None)
+            }
+            ConnectionRole::PrecopyMemory => Ok(Some(socket)),
+        }
+    }
+
+    fn spawn_memory_worker(
+        mut socket: SocketStream,
+        index: usize,
+        terminate_fd: &EventFd,
+        guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
+    ) -> Result<thread::JoinHandle<Result<(), MigratableError>>, MigratableError> {
+        let terminate_fd = terminate_fd
+            .try_clone()
+            .context("Error cloning terminate fd")
+            .map_err(MigratableError::MigrateReceive)?;
+
+        thread::Builder::new()
+            .name(format!("migrate-receive-memory-{index}"))
+            .spawn(move || Self::worker_receive_memory(&mut socket, &terminate_fd, &guest_memory))
+            .map_err(|e| {
+                error!("Error spawning receive-memory thread: {e}");
+                MigratableError::MigrateReceive(
+                    anyhow!(e).context("Error spawning receive-memory thread"),
+                )
+            })
+    }
+
+    fn join_memory_threads(
+        threads: Vec<thread::JoinHandle<Result<(), MigratableError>>>,
+        mut first_err: Result<(), MigratableError>,
+    ) -> Result<(), MigratableError> {
         for thread in threads {
             let err = match thread.join() {
                 Ok(Ok(())) => None,
@@ -452,7 +498,8 @@ impl ReceiveAdditionalConnections {
         first_err
     }
 
-    // Handles a `Memory` request by writing its payload to the VM memory.
+    /// Handles a [`Command::Memory`] request by writing its payload to the VM
+    /// memory.
     fn worker_receive_memory(
         mut socket: &mut SocketStream,
         terminate_fd: &EventFd,

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -278,22 +278,32 @@ fn wait_for_readable(fd: &impl AsFd, abort_event: &impl AsRawFd) -> Result<bool,
     ))
 }
 
-/// Struct to keep track of additional connections for receiving VM migration data.
+/// Coordinates the variable number of receive side TCP connections for
+/// memory transfer and fault handling.
+///
+/// VM migration uses one main connection plus a bounded number of additional
+/// connections. A dedicated accept thread classifies each auxiliary socket by
+/// its [`ConnectionRole`]:
+///
+/// - fault sockets are handed to the main migration thread through `fault_tx`
+/// - precopy memory sockets get a worker thread that receives
+///   [`Command::Memory`] requests and writes them into guest memory.
+///
+/// The accept thread joins all memory workers before exiting when
+/// [`Self::cleanup`] is called.
 #[derive(Debug)]
 pub(crate) struct ReceiveAdditionalConnections {
-    /// This thread accepts incoming connections and spawns a new worker for
-    /// each connection that handles receiving memory.
     accept_thread: Option<thread::JoinHandle<Result<(), MigratableError>>>,
 
-    /// This fd gets signaled when the migration stops, and will then stop
-    /// the [`Self::accept_thread`].
+    /// Shared termination event for the accept thread and memory workers.
     terminate_fd: EventFd,
 }
 
 impl ReceiveAdditionalConnections {
-    /// Starts a thread to accept incoming connections and handle them. These
-    /// additional connections are used to receive additional memory regions
-    /// during VM migration.
+    /// Starts the auxiliary migration receive path.
+    ///
+    /// The caller must call [`Self::cleanup`] once migration finishes so the
+    /// accept thread and its memory workers are signaled and joined.
     pub(crate) fn new(
         listener: ReceiveListener,
         guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
@@ -322,6 +332,17 @@ impl ReceiveAdditionalConnections {
         })
     }
 
+    /// Accepts any incoming migration connections and dispatches them by
+    /// role.
+    ///
+    /// Runs on the accept thread created by [`Self::new`]. It accepts sockets
+    /// until termination is signaled, accepting/classifying a socket fails, or
+    /// the memory connection limit is exceeded.
+    ///
+    /// Each socket must send a [`ConnectionRole`] header soon after connecting.
+    /// Invalid sockets are dropped. Fault sockets are sent through `fault_tx`.
+    /// Precopy memory sockets get a worker thread that receives memory ranges
+    /// until EOF, error, or termination.
     fn accept_connections(
         mut listener: ReceiveListener,
         terminate_fd: &EventFd,

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -363,7 +363,7 @@ impl ReceiveAdditionalConnections {
             let _ = terminate_fd.write(1);
         }
 
-        info!("Stopped accepting additional connections. Cleaning up threads.");
+        debug!("Stopped accepting additional connections. Cleaning up threads.");
 
         Self::join_memory_threads(threads, first_err)
     }
@@ -512,7 +512,7 @@ impl ReceiveAdditionalConnections {
                 .context("Failed to poll fds")
                 .map_err(MigratableError::MigrateReceive)?
             {
-                info!("Got signal to tear down connection.");
+                debug!("Got signal to tear down connection.");
                 return Ok(());
             }
 


### PR DESCRIPTION
ReceiveAdditionalConnections got quite complicated, especially with the
many threads involved for precopy and the special-case of postcopy. We
therefore should add comprehensive documentation.

I tried to keep it short and concise - what remains provides high value
and improves the mental model of the code.

