### PR TITLE
block: Make QcowRawFile cursor free

### DIFF
--- a/block/src/formats/qcow/internal/qcow_raw_file.rs
+++ b/block/src/formats/qcow/internal/qcow_raw_file.rs
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::fmt::Debug;
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Write};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::os::unix::fs::FileExt;
 
@@ -284,7 +284,7 @@ impl QcowRawFile {
     pub fn add_cluster_end(&mut self, max_valid_cluster_offset: u64) -> io::Result<Option<u64>> {
         // Determine where the new end of the file should be and set_len, which
         // translates to truncate(2).
-        let file_end: u64 = self.file.seek(SeekFrom::End(0))?;
+        let file_end: u64 = self.physical_size()?;
         let new_cluster_address: u64 = (file_end + self.cluster_size - 1) & !self.cluster_mask;
 
         if new_cluster_address > max_valid_cluster_offset {

--- a/block/src/formats/qcow/internal/qcow_raw_file.rs
+++ b/block/src/formats/qcow/internal/qcow_raw_file.rs
@@ -395,12 +395,17 @@ mod unit_tests {
     const FILE_LEN: u64 = 0x40000; // 256 KiB filler so all offsets are valid
 
     fn make_qcow_raw() -> (TempFile, QcowRawFile) {
+        make_qcow_raw_bits(16)
+    }
+
+    fn make_qcow_raw_bits(refcount_bits: u64) -> (TempFile, QcowRawFile) {
         let temp_file = TempFile::new().unwrap();
         temp_file.as_file().set_len(FILE_LEN).unwrap();
 
         let file = temp_file.as_file().try_clone().unwrap();
         let raw = AlignedFile::new(file, false);
-        let qcow_raw = QcowRawFile::from(raw, CLUSTER_SIZE, 16).expect("QcowRawFile::from");
+        let qcow_raw =
+            QcowRawFile::from(raw, CLUSTER_SIZE, refcount_bits).expect("QcowRawFile::from");
         (temp_file, qcow_raw)
     }
 
@@ -508,5 +513,56 @@ mod unit_tests {
         verify.seek(SeekFrom::Start(CLUSTER_SIZE)).unwrap();
         verify.read_exact(&mut buf).unwrap();
         assert!(buf.iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn refcount_block_round_trips() {
+        let (_temp_file, mut qcow) = make_qcow_raw_bits(16);
+        let count = qcow.refcount_block_entries as usize;
+        let table: Vec<u64> = (0..count).map(|i| (i % 251) as u64).collect();
+
+        qcow.write_refcount_block(TARGET_OFFSET, &table)
+            .expect("write_refcount_block");
+        let read_back = qcow
+            .read_refcount_block(TARGET_OFFSET)
+            .expect("read_refcount_block");
+
+        assert_eq!(read_back, table);
+    }
+
+    #[test]
+    fn refcount_block_subbyte_round_trips() {
+        let (_temp_file, mut qcow) = make_qcow_raw_bits(4);
+        let count = qcow.refcount_block_entries as usize;
+        let table: Vec<u64> = (0..count).map(|i| (i % 16) as u64).collect();
+
+        qcow.write_refcount_block(TARGET_OFFSET, &table)
+            .expect("write_refcount_block");
+        let read_back = qcow
+            .read_refcount_block(TARGET_OFFSET)
+            .expect("read_refcount_block");
+
+        assert_eq!(read_back, table);
+    }
+
+    #[test]
+    fn add_cluster_end_appends_aligned_cluster() {
+        let (_temp_file, mut qcow) = make_qcow_raw();
+        let before = qcow.physical_size().unwrap();
+
+        let addr = qcow
+            .add_cluster_end(u64::MAX)
+            .expect("add_cluster_end")
+            .expect("a cluster was allocated");
+
+        assert_eq!(addr % CLUSTER_SIZE, 0);
+        assert!(addr >= before);
+        assert_eq!(qcow.physical_size().unwrap(), addr + CLUSTER_SIZE);
+    }
+
+    #[test]
+    fn add_cluster_end_respects_max_offset() {
+        let (_temp_file, mut qcow) = make_qcow_raw();
+        assert!(qcow.add_cluster_end(0).unwrap().is_none());
     }
 }

--- a/block/src/formats/qcow/internal/qcow_raw_file.rs
+++ b/block/src/formats/qcow/internal/qcow_raw_file.rs
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::fmt::Debug;
-use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::os::unix::fs::FileExt;
 
@@ -15,8 +15,8 @@ use vmm_sys_util::write_zeroes::WriteZeroesAt;
 use crate::aligned_file::AlignedFile;
 
 // Type aliases for the refcount read/write function pointers
-type RefcountReader = fn(&mut AlignedFile, usize) -> io::Result<Vec<u64>>;
-type RefcountWriter = fn(&mut AlignedFile, &[u64]) -> io::Result<()>;
+type RefcountReader = fn(&mut AlignedFile, u64, usize) -> io::Result<Vec<u64>>;
+type RefcountWriter = fn(&mut AlignedFile, u64, &[u64]) -> io::Result<()>;
 
 /// Big-endian file access trait.
 pub(super) trait BeUint: Sized + Copy {
@@ -88,10 +88,14 @@ impl BeUint for u64 {
 }
 
 /// Read byte-aligned refcounts.
-fn read_refcount<T: BeUint>(file: &mut AlignedFile, count: usize) -> io::Result<Vec<u64>> {
+fn read_refcount<T: BeUint>(
+    file: &mut AlignedFile,
+    offset: u64,
+    count: usize,
+) -> io::Result<Vec<u64>> {
     let bytes_per_entry = size_of::<T>();
     let mut data = vec![0u8; count * bytes_per_entry];
-    file.read_exact(&mut data)?;
+    file.read_exact_at(&mut data, offset)?;
     Ok(data
         .chunks_exact(bytes_per_entry)
         .map(T::from_be_slice)
@@ -99,22 +103,27 @@ fn read_refcount<T: BeUint>(file: &mut AlignedFile, count: usize) -> io::Result<
 }
 
 /// Write byte-aligned refcounts.
-fn write_refcount<T: BeUint + TryFrom<u64>>(file: &mut AlignedFile, table: &[u64]) -> io::Result<()>
+fn write_refcount<T: BeUint + TryFrom<u64>>(
+    file: &mut AlignedFile,
+    offset: u64,
+    table: &[u64],
+) -> io::Result<()>
 where
     <T as TryFrom<u64>>::Error: Debug,
 {
     let bytes_per_entry = size_of::<T>();
-    let mut buffer = BufWriter::with_capacity(table.len() * bytes_per_entry, file);
+    let mut buffer = Vec::with_capacity(table.len() * bytes_per_entry);
     for &val in table {
         let converted = T::try_from(val).expect("refcount values are validated on increment");
         T::write_be(&mut buffer, converted)?;
     }
-    buffer.flush()
+    file.write_all_at(&buffer, offset)
 }
 
 /// Read sub-byte refcounts. Bit 0 is the least significant bit.
 fn read_refcount_subbyte<const BITS: usize>(
     file: &mut AlignedFile,
+    offset: u64,
     count: usize,
 ) -> io::Result<Vec<u64>> {
     const { assert!(BITS == 1 || BITS == 2 || BITS == 4) };
@@ -122,7 +131,7 @@ fn read_refcount_subbyte<const BITS: usize>(
     let mask = (1u64 << BITS) - 1;
     let bytes_needed = count.div_ceil(entries_per_byte);
     let mut bytes = vec![0u8; bytes_needed];
-    file.read_exact(&mut bytes)?;
+    file.read_exact_at(&mut bytes, offset)?;
 
     let mut table = vec![0u64; count];
     for (i, val) in table.iter_mut().enumerate() {
@@ -136,12 +145,13 @@ fn read_refcount_subbyte<const BITS: usize>(
 /// Write sub-byte refcounts. Bit 0 is the least significant bit.
 fn write_refcount_subbyte<const BITS: usize>(
     file: &mut AlignedFile,
+    offset: u64,
     table: &[u64],
 ) -> io::Result<()> {
     const { assert!(BITS == 1 || BITS == 2 || BITS == 4) };
     let entries_per_byte = 8 / BITS;
     let mask = (1u64 << BITS) - 1;
-    let mut buffer = BufWriter::with_capacity(table.len().div_ceil(entries_per_byte), file);
+    let mut buffer = Vec::with_capacity(table.len().div_ceil(entries_per_byte));
 
     for chunk in table.chunks(entries_per_byte) {
         let mut byte = 0u8;
@@ -149,9 +159,9 @@ fn write_refcount_subbyte<const BITS: usize>(
             let bit_offset = i * BITS;
             byte |= ((val & mask) << bit_offset) as u8;
         }
-        buffer.write_u8(byte)?;
+        buffer.push(byte);
     }
-    buffer.flush()
+    file.write_all_at(&buffer, offset)
 }
 
 /// A qcow file. Allows reading/writing clusters and appending clusters.
@@ -261,15 +271,13 @@ impl QcowRawFile {
     /// Always returns a cluster's worth of data.
     #[inline]
     pub fn read_refcount_block(&mut self, offset: u64) -> io::Result<Vec<u64>> {
-        self.file.seek(SeekFrom::Start(offset))?;
-        (self.read_refcount_fn)(&mut self.file, self.refcount_block_entries as usize)
+        (self.read_refcount_fn)(&mut self.file, offset, self.refcount_block_entries as usize)
     }
 
     /// Writes a refcount block to the file.
     #[inline]
     pub fn write_refcount_block(&mut self, offset: u64, table: &[u64]) -> io::Result<()> {
-        self.file.seek(SeekFrom::Start(offset))?;
-        (self.write_refcount_fn)(&mut self.file, table)
+        (self.write_refcount_fn)(&mut self.file, offset, table)
     }
 
     /// Allocates a new cluster at the end of the current file, return the address.


### PR DESCRIPTION
Continue the `QcowRawFile` simplification after #8486. Cursor based I/O ties every metadata access to a prior seek on shared file position. Positional access drops that hidden state, so each read and write is self contained, which simplifies the code.

This converts the remaining cursor users in `QcowRawFile`, the refcount block helpers and `add_cluster_end`, to positional I/O. With that done `QcowRawFile` no longer touches the file cursor in production code.

The result is unchanged. Access still routes through the `AlignedFile` O_DIRECT bounce, so alignment handling stays the same.