### PR TITLE
vmm: Replace unsafe sysconf with std::thread::available_parallelism

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -26,7 +26,6 @@ use arch::{RegionType, layout};
 use devices::ioapic;
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use hypervisor::HypervisorVmError;
-use libc::_SC_NPROCESSORS_ONLN;
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -2215,10 +2214,8 @@ impl MemoryManager {
         let mut n: usize = 1;
 
         // Do not create more threads than processors available.
-        // SAFETY: FFI call. Trivially safe.
-        let procs = unsafe { libc::sysconf(_SC_NPROCESSORS_ONLN) };
-        if procs > 0 {
-            n = cmp::min(procs as usize, MAX_PREFAULT_THREAD_COUNT);
+        if let Ok(procs) = thread::available_parallelism() {
+            n = cmp::min(procs.get(), MAX_PREFAULT_THREAD_COUNT);
         }
 
         // Do not create more threads than pages being allocated.


### PR DESCRIPTION
get_prefault_num_threads() in memory_manager.rs used an unsafe libc::sysconf call to read _SC_NPROCESSORS_ONLN. The unsafe block was marked "Trivially safe" in the comment, but it's unnecessary: std::thread::available_parallelism() has been stable since Rust 1.59 and returns the same information through safe, portable std.

The replacement drops the unsafe block entirely and removes the now-unused `use libc::_SC_NPROCESSORS_ONLN` import. The clamping logic stays the same — min(procs, MAX_PREFAULT_THREAD_COUNT) — just using .get() on the NonZeroUsize instead of casting from libc::c_long.

Built locally: cargo check passes on the vmm crate. This is a mechanical substitution, no behavioural change.

Closes #8495
