### PR TITLE
build: exempt arch from clippy::absolute_paths, use full paths

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+absolute-paths-allowed-crates = ["arch"]

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -24,8 +24,6 @@ use std::{
 use acpi_tables::rsdp::Rsdp;
 use arch::RegionType;
 #[cfg(target_arch = "aarch64")]
-use arch::aarch64::arch_memory_regions;
-#[cfg(target_arch = "aarch64")]
 use arch::aarch64::layout::{
     MEM_32BIT_DEVICES_START, MEM_32BIT_RESERVED_START, RAM_64BIT_START, RAM_START as HIGH_RAM_START,
 };
@@ -487,7 +485,7 @@ impl FwCfg {
             (STAGE0_START_ADDRESS, STAGE0_SIZE, RegionType::Reserved),
         ];
         #[cfg(target_arch = "aarch64")]
-        let mut mem_regions = arch_memory_regions();
+        let mut mem_regions = arch::aarch64::arch_memory_regions();
         if mem_size < MEM_32BIT_DEVICES_START.0 as usize {
             mem_regions.push((
                 HIGH_RAM_START,

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -13,8 +13,6 @@ use acpi_tables::sdt::Sdt;
 use arch::DeviceType;
 #[cfg(target_arch = "aarch64")]
 use arch::aarch64::DeviceInfoForFdt;
-#[cfg(target_arch = "x86_64")]
-use arch::x86_64;
 use arch::{NumaNodes, layout};
 use bitflags::bitflags;
 use log::{info, warn};
@@ -399,7 +397,7 @@ fn create_srat_table(
 
         for cpu in &node.cpus {
             #[cfg(target_arch = "x86_64")]
-            let x2apic_id = x86_64::get_x2apic_id(*cpu, topology);
+            let x2apic_id = arch::x86_64::get_x2apic_id(*cpu, topology);
             #[cfg(target_arch = "aarch64")]
             let x2apic_id = *cpu;
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -23,10 +23,6 @@ use std::{any, cmp, hint, io, panic, result, thread, time};
 use acpi_tables::sdt::Sdt;
 use acpi_tables::{Aml, aml};
 use anyhow::anyhow;
-#[cfg(target_arch = "x86_64")]
-use arch::x86_64;
-#[cfg(target_arch = "x86_64")]
-use arch::x86_64::get_x2apic_id;
 use arch::{EntryPoint, NumaNodes, layout};
 #[cfg(target_arch = "aarch64")]
 use devices::gic::Gic;
@@ -988,7 +984,7 @@ impl CpuManager {
         #[cfg(target_arch = "x86_64")]
         let topology = self.get_vcpu_topology();
         #[cfg(target_arch = "x86_64")]
-        let x2apic_id = x86_64::get_x2apic_id(cpu_id, topology);
+        let x2apic_id = arch::x86_64::get_x2apic_id(cpu_id, topology);
         #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
         let x2apic_id = cpu_id;
 
@@ -1762,7 +1758,7 @@ impl CpuManager {
             madt.write(36, layout::APIC_START.0);
 
             for cpu in 0..self.config.max_vcpus {
-                let x2apic_id = get_x2apic_id(cpu, self.get_vcpu_topology());
+                let x2apic_id = arch::x86_64::get_x2apic_id(cpu, self.get_vcpu_topology());
 
                 let lapic = LocalX2Apic {
                     r#type: acpi::ACPI_X2APIC_PROCESSOR,
@@ -2327,7 +2323,7 @@ const MADT_CPU_ONLINE_CAPABLE_FLAG: usize = 1;
 impl Cpu {
     #[cfg(target_arch = "x86_64")]
     fn generate_mat(&self) -> Vec<u8> {
-        let x2apic_id = x86_64::get_x2apic_id(self.cpu_id, self.topology);
+        let x2apic_id = arch::x86_64::get_x2apic_id(self.cpu_id, self.topology);
 
         LocalX2Apic {
             r#type: acpi::ACPI_X2APIC_PROCESSOR,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -22,8 +22,6 @@ use anyhow::{Context, anyhow};
 #[cfg(feature = "dbus_api")]
 use api::dbus::{DBusApiOptions, DBusApiShutdownChannels};
 use api::http::HttpApiHandle;
-#[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-use arch::x86_64::MAX_SUPPORTED_CPUS_LEGACY;
 use console_devices::{ConsoleInfo, pre_create_console_devices};
 use event_monitor::event;
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
@@ -1211,7 +1209,7 @@ impl Vmm {
         })?;
 
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-        if config.lock().unwrap().max_apic_id() > MAX_SUPPORTED_CPUS_LEGACY {
+        if config.lock().unwrap().max_apic_id() > arch::x86_64::MAX_SUPPORTED_CPUS_LEGACY {
             vm.enable_x2apic_api().unwrap();
         }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -27,18 +27,10 @@ use std::{any, cmp, result, str, thread};
 use anyhow::{Context, anyhow};
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use arch::PciSpaceInfo;
-#[cfg(not(target_arch = "x86_64"))]
-use arch::aarch64;
 #[cfg(target_arch = "x86_64")]
 use arch::layout::{KVM_IDENTITY_MAP_START, KVM_TSS_START};
 #[cfg(not(target_arch = "x86_64"))]
 use arch::uefi;
-#[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-use arch::x86_64::MAX_SUPPORTED_CPUS_LEGACY;
-#[cfg(feature = "tdx")]
-use arch::x86_64::tdx;
-#[cfg(feature = "tdx")]
-use arch::x86_64::tdx::TdvfSection;
 use arch::{EntryPoint, NumaNode, NumaNodes, get_host_cpu_phys_bits, layout};
 use devices::AcpiNotificationFlags;
 #[cfg(target_arch = "aarch64")]
@@ -145,7 +137,7 @@ pub enum Error {
 
     #[cfg(target_arch = "aarch64")]
     #[error("Cannot load the UEFI binary in memory")]
-    UefiLoad(#[source] aarch64::uefi::Error),
+    UefiLoad(#[source] arch::aarch64::uefi::Error),
 
     #[cfg(target_arch = "riscv64")]
     #[error("Cannot load the UEFI binary in memory")]
@@ -313,11 +305,11 @@ pub enum Error {
 
     #[cfg(feature = "tdx")]
     #[error("Error parsing TDVF")]
-    ParseTdvf(#[source] tdx::TdvfError),
+    ParseTdvf(#[source] arch::x86_64::tdx::TdvfError),
 
     #[cfg(feature = "tdx")]
     #[error("Error populating TDX HOB")]
-    PopulateHob(#[source] tdx::TdvfError),
+    PopulateHob(#[source] arch::x86_64::tdx::TdvfError),
 
     #[cfg(feature = "tdx")]
     #[error("Error allocating TDVF memory")]
@@ -1402,7 +1394,7 @@ impl Vm {
         };
 
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-        if vm_config.lock().unwrap().max_apic_id() > MAX_SUPPORTED_CPUS_LEGACY {
+        if vm_config.lock().unwrap().max_apic_id() > arch::x86_64::MAX_SUPPORTED_CPUS_LEGACY {
             vm.enable_x2apic_api().unwrap();
         }
 
@@ -1919,7 +1911,9 @@ impl Vm {
             .unwrap()
             .get_vgic()
             .map_err(|_| {
-                Error::ConfigureSystem(arch::Error::PlatformSpecific(aarch64::Error::SetupGic))
+                Error::ConfigureSystem(arch::Error::PlatformSpecific(
+                    arch::aarch64::Error::SetupGic,
+                ))
             })?;
 
         // PMU interrupt sticks to PPI, so need to be added by 16 to get real irq number.
@@ -1929,7 +1923,9 @@ impl Vm {
             .unwrap()
             .init_pmu(AARCH64_PMU_IRQ + 16)
             .map_err(|_| {
-                Error::ConfigureSystem(arch::Error::PlatformSpecific(aarch64::Error::VcpuInitPmu))
+                Error::ConfigureSystem(arch::Error::PlatformSpecific(
+                    arch::aarch64::Error::VcpuInitPmu,
+                ))
             })?;
 
         arch::configure_system(
@@ -2425,7 +2421,7 @@ impl Vm {
     }
 
     #[cfg(feature = "tdx")]
-    fn extract_tdvf_sections(&mut self) -> Result<(Vec<TdvfSection>, bool)> {
+    fn extract_tdvf_sections(&mut self) -> Result<(Vec<arch::x86_64::tdx::TdvfSection>, bool)> {
         use arch::x86_64::tdx::*;
 
         let firmware_path = self
@@ -2447,7 +2443,7 @@ impl Vm {
 
     #[cfg(feature = "tdx")]
     fn hob_memory_resources(
-        mut sorted_sections: Vec<TdvfSection>,
+        mut sorted_sections: Vec<arch::x86_64::tdx::TdvfSection>,
         guest_memory: &GuestMemoryMmap,
     ) -> Vec<(u64, u64, bool)> {
         let mut list = Vec::new();
@@ -2508,7 +2504,7 @@ impl Vm {
     #[cfg(feature = "tdx")]
     fn populate_tdx_sections(
         &mut self,
-        sections: &[TdvfSection],
+        sections: &[arch::x86_64::tdx::TdvfSection],
         guid_found: bool,
     ) -> Result<Option<u64>> {
         use arch::x86_64::tdx::*;
@@ -2694,7 +2690,7 @@ impl Vm {
     }
 
     #[cfg(feature = "tdx")]
-    fn init_tdx_memory(&mut self, sections: &[TdvfSection]) -> Result<()> {
+    fn init_tdx_memory(&mut self, sections: &[arch::x86_64::tdx::TdvfSection]) -> Result<()> {
         let guest_memory = self.memory_manager.lock().as_ref().unwrap().guest_memory();
         let mem = guest_memory.memory();
 
@@ -3700,12 +3696,12 @@ mod unit_tests {
     fn test_hob_memory_resources() {
         // Case 1: Two TDVF sections in the middle of the RAM
         let sections = vec![
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0xc000,
                 size: 0x1000,
                 ..Default::default()
             },
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0x1000,
                 size: 0x4000,
                 ..Default::default()
@@ -3729,12 +3725,12 @@ mod unit_tests {
 
         // Case 2: Two TDVF sections with no conflict with the RAM
         let sections = vec![
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0x1000_1000,
                 size: 0x1000,
                 ..Default::default()
             },
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0,
                 size: 0x1000,
                 ..Default::default()
@@ -3756,12 +3752,12 @@ mod unit_tests {
 
         // Case 3: Two TDVF sections with partial conflicts with the RAM
         let sections = vec![
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0x1000_0000,
                 size: 0x2000,
                 ..Default::default()
             },
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0,
                 size: 0x2000,
                 ..Default::default()
@@ -3784,22 +3780,22 @@ mod unit_tests {
         // Case 4: Two TDVF sections with no conflict before the RAM and two
         // more additional sections with no conflict after the RAM.
         let sections = vec![
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0x2000_1000,
                 size: 0x1000,
                 ..Default::default()
             },
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0x2000_0000,
                 size: 0x1000,
                 ..Default::default()
             },
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0x1000,
                 size: 0x1000,
                 ..Default::default()
             },
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0,
                 size: 0x1000,
                 ..Default::default()
@@ -3822,7 +3818,7 @@ mod unit_tests {
         );
 
         // Case 5: One TDVF section overriding the entire RAM
-        let sections = vec![TdvfSection {
+        let sections = vec![arch::x86_64::tdx::TdvfSection {
             address: 0,
             size: 0x2000_0000,
             ..Default::default()
@@ -3839,12 +3835,12 @@ mod unit_tests {
 
         // Case 6: Two TDVF sections with no conflict with 2 RAM regions
         let sections = vec![
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0x1000_2000,
                 size: 0x2000,
                 ..Default::default()
             },
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0,
                 size: 0x2000,
                 ..Default::default()
@@ -3870,12 +3866,12 @@ mod unit_tests {
 
         // Case 7: Two TDVF sections with partial conflicts with 2 RAM regions
         let sections = vec![
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0x1000_0000,
                 size: 0x4000,
                 ..Default::default()
             },
-            TdvfSection {
+            arch::x86_64::tdx::TdvfSection {
                 address: 0,
                 size: 0x4000,
                 ..Default::default()
@@ -3971,8 +3967,6 @@ mod unit_tests {
 #[cfg(target_arch = "aarch64")]
 #[cfg(test)]
 mod unit_tests {
-    use arch::aarch64::fdt::create_fdt;
-    use arch::aarch64::layout;
     use arch::{DeviceType, MmioDeviceInfo};
     use devices::gic::Gic;
 
@@ -3982,7 +3976,10 @@ mod unit_tests {
 
     #[test]
     fn test_create_fdt_with_devices() {
-        let regions = vec![(layout::RAM_START, (layout::FDT_MAX_SIZE + 0x1000) as usize)];
+        let regions = vec![(
+            arch::aarch64::layout::RAM_START,
+            (arch::aarch64::layout::FDT_MAX_SIZE + 0x1000) as usize,
+        )];
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
 
         let dev_info: HashMap<(DeviceType, String), MmioDeviceInfo> = [
@@ -4019,7 +4016,7 @@ mod unit_tests {
         let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
         let vgic_config = Gic::create_default_config(1);
         let gic = vm.create_vgic(&vgic_config).expect("Cannot create gic");
-        create_fdt(
+        arch::aarch64::fdt::create_fdt(
             &mem,
             "console=tty0",
             &[0],

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -10,8 +10,6 @@ use std::str::FromStr;
 use std::{fs, result};
 
 use arch::CpuProfile;
-#[cfg(target_arch = "x86_64")]
-use arch::x86_64;
 use block::ImageType;
 pub use block::fcntl::LockGranularityChoice;
 #[cfg(target_arch = "x86_64")]
@@ -174,7 +172,7 @@ pub struct PlatformConfig {
 impl PlatformConfig {
     /// Returns `None` if no SMBIOS-relevant platform fields are set, otherwise
     /// `Some` with a [`SmbiosConfig`] built from the populated fields.
-    pub fn smbios_config(&self) -> Option<x86_64::SmbiosConfig> {
+    pub fn smbios_config(&self) -> Option<arch::x86_64::SmbiosConfig> {
         let has_system = [
             &self.system_serial_number,
             &self.system_uuid,
@@ -187,7 +185,7 @@ impl PlatformConfig {
         .iter()
         .any(|v| v.is_some());
 
-        let system = has_system.then_some(x86_64::SmbiosSystem {
+        let system = has_system.then_some(arch::x86_64::SmbiosSystem {
             manufacturer: self.system_manufacturer.clone(),
             product_name: self.system_product_name.clone(),
             version: self.system_version.clone(),
@@ -197,14 +195,14 @@ impl PlatformConfig {
             family: self.system_family.clone(),
         });
 
-        let chassis = self
-            .chassis_asset_tag
-            .clone()
-            .map(|asset_tag| x86_64::SmbiosChassisConfig {
-                asset_tag: Some(asset_tag),
-            });
+        let chassis =
+            self.chassis_asset_tag
+                .clone()
+                .map(|asset_tag| arch::x86_64::SmbiosChassisConfig {
+                    asset_tag: Some(asset_tag),
+                });
 
-        let smbios = x86_64::SmbiosConfig {
+        let smbios = arch::x86_64::SmbiosConfig {
             system,
             chassis,
             oem_strings: self.oem_strings.clone().unwrap_or_default(),
@@ -1321,7 +1319,7 @@ impl VmConfig {
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     pub(crate) fn max_apic_id(&self) -> u32 {
         if let Some(topology) = &self.cpus.topology {
-            x86_64::get_max_x2apic_id((
+            arch::x86_64::get_max_x2apic_id((
                 topology.threads_per_core,
                 topology.cores_per_die,
                 topology.dies_per_package,


### PR DESCRIPTION
Suggested by @phip1611 on #8446.

Note: this is the repo's first clippy.toml; it carves arch out of the absolute_paths deny from #7670. Glob imports and trait imports that must be in scope for method-call resolution (e.g. DeviceInfoForFdt for .irq()) are left as-is.