### PR TITLE
block: Convert qcow metadata I/O to positional

### DIFF
--- a/block/src/formats/qcow/internal/metadata.rs
+++ b/block/src/formats/qcow/internal/metadata.rs
@@ -19,6 +19,7 @@
 use std::cmp::min;
 use std::io::{self, Seek};
 use std::mem;
+use std::os::unix::fs::FileExt;
 use std::sync::{Arc, RwLock};
 
 use libc::{EINVAL, EIO};
@@ -548,10 +549,10 @@ impl QcowState {
             let decompressed_cluster = self.decompress_l2_cluster(l2_entry)?;
             let cluster_addr = self.append_data_cluster(None)?;
             self.update_cluster_addr(l1_index, l2_index, cluster_addr, &mut set_refcounts)?;
-            self.raw_file
+            let nwritten = self
+                .raw_file
                 .file_mut()
-                .seek(io::SeekFrom::Start(cluster_addr))?;
-            let nwritten = io::Write::write(self.raw_file.file_mut(), &decompressed_cluster)?;
+                .write_at(&decompressed_cluster, cluster_addr)?;
             if nwritten != decompressed_cluster.len() {
                 self.set_corrupt_bit_best_effort();
                 return Err(io::Error::from_raw_os_error(EIO));
@@ -775,7 +776,7 @@ impl QcowState {
         let new_l1_clusters = div_round_up_u64(new_l1_bytes, cluster_size);
 
         // Allocate contiguous clusters at file end for new L1 table
-        let file_size = self.raw_file.file_mut().seek(io::SeekFrom::End(0))?;
+        let file_size = self.raw_file.physical_size()?;
         let new_l1_offset = self.raw_file.cluster_address(file_size + cluster_size - 1);
 
         let new_file_end = new_l1_offset + new_l1_clusters * cluster_size;
@@ -1052,11 +1053,10 @@ impl QcowState {
     fn decompress_l2_cluster(&mut self, l2_entry: u64) -> io::Result<Vec<u8>> {
         let (compressed_addr, compressed_size) =
             l2_entry_compressed_cluster_layout(l2_entry, self.header.cluster_bits);
+        let mut compressed = vec![0u8; compressed_size];
         self.raw_file
             .file_mut()
-            .seek(io::SeekFrom::Start(compressed_addr))?;
-        let mut compressed = vec![0u8; compressed_size];
-        io::Read::read_exact(self.raw_file.file_mut(), &mut compressed)?;
+            .read_exact_at(&mut compressed, compressed_addr)?;
         let decoder = self.header.get_decoder();
         let cluster_size = self.raw_file.cluster_size() as usize;
         let mut decompressed = vec![0u8; cluster_size];

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -16,7 +16,7 @@ mod vec_cache;
 use std::cmp::{max, min};
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::fs::{OpenOptions, read_link};
-use std::io::{self, Seek, SeekFrom};
+use std::io::{self, Seek};
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::FileExt;
 use std::path::Path;
@@ -42,6 +42,7 @@ use vec_cache::{CacheMap, VecCache};
 
 use crate::aligned_file::AlignedFile;
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
+use crate::query_device_size;
 
 #[sorted]
 #[derive(Debug, Error)]
@@ -215,18 +216,14 @@ impl BackingFile {
 
         let (kind, virtual_size) = match backing_format {
             ImageType::Raw => {
-                let size = raw_file.seek(SeekFrom::End(0)).map_err(|e| {
-                    BlockError::new(
-                        BlockErrorKind::Io,
-                        Error::BackingFileIo(config.path.clone(), e),
-                    )
-                })?;
-                raw_file.rewind().map_err(|e| {
-                    BlockError::new(
-                        BlockErrorKind::Io,
-                        Error::BackingFileIo(config.path.clone(), e),
-                    )
-                })?;
+                let size = query_device_size(raw_file.file())
+                    .map_err(|e| {
+                        BlockError::new(
+                            BlockErrorKind::Io,
+                            Error::BackingFileIo(config.path.clone(), e),
+                        )
+                    })?
+                    .0;
                 (BackingKind::Raw(raw_file), size)
             }
             ImageType::Qcow2 => {

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -32,7 +32,7 @@ use header::{
     offset_is_cluster_boundary,
 };
 use log::warn;
-use qcow_raw_file::{BeUint, QcowRawFile};
+use qcow_raw_file::QcowRawFile;
 use refcount::RefCount;
 use remain::sorted;
 use thiserror::Error;
@@ -874,20 +874,15 @@ fn rebuild_refcounts(raw_file: &mut QcowRawFile, header: QcowHeader) -> BlockRes
 
 /// Detect the type of an image file by checking for a valid qcow2 header.
 pub fn detect_image_type(file: &mut AlignedFile) -> BlockResult<ImageType> {
-    let orig_seek = file
-        .stream_position()
-        .map_err(|e| BlockError::new(BlockErrorKind::Io, Error::SeekingFile(e)))?;
-    file.rewind()
-        .map_err(|e| BlockError::new(BlockErrorKind::Io, Error::SeekingFile(e)))?;
-    let magic = u32::read_be(file)
+    let mut magic_bytes = [0u8; 4];
+    file.read_exact_at(&mut magic_bytes, 0)
         .map_err(|e| BlockError::new(BlockErrorKind::Io, Error::ReadingHeader(e)))?;
+    let magic = u32::from_be_bytes(magic_bytes);
     let image_type = if magic == QCOW_MAGIC {
         ImageType::Qcow2
     } else {
         ImageType::Raw
     };
-    file.seek(SeekFrom::Start(orig_seek))
-        .map_err(|e| BlockError::new(BlockErrorKind::Io, Error::SeekingFile(e)))?;
     Ok(image_type)
 }
 #[cfg(test)]
@@ -905,6 +900,7 @@ mod unit_tests {
         AUTOCLEAR_FEATURES_OFFSET, DEFAULT_CLUSTER_BITS, DEFAULT_REFCOUNT_ORDER,
         HEADER_EXT_BACKING_FORMAT, HEADER_EXT_END, V2_BARE_HEADER_SIZE, V3_BARE_HEADER_SIZE,
     };
+    use super::qcow_raw_file::BeUint;
     use super::util::ZERO_FLAG;
     use super::*;
     use crate::formats::qcow::{QcowDisk, QcowTempDisk};

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -1008,6 +1008,18 @@ mod unit_tests {
     }
 
     #[test]
+    fn detect_image_type_recognizes_qcow2_magic() {
+        let mut file = basic_file(&valid_header_v3());
+        assert_eq!(detect_image_type(&mut file).unwrap(), ImageType::Qcow2);
+    }
+
+    #[test]
+    fn detect_image_type_treats_other_magic_as_raw() {
+        let mut file = basic_file(&[0u8; 16]);
+        assert_eq!(detect_image_type(&mut file).unwrap(), ImageType::Raw);
+    }
+
+    #[test]
     fn default_header_v2() {
         let header = QcowHeader::create_for_size_and_path(2, 0x10_0000, None)
             .expect("Failed to create header.");

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -18,6 +18,7 @@ use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::fs::{OpenOptions, read_link};
 use std::io::{self, Seek, SeekFrom};
 use std::os::fd::AsRawFd;
+use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::{result, str};
 
@@ -387,15 +388,15 @@ pub(crate) fn parse_qcow(
     // The first cluster should always have a non-zero refcount, so if it is 0,
     // this is an old file with broken refcounts, which requires a rebuild.
     let mut refcount_rebuild_required = true;
-    file.seek(SeekFrom::Start(header.refcount_table_offset))
-        .map_err(|e| BlockError::new(BlockErrorKind::Io, Error::SeekingFile(e)))?;
-    let first_refblock_addr = u64::read_be(&mut file)
+    let mut first_refblock_bytes = [0u8; 8];
+    file.read_exact_at(&mut first_refblock_bytes, header.refcount_table_offset)
         .map_err(|e| BlockError::new(BlockErrorKind::Io, Error::ReadingHeader(e)))?;
+    let first_refblock_addr = u64::from_be_bytes(first_refblock_bytes);
     if first_refblock_addr != 0 {
-        file.seek(SeekFrom::Start(first_refblock_addr))
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, Error::SeekingFile(e)))?;
-        let first_cluster_refcount = u16::read_be(&mut file)
+        let mut refcount_bytes = [0u8; 2];
+        file.read_exact_at(&mut refcount_bytes, first_refblock_addr)
             .map_err(|e| BlockError::new(BlockErrorKind::Io, Error::ReadingHeader(e)))?;
+        let first_cluster_refcount = u16::from_be_bytes(refcount_bytes);
         if first_cluster_refcount != 0 {
             refcount_rebuild_required = false;
         }


### PR DESCRIPTION
Continue the qcow cursor simplification after #8486. Cursor based I/O ties every access to a prior seek on shared file position. Positional access drops that hidden state, so each read and write is self contained, which simplifies the code.

This converts the metadata cursor users that do not depend on the header writer: the compressed cluster read and write, the L1 resize size query, the refcount rebuild markers, the image magic check in `detect_image_type`, and the raw backing size query. The header rewrite still uses the cursor and stays for a later change.

The result is unchanged. The compressed paths still route through the `AlignedFile` O_DIRECT bounce, so alignment handling stays the same.