### PR TITLE
vmm: make aborted migrations on receiver side return an error

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3061,6 +3061,9 @@ impl RequestHandler for Vmm {
                 event!("vm", "migration-receive-failed");
                 self.vm = VmOwnership::None;
                 self.vm_config = None;
+                return Err(MigratableError::CompleteMigration(anyhow!(
+                    "Migration was aborted"
+                )));
             }
             ReceiveMigrationState::Completed => {
                 // Serving and resume already happened in the protocol loop.


### PR DESCRIPTION
This upstreams a fix that we need in our larger cloud deployment at our customer (https://github.com/cyberus-technology/cloud-hypervisor/commit/8be5c81041dc2c0f286691ed5b414e9a9a25de3f).

On the receiver side, a live migration with status "aborted" does not return an error. Thus, management software will think that the live migration was successful (from just looking at the API response). This is not expected behaviour.

Part of #7111