### PR TITLE
Add nested Hyper-V (Windows guest) support

### DIFF
--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -5,6 +5,7 @@
 use std::time::Instant;
 
 use acpi_tables::Aml;
+use acpi_tables::gas::{AccessSize, AddressSpace, GAS};
 use acpi_tables::rsdp::Rsdp;
 #[cfg(target_arch = "aarch64")]
 use acpi_tables::sdt::GenericAddress;
@@ -274,7 +275,11 @@ pub fn create_dsdt_table(
 
 const FACP_DSDT_OFFSET: usize = 140;
 
-fn create_facp_table(dsdt_offset: GuestAddress, device_manager: &DeviceManager) -> Sdt {
+fn create_facp_table(
+    dsdt_offset: GuestAddress,
+    device_manager: &DeviceManager,
+    legacy_acpi_pm1a: bool,
+) -> Sdt {
     trace_scoped!("create_facp_table");
 
     // Revision 6 of the ACPI FADT table is 276 bytes long
@@ -325,6 +330,50 @@ fn create_facp_table(dsdt_offset: GuestAddress, device_manager: &DeviceManager) 
     facp.write(FACP_DSDT_OFFSET, dsdt_offset.0);
     // Hypervisor Vendor Identity
     facp.write_bytes(268, b"CLOUDHYP");
+
+    // Windows' nested-Hyper-V hvloader rejects a HW-reduced FADT whose PM1a GAS is
+    // zero; point the blocks at unused ACPI I/O ports (conforming guests ignore them).
+    if legacy_acpi_pm1a {
+        const PM1A_EVT_PORT: u16 = 0x60c;
+        facp.write(56, PM1A_EVT_PORT as u32); // PM1a_EVT_BLK (0x38)
+        facp.write(88, 4u8); // PM1_EVT_LEN (0x58)
+        facp.write_bytes(
+            148, // X_PM1a_EVT_BLK (0x94)
+            GAS::new(
+                AddressSpace::SystemIo,
+                32,
+                0,
+                AccessSize::WordAccess,
+                PM1A_EVT_PORT.into(),
+            )
+            .as_bytes(),
+        );
+
+        const PM1A_CNT_PORT: u16 = 0x610;
+        facp.write(64, PM1A_CNT_PORT as u32); // PM1a_CNT_BLK (0x40)
+        facp.write(89, 2u8); // PM1_CNT_LEN (0x59)
+        facp.write_bytes(
+            172, // X_PM1a_CNT_BLK (0xac)
+            GAS::new(
+                AddressSpace::SystemIo,
+                16,
+                0,
+                AccessSize::WordAccess,
+                PM1A_CNT_PORT.into(),
+            )
+            .as_bytes(),
+        );
+
+        let mut allocator = device_manager.allocator().lock().unwrap();
+        for (port, len) in [(PM1A_EVT_PORT, 4u64), (PM1A_CNT_PORT, 2u64)] {
+            if allocator
+                .allocate_io_addresses(Some(GuestAddress(port.into())), len, None)
+                .is_none()
+            {
+                warn!("Could not reserve PM1a I/O port {port:#x} advertised in the FADT");
+            }
+        }
+    }
 
     facp.update_checksum();
 
@@ -855,7 +904,12 @@ fn create_acpi_tables_internal(
     tables_bytes.extend_from_slice(dsdt.as_slice());
 
     // FACP aka FADT
-    let facp = create_facp_table(dsdt_addr, device_manager);
+    // The legacy PM1a blocks are x86-only; there is nothing to emit on other arches.
+    #[cfg(target_arch = "x86_64")]
+    let legacy_acpi_pm1a = cpu_manager.nested() && cpu_manager.kvm_hyperv();
+    #[cfg(not(target_arch = "x86_64"))]
+    let legacy_acpi_pm1a = false;
+    let facp = create_facp_table(dsdt_addr, device_manager, legacy_acpi_pm1a);
     let facp_addr = dsdt_addr.checked_add(dsdt.len() as u64).unwrap();
     tables_bytes.extend_from_slice(facp.as_slice());
     xsdt_table_pointers.push(facp_addr.0);
@@ -1130,7 +1184,12 @@ pub fn create_acpi_tables_tdx(
     )];
 
     // FACP aka FADT
-    tables.push(create_facp_table(GuestAddress(0), device_manager));
+    let legacy_acpi_pm1a = cpu_manager.nested() && cpu_manager.kvm_hyperv();
+    tables.push(create_facp_table(
+        GuestAddress(0),
+        device_manager,
+        legacy_acpi_pm1a,
+    ));
 
     // MADT
     tables.push(cpu_manager.create_madt());

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1089,6 +1089,16 @@ impl CpuManager {
         Ok(())
     }
 
+    #[cfg(target_arch = "x86_64")]
+    pub fn nested(&self) -> bool {
+        self.config.nested
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn kvm_hyperv(&self) -> bool {
+        self.config.kvm_hyperv
+    }
+
     /// Only create new vCPUs if there aren't any inactive ones to reuse
     fn create_vcpus(
         &mut self,


### PR DESCRIPTION
## Problem

A Windows guest cannot run nested Hyper-V (its own hypervisor — e.g. WSL2) on the KVM
backend: `HypervisorPresent` stays `False`, so WSL2 and other Hyper-V-backed features do
not work.

Root cause (pinned at the instruction level via a kernel-debugger session on the guest's
`hvloader`): during hypervisor launch, `hvloader` registers the FADT's legacy ACPI PM
register blocks and rejects any block whose Generic Address Structure (GAS) Address is 0
with `STATUS_INVALID_DEVICE_REQUEST`, so `hvix64` never loads and `HypervisorPresent` stays
`False`. The HW-reduced-ACPI FADT that cloud-hypervisor builds leaves the PM1a event/control
blocks (and their `X_*` GAS) zero, so the very first registration fails.

## Fix

Populate `PM1a_EVT_BLK` / `PM1a_CNT_BLK` in the FADT (32-bit legacy fields + the 64-bit
`X_PM1a_*_BLK` GAS), pointing at two otherwise-unused I/O ports in the existing ACPI port
range. `HW_REDUCED_ACPI` stays set, so a conforming guest OS continues to ignore the legacy
PM registers entirely — only the Windows hypervisor-launch validation path reads them. This
is a no-op for non-Windows / non-nested guests and unblocks nested Hyper-V.

## Validation

Built on this branch (off current `main`) and verified on a Sapphire Rapids host:

- `(Get-CimInstance Win32_ComputerSystem).HypervisorPresent` → **True**
- `wsl -d <distro> -- uname -a` → `Linux ... 6.18-microsoft-standard-WSL2 ... x86_64`;
  `wsl -l -v` shows the distro **Running / VERSION 2**
