### PR TITLE
virtio-devices: Omit the device config capability for configless devices

### DIFF
--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -108,6 +108,10 @@ pub trait VirtioDevice: Send {
         let _ = value;
     }
 
+    fn config_size(&self) -> Option<u64> {
+        None
+    }
+
     /// Reads this device configuration space at `offset`.
     fn read_config(&self, _offset: u64, _data: &mut [u8]) {
         warn!(

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -230,6 +230,10 @@ impl Rng {
 }
 
 impl VirtioDevice for Rng {
+    fn config_size(&self) -> Option<u64> {
+        Some(0)
+    }
+
     fn device_type(&self) -> u32 {
         self.common.device_type
     }

--- a/virtio-devices/src/rtc.rs
+++ b/virtio-devices/src/rtc.rs
@@ -601,6 +601,10 @@ impl Rtc {
 }
 
 impl VirtioDevice for Rtc {
+    fn config_size(&self) -> Option<u64> {
+        Some(0)
+    }
+
     fn device_type(&self) -> u32 {
         self.common.device_type
     }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1638,4 +1638,72 @@ mod unit_tests {
 
         waiter.join().expect("barrier waiter deadlocked");
     }
+
+    struct TestInterruptManager;
+
+    impl InterruptManager for TestInterruptManager {
+        type GroupConfig = MsiIrqGroupConfig;
+
+        fn create_group(
+            &self,
+            _config: Self::GroupConfig,
+        ) -> io::Result<Arc<dyn InterruptSourceGroup>> {
+            Ok(Arc::new(TestInterruptSourceGroup {
+                event_fd: EventFd::new(0).unwrap(),
+            }))
+        }
+
+        fn destroy_group(&self, _group: Arc<dyn InterruptSourceGroup>) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_virtio_pci_device() -> VirtioPciDevice {
+        let memory = GuestMemoryAtomic::new(
+            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap(),
+        );
+        let device = Arc::new(Mutex::new(TestVirtioDevice {
+            result: Mutex::new(None),
+        }));
+        VirtioPciDevice::new(
+            "test-dev".to_string(),
+            memory,
+            device,
+            None,
+            &TestInterruptManager,
+            0,
+            EventFd::new(EFD_NONBLOCK).unwrap(),
+            false,
+            None,
+            Arc::new(Mutex::new(Vec::new())),
+            None,
+        )
+        .unwrap()
+    }
+
+    fn has_device_config_cap(cfg: &PciConfiguration) -> bool {
+        let mut ptr = (cfg.read_reg(0x34 / 4) & 0xFF) as usize;
+        while ptr != 0 {
+            let dword = cfg.read_reg(ptr / 4);
+            if dword & 0xFF == 0x09 && (dword >> 24) & 0xFF == PciCapabilityType::Device as u32 {
+                return true;
+            }
+            ptr = ((dword >> 8) & 0xFF) as usize;
+        }
+        false
+    }
+
+    #[test]
+    fn add_pci_capabilities_includes_device_config_when_sized() {
+        let mut dev = make_virtio_pci_device();
+        dev.add_pci_capabilities(DEVICE_CONFIG_SIZE).unwrap();
+        assert!(has_device_config_cap(&dev.configuration));
+    }
+
+    #[test]
+    fn add_pci_capabilities_omits_device_config_when_zero() {
+        let mut dev = make_virtio_pci_device();
+        dev.add_pci_capabilities(0).unwrap();
+        assert!(!has_device_config_cap(&dev.configuration));
+    }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -700,7 +700,10 @@ impl VirtioPciDevice {
             .get_bar_addr(VIRTIO_COMMON_BAR_INDEX.into())
     }
 
-    fn add_pci_capabilities(&mut self) -> result::Result<(), PciDeviceError> {
+    fn add_pci_capabilities(
+        &mut self,
+        device_config_size: u64,
+    ) -> result::Result<(), PciDeviceError> {
         // Add pointers to the different configuration structures from the PCI capabilities.
         let common_cap = VirtioPciCap::new(
             PciCapabilityType::Common,
@@ -722,16 +725,17 @@ impl VirtioPciDevice {
             .add_capability(&isr_cap)
             .map_err(PciDeviceError::CapabilitiesSetup)?;
 
-        // TODO(dgreid) - set based on device's configuration size?
-        let device_cap = VirtioPciCap::new(
-            PciCapabilityType::Device,
-            VIRTIO_COMMON_BAR_INDEX,
-            DEVICE_CONFIG_BAR_OFFSET as u32,
-            DEVICE_CONFIG_SIZE as u32,
-        );
-        self.configuration
-            .add_capability(&device_cap)
-            .map_err(PciDeviceError::CapabilitiesSetup)?;
+        if device_config_size > 0 {
+            let device_cap = VirtioPciCap::new(
+                PciCapabilityType::Device,
+                VIRTIO_COMMON_BAR_INDEX,
+                DEVICE_CONFIG_BAR_OFFSET as u32,
+                device_config_size as u32,
+            );
+            self.configuration
+                .add_capability(&device_cap)
+                .map_err(PciDeviceError::CapabilitiesSetup)?;
+        }
 
         let notify_cap = VirtioPciNotifyCap::new(
             PciCapabilityType::Notify,
@@ -1096,7 +1100,8 @@ impl PciDevice for VirtioPciDevice {
             })?;
 
             // Once the BARs are allocated, the capabilities can be added to the PCI configuration.
-            self.add_pci_capabilities()?;
+            let device_config_size = device.config_size().unwrap_or(DEVICE_CONFIG_SIZE);
+            self.add_pci_capabilities(device_config_size)?;
         }
 
         bars.push(bar);

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -310,6 +310,10 @@ fn timerfd_setup(timer: &File, secs: i64) -> Result<(), io::Error> {
 }
 
 impl VirtioDevice for Watchdog {
+    fn config_size(&self) -> Option<u64> {
+        Some(0)
+    }
+
     fn device_type(&self) -> u32 {
         self.common.device_type
     }


### PR DESCRIPTION
Omit the device configuration capability for devices that expose no device configuration fields. The watchdog, rng, and rtc devices have no such fields, but the PCI transport still advertised a device configuration capability backed by a phantom region. A guest read of that unbacked region is unserviceable. On aarch64 it decodes to an ISV=0 data abort, KVM_RUN returns ENOSYS, and the VM is torn down. On x86 the access is absorbed, so the defect was latent.

This adds a `config_size` method to `VirtioDevice` that defaults to `None`, sizes the capability from the device, and omits it when the size is zero, since the virtio driver rejects a zero length capability. The watchdog, rng, and rtc devices now report a zero config size. Unit tests assert the capability is present when sized and absent when zero.

Discovered through the [d0032_config_active_timeout](https://github.com/weltling/virtio-villain/blob/main/tests/watchdog/d0032_config_active_timeout.c) watchdog test, whose contract is to skip a device that exposes no device configuration capability. With this change the configless devices skip cleanly instead of triggering the read that tore down the VM on aarch64.