### PR TITLE
vmm: return error if prefaulting fails

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -157,11 +157,13 @@ _Example_
 
 ### `prefault`
 
-Specifies if the memory must be `mmap(2)` with `MAP_POPULATE` flag.
+Specifies whether guest memory should be prefaulted with `madvise(2)` using
+`MADV_POPULATE_WRITE` after it is `mmap(2)`-ed.
 
-By triggering prefault, one can allocate all required physical memory and create
-its page tables while calling `mmap`. With physical memory allocated, the number
-of page faults will decrease during running, and performance will also improve.
+With prefault enabled, Cloud Hypervisor allocates the required physical memory
+and creates its page tables before the VM starts. This reduces page faults at
+runtime and can surface insufficient backing memory during VM creation. If
+prefaulting fails, VM creation fails with an error.
 
 Note that boot of VM will be slower with `prefault` enabled because of allocating
 physical memory and creating page tables in advance, and physical memory of the
@@ -170,7 +172,7 @@ specified size will be consumed quickly.
 This option only takes effect at boot of VM. There is also a `prefault` option in
 restore and its choice will overwrite `prefault` in memory.
 
-By default this option is turned off.
+By default, this option is turned off.
 
 _Example_
 
@@ -429,11 +431,13 @@ _Example_
 
 ### `prefault`
 
-Specifies if the memory must be `mmap(2)` with `MAP_POPULATE` flag.
+Specifies whether this memory zone should be prefaulted with `madvise(2)` using
+`MADV_POPULATE_WRITE` after it is `mmap(2)`-ed.
 
-By triggering prefault, one can allocate all required physical memory and create
-its page tables while calling `mmap`. With physical memory allocated, the number
-of page faults will decrease during running, and performance will also improve.
+With prefault enabled, Cloud Hypervisor allocates the required physical memory
+and creates its page tables before the VM starts. This reduces page faults at
+runtime and can surface insufficient backing memory during VM creation. If
+prefaulting fails, VM creation fails with an error.
 
 Note that boot of VM will be slower with `prefault` enabled because of allocating
 physical memory and creating page tables in advance, and physical memory of the
@@ -442,7 +446,7 @@ specified size will be consumed quickly.
 This option only takes effect at boot of VM. There is also a `prefault` option in
 restore and its choice will overwrite `prefault` in memory.
 
-By default this option is turned off.
+By default, this option is turned off.
 
 _Example_
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -415,6 +415,10 @@ pub enum Error {
     /// Memory size is misaligned with default page size or its hugepage size
     #[error("Memory size is misaligned with default page size or its hugepage size")]
     MisalignedMemorySize,
+
+    /// Failed to prefault memory
+    #[error("Failed to prefault memory")]
+    PrefaultMemory(#[source] io::Error),
 }
 
 impl From<UffdError> for Error {
@@ -2083,11 +2087,12 @@ impl MemoryManager {
             let remainder = num_pages % num_threads;
 
             let barrier = Arc::new(Barrier::new(num_threads));
-            thread::scope(|s| {
+            thread::scope(|s| -> Result<(), Error> {
                 let r = &region;
+                let mut handles = Vec::new();
                 for i in 0..num_threads {
                     let barrier = Arc::clone(&barrier);
-                    s.spawn(move || {
+                    let handle = s.spawn(move || {
                         // Wait until all threads have been spawned to avoid contention
                         // over mmap_sem between thread stack allocation and page faulting.
                         barrier.wait();
@@ -2100,11 +2105,26 @@ impl MemoryManager {
                         };
                         if ret != 0 {
                             let e = io::Error::last_os_error();
-                            warn!("Failed to prefault pages: {e}");
+                            return Err(e);
                         }
+                        Ok(())
                     });
+                    handles.push(handle);
                 }
-            });
+
+                for handle in handles {
+                    handle
+                        .join()
+                        .map_err(|e| {
+                            Error::PrefaultMemory(io::Error::other(format!(
+                                "Prefault thread panicked: {e:?}"
+                            )))
+                        })?
+                        .map_err(Error::PrefaultMemory)?;
+                }
+
+                Ok(())
+            })?;
         }
 
         info!(


### PR DESCRIPTION
This upstreams a fix that we need in our larger cloud deployment at our customer (https://github.com/cyberus-technology/cloud-hypervisor/commit/fc81e2ac407d72e9b22969201767e099d4f7812c).

Prefaulting pages was done on a best-effort basis before, meaning that errors were ignored. This could lead to errors during runtime, especially when used with hugepages, because there was no guarantee that enough pages are available. With this change errors during prefaulting will be reported.

Part of #7111