### PR TITLE
block: Convert qcow raw file metadata I/O to positional access

### DIFF
--- a/block/src/formats/qcow/internal/qcow_raw_file.rs
+++ b/block/src/formats/qcow/internal/qcow_raw_file.rs
@@ -443,4 +443,62 @@ mod unit_tests {
             "write_pointer_table_direct did not land at {TARGET_OFFSET:#x}"
         );
     }
+
+    #[test]
+    fn read_pointer_table_round_trips() {
+        let (_temp_file, mut qcow) = make_qcow_raw();
+        let entries: Vec<u64> = vec![
+            0x0000_0000_0000_0000,
+            0x0011_2233_4455_6677,
+            0x8899_aabb_ccdd_eeff,
+            0xffff_ffff_ffff_ffff,
+        ];
+
+        qcow.write_pointer_table_direct(TARGET_OFFSET, entries.iter())
+            .expect("write_pointer_table_direct");
+
+        let read_back = qcow
+            .read_pointer_table(TARGET_OFFSET, entries.len() as u64, None)
+            .expect("read_pointer_table");
+
+        assert_eq!(read_back, entries);
+    }
+
+    #[test]
+    fn read_pointer_table_applies_mask() {
+        let (_temp_file, mut qcow) = make_qcow_raw();
+        let entries: Vec<u64> = vec![0xffff_ffff_ffff_ffffu64; 4];
+        let mask = 0x00ff_ffff_ffff_fe00u64;
+
+        qcow.write_pointer_table_direct(TARGET_OFFSET, entries.iter())
+            .expect("write_pointer_table_direct");
+
+        let read_back = qcow
+            .read_pointer_table(TARGET_OFFSET, entries.len() as u64, Some(mask))
+            .expect("read_pointer_table");
+
+        assert!(read_back.iter().all(|&e| e == mask));
+    }
+
+    #[test]
+    fn write_cluster_then_zero_cluster_round_trips() {
+        let (temp_file, mut qcow) = make_qcow_raw();
+        let cluster_size = CLUSTER_SIZE as usize;
+        let data: Vec<u8> = (0..cluster_size).map(|i| (i % 251) as u8).collect();
+
+        qcow.write_cluster(CLUSTER_SIZE, &data)
+            .expect("write_cluster");
+
+        let mut verify = temp_file.as_file().try_clone().unwrap();
+        let mut buf = vec![0u8; cluster_size];
+        verify.seek(SeekFrom::Start(CLUSTER_SIZE)).unwrap();
+        verify.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, data);
+
+        qcow.zero_cluster(CLUSTER_SIZE).expect("zero_cluster");
+
+        verify.seek(SeekFrom::Start(CLUSTER_SIZE)).unwrap();
+        verify.read_exact(&mut buf).unwrap();
+        assert!(buf.iter().all(|&b| b == 0));
+    }
 }

--- a/block/src/formats/qcow/internal/qcow_raw_file.rs
+++ b/block/src/formats/qcow/internal/qcow_raw_file.rs
@@ -7,9 +7,10 @@
 use std::fmt::Debug;
 use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use std::os::unix::fs::FileExt;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use vmm_sys_util::write_zeroes::WriteZeroes;
+use vmm_sys_util::write_zeroes::WriteZeroesAt;
 
 use crate::aligned_file::AlignedFile;
 
@@ -205,14 +206,13 @@ impl QcowRawFile {
         count: u64,
         mask: Option<u64>,
     ) -> io::Result<Vec<u64>> {
-        let mut table = vec![0; count as usize];
-        self.file.seek(SeekFrom::Start(offset))?;
-        self.file.read_u64_into::<BigEndian>(&mut table)?;
-        if let Some(m) = mask {
-            for ptr in &mut table {
-                *ptr &= m;
-            }
-        }
+        let mut bytes = vec![0u8; count as usize * size_of::<u64>()];
+        self.file.read_exact_at(&mut bytes, offset)?;
+        let m = mask.unwrap_or(u64::MAX);
+        let table = bytes
+            .chunks_exact(size_of::<u64>())
+            .map(|c| u64::from_be_bytes(c.try_into().unwrap()) & m)
+            .collect();
         Ok(table)
     }
 
@@ -227,7 +227,7 @@ impl QcowRawFile {
     /// Entries are computed on-the-fly by the callback.
     ///
     /// The callback may perform metadata I/O on this `QcowRawFile`, so all
-    /// entries are materialized before seeking to the final write offset.
+    /// entries are materialized before the final positional write.
     pub fn write_pointer_table<'a, T: Copy + 'a>(
         &mut self,
         offset: u64,
@@ -239,8 +239,7 @@ impl QcowRawFile {
             let entry = f(self, *addr)?;
             buffer.extend_from_slice(&entry.to_be_bytes());
         }
-        self.file.seek(SeekFrom::Start(offset))?;
-        self.file.write_all(&buffer)
+        self.file.write_all_at(&buffer, offset)
     }
 
     /// Writes a pointer table directly without transforming values.
@@ -255,8 +254,7 @@ impl QcowRawFile {
         for &entry in entries {
             buffer.extend_from_slice(&entry.to_be_bytes());
         }
-        self.file.seek(SeekFrom::Start(offset))?;
-        self.file.write_all(&buffer)
+        self.file.write_all_at(&buffer, offset)
     }
 
     /// Read a refcount block from the file and returns a Vec containing the block.
@@ -318,16 +316,14 @@ impl QcowRawFile {
     /// Zeros out a cluster in the file.
     pub fn zero_cluster(&mut self, address: u64) -> io::Result<()> {
         let cluster_size = self.cluster_size as usize;
-        self.file.seek(SeekFrom::Start(address))?;
-        self.file.write_zeroes(cluster_size)?;
+        self.file.write_all_zeroes_at(address, cluster_size)?;
         Ok(())
     }
 
     /// Writes
     pub fn write_cluster(&mut self, address: u64, data: &[u8]) -> io::Result<()> {
         let cluster_size = self.cluster_size as usize;
-        self.file.seek(SeekFrom::Start(address))?;
-        self.file.write_all(&data[0..cluster_size])
+        self.file.write_all_at(&data[0..cluster_size], address)
     }
 
     pub fn physical_size(&self) -> io::Result<u64> {


### PR DESCRIPTION
QcowRawFile pointer table and cluster reads and writes seeked then read or wrote. This converts them to positional access on AlignedFile, leaving the cursor untouched. Each drops its preceding seek and stops depending on the shared cursor position, simplifying the call sites.

Behavior is preserved, as the calls still route through the AlignedFile O_DIRECT bounce. Adds round trip unit tests.