### PR TITLE
block: Test write_unaligned closure error propagation

### DIFF
--- a/block/src/aligned_file.rs
+++ b/block/src/aligned_file.rs
@@ -484,4 +484,16 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
+
+    #[test]
+    fn write_unaligned_propagates_closure_error() {
+        let file = pattern_file(8192);
+        let aligned_file = forced(file.as_file().try_clone().unwrap(), 512);
+        let err = aligned_file
+            .write_unaligned(100, 200, |_| {
+                Err(io::Error::new(io::ErrorKind::InvalidInput, "boom"))
+            })
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
 }


### PR DESCRIPTION
Add a write side counterpart to read_unaligned_propagates_closure_error. The test drives write_unaligned with a gather closure that returns an error and checks that write_unaligned surfaces it unchanged.