### PR TITLE
hypervisor, vmm: Reduce memory usage of KVM SEV-SNP VMs with VFIO 

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -1687,7 +1687,12 @@ pub(crate) fn _test_simple_launch(guest: &Guest) {
 
 pub(crate) fn _test_multi_cpu(guest: &Guest) {
     let mut cmd = GuestCommand::new(guest);
-    cmd.args(["--cpus", "boot=2,max=4"])
+    let cpus = if guest.vm_type == GuestVmType::Confidential {
+        "boot=2"
+    } else {
+        "boot=2,max=4"
+    };
+    cmd.args(["--cpus", cpus])
         .default_memory()
         .default_kernel_cmdline()
         .capture_output()

--- a/docs/amd_sev_snp.md
+++ b/docs/amd_sev_snp.md
@@ -44,3 +44,9 @@ You can run a SEV-SNP VM using the following command:
 ```
 
 For more information related to Microsoft Hypervisor, please see [mshv.md](mshv.md).
+
+**Limitations**
+Note that Cloud Hypervisor does not support the following features with SEV-SNP:
+- Memory & CPU hotplug
+- Huge Pages (HugeTLB)
+- Virtual IOMMU

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -638,6 +638,8 @@ pub struct KvmVm {
     snp_guest_policy: OnceLock<u64>,
     dirty_log_slots: RwLock<HashMap<u32, KvmDirtyLogSlot>>,
     memory_slots: Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
+    #[cfg(feature = "sev_snp")]
+    memory_conversion_handler: Arc<OnceLock<Arc<dyn vm::MemoryConversionHandler>>>,
 }
 
 impl KvmVm {
@@ -747,6 +749,14 @@ impl KvmVm {
 /// let vm = hypervisor.create_vm(HypervisorVmConfig::default()).expect("new VM fd creation failed");
 /// ```
 impl vm::Vm for KvmVm {
+    #[cfg(feature = "sev_snp")]
+    fn register_memory_conversion_handler(&self, handler: Arc<dyn vm::MemoryConversionHandler>) {
+        self.memory_conversion_handler
+            .set(handler)
+            .ok()
+            .expect("Memory conversion handler already registered");
+    }
+
     #[cfg(feature = "sev_snp")]
     fn sev_snp_init(&self, guest_policy: igvm_defs::SnpPolicy) -> vm::Result<()> {
         self.sev_fd
@@ -942,6 +952,8 @@ impl vm::Vm for KvmVm {
             vm_fd: self.fd.clone(),
             #[cfg(feature = "sev_snp")]
             memory_slots: self.memory_slots.clone(),
+            #[cfg(feature = "sev_snp")]
+            memory_conversion_handler: self.memory_conversion_handler.clone(),
         };
         Ok(Box::new(vcpu))
     }
@@ -1784,6 +1796,8 @@ impl hypervisor::Hypervisor for KvmHypervisor {
                 #[cfg(feature = "sev_snp")]
                 snp_guest_policy: OnceLock::new(),
                 memory_slots,
+                #[cfg(feature = "sev_snp")]
+                memory_conversion_handler: Arc::new(OnceLock::new()),
             }))
         }
 
@@ -1926,10 +1940,26 @@ pub struct KvmVcpu {
     vm_fd: Arc<VmFd>,
     #[cfg(feature = "sev_snp")]
     memory_slots: Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
+    #[cfg(feature = "sev_snp")]
+    memory_conversion_handler: Arc<OnceLock<Arc<dyn vm::MemoryConversionHandler>>>,
 }
 
 #[cfg(feature = "sev_snp")]
 impl KvmVcpu {
+    fn notify_memory_conversion_handler(
+        &self,
+        gpa: u64,
+        size: u64,
+        to_shared: bool,
+    ) -> cpu::Result<()> {
+        if let Some(handler) = self.memory_conversion_handler.get() {
+            handler
+                .handle_conversion(gpa, size, to_shared)
+                .map_err(cpu::HypervisorCpuError::RunVcpu)?;
+        }
+        Ok(())
+    }
+
     fn punch_holes_in_guest_memfd(
         memory_slots: &Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
         gpa: u64,
@@ -2650,6 +2680,12 @@ impl cpu::Vcpu for KvmVcpu {
                                 Self::punch_holes_in_guest_memfd(&self.memory_slots, address, size);
                             }
 
+                            self.notify_memory_conversion_handler(
+                                address,
+                                size,
+                                set_private_attr == 0,
+                            )?;
+
                             Ok(cpu::VmExit::Ignore)
                         }
                         _ => Ok(cpu::VmExit::Ignore),
@@ -2689,6 +2725,8 @@ impl cpu::Vcpu for KvmVcpu {
                     if attributes == 0 {
                         Self::punch_holes_in_guest_memfd(&self.memory_slots, gpa, size);
                     }
+
+                    self.notify_memory_conversion_handler(gpa, size, attributes == 0)?;
 
                     Ok(cpu::VmExit::Ignore)
                 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -2693,8 +2693,13 @@ impl cpu::Vcpu for KvmVcpu {
                             attributes,
                             flags: 0,
                         })
-                        .map(|_| cpu::VmExit::Ignore)
-                        .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()))
+                        .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()))?;
+
+                    if attributes == 0 {
+                        Self::punch_holes_in_guest_memfd(&self.memory_slots, gpa, size);
+                    }
+
+                    Ok(cpu::VmExit::Ignore)
                 }
 
                 r => Err(cpu::HypervisorCpuError::RunVcpu(anyhow!(

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -16,12 +16,9 @@ use std::collections::HashMap;
 use std::mem::offset_of;
 #[cfg(feature = "sev_snp")]
 use std::num;
-#[cfg(feature = "sev_snp")]
-use std::os::fd::FromRawFd;
-use std::os::fd::OwnedFd;
+use std::os::fd::{FromRawFd, OwnedFd};
 #[cfg(feature = "tdx")]
 use std::os::raw;
-#[cfg(any(feature = "sev_snp", feature = "tdx"))]
 use std::os::unix::io::AsRawFd;
 #[cfg(feature = "tdx")]
 use std::os::unix::io::RawFd;
@@ -44,7 +41,6 @@ use anyhow::anyhow;
 #[cfg(feature = "sev_snp")]
 use igvm::snp_defs::{SevSelector, SevVmsa};
 use kvm_bindings::fam_wrappers::KvmIrqRouting;
-#[cfg(feature = "sev_snp")]
 use kvm_bindings::kvm_create_guest_memfd;
 use kvm_ioctls::{NoDatamatch, VcpuFd, VmFd};
 #[cfg(feature = "sev_snp")]
@@ -616,6 +612,7 @@ struct KvmDirtyLogSlot {
     guest_phys_addr: u64,
     memory_size: u64,
     userspace_addr: u64,
+    flags: u32,
     // Following fields are used by kvm_userspace_memory_region2.
     guest_memfd_offset: u64,
     guest_memfd: u32,
@@ -733,15 +730,6 @@ impl KvmVm {
                     memory_size: region.memory_size,
                 })
             }
-        }
-    }
-
-    /// Get flag for kvm_userspace_memory_region based on memfd support.
-    fn get_kvm_userspace_memory_region_flag(&self, flag: u32) -> u32 {
-        flag | if self.memory_slots.is_some() {
-            KVM_MEM_GUEST_MEMFD
-        } else {
-            0
         }
     }
 }
@@ -1112,6 +1100,7 @@ impl vm::Vm for KvmVm {
         userspace_addr: *mut u8,
         readonly: bool,
         log_dirty_pages: bool,
+        visibility: vm::MemoryVisibility,
     ) -> vm::Result<()> {
         let mut flags = 0;
         if readonly {
@@ -1121,8 +1110,12 @@ impl vm::Vm for KvmVm {
 
         // Create a per-region guest_memfd when supported.
         // Each region gets its own fd sized exactly to memory_size
-        #[cfg(feature = "sev_snp")]
-        let guest_memfd = if let Some(slots) = &self.memory_slots {
+        let guest_memfd = if let Some(slots) = self
+            .memory_slots
+            .as_ref()
+            .filter(|_| visibility == vm::MemoryVisibility::Private)
+        {
+            flags |= KVM_MEM_GUEST_MEMFD;
             // SAFETY: Safe because guest regions are guaranteed not to overlap.
             let fd = unsafe {
                 OwnedFd::from_raw_fd(
@@ -1147,16 +1140,13 @@ impl vm::Vm for KvmVm {
         } else {
             0
         };
-        #[cfg(not(feature = "sev_snp"))]
-        let guest_memfd = 0;
 
         let region = kvm_userspace_memory_region2 {
             slot,
-            flags: self.get_kvm_userspace_memory_region_flag(flags),
+            flags,
             guest_phys_addr,
             memory_size: memory_size as u64,
             userspace_addr: userspace_addr as usize as u64,
-            #[cfg(not(target_arch = "riscv64"))]
             guest_memfd,
             // Each guest_memfd is per-region and sized to memory_size,
             // so the region's data always starts at offset 0.
@@ -1178,6 +1168,7 @@ impl vm::Vm for KvmVm {
                     guest_phys_addr: region.guest_phys_addr,
                     memory_size: region.memory_size,
                     userspace_addr: region.userspace_addr,
+                    flags: region.flags,
                     guest_memfd_offset: region.guest_memfd_offset,
                     guest_memfd: region.guest_memfd,
                 },
@@ -1191,7 +1182,7 @@ impl vm::Vm for KvmVm {
         }
 
         #[cfg(feature = "sev_snp")]
-        if self.memory_slots.is_some() {
+        if visibility == vm::MemoryVisibility::Private && self.memory_slots.is_some() {
             self.fd
                 .set_memory_attributes(kvm_memory_attributes {
                     address: region.guest_phys_addr,
@@ -1423,7 +1414,7 @@ impl vm::Vm for KvmVm {
                 guest_phys_addr: s.guest_phys_addr,
                 memory_size: s.memory_size,
                 userspace_addr: s.userspace_addr,
-                flags: self.get_kvm_userspace_memory_region_flag(KVM_MEM_LOG_DIRTY_PAGES),
+                flags: s.flags | KVM_MEM_LOG_DIRTY_PAGES,
                 guest_memfd: s.guest_memfd,
                 guest_memfd_offset: s.guest_memfd_offset,
                 ..Default::default()
@@ -1449,7 +1440,7 @@ impl vm::Vm for KvmVm {
                 guest_phys_addr: s.guest_phys_addr,
                 memory_size: s.memory_size,
                 userspace_addr: s.userspace_addr,
-                flags: self.get_kvm_userspace_memory_region_flag(0),
+                flags: s.flags & !KVM_MEM_LOG_DIRTY_PAGES,
                 guest_memfd: s.guest_memfd,
                 guest_memfd_offset: s.guest_memfd_offset,
                 ..Default::default()

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -2710,8 +2710,13 @@ impl cpu::Vcpu for KvmVcpu {
                             attributes,
                             flags: 0,
                         })
-                        .map(|_| cpu::VmExit::Ignore)
-                        .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()))
+                        .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()))?;
+
+                    if attributes == 0 {
+                        Self::punch_holes_in_guest_memfd(&self.memory_slots, gpa, size);
+                    }
+
+                    Ok(cpu::VmExit::Ignore)
                 }
 
                 r => Err(cpu::HypervisorCpuError::RunVcpu(anyhow!(

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -625,6 +625,8 @@ struct KvmMemorySlot {
     guest_phys_addr: u64,
     #[cfg_attr(not(feature = "sev_snp"), expect(dead_code))]
     memory_size: u64,
+    #[cfg_attr(not(feature = "sev_snp"), expect(dead_code))]
+    userspace_addr: u64,
 }
 
 /// Wrapper over KVM VM ioctls.
@@ -1146,6 +1148,7 @@ impl vm::Vm for KvmVm {
                     guest_memfd: fd,
                     guest_phys_addr,
                     memory_size: memory_size as u64,
+                    userspace_addr: userspace_addr as usize as u64,
                 },
             );
             raw_fd
@@ -1960,6 +1963,13 @@ impl KvmVcpu {
         Ok(())
     }
 
+    /// Whether to discard the stale shared mapping on conversion to private.
+    fn should_discard_shared_mapping(&self) -> bool {
+        self.memory_conversion_handler
+            .get()
+            .is_some_and(|h| h.reclaims_shared_mapping())
+    }
+
     fn punch_holes_in_guest_memfd(
         memory_slots: &Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
         gpa: u64,
@@ -1994,6 +2004,50 @@ impl KvmVcpu {
             if ret != 0 {
                 error!(
                     "Error punching hole in the guest_memfd: gpa={gpa:#x} offset={offset:#x} len={len:#x}: {}",
+                    io::Error::last_os_error()
+                );
+            }
+        }
+    }
+
+    /// Discard the stale *shared* mapping for `[gpa, gpa + size)`.
+    fn discard_shared_mapping(
+        memory_slots: &Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
+        gpa: u64,
+        size: u64,
+    ) {
+        let Some(slots) = memory_slots else {
+            return;
+        };
+        let slots = slots.read().unwrap();
+        let req_end = gpa.saturating_add(size);
+
+        for slot in slots.values() {
+            let slot_end = slot.guest_phys_addr.saturating_add(slot.memory_size);
+            if gpa >= slot_end || req_end <= slot.guest_phys_addr {
+                continue;
+            }
+
+            let overlap_start = gpa.max(slot.guest_phys_addr);
+            let overlap_end = req_end.min(slot_end);
+            let offset = overlap_start - slot.guest_phys_addr;
+            let len = overlap_end - overlap_start;
+
+            let addr = (slot.userspace_addr as usize + offset as usize) as *mut libc::c_void;
+
+            // MADV_REMOVE frees the backing store for shmem/memfd/hugetlb (shared=on,
+            // hugepages). So fall back to MADV_DONTNEED if MADV_REMOVE is rejected for
+            // default anonymous backing.
+            //
+            // SAFETY: [userspace_addr + offset, + len) lies within the slot's range.
+            let mut ret = unsafe { libc::madvise(addr, len as usize, libc::MADV_REMOVE) };
+            if ret != 0 {
+                // SAFETY: [userspace_addr + offset, + len) lies within the slot's range.
+                ret = unsafe { libc::madvise(addr, len as usize, libc::MADV_DONTNEED) };
+            }
+            if ret != 0 {
+                error!(
+                    "Error discarding shared backing: gpa={gpa:#x} offset={offset:#x} len={len:#x}: {}",
                     io::Error::last_os_error()
                 );
             }
@@ -2686,6 +2740,10 @@ impl cpu::Vcpu for KvmVcpu {
                                 set_private_attr == 0,
                             )?;
 
+                            if set_private_attr != 0 && self.should_discard_shared_mapping() {
+                                Self::discard_shared_mapping(&self.memory_slots, address, size);
+                            }
+
                             Ok(cpu::VmExit::Ignore)
                         }
                         _ => Ok(cpu::VmExit::Ignore),
@@ -2727,6 +2785,10 @@ impl cpu::Vcpu for KvmVcpu {
                     }
 
                     self.notify_memory_conversion_handler(gpa, size, attributes == 0)?;
+
+                    if attributes != 0 && self.should_discard_shared_mapping() {
+                        Self::discard_shared_mapping(&self.memory_slots, gpa, size);
+                    }
 
                     Ok(cpu::VmExit::Ignore)
                 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -641,6 +641,8 @@ pub struct KvmVm {
     snp_guest_policy: OnceLock<u64>,
     dirty_log_slots: RwLock<HashMap<u32, KvmDirtyLogSlot>>,
     memory_slots: Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
+    #[cfg(feature = "sev_snp")]
+    memory_conversion_handler: Arc<OnceLock<Arc<dyn vm::MemoryConversionHandler>>>,
 }
 
 impl KvmVm {
@@ -759,6 +761,18 @@ impl KvmVm {
 /// let vm = hypervisor.create_vm(HypervisorVmConfig::default()).expect("new VM fd creation failed");
 /// ```
 impl vm::Vm for KvmVm {
+    #[cfg(feature = "sev_snp")]
+    fn register_memory_conversion_handler(
+        &self,
+        handler: Arc<dyn vm::MemoryConversionHandler>,
+    ) -> vm::Result<()> {
+        self.memory_conversion_handler.set(handler).map_err(|_| {
+            vm::HypervisorVmError::RegisterMemoryConversionHandler(anyhow!(
+                "a memory conversion handler is already registered"
+            ))
+        })
+    }
+
     #[cfg(feature = "sev_snp")]
     fn sev_snp_init(&self, guest_policy: igvm_defs::SnpPolicy) -> vm::Result<()> {
         self.sev_fd
@@ -954,6 +968,8 @@ impl vm::Vm for KvmVm {
             vm_fd: self.fd.clone(),
             #[cfg(feature = "sev_snp")]
             memory_slots: self.memory_slots.clone(),
+            #[cfg(feature = "sev_snp")]
+            memory_conversion_handler: self.memory_conversion_handler.clone(),
         };
         Ok(Box::new(vcpu))
     }
@@ -1810,6 +1826,8 @@ impl hypervisor::Hypervisor for KvmHypervisor {
                 #[cfg(feature = "sev_snp")]
                 snp_guest_policy: OnceLock::new(),
                 memory_slots,
+                #[cfg(feature = "sev_snp")]
+                memory_conversion_handler: Arc::new(OnceLock::new()),
             }))
         }
 
@@ -1952,10 +1970,26 @@ pub struct KvmVcpu {
     vm_fd: Arc<VmFd>,
     #[cfg(feature = "sev_snp")]
     memory_slots: Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
+    #[cfg(feature = "sev_snp")]
+    memory_conversion_handler: Arc<OnceLock<Arc<dyn vm::MemoryConversionHandler>>>,
 }
 
 #[cfg(feature = "sev_snp")]
 impl KvmVcpu {
+    fn notify_memory_conversion_handler(
+        &self,
+        gpa: u64,
+        size: u64,
+        to_shared: bool,
+    ) -> cpu::Result<()> {
+        if let Some(handler) = self.memory_conversion_handler.get() {
+            handler
+                .handle_conversion(gpa, size, to_shared)
+                .map_err(cpu::HypervisorCpuError::RunVcpu)?;
+        }
+        Ok(())
+    }
+
     fn punch_holes_in_guest_memfd(
         memory_slots: &Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
         gpa: u64,
@@ -2676,6 +2710,12 @@ impl cpu::Vcpu for KvmVcpu {
                                 Self::punch_holes_in_guest_memfd(&self.memory_slots, address, size);
                             }
 
+                            self.notify_memory_conversion_handler(
+                                address,
+                                size,
+                                set_private_attr == 0,
+                            )?;
+
                             Ok(cpu::VmExit::Ignore)
                         }
                         _ => Ok(cpu::VmExit::Ignore),
@@ -2715,6 +2755,8 @@ impl cpu::Vcpu for KvmVcpu {
                     if attributes == 0 {
                         Self::punch_holes_in_guest_memfd(&self.memory_slots, gpa, size);
                     }
+
+                    self.notify_memory_conversion_handler(gpa, size, attributes == 0)?;
 
                     Ok(cpu::VmExit::Ignore)
                 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -741,8 +741,8 @@ impl KvmVm {
     }
 
     /// Get flag for kvm_userspace_memory_region based on memfd support.
-    fn get_kvm_userspace_memory_region_flag(&self, flag: u32) -> u32 {
-        flag | if self.memory_slots.is_some() {
+    fn get_kvm_userspace_memory_region_flag(&self, flag: u32, private: bool) -> u32 {
+        flag | if private && self.memory_slots.is_some() {
             KVM_MEM_GUEST_MEMFD
         } else {
             0
@@ -1130,7 +1130,9 @@ impl vm::Vm for KvmVm {
         userspace_addr: *mut u8,
         readonly: bool,
         log_dirty_pages: bool,
+        visibility: vm::MemoryVisibility,
     ) -> vm::Result<()> {
+        let private = matches!(visibility, vm::MemoryVisibility::Private);
         let mut flags = 0;
         if readonly {
             flags |= KVM_MEM_READONLY;
@@ -1144,7 +1146,7 @@ impl vm::Vm for KvmVm {
         // Create a per-region guest_memfd when supported.
         // Each region gets its own fd sized exactly to memory_size
         #[cfg(feature = "sev_snp")]
-        let guest_memfd = if let Some(slots) = &self.memory_slots {
+        let guest_memfd = if let Some(slots) = self.memory_slots.as_ref().filter(|_| private) {
             // SAFETY: Safe because guest regions are guaranteed not to overlap.
             let fd = unsafe {
                 OwnedFd::from_raw_fd(
@@ -1175,7 +1177,7 @@ impl vm::Vm for KvmVm {
 
         let mut region = kvm_userspace_memory_region2 {
             slot,
-            flags: self.get_kvm_userspace_memory_region_flag(flags),
+            flags: self.get_kvm_userspace_memory_region_flag(flags, private),
             guest_phys_addr,
             memory_size: memory_size as u64,
             userspace_addr: userspace_addr as usize as u64,
@@ -1208,7 +1210,7 @@ impl vm::Vm for KvmVm {
 
             // Always create guest physical memory region without `KVM_MEM_LOG_DIRTY_PAGES`.
             // For regions that need this flag, dirty pages log will be turned on in `start_dirty_log`.
-            region.flags = self.get_kvm_userspace_memory_region_flag(0);
+            region.flags = self.get_kvm_userspace_memory_region_flag(0, private);
         }
 
         // SAFETY: Safe because caller promised this is safe.
@@ -1218,7 +1220,7 @@ impl vm::Vm for KvmVm {
         }
 
         #[cfg(feature = "sev_snp")]
-        if self.memory_slots.is_some() {
+        if private && self.memory_slots.is_some() {
             self.fd
                 .set_memory_attributes(kvm_memory_attributes {
                     address: region.guest_phys_addr,
@@ -1459,7 +1461,10 @@ impl vm::Vm for KvmVm {
                 guest_phys_addr: s.guest_phys_addr,
                 memory_size: s.memory_size,
                 userspace_addr: s.userspace_addr,
-                flags: self.get_kvm_userspace_memory_region_flag(KVM_MEM_LOG_DIRTY_PAGES),
+                flags: self.get_kvm_userspace_memory_region_flag(
+                    KVM_MEM_LOG_DIRTY_PAGES,
+                    s.guest_memfd != 0,
+                ),
                 guest_memfd: s.guest_memfd,
                 guest_memfd_offset: s.guest_memfd_offset,
                 ..Default::default()
@@ -1485,7 +1490,7 @@ impl vm::Vm for KvmVm {
                 guest_phys_addr: s.guest_phys_addr,
                 memory_size: s.memory_size,
                 userspace_addr: s.userspace_addr,
-                flags: self.get_kvm_userspace_memory_region_flag(0),
+                flags: self.get_kvm_userspace_memory_region_flag(0, s.guest_memfd != 0),
                 guest_memfd: s.guest_memfd,
                 guest_memfd_offset: s.guest_memfd_offset,
                 ..Default::default()

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -628,6 +628,8 @@ struct KvmMemorySlot {
     guest_phys_addr: u64,
     #[cfg_attr(not(feature = "sev_snp"), expect(dead_code))]
     memory_size: u64,
+    #[cfg_attr(not(feature = "sev_snp"), expect(dead_code))]
+    userspace_addr: u64,
 }
 
 /// Wrapper over KVM VM ioctls.
@@ -1161,6 +1163,7 @@ impl vm::Vm for KvmVm {
                     guest_memfd: fd,
                     guest_phys_addr,
                     memory_size: memory_size as u64,
+                    userspace_addr: userspace_addr as usize as u64,
                 },
             );
             raw_fd
@@ -1990,6 +1993,13 @@ impl KvmVcpu {
         Ok(())
     }
 
+    /// Whether to discard the stale shared mapping on conversion to private.
+    fn should_discard_shared_mapping(&self) -> bool {
+        self.memory_conversion_handler
+            .get()
+            .is_some_and(|h| h.reclaims_shared_mapping())
+    }
+
     fn punch_holes_in_guest_memfd(
         memory_slots: &Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
         gpa: u64,
@@ -2024,6 +2034,50 @@ impl KvmVcpu {
             if ret != 0 {
                 error!(
                     "Error punching hole in the guest_memfd: gpa={gpa:#x} offset={offset:#x} len={len:#x}: {}",
+                    io::Error::last_os_error()
+                );
+            }
+        }
+    }
+
+    /// Discard the stale *shared* mapping for `[gpa, gpa + size)`.
+    fn discard_shared_mapping(
+        memory_slots: &Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
+        gpa: u64,
+        size: u64,
+    ) {
+        let Some(slots) = memory_slots else {
+            return;
+        };
+        let slots = slots.read().unwrap();
+        let req_end = gpa.saturating_add(size);
+
+        for slot in slots.values() {
+            let slot_end = slot.guest_phys_addr.saturating_add(slot.memory_size);
+            if gpa >= slot_end || req_end <= slot.guest_phys_addr {
+                continue;
+            }
+
+            let overlap_start = gpa.max(slot.guest_phys_addr);
+            let overlap_end = req_end.min(slot_end);
+            let offset = overlap_start - slot.guest_phys_addr;
+            let len = overlap_end - overlap_start;
+
+            let addr = (slot.userspace_addr as usize + offset as usize) as *mut libc::c_void;
+
+            // MADV_REMOVE frees the backing store for shmem/memfd/hugetlb (shared=on,
+            // hugepages). So fall back to MADV_DONTNEED if MADV_REMOVE is rejected for
+            // default anonymous backing.
+            //
+            // SAFETY: [userspace_addr + offset, + len) lies within the slot's range.
+            let mut ret = unsafe { libc::madvise(addr, len as usize, libc::MADV_REMOVE) };
+            if ret != 0 {
+                // SAFETY: [userspace_addr + offset, + len) lies within the slot's range.
+                ret = unsafe { libc::madvise(addr, len as usize, libc::MADV_DONTNEED) };
+            }
+            if ret != 0 {
+                error!(
+                    "Error discarding shared backing: gpa={gpa:#x} offset={offset:#x} len={len:#x}: {}",
                     io::Error::last_os_error()
                 );
             }
@@ -2716,6 +2770,10 @@ impl cpu::Vcpu for KvmVcpu {
                                 set_private_attr == 0,
                             )?;
 
+                            if set_private_attr != 0 && self.should_discard_shared_mapping() {
+                                Self::discard_shared_mapping(&self.memory_slots, address, size);
+                            }
+
                             Ok(cpu::VmExit::Ignore)
                         }
                         _ => Ok(cpu::VmExit::Ignore),
@@ -2757,6 +2815,10 @@ impl cpu::Vcpu for KvmVcpu {
                     }
 
                     self.notify_memory_conversion_handler(gpa, size, attributes == 0)?;
+
+                    if attributes != 0 && self.should_discard_shared_mapping() {
+                        Self::discard_shared_mapping(&self.memory_slots, gpa, size);
+                    }
 
                     Ok(cpu::VmExit::Ignore)
                 }

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -64,7 +64,7 @@ pub use kvm::aarch64;
 pub use kvm::{AiaState, riscv64};
 pub use vm::{
     DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig,
-    MemoryConversionHandler, MsiIrqSourceConfig, Vm, VmOps,
+    MemoryConversionHandler, MemoryVisibility, MsiIrqSourceConfig, Vm, VmOps,
 };
 
 pub use crate::hypervisor::{Hypervisor, HypervisorError};

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -63,8 +63,8 @@ pub use kvm::aarch64;
 #[cfg(all(feature = "kvm", target_arch = "riscv64"))]
 pub use kvm::{AiaState, riscv64};
 pub use vm::{
-    DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig, MsiIrqSourceConfig,
-    Vm, VmOps,
+    DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig,
+    MemoryConversionHandler, MsiIrqSourceConfig, Vm, VmOps,
 };
 
 pub use crate::hypervisor::{Hypervisor, HypervisorError};

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -63,8 +63,8 @@ pub use kvm::aarch64;
 #[cfg(all(feature = "kvm", target_arch = "riscv64"))]
 pub use kvm::{AiaState, riscv64};
 pub use vm::{
-    DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig, MsiIrqSourceConfig,
-    Vm, VmOps,
+    DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig, MemoryVisibility,
+    MsiIrqSourceConfig, Vm, VmOps,
 };
 
 pub use crate::hypervisor::{Hypervisor, HypervisorError};

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -63,8 +63,8 @@ pub use kvm::aarch64;
 #[cfg(all(feature = "kvm", target_arch = "riscv64"))]
 pub use kvm::{AiaState, riscv64};
 pub use vm::{
-    DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig, MemoryVisibility,
-    MsiIrqSourceConfig, Vm, VmOps,
+    DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig,
+    MemoryConversionHandler, MemoryVisibility, MsiIrqSourceConfig, Vm, VmOps,
 };
 
 pub use crate::hypervisor::{Hypervisor, HypervisorError};

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -2026,6 +2026,7 @@ impl vm::Vm for MshvVm {
         userspace_addr: *mut u8,
         readonly: bool,
         _log_dirty_pages: bool,
+        _visibility: vm::MemoryVisibility,
     ) -> vm::Result<()> {
         let mut flags = 1 << MSHV_SET_MEM_BIT_EXECUTABLE;
         if !readonly {

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -2024,6 +2024,7 @@ impl vm::Vm for MshvVm {
         userspace_addr: *mut u8,
         readonly: bool,
         _log_dirty_pages: bool,
+        _visibility: vm::MemoryVisibility,
     ) -> vm::Result<()> {
         let mut flags = 1 << MSHV_SET_MEM_BIT_EXECUTABLE;
         if !readonly {

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -329,6 +329,15 @@ pub enum InterruptSourceConfig {
     MsiIrq(MsiIrqSourceConfig),
 }
 
+/// Whether guest memory is shared or private from the host
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MemoryVisibility {
+    /// Host-visible guest RAM.
+    Shared,
+    /// Confidential guest RAM (guest_memfd).
+    Private,
+}
+
 ///
 /// Trait to represent a Vm
 ///
@@ -379,6 +388,7 @@ pub trait Vm: Send + Sync + Any {
     ///
     /// `[userspace_addr, userspace_addr + memory_size)` must be valid memory,
     /// and that address range must remain valid until [`Vm::remove_user_memory_region`] is called.
+    #[expect(clippy::too_many_arguments)]
     unsafe fn create_user_memory_region(
         &self,
         slot: u32,
@@ -387,6 +397,7 @@ pub trait Vm: Send + Sync + Any {
         userspace_addr: *mut u8,
         readonly: bool,
         log_dirty_pages: bool,
+        visibility: MemoryVisibility,
     ) -> Result<()>;
     /// Removes a guest physical memory slot.
     ///

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -334,6 +334,12 @@ pub enum InterruptSourceConfig {
 pub trait MemoryConversionHandler: Send + Sync {
     /// Handles conversion of `[gpa, gpa + size)` to shared or private memory.
     fn handle_conversion(&self, gpa: u64, size: u64, to_shared: bool) -> anyhow::Result<()>;
+
+    /// Whether this strategy allows reclaiming host RAM after a page is
+    /// converted to private.
+    fn reclaims_shared_mapping(&self) -> bool {
+        false
+    }
 }
 
 /// Whether guest memory is shared or private from the host

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -329,6 +329,13 @@ pub enum InterruptSourceConfig {
     MsiIrq(MsiIrqSourceConfig),
 }
 
+/// Handler invoked when a confidential VM converts guest memory between shared
+/// and private states.
+pub trait MemoryConversionHandler: Send + Sync {
+    /// Handles conversion of `[gpa, gpa + size)` to shared or private memory.
+    fn handle_conversion(&self, gpa: u64, size: u64, to_shared: bool) -> anyhow::Result<()>;
+}
+
 /// Whether guest memory is shared or private from the host
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum MemoryVisibility {
@@ -504,6 +511,12 @@ pub trait Vm: Send + Sync + Any {
     ) -> Result<()> {
         unimplemented!()
     }
+
+    /// Register a handler invoked on guest-memory shared/private conversions.
+    fn register_memory_conversion_handler(&self, _handler: Arc<dyn MemoryConversionHandler>) {
+        unimplemented!("memory conversion handlers are only supported on the KVM backend")
+    }
+
     /// Initialize the VM
     fn init(&self) -> Result<()> {
         Ok(())

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -347,6 +347,15 @@ pub trait MemoryConversionHandler: Send + Sync {
     }
 }
 
+/// Whether guest memory is shared or private from the host
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MemoryVisibility {
+    /// Host-visible guest RAM.
+    Shared,
+    /// Confidential guest RAM (guest_memfd).
+    Private,
+}
+
 ///
 /// Trait to represent a Vm
 ///
@@ -397,6 +406,7 @@ pub trait Vm: Send + Sync + Any {
     ///
     /// `[userspace_addr, userspace_addr + memory_size)` must be valid memory,
     /// and that address range must remain valid until [`Vm::remove_user_memory_region`] is called.
+    #[expect(clippy::too_many_arguments)]
     unsafe fn create_user_memory_region(
         &self,
         slot: u32,
@@ -405,6 +415,7 @@ pub trait Vm: Send + Sync + Any {
         userspace_addr: *mut u8,
         readonly: bool,
         log_dirty_pages: bool,
+        visibility: MemoryVisibility,
     ) -> Result<()>;
     /// Removes a guest physical memory slot.
     ///

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -339,6 +339,12 @@ pub enum InterruptSourceConfig {
 pub trait MemoryConversionHandler: Send + Sync {
     /// Handles conversion of `[gpa, gpa + size)` to shared or private memory.
     fn handle_conversion(&self, gpa: u64, size: u64, to_shared: bool) -> anyhow::Result<()>;
+
+    /// Whether this strategy allows reclaiming host RAM after a page is
+    /// converted to private.
+    fn reclaims_shared_mapping(&self) -> bool {
+        false
+    }
 }
 
 ///

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -263,6 +263,11 @@ pub enum HypervisorVmError {
     ///
     #[error("Failed to complete isolated import")]
     CompleteIsolatedImport(#[source] anyhow::Error),
+    ///
+    /// Failed to register the memory conversion handler
+    ///
+    #[error("Failed to register the memory conversion handler")]
+    RegisterMemoryConversionHandler(#[source] anyhow::Error),
     /// Failed to set VM property
     ///
     #[error("Failed to set VM property")]
@@ -327,6 +332,13 @@ pub enum InterruptSourceConfig {
     LegacyIrq(LegacyIrqSourceConfig),
     /// Configuration data for PciMsi, PciMsix and generic MSI interrupts.
     MsiIrq(MsiIrqSourceConfig),
+}
+
+/// Handler invoked when a confidential VM converts guest memory between shared
+/// and private states.
+pub trait MemoryConversionHandler: Send + Sync {
+    /// Handles conversion of `[gpa, gpa + size)` to shared or private memory.
+    fn handle_conversion(&self, gpa: u64, size: u64, to_shared: bool) -> anyhow::Result<()>;
 }
 
 ///
@@ -494,6 +506,17 @@ pub trait Vm: Send + Sync + Any {
     ) -> Result<()> {
         unimplemented!()
     }
+
+    /// Register a handler invoked on guest-memory shared/private conversions.
+    fn register_memory_conversion_handler(
+        &self,
+        _handler: Arc<dyn MemoryConversionHandler>,
+    ) -> Result<()> {
+        Err(HypervisorVmError::RegisterMemoryConversionHandler(
+            anyhow::anyhow!("memory conversion handler not supported"),
+        ))
+    }
+
     /// Initialize the VM
     fn init(&self) -> Result<()> {
         Ok(())

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -2208,6 +2208,7 @@ impl VfioPciDevice {
                             user_memory_region.mapping.addr(),
                             false,
                             false,
+                            hypervisor::MemoryVisibility::Shared,
                         )
                     }
                     .map_err(VfioPciError::CreateUserMemoryRegion)?;
@@ -2468,6 +2469,7 @@ iova 0x{:x}, size 0x{:x}: {}, ",
                             host_addr,
                             false,
                             false,
+                            hypervisor::MemoryVisibility::Shared,
                         )
                     }
                     .map_err(io::Error::other)?;

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -2260,6 +2260,7 @@ impl VfioPciDevice {
                             user_memory_region.mapping.addr(),
                             false,
                             false,
+                            hypervisor::MemoryVisibility::Shared,
                         )
                     }
                     .map_err(VfioPciError::CreateUserMemoryRegion)?;
@@ -2518,6 +2519,7 @@ iova 0x{:x}, size 0x{:x}: {}, ",
                             host_addr,
                             false,
                             false,
+                            hypervisor::MemoryVisibility::Shared,
                         )
                     }
                     .map_err(io::Error::other)?;

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -199,6 +199,7 @@ impl VfioUserPciDevice {
                             user_memory_region.mapping.addr(),
                             false,
                             false,
+                            hypervisor::MemoryVisibility::Shared,
                         )
                     }
                     .map_err(VfioUserPciDeviceError::MapRegionGuest)?;
@@ -469,6 +470,7 @@ impl PciDevice for VfioUserPciDevice {
                             user_memory_region.mapping.addr(),
                             false,
                             false,
+                            hypervisor::MemoryVisibility::Shared,
                         )
                     }
                     .map_err(io::Error::other)?;

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -199,6 +199,7 @@ impl VfioUserPciDevice {
                             user_memory_region.mapping.addr(),
                             false,
                             false,
+                            hypervisor::MemoryVisibility::Shared,
                         )
                     }
                     .map_err(VfioUserPciDeviceError::MapRegionGuest)?;
@@ -467,6 +468,7 @@ impl PciDevice for VfioUserPciDevice {
                             user_memory_region.mapping.addr(),
                             false,
                             false,
+                            hypervisor::MemoryVisibility::Shared,
                         )
                     }
                     .map_err(io::Error::other)?;

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -387,6 +387,22 @@ pub enum ValidationError {
     #[cfg(feature = "sev_snp")]
     #[error("SEV-SNP requires an IGVM payload (--payload igvm=<path>)")]
     SevSnpRequiresIgvm,
+    /// Memory hotplug is not supported with SEV-SNP
+    #[cfg(feature = "sev_snp")]
+    #[error("Memory hotplug is not supported with SEV-SNP")]
+    SevSnpNoMemoryHotplug,
+    /// CPU hotplug is not supported with SEV-SNP
+    #[cfg(feature = "sev_snp")]
+    #[error("CPU hotplug is not supported with SEV-SNP")]
+    SevSnpNoCpuHotplug,
+    /// Huge pages are not supported with SEV-SNP
+    #[cfg(feature = "sev_snp")]
+    #[error("Huge pages are not supported with SEV-SNP")]
+    SevSnpNoHugePages,
+    /// A virtual IOMMU is not supported with SEV-SNP
+    #[cfg(feature = "sev_snp")]
+    #[error("Virtual IOMMU is not supported with SEV-SNP")]
+    SevSnpNoViommu,
     /// Restore expects all net ids that have fds
     #[error("Net id {0} is associated with FDs and is required")]
     RestoreMissingRequiredNetId(String),
@@ -1285,6 +1301,26 @@ impl MemoryConfig {
                 .flatten()
                 .filter_map(|zone| zone.hotplugged_size)
                 .sum::<u64>()
+    }
+
+    pub fn hotplug_size(&self) -> u64 {
+        self.hotplug_size.unwrap_or(0)
+            + self
+                .zones
+                .iter()
+                .flatten()
+                .filter_map(|zone| zone.hotplug_size)
+                .sum::<u64>()
+    }
+
+    pub fn hugepages_enabled(&self) -> bool {
+        self.hugepages
+            || self.hugepage_size.is_some()
+            || self
+                .zones
+                .iter()
+                .flatten()
+                .any(|zone| zone.hugepages || zone.hugepage_size.is_some())
     }
 }
 
@@ -3268,6 +3304,18 @@ impl VmConfig {
                 {
                     return Err(ValidationError::SevSnpRequiresIgvm);
                 }
+
+                if self.memory.hotplug_size() > 0 || self.memory.hotplugged_size() > 0 {
+                    return Err(ValidationError::SevSnpNoMemoryHotplug);
+                }
+
+                if self.cpus.max_vcpus != self.cpus.boot_vcpus {
+                    return Err(ValidationError::SevSnpNoCpuHotplug);
+                }
+
+                if self.memory.hugepages_enabled() {
+                    return Err(ValidationError::SevSnpNoHugePages);
+                }
             }
         }
         // The 'conflict' check is introduced in commit 24438e0390d3
@@ -3619,6 +3667,12 @@ impl VmConfig {
             .as_ref()
             .map(|p| p.iommu_segments.is_some())
             .unwrap_or_default();
+
+        // Checked after self.iommu changes, so it sees devices and iommu_segments
+        #[cfg(feature = "sev_snp")]
+        if self.iommu && self.platform.as_ref().is_some_and(|p| p.sev_snp) {
+            return Err(ValidationError::SevSnpNoViommu);
+        }
 
         if let Some(landlock_rules) = &self.landlock_rules {
             for landlock_rule in landlock_rules {
@@ -6860,6 +6914,82 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 fw_cfg_config: None,
             });
             config_with_invalid_host_data.validate().unwrap_err();
+
+            let payload = sev_snp_config.payload.as_mut().unwrap();
+            payload.kernel = None;
+            payload.igvm = Some(PathBuf::from("/path/to/igvm"));
+            sev_snp_config.validate().unwrap();
+
+            let mut invalid_config = sev_snp_config.clone();
+            invalid_config.memory.hotplug_size = Some(1);
+            assert_eq!(
+                invalid_config.validate(),
+                Err(ValidationError::SevSnpNoMemoryHotplug)
+            );
+
+            let mut invalid_config = sev_snp_config.clone();
+            invalid_config.memory.hotplugged_size = Some(1);
+            assert_eq!(
+                invalid_config.validate(),
+                Err(ValidationError::SevSnpNoMemoryHotplug)
+            );
+
+            let mut invalid_config = sev_snp_config.clone();
+            invalid_config.cpus.max_vcpus = 2;
+            assert_eq!(
+                invalid_config.validate(),
+                Err(ValidationError::SevSnpNoCpuHotplug)
+            );
+
+            let mut invalid_config = sev_snp_config.clone();
+            invalid_config.memory.hugepages = true;
+            assert_eq!(
+                invalid_config.validate(),
+                Err(ValidationError::SevSnpNoHugePages)
+            );
+
+            let iommu_pci_common = PciDeviceCommonConfig {
+                iommu: true,
+                ..Default::default()
+            };
+
+            let mut invalid_config = sev_snp_config.clone();
+            invalid_config.disks = Some(vec![DiskConfig {
+                pci_common: iommu_pci_common.clone(),
+                ..raw_disk_fixture()
+            }]);
+            assert_eq!(
+                invalid_config.validate(),
+                Err(ValidationError::SevSnpNoViommu)
+            );
+
+            let mut invalid_config = sev_snp_config.clone();
+            invalid_config.devices = Some(vec![DeviceConfig {
+                pci_common: iommu_pci_common.clone(),
+                ..device_fixture()
+            }]);
+            assert_eq!(
+                invalid_config.validate(),
+                Err(ValidationError::SevSnpNoViommu)
+            );
+
+            let mut invalid_config = sev_snp_config.clone();
+            invalid_config.platform = Some(PlatformConfig {
+                sev_snp: true,
+                iommu_segments: Some(Box::new([1])),
+                ..platform_fixture()
+            });
+            assert_eq!(
+                invalid_config.validate(),
+                Err(ValidationError::SevSnpNoViommu)
+            );
+
+            let mut invalid_config = sev_snp_config.clone();
+            invalid_config.iommu = true;
+            assert_eq!(
+                invalid_config.validate(),
+                Err(ValidationError::SevSnpNoViommu)
+            );
         }
 
         // x_nv_gpudirect_clique with vfio_p2p_dma=off should fail

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -904,6 +904,7 @@ impl DeviceRelocation for AddressManager {
                                 shm_regions.mapping.as_ptr(),
                                 false,
                                 false,
+                                hypervisor::MemoryVisibility::Shared,
                             )
                             .map_err(|e| {
                                 io::Error::other(format!(
@@ -3401,7 +3402,15 @@ impl DeviceManager {
             self.memory_manager
                 .lock()
                 .unwrap()
-                .create_userspace_mapping(region_base, region_size, host_addr, false, false, false)
+                .create_userspace_mapping(
+                    region_base,
+                    region_size,
+                    host_addr,
+                    false,
+                    false,
+                    false,
+                    hypervisor::MemoryVisibility::Shared,
+                )
                 .map_err(DeviceManagerError::MemoryManager)
         }?;
 
@@ -5617,6 +5626,7 @@ impl IvshmemOps for IvshmemHandler {
                     false,
                     false,
                     false,
+                    hypervisor::MemoryVisibility::Shared,
                 )
             }
         }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -130,6 +130,8 @@ use crate::interrupt::{LegacyUserspaceInterruptManager, MsiInterruptManager};
 use crate::memory_manager::{Error as MemoryManagerError, MEMORY_MANAGER_ACPI_SIZE, MemoryManager};
 use crate::pci_segment::PciSegment;
 use crate::serial_manager::{Error as SerialManagerError, SerialManager};
+#[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+use crate::sev::SevSnpSharedPageTracker;
 #[cfg(feature = "ivshmem")]
 use crate::vm_config::IvshmemConfig;
 use crate::vm_config::{
@@ -605,6 +607,11 @@ pub enum DeviceManagerError {
     #[error("Failed to remove DMA mapping handler from virtio-mem device")]
     RemoveDmaMappingHandlerVirtioMem(#[source] mem::Error),
 
+    /// Failed to add a DMA mapping handler to the SEV-SNP shared-page tracker.
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+    #[error("Failed to add DMA mapping handler to SEV-SNP shared-page tracker")]
+    AddDmaMappingHandlerSevSnp(#[source] anyhow::Error),
+
     /// Failed to create vfio-user client
     #[error("Failed to create vfio-user client")]
     VfioUserCreateClient(#[source] vfio_user::Error),
@@ -628,6 +635,11 @@ pub enum DeviceManagerError {
     /// Failed to update memory mappings for VFIO user device
     #[error("Failed to update memory mappings for VFIO user device")]
     UpdateMemoryForVfioUserPciDevice(#[source] VfioUserPciDeviceError),
+
+    /// vfio-user cannot be hot-added while SEV-SNP shared-page tracking is active
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+    #[error("Cannot hot-add a vfio-user device while SEV-SNP shared-page tracking is active")]
+    VfioUserHotplugSevSnpTracker,
 
     /// Cannot duplicate file descriptor
     #[error("Cannot duplicate file descriptor")]
@@ -1088,6 +1100,10 @@ pub struct DeviceManager {
     // DeviceManager to be reused.
     vfio_ops: Option<Arc<dyn VfioOps>>,
 
+    // Number of active VFIO devices sharing `vfio_ops`.
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+    shared_vfio_devices: usize,
+
     // Paravirtualized IOMMU
     iommu_device: Option<Arc<Mutex<virtio_devices::Iommu>>>,
     iommu_mapping: Option<Arc<IommuMapping>>,
@@ -1165,6 +1181,10 @@ pub struct DeviceManager {
     rate_limit_groups: HashMap<String, Arc<RateLimiterGroup>>,
 
     mmio_regions: Arc<Mutex<Vec<MmioRegion>>>,
+
+    // Track shared pages for SEV-SNP VFIO
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+    sev_snp_shared_page_tracker: Option<Arc<SevSnpSharedPageTracker>>,
 
     #[cfg(feature = "fw_cfg")]
     fw_cfg: Option<Arc<Mutex<FwCfg>>>,
@@ -1400,6 +1420,14 @@ impl DeviceManager {
             }
         }
 
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        let sev_snp_shared_page_tracker = Self::create_sev_snp_shared_page_tracker(
+            &address_manager,
+            &config,
+            &cpu_manager,
+            &memory_manager,
+        );
+
         let device_manager = DeviceManager {
             address_manager: Arc::clone(&address_manager),
             console: Arc::new(Console::default()),
@@ -1418,6 +1446,8 @@ impl DeviceManager {
             legacy_interrupt_manager: None,
             passthrough_device: None,
             vfio_ops: None,
+            #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+            shared_vfio_devices: 0,
             iommu_device: None,
             iommu_mapping: None,
             iommu_attached_devices: None,
@@ -1454,6 +1484,8 @@ impl DeviceManager {
             acpi_platform_addresses: AcpiPlatformAddresses::default(),
             rate_limit_groups,
             mmio_regions: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+            sev_snp_shared_page_tracker,
             #[cfg(feature = "fw_cfg")]
             fw_cfg: None,
             #[cfg(feature = "ivshmem")]
@@ -4060,32 +4092,60 @@ impl DeviceManager {
         };
 
         if needs_dma_mapping {
-            // Register DMA mapping in IOMMU.
-            // Do not register virtio-mem regions, as they are handled directly by
-            // virtio-mem device itself.
-            for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
-                for region in zone.regions() {
-                    // vfio_dma_map is unsound and ought to be marked as unsafe
-                    #[allow(unused_unsafe)]
-                    // SAFETY: GuestMemoryMmap guarantees that region points
-                    // to len bytes of valid memory starting at as_ptr()
-                    // that will only be freed with munmap().
-                    unsafe {
-                        vfio_ops.vfio_dma_map(
-                            region.start_addr().raw_value(),
-                            region.len() as usize,
-                            region.as_ptr(),
-                        )
-                    }
-                    .map_err(DeviceManagerError::VfioDmaMap)?;
-                }
-            }
-
             let vfio_mapping = Arc::new(VfioDmaMapping::new(
                 Arc::clone(&vfio_ops),
                 Arc::new(self.memory_manager.lock().unwrap().guest_memory()),
                 Arc::clone(&self.mmio_regions),
             ));
+
+            #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+            let static_map_all_ram = match self.sev_snp_shared_page_tracker.as_ref() {
+                // Confidential VM over iommufd supports shared/private tracking.
+                Some(tracker) => {
+                    tracker
+                        .add_dma_mapping_handler(vfio_mapping.clone())
+                        .map_err(DeviceManagerError::AddDmaMappingHandlerSevSnp)?;
+                    false
+                }
+                None => {
+                    if self.config.lock().unwrap().is_sev_snp_enabled()
+                        && self.cpu_manager.lock().unwrap().hypervisor_type()
+                            == hypervisor::HypervisorType::Kvm
+                    {
+                        warn!(
+                            "SEV-SNP: static-pinning all guest RAM (no reclaim); per-page \
+                             shared-page tracking needs an iommufd backend, non-hugepage \
+                             RAM, and no vfio-user devices."
+                        );
+                    }
+                    true
+                }
+            };
+            #[cfg(not(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg")))]
+            let static_map_all_ram = true;
+
+            if static_map_all_ram {
+                // Statically map all guest RAM into the IOMMU. Do not register
+                // virtio-mem regions, as they are handled directly by the
+                // virtio-mem device itself.
+                for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
+                    for region in zone.regions() {
+                        // vfio_dma_map is unsound and ought to be marked as unsafe
+                        #[allow(unused_unsafe)]
+                        // SAFETY: GuestMemoryMmap guarantees that region points
+                        // to len bytes of valid memory starting at as_ptr()
+                        // that will only be freed with munmap().
+                        unsafe {
+                            vfio_ops.vfio_dma_map(
+                                region.start_addr().raw_value(),
+                                region.len() as usize,
+                                region.as_ptr(),
+                            )
+                        }
+                        .map_err(DeviceManagerError::VfioDmaMap)?;
+                    }
+                }
+            }
 
             for virtio_mem_device in self.virtio_mem_devices.iter() {
                 virtio_mem_device
@@ -4190,6 +4250,11 @@ impl DeviceManager {
             pci_device_bdf,
             bars,
         )?;
+
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        if !device_cfg.pci_common.iommu {
+            self.shared_vfio_devices += 1;
+        }
 
         Ok((pci_device_bdf, vfio_name))
     }
@@ -4921,6 +4986,11 @@ impl DeviceManager {
             ));
         }
 
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        if self.sev_snp_shared_page_tracker.is_some() {
+            return Err(DeviceManagerError::VfioUserHotplugSevSnpTracker);
+        }
+
         let (bdf, device_name) = self.add_vfio_user_device(device_cfg, None)?;
 
         // Update the PCIU bitmap
@@ -5132,10 +5202,20 @@ impl DeviceManager {
             iommu_attached = true;
         }
 
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        let mut removed_shared_vfio_device = false;
+
         let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
-            // VirtioMemMappingSource::Container cleanup is handled by
-            // cleanup_vfio_ops when the last VFIO device is removed.
+            // The container-wide VirtioMemMappingSource::Container mapping is
+            // shared across VFIO devices, so it is not removed per-device here.
+            // It goes away when cleanup_vfio_ops drops the container after the
+            // last shared VFIO device is removed.
             PciDeviceHandle::Vfio(vfio_pci_device) => {
+                #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+                {
+                    removed_shared_vfio_device = !vfio_pci_device.lock().unwrap().iommu_attached();
+                }
+
                 // Remove this device's MMIO regions from the DeviceManager's
                 // mmio_regions list. We match on UserMemoryRegion slot numbers
                 // rather than MmioRegion start addresses because move_bar()
@@ -5322,6 +5402,15 @@ impl DeviceManager {
         // buses where it was stored. At the end of this function, after
         // any_device, bus_device and pci_device are released, the actual
         // device will be dropped.
+
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        if removed_shared_vfio_device {
+            if self.shared_vfio_devices == 0 {
+                error!("shared VFIO device count underflow on eject, falling to 0");
+            }
+            self.shared_vfio_devices = self.shared_vfio_devices.saturating_sub(1);
+        }
+
         Ok(())
     }
 
@@ -5568,11 +5657,66 @@ impl DeviceManager {
     }
 
     fn cleanup_vfio_ops(&mut self) {
-        // Drop the VfioOps instance when "Self" is the only reference
+        // We need to release every other container reference before dropping
+        // `self.vfio_ops`, so its drop closes the container fd and unpins
+        // the shared pages.
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        if let Some(tracker) = &self.sev_snp_shared_page_tracker {
+            if self.vfio_ops.is_some() && self.shared_vfio_devices == 0 {
+                // Drop the tracker's handler. The tracker itself persists so a
+                // later VFIO attach replays the current shared set.
+                tracker.clear_dma_mapping_handler();
+                self.vfio_ops = None;
+            }
+            return;
+        }
+
+        // Drop the VfioOps instance when "Self" is the only reference.
         if let Some(1) = self.vfio_ops.as_ref().map(Arc::strong_count) {
             debug!("Drop VfioOps given no active VFIO devices.");
             self.vfio_ops = None;
         }
+    }
+
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+    fn create_sev_snp_shared_page_tracker(
+        address_manager: &Arc<AddressManager>,
+        config: &Arc<Mutex<VmConfig>>,
+        cpu_manager: &Arc<Mutex<CpuManager>>,
+        memory_manager: &Arc<Mutex<MemoryManager>>,
+    ) -> Option<Arc<SevSnpSharedPageTracker>> {
+        // The SEV-SNP per-page tracker is only supported over an iommufd backend
+        // with no vfio-user devices. Otherwise, confidential VFIO falls back to
+        // static-mapping all pages.
+        let sev_snp_config_enabled = {
+            let config = config.lock().unwrap();
+            config.is_sev_snp_enabled()
+                && config.platform.as_ref().is_some_and(|p| p.iommufd)
+                && config
+                    .user_devices
+                    .as_ref()
+                    .is_none_or(|devices| devices.is_empty())
+        };
+
+        if !sev_snp_config_enabled {
+            return None;
+        }
+
+        if cpu_manager.lock().unwrap().hypervisor_type() != hypervisor::HypervisorType::Kvm {
+            return None;
+        }
+
+        let tracker = Arc::new(SevSnpSharedPageTracker::new());
+        for zone in memory_manager.lock().unwrap().memory_zones().values() {
+            for region in zone.regions() {
+                tracker.register_region(region.start_addr().raw_value(), region.len());
+            }
+        }
+        address_manager
+            .vm
+            .register_memory_conversion_handler(tracker.clone());
+
+        Some(tracker)
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -131,6 +131,8 @@ use crate::interrupt::{LegacyUserspaceInterruptManager, MsiInterruptManager};
 use crate::memory_manager::{Error as MemoryManagerError, MEMORY_MANAGER_ACPI_SIZE, MemoryManager};
 use crate::pci_segment::PciSegment;
 use crate::serial_manager::{Error as SerialManagerError, SerialManager};
+#[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+use crate::sev::{PAGE_SIZE_4K, SevSnpSharedPageTracker};
 #[cfg(feature = "ivshmem")]
 use crate::vm_config::IvshmemConfig;
 use crate::vm_config::{
@@ -601,6 +603,16 @@ pub enum DeviceManagerError {
     /// Failed to remove DMA mapping handler from virtio-mem device.
     #[error("Failed to remove DMA mapping handler from virtio-mem device")]
     RemoveDmaMappingHandlerVirtioMem(#[source] mem::Error),
+
+    /// Failed to add a DMA mapping handler to the SEV-SNP shared-page tracker.
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+    #[error("Failed to add DMA mapping handler to SEV-SNP shared-page tracker")]
+    AddDmaMappingHandlerSevSnp(#[source] anyhow::Error),
+
+    /// virtio-mem is unsupported alongside confidential SEV-SNP VFIO over iommufd.
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+    #[error("virtio-mem is unsupported with confidential SEV-SNP VFIO over iommufd")]
+    VirtioMemUnsupportedWithConfidentialVfio,
 
     /// Failed to create vfio-user client
     #[error("Failed to create vfio-user client")]
@@ -1090,6 +1102,10 @@ pub struct DeviceManager {
     // DeviceManager to be reused.
     vfio_ops: Option<Arc<dyn VfioOps>>,
 
+    // Number of active VFIO devices sharing `vfio_ops`.
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+    shared_vfio_devices: usize,
+
     // Paravirtualized IOMMU
     iommu_device: Option<Arc<Mutex<virtio_devices::Iommu>>>,
     iommu_mapping: Option<Arc<IommuMapping>>,
@@ -1167,6 +1183,10 @@ pub struct DeviceManager {
     rate_limit_groups: HashMap<String, Arc<RateLimiterGroup>>,
 
     mmio_regions: Arc<Mutex<Vec<MmioRegion>>>,
+
+    // Track shared pages for SEV-SNP VFIO
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+    sev_snp_shared_page_tracker: Option<Arc<SevSnpSharedPageTracker>>,
 
     #[cfg(feature = "fw_cfg")]
     fw_cfg: Option<Arc<Mutex<FwCfg>>>,
@@ -1421,6 +1441,8 @@ impl DeviceManager {
             legacy_interrupt_manager: None,
             passthrough_device: None,
             vfio_ops: None,
+            #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+            shared_vfio_devices: 0,
             iommu_device: None,
             iommu_mapping: None,
             iommu_attached_devices: None,
@@ -1457,11 +1479,21 @@ impl DeviceManager {
             acpi_platform_addresses: AcpiPlatformAddresses::default(),
             rate_limit_groups,
             mmio_regions: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+            sev_snp_shared_page_tracker: None,
             #[cfg(feature = "fw_cfg")]
             fw_cfg: None,
             #[cfg(feature = "ivshmem")]
             ivshmem_device: None,
             _acpi_cpu_hotplug_controller: acpi_cpu_hotplug_controller,
+        };
+
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        let device_manager = {
+            let mut device_manager = device_manager;
+            // Set up the SEV-SNP shared-page tracker
+            device_manager.create_sev_snp_shared_page_tracker_if_enabled();
+            device_manager
         };
 
         let device_manager = Arc::new(Mutex::new(device_manager));
@@ -3862,6 +3894,14 @@ impl DeviceManager {
         device_cfg: &mut DeviceConfig,
         snapshot: Option<&Snapshot>,
     ) -> DeviceManagerResult<(PciBdf, String)> {
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        if !device_cfg.pci_common.iommu
+            && self.sev_snp_shared_page_tracker.is_some()
+            && !self.virtio_mem_devices.is_empty()
+        {
+            return Err(DeviceManagerError::VirtioMemUnsupportedWithConfidentialVfio);
+        }
+
         // If the passthrough device has not been created yet, it is created
         // here and stored in the DeviceManager structure for future needs.
         if self.passthrough_device.is_none() {
@@ -4088,32 +4128,56 @@ impl DeviceManager {
         };
 
         if needs_dma_mapping {
-            // Register DMA mapping in IOMMU.
-            // Do not register virtio-mem regions, as they are handled directly by
-            // virtio-mem device itself.
-            for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
-                for region in zone.regions() {
-                    // vfio_dma_map is unsound and ought to be marked as unsafe
-                    #[allow(unused_unsafe)]
-                    // SAFETY: GuestMemoryMmap guarantees that region points
-                    // to len bytes of valid memory starting at as_ptr()
-                    // that will only be freed with munmap().
-                    unsafe {
-                        vfio_ops.vfio_dma_map(
-                            region.start_addr().raw_value(),
-                            region.len() as usize,
-                            region.as_ptr(),
-                        )
-                    }
-                    .map_err(DeviceManagerError::VfioDmaMap)?;
-                }
-            }
-
             let vfio_mapping = Arc::new(VfioDmaMapping::new(
                 Arc::clone(&vfio_ops),
                 Arc::new(self.memory_manager.lock().unwrap().guest_memory()),
                 Arc::clone(&self.mmio_regions),
             ));
+
+            #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+            let static_map_all_ram = match self.sev_snp_shared_page_tracker.as_ref() {
+                // Confidential VM over iommufd supports shared/private tracking.
+                Some(tracker) => {
+                    tracker
+                        .add_dma_mapping_handler(vfio_mapping.clone())
+                        .map_err(DeviceManagerError::AddDmaMappingHandlerSevSnp)?;
+                    false
+                }
+                None => {
+                    if self.config.lock().unwrap().is_sev_snp_enabled() {
+                        warn!(
+                            "SEV-SNP: static-pinning all guest RAM (no reclaim); per-page \
+                             shared-page tracking needs an iommufd backend and non-hugepage RAM."
+                        );
+                    }
+                    true
+                }
+            };
+            #[cfg(not(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg")))]
+            let static_map_all_ram = true;
+
+            if static_map_all_ram {
+                // Statically map all guest RAM into the IOMMU. Do not register
+                // virtio-mem regions, as they are handled directly by the
+                // virtio-mem device itself.
+                for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
+                    for region in zone.regions() {
+                        // vfio_dma_map is unsound and ought to be marked as unsafe
+                        #[allow(unused_unsafe)]
+                        // SAFETY: GuestMemoryMmap guarantees that region points
+                        // to len bytes of valid memory starting at as_ptr()
+                        // that will only be freed with munmap().
+                        unsafe {
+                            vfio_ops.vfio_dma_map(
+                                region.start_addr().raw_value(),
+                                region.len() as usize,
+                                region.as_ptr(),
+                            )
+                        }
+                        .map_err(DeviceManagerError::VfioDmaMap)?;
+                    }
+                }
+            }
 
             for virtio_mem_device in self.virtio_mem_devices.iter() {
                 virtio_mem_device
@@ -4218,6 +4282,11 @@ impl DeviceManager {
             pci_device_bdf,
             bars,
         )?;
+
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        if !device_cfg.pci_common.iommu {
+            self.shared_vfio_devices += 1;
+        }
 
         Ok((pci_device_bdf, vfio_name))
     }
@@ -5143,10 +5212,20 @@ impl DeviceManager {
             iommu_attached = true;
         }
 
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        let mut removed_shared_vfio_device = false;
+
         let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
-            // VirtioMemMappingSource::Container cleanup is handled by
-            // cleanup_vfio_ops when the last VFIO device is removed.
+            // The container-wide VirtioMemMappingSource::Container mapping is
+            // shared across VFIO devices, so it is not removed per-device here.
+            // It goes away when cleanup_vfio_ops drops the container after the
+            // last shared VFIO device is removed.
             PciDeviceHandle::Vfio(vfio_pci_device) => {
+                #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+                {
+                    removed_shared_vfio_device = !vfio_pci_device.lock().unwrap().iommu_attached();
+                }
+
                 // Remove this device's MMIO regions from the DeviceManager's
                 // mmio_regions list. We match on UserMemoryRegion slot numbers
                 // rather than MmioRegion start addresses because move_bar()
@@ -5330,6 +5409,15 @@ impl DeviceManager {
         // buses where it was stored. At the end of this function, after
         // any_device, bus_device and pci_device are released, the actual
         // device will be dropped.
+
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        if removed_shared_vfio_device {
+            if self.shared_vfio_devices == 0 {
+                error!("shared VFIO device count underflow on eject, falling to 0");
+            }
+            self.shared_vfio_devices = self.shared_vfio_devices.saturating_sub(1);
+        }
+
         Ok(())
     }
 
@@ -5564,11 +5652,78 @@ impl DeviceManager {
     }
 
     fn cleanup_vfio_ops(&mut self) {
-        // Drop the VfioOps instance when "Self" is the only reference
+        // We need to release every other container reference before dropping
+        // `self.vfio_ops`, so its drop closes the container fd and unpins
+        // the shared pages.
+        #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+        if self.sev_snp_shared_page_tracker.is_some() {
+            if self.vfio_ops.is_some() && self.shared_vfio_devices == 0 {
+                // Drop the tracker's handler. The tracker itself persists so a
+                // later VFIO attach replays the current shared set.
+                if let Some(tracker) = &self.sev_snp_shared_page_tracker {
+                    tracker.clear_dma_mapping_handler();
+                }
+                self.vfio_ops = None;
+            }
+            return;
+        }
+
+        // Drop the VfioOps instance when "Self" is the only reference.
         if let Some(1) = self.vfio_ops.as_ref().map(Arc::strong_count) {
             debug!("Drop VfioOps given no active VFIO devices.");
             self.vfio_ops = None;
         }
+    }
+
+    #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]
+    fn create_sev_snp_shared_page_tracker_if_enabled(&mut self) {
+        if self.sev_snp_shared_page_tracker.is_some() {
+            return;
+        }
+        if !self.config.lock().unwrap().is_sev_snp_enabled() {
+            return;
+        }
+        // The per-page tracker is only supported over an iommufd backend.
+        // Without it, confidential VFIO falls back to static-mapping all pages.
+        let iommufd = self
+            .config
+            .lock()
+            .unwrap()
+            .platform
+            .as_ref()
+            .is_some_and(|p| p.iommufd);
+        if !iommufd {
+            return;
+        }
+
+        // Hugepages are not supported in the shared tracker which tracks
+        // at 4KiB granularity only.
+        if self
+            .memory_manager
+            .lock()
+            .unwrap()
+            .memory_zones()
+            .values()
+            .any(|z| z.backing_page_size() > PAGE_SIZE_4K)
+        {
+            return;
+        }
+
+        let tracker = Arc::new(SevSnpSharedPageTracker::new());
+        if let Err(e) = self
+            .address_manager
+            .vm
+            .register_memory_conversion_handler(tracker.clone())
+        {
+            warn!("SEV-SNP VM: failed to register the shared-page tracker: {e:?}");
+            return;
+        }
+        for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
+            for region in zone.regions() {
+                tracker.register_region(region.start_addr().raw_value(), region.len());
+            }
+        }
+        self.sev_snp_shared_page_tracker = Some(tracker);
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -919,6 +919,7 @@ impl DeviceRelocation for AddressManager {
                                 shm_regions.mapping.as_ptr(),
                                 false,
                                 false,
+                                hypervisor::MemoryVisibility::Shared,
                             )
                             .map_err(|e| {
                                 io::Error::other(format!(
@@ -3475,7 +3476,15 @@ impl DeviceManager {
             self.memory_manager
                 .lock()
                 .unwrap()
-                .create_userspace_mapping(region_base, region_size, host_addr, false, false, false)
+                .create_userspace_mapping(
+                    region_base,
+                    region_size,
+                    host_addr,
+                    false,
+                    false,
+                    false,
+                    hypervisor::MemoryVisibility::Shared,
+                )
                 .map_err(DeviceManagerError::MemoryManager)
         }?;
 
@@ -5767,6 +5776,7 @@ impl IvshmemOps for IvshmemHandler {
                     false,
                     false,
                     false,
+                    hypervisor::MemoryVisibility::Shared,
                 )
             }
         }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1625,6 +1625,7 @@ impl MemoryManager {
                         zone_mergeable,
                         false,
                         self.log_dirty,
+                        hypervisor::MemoryVisibility::Private,
                     )
                 }?;
 
@@ -1689,6 +1690,7 @@ impl MemoryManager {
                     uefi_region.as_ptr(),
                     false,
                     false,
+                    hypervisor::MemoryVisibility::Private,
                 )
                 .map_err(Error::CreateUefiFlash)?;
         }
@@ -2416,6 +2418,7 @@ impl MemoryManager {
                     .map_or(self.mergeable, |z| z.mergeable),
                 false,
                 self.log_dirty,
+                hypervisor::MemoryVisibility::Private,
             )
         }?;
         self.guest_ram_mappings.push(GuestRamMapping {
@@ -2531,6 +2534,7 @@ impl MemoryManager {
     ///
     /// `userspace_addr` and `memory_size` must be and remain valid
     /// until `remove_userspace_mapping` is called.
+    #[expect(clippy::too_many_arguments)]
     pub unsafe fn create_userspace_mapping(
         &mut self,
         guest_phys_addr: u64,
@@ -2539,6 +2543,7 @@ impl MemoryManager {
         mergeable: bool,
         readonly: bool,
         log_dirty: bool,
+        visibility: hypervisor::MemoryVisibility,
     ) -> Result<u32, Error> {
         let slot = self.allocate_memory_slot();
 
@@ -2557,6 +2562,7 @@ impl MemoryManager {
                     userspace_addr,
                     readonly,
                     log_dirty,
+                    visibility,
                 )
                 .map_err(Error::CreateUserMemoryRegion)?;
         }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1561,6 +1561,7 @@ impl MemoryManager {
                         zone_mergeable,
                         false,
                         self.log_dirty,
+                        hypervisor::MemoryVisibility::Private,
                     )
                 }?;
 
@@ -1625,6 +1626,7 @@ impl MemoryManager {
                     uefi_region.as_ptr(),
                     false,
                     false,
+                    hypervisor::MemoryVisibility::Private,
                 )
                 .map_err(Error::CreateUefiFlash)?;
         }
@@ -2336,6 +2338,7 @@ impl MemoryManager {
                     .map_or(self.mergeable, |z| z.mergeable),
                 false,
                 self.log_dirty,
+                hypervisor::MemoryVisibility::Private,
             )
         }?;
         self.guest_ram_mappings.push(GuestRamMapping {
@@ -2434,6 +2437,7 @@ impl MemoryManager {
     ///
     /// `userspace_addr` and `memory_size` must be and remain valid
     /// until `remove_userspace_mapping` is called.
+    #[expect(clippy::too_many_arguments)]
     pub unsafe fn create_userspace_mapping(
         &mut self,
         guest_phys_addr: u64,
@@ -2442,6 +2446,7 @@ impl MemoryManager {
         mergeable: bool,
         readonly: bool,
         log_dirty: bool,
+        visibility: hypervisor::MemoryVisibility,
     ) -> Result<u32, Error> {
         let slot = self.allocate_memory_slot();
 
@@ -2460,6 +2465,7 @@ impl MemoryManager {
                     userspace_addr,
                     readonly,
                     log_dirty,
+                    visibility,
                 )
                 .map_err(Error::CreateUserMemoryRegion)?;
         }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -159,6 +159,9 @@ impl MemoryZone {
     pub fn regions(&self) -> &Vec<Arc<GuestRegionMmap>> {
         &self.regions
     }
+    pub fn backing_page_size(&self) -> u64 {
+        self.backing_page_size
+    }
     pub fn virtio_mem_zone(&self) -> &Option<VirtioMemZone> {
         &self.virtio_mem_zone
     }

--- a/vmm/src/sev.rs
+++ b/vmm/src/sev.rs
@@ -8,10 +8,13 @@ use std::fs::File;
 use std::io::{self, Cursor, Read, Seek, SeekFrom};
 use std::os::unix::fs::FileExt;
 use std::result;
+use std::sync::{Arc, Mutex};
 
 use linux_loader::bootparam::boot_params;
+use log::error;
 use sha2::{Digest, Sha256};
 use uuid::{Uuid, uuid};
+use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::ByteValued;
 use vmm_sys_util::errno;
 use zerocopy::{Immutable, IntoBytes};
@@ -177,6 +180,202 @@ impl MeasuredBootInfo {
         // The remainder of the page is zeroed to ensure measurements are reliably calculated
         hash_block[..size_of::<PaddedSevHashTable>()].copy_from_slice(table.as_bytes());
         Ok(hash_block)
+    }
+}
+
+/// SEV-SNP RMP/PSC minimum conversion granule.
+const PAGE_SIZE_4K: u64 = 4096;
+
+const BITS_PER_U64: usize = u64::BITS as usize;
+
+struct TrackedRegion {
+    base: u64,
+    /// One bit per 4KiB page, bits past num_pages are just padding
+    shared: Vec<u64>,
+    /// Number of 4KiB tracked pages
+    num_pages: usize,
+}
+
+impl TrackedRegion {
+    fn new(base: u64, size: u64) -> Self {
+        let num_pages = size.div_ceil(PAGE_SIZE_4K) as usize;
+        Self {
+            base,
+            shared: vec![0; num_pages.div_ceil(BITS_PER_U64)],
+            num_pages,
+        }
+    }
+
+    fn end(&self) -> u64 {
+        self.base + self.num_pages as u64 * PAGE_SIZE_4K
+    }
+
+    fn is_shared(&self, page: usize) -> bool {
+        self.shared[page / BITS_PER_U64] & (1 << (page % BITS_PER_U64)) != 0
+    }
+
+    fn shared_gpas(&self) -> impl Iterator<Item = u64> + '_ {
+        (0..self.num_pages)
+            .filter(|&i| self.is_shared(i))
+            .map(|i| self.base + i as u64 * PAGE_SIZE_4K)
+    }
+}
+
+#[derive(Default)]
+struct Inner {
+    regions: Vec<TrackedRegion>,
+    handler: Option<Arc<dyn ExternalDmaMapping>>,
+}
+
+/// Tracks which confidential guest pages are shared and keeps the device
+/// IOMMU mapping exactly those pages.
+#[derive(Default)]
+pub struct SevSnpSharedPageTracker {
+    inner: Mutex<Inner>,
+}
+
+#[expect(dead_code)]
+impl SevSnpSharedPageTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a confidential RAM region `[base, base + size)`.
+    pub fn register_region(&self, base: u64, size: u64) {
+        self.inner
+            .lock()
+            .unwrap()
+            .regions
+            .push(TrackedRegion::new(base, size));
+    }
+
+    /// Register a VFIO DMA handler, replaying the currently shared pages into it.
+    /// A partial replay is rolled back, so a failed registration leaves nothing
+    /// mapped in the IOMMU.
+    pub fn add_dma_mapping_handler(
+        &self,
+        handler: Arc<dyn ExternalDmaMapping>,
+    ) -> anyhow::Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+        assert!(
+            inner.handler.is_none(),
+            "DMA mapping handler already registered"
+        );
+
+        let shared = inner.regions.iter().flat_map(TrackedRegion::shared_gpas);
+        for (mapped, gpa) in shared.enumerate() {
+            if let Err(e) = handler.map(gpa, gpa, PAGE_SIZE_4K) {
+                // The handler stays unregistered, so no later conversion would
+                // ever unmap what the replay already mapped.
+                Self::undo_replay(handler.as_ref(), &inner.regions, mapped);
+                return Err(anyhow::anyhow!("VFIO replay map failed gpa={gpa:#x}: {e}"));
+            }
+        }
+
+        inner.handler = Some(handler);
+        Ok(())
+    }
+
+    fn undo_replay(handler: &dyn ExternalDmaMapping, regions: &[TrackedRegion], count: usize) {
+        let shared = regions.iter().flat_map(TrackedRegion::shared_gpas);
+        for gpa in shared.take(count) {
+            if let Err(e) = handler.unmap(gpa, PAGE_SIZE_4K) {
+                error!("VFIO replay rollback failed gpa={gpa:#x}: {e}");
+            }
+        }
+    }
+
+    /// Drop the registered DMA handler.
+    pub fn clear_dma_mapping_handler(&self) {
+        self.inner.lock().unwrap().handler = None;
+    }
+
+    fn has_dma_handler(&self) -> bool {
+        self.inner.lock().unwrap().handler.is_some()
+    }
+
+    /// Flip `[gpa, gpa + size)` shared/private in the tracker, driving the
+    /// handler so the device IOMMU maps the shared pages only.
+    fn set_shared(&self, gpa: u64, size: u64, shared: bool) -> io::Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+        let Inner { regions, handler } = &mut *inner;
+        let req_end = gpa.saturating_add(size);
+
+        for region in regions.iter_mut() {
+            let start = gpa.max(region.base);
+            let end = req_end.min(region.end());
+            if start >= end {
+                continue;
+            }
+            let first_page = ((start - region.base) / PAGE_SIZE_4K) as usize;
+            let end_page = (end - region.base).div_ceil(PAGE_SIZE_4K) as usize;
+
+            if shared {
+                Self::map_pages(handler.as_deref(), region, first_page, end_page)?;
+            } else {
+                Self::unmap_pages(handler.as_deref(), region, first_page, end_page)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Map each newly shared page one at a time. We map one page per call,
+    /// not one big mapping for the whole range. A  mapping can only be removed
+    /// as a whole, never split, so the size we map here is the smallest unit we
+    /// can later unmap. This lets `unmap_pages()` remove any single page.
+    fn map_pages(
+        handler: Option<&dyn ExternalDmaMapping>,
+        region: &mut TrackedRegion,
+        first_page: usize,
+        end_page: usize,
+    ) -> io::Result<()> {
+        assert!(end_page <= region.num_pages);
+        for i in first_page..end_page {
+            if region.is_shared(i) {
+                continue;
+            }
+            let gpa = region.base + i as u64 * PAGE_SIZE_4K;
+            if let Some(handler) = handler {
+                handler
+                    .map(gpa, gpa, PAGE_SIZE_4K)
+                    .map_err(|e| io::Error::other(format!("DMA map failed gpa={gpa:#x}: {e}")))?;
+            }
+            region.shared[i / BITS_PER_U64] |= 1 << (i % BITS_PER_U64);
+        }
+        Ok(())
+    }
+
+    /// Clear each shared page in `[first_page, end_page)`, coalescing contiguous runs
+    /// into a single unmap.
+    fn unmap_pages(
+        handler: Option<&dyn ExternalDmaMapping>,
+        region: &mut TrackedRegion,
+        first_page: usize,
+        end_page: usize,
+    ) -> io::Result<()> {
+        assert!(end_page <= region.num_pages);
+        let mut i = first_page;
+        while i < end_page {
+            if !region.is_shared(i) {
+                i += 1;
+                continue;
+            }
+            let run = i;
+            while i < end_page && region.is_shared(i) {
+                i += 1;
+            }
+            let gpa = region.base + run as u64 * PAGE_SIZE_4K;
+            let len = (i - run) as u64 * PAGE_SIZE_4K;
+            if let Some(handler) = handler {
+                handler.unmap(gpa, len).map_err(|e| {
+                    io::Error::other(format!("DMA unmap failed gpa={gpa:#x} len={len:#x}: {e}"))
+                })?;
+            }
+            for page in run..i {
+                region.shared[page / BITS_PER_U64] &= !(1 << (page % BITS_PER_U64));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -388,5 +587,133 @@ mod tests {
         let expected = expected_kernel_digest(8, payload);
         let offset = kernel_hash_offset();
         assert_eq!(&block[offset..offset + 32], &expected);
+    }
+
+    #[derive(Default)]
+    struct Recorder {
+        maps: Mutex<Vec<(u64, u64)>>,
+        unmaps: Mutex<Vec<(u64, u64)>>,
+        fail_map_gpa: Option<u64>,
+    }
+
+    impl ExternalDmaMapping for Recorder {
+        fn map(&self, iova: u64, gpa: u64, size: u64) -> io::Result<()> {
+            assert_eq!(iova, gpa, "tracker must identity-map (iova == gpa)");
+            if self.fail_map_gpa == Some(gpa) {
+                return Err(io::Error::other("injected map failure"));
+            }
+            self.maps.lock().unwrap().push((gpa, size));
+            Ok(())
+        }
+        fn unmap(&self, iova: u64, size: u64) -> io::Result<()> {
+            self.unmaps.lock().unwrap().push((iova, size));
+            Ok(())
+        }
+    }
+
+    fn page(n: u64) -> u64 {
+        n * PAGE_SIZE_4K
+    }
+
+    fn tracker_with_region(base: u64, size: u64) -> (SevSnpSharedPageTracker, Arc<Recorder>) {
+        let t = SevSnpSharedPageTracker::new();
+        t.register_region(base, size);
+        let rec = Arc::new(Recorder::default());
+        t.add_dma_mapping_handler(rec.clone()).unwrap();
+        (t, rec)
+    }
+
+    #[test]
+    fn shared_maps_each_page_individually() {
+        let (t, rec) = tracker_with_region(page(0), 4 * PAGE_SIZE_4K);
+        t.set_shared(page(0), 3 * PAGE_SIZE_4K, true).unwrap();
+        assert_eq!(
+            *rec.maps.lock().unwrap(),
+            vec![
+                (page(0), PAGE_SIZE_4K),
+                (page(1), PAGE_SIZE_4K),
+                (page(2), PAGE_SIZE_4K),
+            ]
+        );
+    }
+
+    #[test]
+    fn shared_is_idempotent() {
+        let (t, rec) = tracker_with_region(page(0), 4 * PAGE_SIZE_4K);
+        t.set_shared(page(0), 2 * PAGE_SIZE_4K, true).unwrap();
+        t.set_shared(page(0), 2 * PAGE_SIZE_4K, true).unwrap();
+        assert_eq!(rec.maps.lock().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn private_coalesces_contiguous_runs() {
+        let (t, rec) = tracker_with_region(page(0), 4 * PAGE_SIZE_4K);
+        t.set_shared(page(0), 4 * PAGE_SIZE_4K, true).unwrap();
+        rec.unmaps.lock().unwrap().clear();
+        t.set_shared(page(0), 4 * PAGE_SIZE_4K, false).unwrap();
+        assert_eq!(
+            *rec.unmaps.lock().unwrap(),
+            vec![(page(0), 4 * PAGE_SIZE_4K)]
+        );
+    }
+
+    #[test]
+    fn private_splits_runs_around_holes() {
+        let (t, rec) = tracker_with_region(page(0), 4 * PAGE_SIZE_4K);
+        t.set_shared(page(0), 2 * PAGE_SIZE_4K, true).unwrap();
+        t.set_shared(page(3), PAGE_SIZE_4K, true).unwrap();
+        rec.unmaps.lock().unwrap().clear();
+        t.set_shared(page(0), 4 * PAGE_SIZE_4K, false).unwrap();
+        assert_eq!(
+            *rec.unmaps.lock().unwrap(),
+            vec![(page(0), 2 * PAGE_SIZE_4K), (page(3), PAGE_SIZE_4K)]
+        );
+    }
+
+    #[test]
+    fn add_handler_replays_shared_set() {
+        let (t, _first) = tracker_with_region(page(0), 4 * PAGE_SIZE_4K);
+        t.set_shared(page(1), 2 * PAGE_SIZE_4K, true).unwrap();
+        t.clear_dma_mapping_handler();
+        let late = Arc::new(Recorder::default());
+        t.add_dma_mapping_handler(late.clone()).unwrap();
+        assert_eq!(
+            *late.maps.lock().unwrap(),
+            vec![(page(1), PAGE_SIZE_4K), (page(2), PAGE_SIZE_4K)]
+        );
+    }
+
+    #[test]
+    fn replay_failure_rolls_back_partial_maps() {
+        // Pages shared before any attach, as a guest converts them.
+        let t = SevSnpSharedPageTracker::new();
+        t.register_region(page(0), 2 * PAGE_SIZE_4K);
+        t.register_region(page(8), 2 * PAGE_SIZE_4K);
+        t.set_shared(page(0), 2 * PAGE_SIZE_4K, true).unwrap();
+        t.set_shared(page(8), 2 * PAGE_SIZE_4K, true).unwrap();
+
+        // The first page of the second region fails, so the rollback has to
+        // reach back into the first one.
+        let failed = Arc::new(Recorder {
+            fail_map_gpa: Some(page(8)),
+            ..Default::default()
+        });
+        assert!(t.add_dma_mapping_handler(failed.clone()).is_err());
+        assert_eq!(
+            *failed.unmaps.lock().unwrap(),
+            vec![(page(0), PAGE_SIZE_4K), (page(1), PAGE_SIZE_4K)]
+        );
+
+        // The shared set is untouched, so a later attach replays all of it.
+        let late = Arc::new(Recorder::default());
+        t.add_dma_mapping_handler(late.clone()).unwrap();
+        assert_eq!(late.maps.lock().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn conversion_outside_any_region_is_ignored() {
+        let (t, rec) = tracker_with_region(page(0), 2 * PAGE_SIZE_4K);
+        t.set_shared(page(100), 4 * PAGE_SIZE_4K, true).unwrap();
+        assert!(rec.maps.lock().unwrap().is_empty());
     }
 }

--- a/vmm/src/sev.rs
+++ b/vmm/src/sev.rs
@@ -10,6 +10,7 @@ use std::os::unix::fs::FileExt;
 use std::result;
 use std::sync::{Arc, Mutex};
 
+use hypervisor::MemoryConversionHandler;
 use linux_loader::bootparam::boot_params;
 use log::error;
 use sha2::{Digest, Sha256};
@@ -184,7 +185,7 @@ impl MeasuredBootInfo {
 }
 
 /// SEV-SNP RMP/PSC minimum conversion granule.
-const PAGE_SIZE_4K: u64 = 4096;
+pub(crate) const PAGE_SIZE_4K: u64 = 4096;
 
 const BITS_PER_U64: usize = u64::BITS as usize;
 
@@ -234,7 +235,6 @@ pub struct SevSnpSharedPageTracker {
     inner: Mutex<Inner>,
 }
 
-#[expect(dead_code)]
 impl SevSnpSharedPageTracker {
     pub fn new() -> Self {
         Self::default()
@@ -376,6 +376,19 @@ impl SevSnpSharedPageTracker {
             }
         }
         Ok(())
+    }
+}
+
+impl MemoryConversionHandler for SevSnpSharedPageTracker {
+    fn handle_conversion(&self, gpa: u64, size: u64, to_shared: bool) -> anyhow::Result<()> {
+        self.set_shared(gpa, size, to_shared)
+            .map_err(|e| anyhow::anyhow!("confidential VFIO conversion failed: {e}"))
+    }
+
+    /// Only reclaim once a VFIO device is attached as `handle_conversion` would
+    /// have unmapped the page, so freeing its stale mapping is safe.
+    fn reclaims_shared_mapping(&self) -> bool {
+        self.has_dma_handler()
     }
 }
 

--- a/vmm/src/sev.rs
+++ b/vmm/src/sev.rs
@@ -10,6 +10,7 @@ use std::os::unix::fs::FileExt;
 use std::result;
 use std::sync::{Arc, Mutex};
 
+use hypervisor::MemoryConversionHandler;
 use linux_loader::bootparam::boot_params;
 use sha2::{Digest, Sha256};
 use uuid::{Uuid, uuid};
@@ -183,7 +184,7 @@ impl MeasuredBootInfo {
 }
 
 /// SEV-SNP RMP/PSC minimum conversion granule.
-const PAGE_SIZE_4K: u64 = 4096;
+pub(crate) const PAGE_SIZE_4K: u64 = 4096;
 
 struct TrackedRegion {
     base: u64,
@@ -216,7 +217,6 @@ pub struct SevSnpSharedPageTracker {
     inner: Mutex<Inner>,
 }
 
-#[expect(dead_code)]
 impl SevSnpSharedPageTracker {
     pub fn new() -> Self {
         Self::default()
@@ -338,6 +338,19 @@ impl SevSnpSharedPageTracker {
             }
         }
         Ok(())
+    }
+}
+
+impl MemoryConversionHandler for SevSnpSharedPageTracker {
+    fn handle_conversion(&self, gpa: u64, size: u64, to_shared: bool) -> anyhow::Result<()> {
+        self.set_shared(gpa, size, to_shared)
+            .map_err(|e| anyhow::anyhow!("confidential VFIO conversion failed: {e}"))
+    }
+
+    /// Only reclaim once a VFIO device is attached as `handle_conversion` would
+    /// have unmapped the page, so freeing its stale mapping is safe.
+    fn reclaims_shared_mapping(&self) -> bool {
+        self.has_dma_handler()
     }
 }
 

--- a/vmm/src/sev.rs
+++ b/vmm/src/sev.rs
@@ -8,10 +8,12 @@ use std::fs::File;
 use std::io::{self, Cursor, Read, Seek, SeekFrom};
 use std::os::unix::fs::FileExt;
 use std::result;
+use std::sync::{Arc, Mutex};
 
 use linux_loader::bootparam::boot_params;
 use sha2::{Digest, Sha256};
 use uuid::{Uuid, uuid};
+use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::ByteValued;
 use vmm_sys_util::errno;
 use zerocopy::{Immutable, IntoBytes};
@@ -177,6 +179,165 @@ impl MeasuredBootInfo {
         // The remainder of the page is zeroed to ensure measurements are reliably calculated
         hash_block[..size_of::<PaddedSevHashTable>()].copy_from_slice(table.as_bytes());
         Ok(hash_block)
+    }
+}
+
+/// SEV-SNP RMP/PSC minimum conversion granule.
+const PAGE_SIZE_4K: u64 = 4096;
+
+struct TrackedRegion {
+    base: u64,
+    shared: Vec<bool>, // one bool per 4KiB page
+}
+
+impl TrackedRegion {
+    fn new(base: u64, size: u64) -> Self {
+        Self {
+            base,
+            shared: vec![false; size.div_ceil(PAGE_SIZE_4K) as usize],
+        }
+    }
+
+    fn end(&self) -> u64 {
+        self.base + self.shared.len() as u64 * PAGE_SIZE_4K
+    }
+}
+
+#[derive(Default)]
+struct Inner {
+    regions: Vec<TrackedRegion>,
+    handler: Option<Arc<dyn ExternalDmaMapping>>,
+}
+
+/// Tracks which confidential guest pages are shared and keeps the device
+/// IOMMU mapping exactly those pages.
+#[derive(Default)]
+pub struct SevSnpSharedPageTracker {
+    inner: Mutex<Inner>,
+}
+
+#[expect(dead_code)]
+impl SevSnpSharedPageTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a confidential RAM region `[base, base + size)`.
+    pub fn register_region(&self, base: u64, size: u64) {
+        self.inner
+            .lock()
+            .unwrap()
+            .regions
+            .push(TrackedRegion::new(base, size));
+    }
+
+    /// Register a VFIO DMA handler, replaying the currently shared pages into it.
+    pub fn add_dma_mapping_handler(
+        &self,
+        handler: Arc<dyn ExternalDmaMapping>,
+    ) -> anyhow::Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+        for region in inner.regions.iter() {
+            for (i, &shared) in region.shared.iter().enumerate() {
+                if shared {
+                    let gpa = region.base + i as u64 * PAGE_SIZE_4K; // iova == gpa
+                    handler
+                        .map(gpa, gpa, PAGE_SIZE_4K)
+                        .map_err(|e| anyhow::anyhow!("VFIO replay map failed gpa={gpa:#x}: {e}"))?;
+                }
+            }
+        }
+        inner.handler = Some(handler);
+        Ok(())
+    }
+
+    /// Drop the registered DMA handler.
+    pub fn clear_dma_mapping_handler(&self) {
+        self.inner.lock().unwrap().handler = None;
+    }
+
+    fn has_dma_handler(&self) -> bool {
+        self.inner.lock().unwrap().handler.is_some()
+    }
+
+    /// Flip `[gpa, gpa + size)` shared/private in the tracker, driving the
+    /// handler so the device IOMMU maps the shared pages only.
+    fn set_shared(&self, gpa: u64, size: u64, shared: bool) -> io::Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+        let Inner { regions, handler } = &mut *inner;
+        let req_end = gpa.saturating_add(size);
+
+        for region in regions.iter_mut() {
+            let start = gpa.max(region.base);
+            let end = req_end.min(region.end());
+            if start >= end {
+                continue;
+            }
+            let first = ((start - region.base) / PAGE_SIZE_4K) as usize;
+            let last = (end - region.base).div_ceil(PAGE_SIZE_4K) as usize;
+
+            if shared {
+                Self::map_pages(handler.as_deref(), region, first, last)?;
+            } else {
+                Self::unmap_pages(handler.as_deref(), region, first, last)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Map each newly shared page one at a time. We map one page per call,
+    /// not one big mapping for the whole range. A  mapping can only be removed
+    /// as a whole, never split, so the size we map here is the smallest unit we
+    /// can later unmap. This lets `unmap_pages()` remove any single page.
+    fn map_pages(
+        handler: Option<&dyn ExternalDmaMapping>,
+        region: &mut TrackedRegion,
+        first: usize,
+        last: usize,
+    ) -> io::Result<()> {
+        for i in first..last {
+            if region.shared[i] {
+                continue;
+            }
+            let gpa = region.base + i as u64 * PAGE_SIZE_4K;
+            if let Some(handler) = handler {
+                handler
+                    .map(gpa, gpa, PAGE_SIZE_4K)
+                    .map_err(|e| io::Error::other(format!("DMA map failed gpa={gpa:#x}: {e}")))?;
+            }
+            region.shared[i] = true;
+        }
+        Ok(())
+    }
+
+    /// Clear each shared page in `[first, last)`, coalescing contiguous runs
+    /// into a single unmap.
+    fn unmap_pages(
+        handler: Option<&dyn ExternalDmaMapping>,
+        region: &mut TrackedRegion,
+        first: usize,
+        last: usize,
+    ) -> io::Result<()> {
+        let mut i = first;
+        while i < last {
+            if !region.shared[i] {
+                i += 1;
+                continue;
+            }
+            let run = i;
+            while i < last && region.shared[i] {
+                region.shared[i] = false;
+                i += 1;
+            }
+            let gpa = region.base + run as u64 * PAGE_SIZE_4K;
+            let len = (i - run) as u64 * PAGE_SIZE_4K;
+            if let Some(handler) = handler {
+                handler.unmap(gpa, len).map_err(|e| {
+                    io::Error::other(format!("DMA unmap failed gpa={gpa:#x} len={len:#x}: {e}"))
+                })?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -388,5 +549,101 @@ mod tests {
         let expected = expected_kernel_digest(8, payload);
         let offset = kernel_hash_offset();
         assert_eq!(&block[offset..offset + 32], &expected);
+    }
+
+    #[derive(Default)]
+    struct Recorder {
+        maps: Mutex<Vec<(u64, u64)>>,
+        unmaps: Mutex<Vec<(u64, u64)>>,
+    }
+
+    impl ExternalDmaMapping for Recorder {
+        fn map(&self, iova: u64, gpa: u64, size: u64) -> io::Result<()> {
+            assert_eq!(iova, gpa, "tracker must identity-map (iova == gpa)");
+            self.maps.lock().unwrap().push((gpa, size));
+            Ok(())
+        }
+        fn unmap(&self, iova: u64, size: u64) -> io::Result<()> {
+            self.unmaps.lock().unwrap().push((iova, size));
+            Ok(())
+        }
+    }
+
+    fn page(n: u64) -> u64 {
+        n * PAGE_SIZE_4K
+    }
+
+    fn tracker_with_region(base: u64, size: u64) -> (SevSnpSharedPageTracker, Arc<Recorder>) {
+        let t = SevSnpSharedPageTracker::new();
+        t.register_region(base, size);
+        let rec = Arc::new(Recorder::default());
+        t.add_dma_mapping_handler(rec.clone()).unwrap();
+        (t, rec)
+    }
+
+    #[test]
+    fn shared_maps_each_page_individually() {
+        let (t, rec) = tracker_with_region(page(0), 4 * PAGE_SIZE_4K);
+        t.set_shared(page(0), 3 * PAGE_SIZE_4K, true).unwrap();
+        assert_eq!(
+            *rec.maps.lock().unwrap(),
+            vec![
+                (page(0), PAGE_SIZE_4K),
+                (page(1), PAGE_SIZE_4K),
+                (page(2), PAGE_SIZE_4K),
+            ]
+        );
+    }
+
+    #[test]
+    fn shared_is_idempotent() {
+        let (t, rec) = tracker_with_region(page(0), 4 * PAGE_SIZE_4K);
+        t.set_shared(page(0), 2 * PAGE_SIZE_4K, true).unwrap();
+        t.set_shared(page(0), 2 * PAGE_SIZE_4K, true).unwrap();
+        assert_eq!(rec.maps.lock().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn private_coalesces_contiguous_runs() {
+        let (t, rec) = tracker_with_region(page(0), 4 * PAGE_SIZE_4K);
+        t.set_shared(page(0), 4 * PAGE_SIZE_4K, true).unwrap();
+        rec.unmaps.lock().unwrap().clear();
+        t.set_shared(page(0), 4 * PAGE_SIZE_4K, false).unwrap();
+        assert_eq!(
+            *rec.unmaps.lock().unwrap(),
+            vec![(page(0), 4 * PAGE_SIZE_4K)]
+        );
+    }
+
+    #[test]
+    fn private_splits_runs_around_holes() {
+        let (t, rec) = tracker_with_region(page(0), 4 * PAGE_SIZE_4K);
+        t.set_shared(page(0), 2 * PAGE_SIZE_4K, true).unwrap();
+        t.set_shared(page(3), PAGE_SIZE_4K, true).unwrap();
+        rec.unmaps.lock().unwrap().clear();
+        t.set_shared(page(0), 4 * PAGE_SIZE_4K, false).unwrap();
+        assert_eq!(
+            *rec.unmaps.lock().unwrap(),
+            vec![(page(0), 2 * PAGE_SIZE_4K), (page(3), PAGE_SIZE_4K)]
+        );
+    }
+
+    #[test]
+    fn add_handler_replays_shared_set() {
+        let (t, _first) = tracker_with_region(page(0), 4 * PAGE_SIZE_4K);
+        t.set_shared(page(1), 2 * PAGE_SIZE_4K, true).unwrap();
+        let late = Arc::new(Recorder::default());
+        t.add_dma_mapping_handler(late.clone()).unwrap();
+        assert_eq!(
+            *late.maps.lock().unwrap(),
+            vec![(page(1), PAGE_SIZE_4K), (page(2), PAGE_SIZE_4K)]
+        );
+    }
+
+    #[test]
+    fn conversion_outside_any_region_is_ignored() {
+        let (t, rec) = tracker_with_region(page(0), 2 * PAGE_SIZE_4K);
+        t.set_shared(page(100), 4 * PAGE_SIZE_4K, true).unwrap();
+        assert!(rec.maps.lock().unwrap().is_empty());
     }
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3928,6 +3928,7 @@ mod unit_tests {
                     region.as_ptr(),
                     false,
                     false,
+                    hypervisor::MemoryVisibility::Shared,
                 )
                 .expect("Cannot configure guest memory");
             }
@@ -4068,6 +4069,7 @@ pub fn test_vm() {
                 region.as_ptr().cast(),
                 false,
                 false,
+                hypervisor::MemoryVisibility::Shared,
             )
             .expect("Cannot configure guest memory");
         }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3982,6 +3982,7 @@ mod tests {
                     region.as_ptr(),
                     false,
                     false,
+                    hypervisor::MemoryVisibility::Shared,
                 )
                 .expect("Cannot configure guest memory");
             }
@@ -4122,6 +4123,7 @@ pub fn test_vm() {
                 region.as_ptr().cast(),
                 false,
                 false,
+                hypervisor::MemoryVisibility::Shared,
             )
             .expect("Cannot configure guest memory");
         }


### PR DESCRIPTION
#### Summary
SEV-SNP VMs with VFIO cost about 2x the memory of non-VFIO ones. This is because to give a passthrough device DMA, we statically map all of guest RAM into the IOMMU through the shared mmap, which pins the whole shared pool. While this mechanism is similar to regular non-confidential VMs, the penalty here is particularly bad because the guest memfd-backed pages already live actively in RAM and cannot be touched/swapped by the host.

But a confidential guest only DMAs through its shared pages. So this PR tracks shared/private state per page, maps only the currently-shared pages into the IOMMU, and frees a page's shared backing once it goes private. This shrinks the memory consumption roughly back to ~1x.

#### Testing
Tested with a DMA-capable passthrough device. On the main branch, with a 16 GiB guest, we pin all 16GiB of the guest RAM in the host:
```
$ grep -E 'VmRSS|VmPin' /proc/$(pgrep -n cloud-hyperviso)/status
VmPin:	16777216 kB
VmRSS:	16802092 kB
```

With this PR this goes down to ~1 GiB:
```
$ grep -E 'VmRSS|VmPin' /proc/$(pgrep -n cloud-hyperviso)/status
VmPin:	 1239476 kB
VmRSS:	 1264740 kB
```