### PR TITLE
block: Remove the redundant copy on the raw unaligned O_DIRECT path

### DIFF
--- a/block/src/aligned_file.rs
+++ b/block/src/aligned_file.rs
@@ -111,6 +111,33 @@ impl AlignedFile {
             position: 0,
         }
     }
+
+    /// Read `len` bytes at `offset` through an aligned bounce buffer.
+    pub(crate) fn read_unaligned(
+        &self,
+        offset: u64,
+        len: usize,
+        scatter: impl FnOnce(&[u8]) -> io::Result<()>,
+    ) -> io::Result<usize> {
+        let mut abuf = AlignedBuffer::new(offset, len, self.alignment)?;
+        let n = abuf.read_from(&self.file)?;
+        scatter(&abuf.as_slice()[..n])?;
+        Ok(n)
+    }
+
+    /// Write `len` bytes at `offset` through an aligned bounce buffer.
+    pub(crate) fn write_unaligned(
+        &self,
+        offset: u64,
+        len: usize,
+        gather: impl FnOnce(&mut [u8]) -> io::Result<()>,
+    ) -> io::Result<usize> {
+        let mut abuf = AlignedBuffer::new(offset, len, self.alignment)?;
+        abuf.read_from(&self.file)?; // RMW: preserve head/tail padding
+        gather(abuf.as_mut_slice())?;
+        abuf.write_to(&self.file)?;
+        Ok(len)
+    }
 }
 
 impl FileExt for AlignedFile {
@@ -121,10 +148,10 @@ impl FileExt for AlignedFile {
         if is_aligned(self.alignment, buf.as_ptr() as usize, buf.len(), offset) {
             return self.file.read_at(buf, offset);
         }
-        let mut abuf = AlignedBuffer::new(offset, buf.len(), self.alignment)?;
-        let n = abuf.read_from(&self.file)?;
-        buf[..n].copy_from_slice(&abuf.as_slice()[..n]);
-        Ok(n)
+        self.read_unaligned(offset, buf.len(), |data| {
+            buf[..data.len()].copy_from_slice(data);
+            Ok(())
+        })
     }
 
     fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
@@ -134,11 +161,10 @@ impl FileExt for AlignedFile {
         if is_aligned(self.alignment, buf.as_ptr() as usize, buf.len(), offset) {
             return self.file.write_at(buf, offset);
         }
-        let mut abuf = AlignedBuffer::new(offset, buf.len(), self.alignment)?;
-        abuf.read_from(&self.file)?; // RMW: preserve head/tail padding
-        abuf.as_mut_slice().copy_from_slice(buf);
-        abuf.write_to(&self.file)?;
-        Ok(buf.len())
+        self.write_unaligned(offset, buf.len(), |dst| {
+            dst.copy_from_slice(buf);
+            Ok(())
+        })
     }
 }
 

--- a/block/src/aligned_file.rs
+++ b/block/src/aligned_file.rs
@@ -419,4 +419,69 @@ mod tests {
         assert_eq!(af.write(&[]).unwrap(), 0);
         assert_eq!(af.position, 1);
     }
+
+    #[test]
+    fn read_unaligned_scatters_in_a_single_copy() {
+        let file = pattern_file(8192);
+        let aligned_file = forced(file.as_file().try_clone().unwrap(), 512);
+        let mut out = vec![0u8; 200];
+        let n = aligned_file
+            .read_unaligned(100, 200, |data| {
+                out.copy_from_slice(data);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(n, 200);
+        let want: Vec<u8> = (100..300).map(|i| (i % 251) as u8).collect();
+        assert_eq!(out, want);
+    }
+
+    #[test]
+    fn read_unaligned_closure_short_at_eof() {
+        let file = pattern_file(100);
+        let aligned_file = forced(file.as_file().try_clone().unwrap(), 512);
+        let mut seen = 0usize;
+        let n = aligned_file
+            .read_unaligned(10, 200, |data| {
+                seen = data.len();
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(n, 90);
+        assert_eq!(seen, 90);
+    }
+
+    #[test]
+    fn write_unaligned_gather_is_rmw() {
+        let file = pattern_file(8192);
+        let aligned_file = forced(file.as_file().try_clone().unwrap(), 512);
+        let data: Vec<u8> = (0..200).map(|i| ((i + 1) % 239) as u8).collect();
+        let n = aligned_file
+            .write_unaligned(100, 200, |buf| {
+                buf.copy_from_slice(&data);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(n, 200);
+
+        let mut whole = vec![0u8; 8192];
+        file.as_file().read_exact_at(&mut whole, 0).unwrap();
+        let before: Vec<u8> = (0..100).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[..100], &before[..]);
+        assert_eq!(&whole[100..300], &data[..]);
+        let after: Vec<u8> = (300..8192).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[300..], &after[..]);
+    }
+
+    #[test]
+    fn read_unaligned_propagates_closure_error() {
+        let file = pattern_file(8192);
+        let aligned_file = forced(file.as_file().try_clone().unwrap(), 512);
+        let err = aligned_file
+            .read_unaligned(100, 200, |_| {
+                Err(io::Error::new(io::ErrorKind::InvalidInput, "boom"))
+            })
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
 }

--- a/block/src/formats/raw/worker/mod.rs
+++ b/block/src/formats/raw/worker/mod.rs
@@ -7,8 +7,6 @@
 //! Each backend implements the [`AsyncIo`](crate::async_io::AsyncIo)
 //! trait.
 
-use std::os::unix::fs::FileExt;
-
 use crate::AlignedFile;
 use crate::async_io::{AsyncIoError, AsyncIoOperation, AsyncIoResult};
 
@@ -40,20 +38,15 @@ pub(crate) fn run_unaligned_operation(
 ) -> AsyncIoResult<i32> {
     let offset = op.offset() as u64;
     let total_len = op.total_len();
-    let mut buf = vec![0u8; total_len];
 
     if op.is_read() {
         let n = aligned_file
-            .read_at(&mut buf, offset)
-            .map_err(AsyncIoError::ReadVectored)?;
-        op.write_bytes_at(0, &buf[..n])
+            .read_unaligned(offset, total_len, |data| op.write_bytes_at(0, data))
             .map_err(AsyncIoError::ReadVectored)?;
         Ok(n as i32)
     } else {
-        op.read_bytes_at(0, &mut buf)
-            .map_err(AsyncIoError::WriteVectored)?;
         let n = aligned_file
-            .write_at(&buf, offset)
+            .write_unaligned(offset, total_len, |data| op.read_bytes_at(0, data))
             .map_err(AsyncIoError::WriteVectored)?;
         Ok(n as i32)
     }


### PR DESCRIPTION
The raw format worker bounced every unaligned O_DIRECT request twice. One staging buffer was redundant because it only provided a contiguous range that the aligned bounce buffer already offered. Each unaligned request through the raw worker therefore carried an extra allocation and a full length copy for no benefit.

Now the request scatters and gathers directly through the aligned bounce buffer, so the data moves between the guest and the kernel across a single copy instead of being staged into a separate buffer first and copied again. One allocation is dropped per unaligned request, and the aligned read-modify-write staging lives in one place shared by the raw worker and the AlignedFile read_at and write_at paths. The aligned fast path is untouched and slow path behavior is unchanged.

Covered by additional unit tests.