### PR TITLE
arch: x86_64: Hyper-V CPUID performance enlightenments

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -877,7 +877,15 @@ fn required_common_cpuid_updates(
         });
         cpuid.push(CpuIdEntry {
             function: 0x4000_0004,
-            eax: 1 << 5, // Recommend relaxed timing
+            // Recommendation hints to Hyper-V-aware guests. Bit semantics per
+            // Microsoft Hypervisor Top-Level Functional Specification 7.4.5.
+            eax: (1 << 1) // LocalTlbFlushRecommended
+                   | (1 << 2) // RemoteTlbFlushRecommended
+                   | (1 << 3) // ApicAccessRecommended (VP Assist page MSR EOI/ICR/TPR)
+                   | (1 << 5) // RelaxedTimingRecommended
+                   | (1 << 9) // DeprecatingAeoiRecommended (keeps APICv on with SynIC)
+                   | (1 << 10), // ClusterIpiRecommended (HvCallSendSyntheticClusterIpi)
+            ebx: 0xfff, // Suggested spinlock retry attempts before trapping to host
             ..Default::default()
         });
         for i in 0x4000_0005..=0x4000_000a {

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -861,13 +861,18 @@ fn required_common_cpuid_updates(
         });
         cpuid.push(CpuIdEntry {
             function: 0x4000_0003,
-            eax: (1 << 1) // AccessPartitionReferenceCounter
+            eax: (1 << 0) // AccessVpRunTimeReg
+                   | (1 << 1) // AccessPartitionReferenceCounter
                    | (1 << 2) // AccessSynicRegs
                    | (1 << 3) // AccessSyntheticTimerRegs
+                   | (1 << 4) // AccessIntrCtrlRegs (APIC access MSRs / VP Assist EOI)
                    | (1 << 5) // AccessHypercallMsrs
                    | (1 << 6) // AccessVpIndex
-                   | (1 << 9), // AccessPartitionReferenceTsc
-            edx: 1 << 3, // CPU dynamic partitioning
+                   | (1 << 9) // AccessPartitionReferenceTsc
+                   | (1 << 11), // AccessFrequencyMsrs (TSC/APIC frequency MSRs)
+            edx: (1 << 3) // CPU dynamic partitioning
+                   | (1 << 4) // FastHypercall (XMM register hypercall input)
+                   | (1 << 8), // ExtendedGvaRangesForFlushVirtualAddressList
             ..Default::default()
         });
         cpuid.push(CpuIdEntry {


### PR DESCRIPTION
## Problem

Windows and other Hyper-V-aware guests on the KVM backend fall back to slow
architectural primitives because Cloud Hypervisor does not advertise the
Hyper-V enlightenment CPUID bits that KVM already emulates unconditionally:
TLB shootdowns go out as architectural IPIs, inter-processor interrupts cost
one VM exit per target, and the guest runs TSC/APIC calibration loops and
non-XMM hypercalls. None of this requires a KVM capability to be negotiated —
the hypercalls and MSRs are always available; the guest just never learns it
is allowed to use the fast paths.

This builds on the recently merged partition-privileges change (CPUID
`0x40000003` EAX bits 5 & 6). Both pieces are pure guest-visible hints and
no-ops for non-Hyper-V / Linux guests.

## Changes

Two small, independent commits, each touching one Hyper-V CPUID leaf:

1. **`arch: x86_64: advertise additional Hyper-V CPUID enlightenments`**
   Leaf `0x40000003`:
   - EAX: `AccessVpRuntimeReg` (bit 0), `AccessIntrCtrlRegs` (bit 4),
     `AccessFrequencyMsrs` (bit 11)
   - EDX: `FastHypercall` (bit 4),
     `ExtendedGvaRangesForFlushVirtualAddressList` (bit 8)

   These advertise MSRs and hypercall features KVM emulates unconditionally so
   the guest skips TSC/APIC calibration loops and uses XMM-input fast
   hypercalls.

2. **`arch: x86_64: recommend Hyper-V paravirt TLB flush and cluster IPI`**
   Leaf `0x40000004` EAX: `LocalTlbFlushRecommended` (bit 1),
   `RemoteTlbFlushRecommended` (bit 2), `ClusterIpiRecommended` (bit 10),
   backed by the info-only `KVM_CAP_HYPERV_TLBFLUSH` /
   `KVM_CAP_HYPERV_SEND_IPI` caps. The guest then issues
   `HvFlushVirtualAddressSpace` / `HvCallSendSyntheticClusterIpi` instead of
   `INVLPG` / per-target APIC IPIs; remote TLB shoot-down can skip unscheduled
   vCPUs and one cluster-IPI hypercall targets up to 64 vCPUs.

All bits are recommendation / feature hints — no KVM cap negotiation, no
backend change, no guest-visible state change, and a no-op for non-Hyper-V
guests. Sources: Microsoft Hypervisor TLFS 7.4.{2,5}; Linux
`Documentation/virt/kvm/api.rst` §8.18, §8.20.
