### PR TITLE
treewide: trivial streamlining of inconsistent error format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,11 @@ reviewable, and compatible with the project's normal engineering constraints.
   migration implications.
 - Do not invent APIs, behavior, or requirements. If something is uncertain,
   state the uncertainty and proceed only with minimal, explicit assumptions.
+- For `thiserror`-style errors, start messages with a capital letter and keep
+  the outer `Display` text short. Put all non-`#[source]` attributes in the
+  message to improve helpfulness, but do not repeat a `#[source]` value
+  inline: Cloud Hypervisor prints the full error chain, so only include the
+  concrete failure text directly when there is no source to report.
 
 ### Safety and Domain Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,12 @@ state changes that matter in production; use `warn!` or `error!` only for
 abnormal conditions. Keep `debug!` for focused diagnostics. Please find more
 information in [`docs/logging.md`](docs/logging.md).
 
+Error messages should be sentence-style: start with a capital letter and stay
+concise. For `thiserror`-style errors, put all non-`#[source]` attributes
+(if they provide clear value) in the outer `Display` text to improve helpfulness,
+but do not repeat a `#[source]` value there because Cloud Hypervisor prints the
+full chain elsewhere.
+
 [Rust Style]: https://github.com/rust-lang/rust/tree/HEAD/src/doc/style-guide/src
 
 ## Basic Checks

--- a/block/src/formats/vhdx/internal/header.rs
+++ b/block/src/formats/vhdx/internal/header.rs
@@ -41,7 +41,7 @@ pub enum VhdxHeaderError {
     DuplicateBATEntry,
     #[error("Metadata region entry is not unique")]
     DuplicateMDREntry,
-    #[error("Checksum doesn't match for")]
+    #[error("Checksum doesn't match for {0}")]
     InvalidChecksum(String),
     #[error("Invalid entry count")]
     InvalidEntryCount,

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -55,7 +55,7 @@ use crate::request::SECTOR_SIZE;
 pub enum Error {
     #[error("Guest gave us bad memory addresses")]
     GuestMemory(#[source] GuestMemoryError),
-    #[error("Guest gave us offsets that would have overflowed a usize")]
+    #[error("Guest address {0:?} with sector offset {1} would overflow a usize")]
     CheckedOffset(GuestAddress, usize /* sector offset */),
     #[error("Guest gave us a write only descriptor that protocol says to read from")]
     UnexpectedWriteOnlyDescriptor,

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -33,7 +33,7 @@ pub enum Error {
     GetFeatures(#[source] IoError),
     #[error("Missing multiqueue support in the kernel")]
     MultiQueueKernelSupport,
-    #[error("ioctl ({0}) failed: {1}")]
+    #[error("Ioctl failed ({0})")]
     IoctlError(c_ulong, #[source] IoError),
     #[error("Failed to create a socket")]
     NetUtil(#[source] NetUtilError),

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -22,10 +22,10 @@ pub enum Error {
     #[error("Setup of the device capabilities failed")]
     CapabilitiesSetup(#[source] configuration::Error),
     /// Allocating space for an IO BAR failed.
-    #[error("Allocating space for an IO BAR failed")]
+    #[error("Allocating space for an IO BAR of size {0} failed")]
     IoAllocationFailed(u64),
     /// Registering an IO BAR failed.
-    #[error("Registering an IO BAR failed")]
+    #[error("Registering an IO BAR at address {0:#x} failed")]
     IoRegistrationFailed(u64, #[source] configuration::Error),
     /// Expected resource not found.
     #[error("Expected resource not found")]

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -313,7 +313,7 @@ pub enum VmReceiveMigrationConfigError {
     #[error("Error parsing receive migration parameters")]
     ParseError(#[source] OptionParserError),
 
-    #[error("Error validating receive migration parameters")]
+    #[error("Error validating receive migration parameters: {0}")]
     ValidationError(String),
 }
 
@@ -422,7 +422,7 @@ pub enum VmSendMigrationConfigError {
     )]
     InvalidDestinationUrl(#[source] TcpAddressParseError),
 
-    #[error("Error validating send migration parameters")]
+    #[error("Error validating send migration parameters: {0}")]
     ValidationError(String),
 }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -394,18 +394,18 @@ pub enum ValidationError {
     #[error("Path {0:?} provided in landlock-rules does not exist")]
     LandlockPathDoesNotExist(PathBuf),
     /// Access provided in landlock-rules in invalid
-    #[error("access provided in landlock-rules in invalid")]
+    #[error("Invalid landlock access: {0}")]
     InvalidLandlockAccess(String),
     /// Invalid block device serial length
     #[error("Block device serial length ({0}) exceeds maximum allowed length ({1})")]
     InvalidSerialLength(usize, usize),
     #[cfg(feature = "ivshmem")]
     /// Invalid Ivshmem input size
-    #[error("Invalid ivshmem input size")]
+    #[error("Invalid ivshmem input size: {0}")]
     InvalidIvshmemInputSize(u64),
     #[cfg(feature = "ivshmem")]
     /// Invalid Ivshmem backend file size
-    #[error("Invalid ivshmem backend file size")]
+    #[error("Invalid ivshmem backend file size: {0}")]
     InvalidIvshmemSize(u64),
     #[cfg(feature = "ivshmem")]
     /// Invalid Ivshmem backend file path
@@ -418,7 +418,7 @@ pub enum ValidationError {
     #[error("IP provided without a mask")]
     IpProvidedWithoutMask,
     /// Invalid NUMA Configuration
-    #[error("NUMA Configuration is invalid")]
+    #[error("Invalid NUMA configuration: {0}")]
     InvalidNumaConfig(String),
     /// The supplied PCI ID was greater then the max. supported number
     /// of devices per Bus

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -493,7 +493,7 @@ pub enum DeviceManagerError {
     RemoveDeviceFromMmioBus(#[source] vm_device::BusError),
 
     /// Failed to find the device corresponding to a specific PCI b/d/f.
-    #[error("Failed to find the device corresponding to a specific PCI b/d/f")]
+    #[error("Failed to find the device corresponding to a specific PCI b/d/f: {0:#x}")]
     UnknownPciBdf(u32),
 
     /// Not allowed to remove this type of device from the VM.
@@ -501,7 +501,7 @@ pub enum DeviceManagerError {
     RemovalNotAllowed(vm_virtio::VirtioDeviceType),
 
     /// Failed to find device corresponding to the given identifier.
-    #[error("Failed to find device corresponding to the given identifier")]
+    #[error("Failed to find device corresponding to the given identifier: {0}")]
     UnknownDeviceId(String),
 
     /// Failed to find an available PCI device ID.
@@ -649,7 +649,7 @@ pub enum DeviceManagerError {
     InvalidIdentifier(String),
 
     /// vfio-user socket path already in use by another user device.
-    #[error("vfio-user socket path already in use: {0:?}")]
+    #[error("VFIO-user socket path already in use: {0:?}")]
     UserDeviceSocketInUse(path::PathBuf),
 
     /// Failed retrieving device state from snapshot

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -105,7 +105,7 @@ pub enum Error {
     #[error("Error decoding host data")]
     FailedToDecodeHostData(#[source] hex::FromHexError),
     #[error("Error allocating address space")]
-    MemoryManager(MemoryManagerError),
+    MemoryManager(#[source] MemoryManagerError),
     #[error("IGVM file not provided")]
     MissingIgvm,
     #[error("Error applying VMSA to vCPU registers: {0}")]

--- a/vmm/src/igvm/loader.rs
+++ b/vmm/src/igvm/loader.rs
@@ -37,8 +37,6 @@ pub enum Error {
     MemoryUnavailable,
     #[error("failed to import pages")]
     ImportPagesFailed,
-    #[error("invalid vp context memory")]
-    InvalidVpContextMemory(&'static str),
     #[error("data larger than imported region")]
     DataTooLarge,
 }

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -90,11 +90,11 @@ pub enum Error {
 
     /// Cannot create seccomp filter.
     #[error("Error creating seccomp filter")]
-    CreateSeccompFilter(seccompiler::Error),
+    CreateSeccompFilter(#[source] seccompiler::Error),
 
     /// Cannot apply seccomp filter.
     #[error("Error applying seccomp filter")]
-    ApplySeccompFilter(seccompiler::Error),
+    ApplySeccompFilter(#[source] seccompiler::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 


### PR DESCRIPTION
Treewide streamlining of inconsistent error formats. In #7066 we agreed on the current format.

Uncontroversial and should be a quick win