### PR TITLE
block: write real data in sparse-size test for filesystem portability

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -827,27 +827,32 @@ mod unit_tests {
     #[test]
     fn test_query_device_size_sparse_file_punch_hole() {
         let temp_file = TempFile::new().unwrap();
-        let f = temp_file.as_file();
-        // Allocate 1 MiB
+        let mut f = temp_file.into_file();
         let size: i64 = 1 << 20;
-        f.set_len(size as u64).unwrap();
-        // SAFETY: fd is valid, range is within file size.
-        let ret = unsafe {
-            libc::fallocate(
-                f.as_raw_fd(),
-                0, // allocate
-                0,
-                size,
-            )
-        };
-        assert_eq!(ret, 0, "fallocate failed: {}", io::Error::last_os_error());
+
+        // Allocate 1 MiB by writing real, incompressible data. fallocate()
+        // preallocation is unreliable across filesystems (a no-op on
+        // copy-on-write filesystems such as zfs, and not reflected through
+        // virtiofs), whereas an actual write always allocates blocks that
+        // st_blocks accounts for. The data must be incompressible so that
+        // filesystems with transparent compression (e.g. zfs with the default
+        // lz4) still allocate the full extent. See issue #8296.
+        let mut data = vec![0u8; size as usize];
+        File::open("/dev/urandom")
+            .unwrap()
+            .read_exact(&mut data)
+            .unwrap();
+        f.write_all(&data).unwrap();
         f.sync_all().unwrap();
 
-        let (log_before, phys_before) = query_device_size(f).unwrap();
+        let (log_before, phys_before) = query_device_size(&f).unwrap();
         assert_eq!(log_before, size as u64);
-        assert_eq!(phys_before, size as u64);
+        assert!(
+            phys_before > 0,
+            "written data should allocate blocks (phys_before={phys_before})"
+        );
 
-        // Punch a hole in the middle 512 KiB
+        // Punch a hole in the middle 512 KiB.
         // SAFETY: fd is valid, range is within file size.
         let ret = unsafe {
             libc::fallocate(
@@ -857,14 +862,24 @@ mod unit_tests {
                 size / 2,
             )
         };
-        assert_eq!(ret, 0, "punch hole failed: {}", io::Error::last_os_error());
+        if ret != 0 {
+            let err = io::Error::last_os_error();
+            // Not every filesystem supports hole punching; the physical-size
+            // reduction can only be exercised where it does.
+            if err.raw_os_error() == Some(libc::EOPNOTSUPP) {
+                eprintln!("skipping hole-punch check: FALLOC_FL_PUNCH_HOLE unsupported: {err}");
+                return;
+            }
+            panic!("punch hole failed: {err}");
+        }
         f.sync_all().unwrap();
 
-        let (logical, physical) = query_device_size(f).unwrap();
+        let (logical, physical) = query_device_size(&f).unwrap();
         assert_eq!(logical, size as u64, "logical size must not change");
         assert!(
-            physical < logical,
-            "physical ({physical}) should be less than logical ({logical}) after punch hole"
+            physical < phys_before,
+            "physical ({physical}) should drop below the pre-punch size \
+             ({phys_before}) after punching a hole"
         );
     }
 


### PR DESCRIPTION
`test_query_device_size_sparse_file_punch_hole` used `fallocate()` with
mode 0 to preallocate 1 MiB and asserted the allocation was reflected in
`st_blocks`. That assumption only holds on some filesystems: `fallocate()`
preallocation is a no-op on copy-on-write filesystems such as zfs and is
not reflected through virtiofs, so the test failed at the `phys_before`
assertion (`st_blocks` reported 0 on virtiofs, a single block on
zfs/tmpfs).

Write real, incompressible data instead, which forces actual block
allocation that `st_blocks` accounts for on every filesystem. The data is
incompressible so transparent compression (e.g. zfs lz4) does not
collapse the extent. The hole-punch check now compares against the
pre-punch physical size and is skipped only where `FALLOC_FL_PUNCH_HOLE`
is genuinely unsupported.

Verified on ext4, tmpfs and virtiofs: the test now runs and passes on all
three (previously it failed on virtiofs).

Fixes #8296.