### PR TITLE
block: vhdx: reject overflowing region table entries

### DIFF
--- a/block/src/formats/vhdx/internal/header.rs
+++ b/block/src/formats/vhdx/internal/header.rs
@@ -68,6 +68,8 @@ pub enum VhdxHeaderError {
     ReadRegionTableHeader(#[source] io::Error),
     #[error("Failed to read region entries")]
     RegionEntryCollectionFailed,
+    #[error("Region entry file offset ({0}) and length ({1}) overflow u64")]
+    RegionEntryOverflow(u64 /* start */, usize /* length */),
     #[error("Overlapping regions found")]
     RegionOverlap,
     #[error("Reserved region has non-zero value")]
@@ -266,7 +268,9 @@ impl RegionInfo {
 
             offset += size_of::<RegionTableEntry>();
             let start = entry.file_offset;
-            let end = start + entry.length as u64;
+            let end = start.checked_add(entry.length as u64).ok_or(
+                VhdxHeaderError::RegionEntryOverflow(start, entry.length as usize),
+            )?;
 
             for (region_ent_start, region_ent_end) in region_entries.iter() {
                 if ranges_overlap(start, end, *region_ent_start, *region_ent_end) {
@@ -274,7 +278,7 @@ impl RegionInfo {
                 }
             }
 
-            region_entries.insert(entry.file_offset, entry.file_offset + entry.length as u64);
+            region_entries.insert(start, end);
 
             if entry.guid == Uuid::parse_str(BAT_GUID).map_err(VhdxHeaderError::InvalidUuid)? {
                 if bat_entry.is_none() {
@@ -545,6 +549,28 @@ mod tests {
         assert!(
             matches!(res, Err(VhdxHeaderError::RegionOverlap)),
             "expected RegionOverlap for an overlapping region table"
+        );
+    }
+
+    #[test]
+    fn test_region_info_rejects_overflowing_region() {
+        // A region whose file offset plus length wraps past u64::MAX must be
+        // rejected rather than silently producing a small end offset that
+        // could mask a genuine overlap.
+        let region_start = REGION_TABLE_1_START;
+        let entries_at = region_start + size_of::<RegionTableHeader>() as u64;
+
+        let temp = TempFile::new().unwrap();
+        let f = temp.into_file();
+        f.set_len(entries_at + 64 * 1024).unwrap();
+        f.write_all_at(&region_entry(BAT_GUID, u64::MAX, 0x1000), entries_at)
+            .unwrap();
+
+        let af = AlignedFile::new(f, false);
+        let res = RegionInfo::new(&af, region_start, 1);
+        assert!(
+            matches!(res, Err(VhdxHeaderError::RegionEntryOverflow(..))),
+            "expected RegionEntryOverflow for a wrapping region entry"
         );
     }
 }


### PR DESCRIPTION
Follow-up to #8483 (and the closed #8445), per @rbradford's suggestion to split out the `checked_add` behaviour.

**Problem**

`RegionInfo::new` now rejects overlapping region entries via the half-open interval test added in #8483, but it still computes each entry's end offset as `file_offset + length`. Both fields come straight from the on-disk region table, so a crafted or corrupt VHDX can put a file offset near `u64::MAX` and make that addition wrap. A wrapped end offset compares as a small value, which can slip a genuinely overlapping region past the overlap check.

**Fix**

Compute the end offset with `checked_add` and return a new `RegionEntryOverflow` error when it wraps, instead of folding a bad entry into a valid-looking range. The checked end is reused for the `region_entries` map so the bound is only worked out once. Added a regression test that feeds a wrapping entry and asserts it is rejected.

Scope is limited to the overflow path; the overlap detection itself is unchanged from #8483.