### PR TITLE
arch: Remove some easy to replace unsafe blocks

### DIFF
--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
-use std::{result, slice};
+use std::result;
 
 use libc::c_uchar;
 use log::{info, warn};
@@ -101,11 +101,8 @@ const CPU_FEATURE_APIC: u32 = 0x200;
 const CPU_FEATURE_FPU: u32 = 0x001;
 
 fn compute_checksum<T: Copy + ByteValued>(v: &T) -> u8 {
-    let v: *const T = v;
-    // SAFETY: we are only reading the bytes within the size of the `T` reference `v`.
-    let v_slice = unsafe { slice::from_raw_parts(v.cast(), size_of::<T>()) };
     let mut checksum: u8 = 0;
-    for i in v_slice.iter() {
+    for i in v.as_slice().iter() {
         checksum = checksum.wrapping_add(*i);
     }
     checksum

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::{result, slice};
+use std::result;
 
 use thiserror::Error;
 use uuid::Uuid;
@@ -87,12 +87,9 @@ impl SmbiosConfig {
     }
 }
 
-fn compute_checksum<T: Copy>(v: &T) -> u8 {
-    let v: *const T = v;
-    // SAFETY: we are only reading the bytes within the size of the `T` reference `v`.
-    let v_slice = unsafe { slice::from_raw_parts(v.cast(), size_of::<T>()) };
+fn compute_checksum<T: Copy + ByteValued>(v: &T) -> u8 {
     let mut checksum: u8 = 0;
-    for i in v_slice.iter() {
+    for i in v.as_slice().iter() {
         checksum = checksum.wrapping_add(*i);
     }
     (!checksum).wrapping_add(1)


### PR DESCRIPTION
These structs already implemented ByteValued so replacing the use of unsafe for
getting the data as a slice is trivial.

- **arch: mptable: Avoid unsafe slice::from_raw_parts()**
- **arch: smbios: Avoid unsafe slice::from_raw_parts()**
