### PR TITLE
vmm: Improved config validation

### DIFF
--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -354,9 +354,11 @@ impl FromStr for ByteSized {
 /// A list of integers parsed from a bracket-enclosed, comma-separated string.
 ///
 /// Ranges are supported with `-`: `"[0,2-4,6]"` produces `[0, 2, 3, 4, 6]`.
-pub struct IntegerList(pub Vec<u64>);
+/// The element type defaults to `u64`. Use e.g `IntegerList<u16>` to parse
+/// into a narrower type, which rejects values that do not fit.
+pub struct IntegerList<T = u64>(pub Vec<T>);
 
-impl Display for IntegerList {
+impl<T: Display> Display for IntegerList<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_char('[')?;
         let mut iter = self.0.iter();
@@ -377,7 +379,7 @@ pub enum IntegerListParseError {
     InvalidValue(String),
 }
 
-impl Parseable for IntegerList {
+impl<T: TryFrom<u64>> Parseable for IntegerList<T> {
     type Err = IntegerListParseError;
 
     fn from_str(s: &str) -> result::Result<Self, Self::Err> {
@@ -399,19 +401,22 @@ impl Parseable for IntegerList {
                 .parse::<u64>()
                 .map_err(|_| IntegerListParseError::InvalidValue(items[0].to_owned()))?;
 
-            integer_list.push(start_range);
-
-            if items.len() == 2 {
+            let end_range = if items.len() == 2 {
                 let end_range = items[1]
                     .parse::<u64>()
                     .map_err(|_| IntegerListParseError::InvalidValue(items[1].to_owned()))?;
                 if start_range >= end_range {
                     return Err(IntegerListParseError::InvalidValue((*range).to_string()));
                 }
+                end_range
+            } else {
+                start_range
+            };
 
-                for i in start_range..end_range {
-                    integer_list.push(i + 1);
-                }
+            for value in start_range..=end_range {
+                let value = T::try_from(value)
+                    .map_err(|_| IntegerListParseError::InvalidValue(value.to_string()))?;
+                integer_list.push(value);
             }
         }
 
@@ -437,18 +442,15 @@ impl TupleValue for u64 {
 
 impl TupleValue for Vec<u8> {
     fn parse_value(input: &str) -> Result<Self, TupleError> {
-        Ok(IntegerList::from_str(input)
+        Ok(IntegerList::<u8>::from_str(input)
             .map_err(TupleError::InvalidIntegerList)?
-            .0
-            .iter()
-            .map(|v| *v as u8)
-            .collect())
+            .0)
     }
 }
 
 impl TupleValue for Vec<u64> {
     fn parse_value(input: &str) -> Result<Self, TupleError> {
-        Ok(IntegerList::from_str(input)
+        Ok(IntegerList::<u64>::from_str(input)
             .map_err(TupleError::InvalidIntegerList)?
             .0)
     }
@@ -456,12 +458,9 @@ impl TupleValue for Vec<u64> {
 
 impl TupleValue for Vec<usize> {
     fn parse_value(input: &str) -> Result<Self, TupleError> {
-        Ok(IntegerList::from_str(input)
+        Ok(IntegerList::<usize>::from_str(input)
             .map_err(TupleError::InvalidIntegerList)?
-            .0
-            .iter()
-            .map(|v| *v as usize)
-            .collect())
+            .0)
     }
 }
 
@@ -779,36 +778,47 @@ mod unit_tests {
 
     #[test]
     fn test_integer_list_single_values() {
-        let list = IntegerList::from_str("[1,3,5]").unwrap();
+        let list = IntegerList::<u64>::from_str("[1,3,5]").unwrap();
         assert_eq!(list.0, vec![1, 3, 5]);
     }
 
     #[test]
     fn test_integer_list_ranges() {
-        let list = IntegerList::from_str("[0,2-4,7]").unwrap();
+        let list = IntegerList::<u64>::from_str("[0,2-4,7]").unwrap();
         assert_eq!(list.0, vec![0, 2, 3, 4, 7]);
     }
 
     #[test]
     fn test_integer_list_invalid_range() {
-        assert!(IntegerList::from_str("[5-3]").is_err());
-        assert!(IntegerList::from_str("[5-5]").is_err());
+        assert!(IntegerList::<u64>::from_str("[5-3]").is_err());
+        assert!(IntegerList::<u64>::from_str("[5-5]").is_err());
     }
 
     #[test]
     fn test_integer_list_too_many_dashes() {
-        assert!(IntegerList::from_str("[1-2-3]").is_err());
+        assert!(IntegerList::<u64>::from_str("[1-2-3]").is_err());
+    }
+
+    #[test]
+    fn test_integer_list_narrow_type() {
+        // A narrower element type parses ranges the same way ...
+        let list = IntegerList::<u16>::from_str("[1,3-5]").unwrap();
+        assert_eq!(list.0, vec![1u16, 3, 4, 5]);
+
+        // ... but rejects values that do not fit, rather than truncating.
+        assert!(IntegerList::<u16>::from_str("[65536]").is_err());
+        assert!(IntegerList::<u8>::from_str("[256]").is_err());
     }
 
     #[test]
     fn test_integer_list_display() {
-        let list = IntegerList(vec![1, 2, 3]);
+        let list = IntegerList(vec![1u64, 2, 3]);
         assert_eq!(format!("{list}"), "[1,2,3]");
 
-        let empty = IntegerList(vec![]);
+        let empty = IntegerList::<u64>(vec![]);
         assert_eq!(format!("{empty}"), "[]");
 
-        let single = IntegerList(vec![42]);
+        let single = IntegerList(vec![42u64]);
         assert_eq!(format!("{single}"), "[42]");
     }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -3206,6 +3206,9 @@ impl VmConfig {
                 if net.vhost_user && !self.backed_by_shared_memory() {
                     return Err(ValidationError::VhostUserRequiresSharedMemory);
                 }
+                if net.vhost_user && net.vhost_socket.is_none() {
+                    return Err(ValidationError::VhostUserMissingSocket);
+                }
                 if net.vhost_user && net.rate_limiter_config.is_some() {
                     return Err(ValidationError::VhostUserRateLimiterNotSupported);
                 }
@@ -5637,6 +5640,17 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             invalid_config.validate(),
             Err(ValidationError::VhostUserRequiresSharedMemory)
+        );
+
+        let mut invalid_config = valid_config.clone();
+        invalid_config.memory.shared = true;
+        invalid_config.net = Some(vec![NetConfig {
+            vhost_user: true,
+            ..net_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::VhostUserMissingSocket)
         );
 
         let mut still_valid_config = valid_config.clone();

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -72,9 +72,6 @@ pub enum Error {
     /// Generic vhost-user available features is missing
     #[error("Error parsing --generic-vhost-user: available features missing")]
     ParseGenericVhostUserAvailFeaturesMissing,
-    /// Generic vhost-user queue size is too large
-    #[error("Error parsing --generic-vhost-user: queue size {0} is {1}, but limit is 65535")]
-    ParseGenericVhostUserQueueSizeTooLarge(usize, u64),
     /// Generic vhost-user queue size missing
     #[error("Error parsing --generic-vhost-user: queue size missing")]
     ParseGenericVhostUserQueueSizeMissing,
@@ -2002,7 +1999,7 @@ impl GenericVhostUserConfig {
             .ok_or(Error::ParseGenericVhostUserSockMissing)?;
 
         let IntegerList(queue_sizes) = parser
-            .convert::<IntegerList>("queue_sizes")
+            .convert::<IntegerList<u16>>("queue_sizes")
             .map_err(Error::ParseGenericVhostUser)?
             .ok_or(Error::ParseGenericVhostUserQueueSizeMissing)?;
         let device_type_str = parser
@@ -2076,23 +2073,12 @@ impl GenericVhostUserConfig {
             _ => {}
         }
         let pci_common = PciDeviceCommonConfig::parse(vhost_user)?;
-        let mut converted_queue_sizes: Vec<u16> = Vec::new();
-        for (offset, &queue_size) in queue_sizes.iter().enumerate() {
-            match queue_size.try_into() {
-                Err(_) => {
-                    return Err(Error::ParseGenericVhostUserQueueSizeTooLarge(
-                        offset, queue_size,
-                    ));
-                }
-                Ok(queue_size) => converted_queue_sizes.push(queue_size),
-            }
-        }
 
         Ok(GenericVhostUserConfig {
             pci_common,
             socket: socket.into(),
             device_type,
-            queue_sizes: converted_queue_sizes,
+            queue_sizes,
         })
     }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -33,6 +33,9 @@ use crate::vm_config::*;
 const MAX_NUM_PCI_SEGMENTS: u16 = 96;
 const MAX_IOMMU_ADDRESS_WIDTH_BITS: u8 = 64;
 
+// Maximum queue size is largest power of 2 that fits into a u16
+const VIRTIO_MAX_QUEUE_SIZE: u16 = 32768;
+
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 const MAX_SUPPORTED_CPUS: u32 = 8192;
 #[cfg(not(all(feature = "kvm", target_arch = "x86_64")))]
@@ -290,9 +293,12 @@ pub enum ValidationError {
     /// Insufficient vCPUs for queues
     #[error("Queue count ({0}) must not exceed boot vCPUs ({1})")]
     TooManyQueues(usize /* queues */, usize /* vCPUs */),
-    /// Invalid queue size
-    #[error("Queue size is smaller than {MINIMUM_BLOCK_QUEUE_SIZE}: {0}")]
+    /// Queue size is not a power of 2 within the spec-permitted range
+    #[error("Queue size must be a power of 2 no greater than {VIRTIO_MAX_QUEUE_SIZE}: {0}")]
     InvalidQueueSize(u16),
+    /// Block queue size too small to advertise a usable seg_max
+    #[error("Block queue size must be greater than {MINIMUM_BLOCK_QUEUE_SIZE}: {0}")]
+    BlockQueueSizeTooSmall(u16),
     /// Need shared memory for vfio-user
     #[error("Using user devices requires using shared memory or huge pages")]
     UserDevicesRequireSharedMemory,
@@ -449,6 +455,16 @@ fn validate_pci_device_id(device_id: u8) -> ValidationResult<()> {
         // Check the ID isn't any reserved one. Currently, only the device ID
         // for the root device is reserved.
         return Err(ValidationError::ReservedPciDeviceId(device_id));
+    }
+
+    Ok(())
+}
+
+/// Reject a virtio queue size that is not a power of 2 as required by the
+/// spec. The `u16` type already handles the maximum queue size.
+fn validate_queue_size(queue_size: u16) -> ValidationResult<()> {
+    if !queue_size.is_power_of_two() {
+        return Err(ValidationError::InvalidQueueSize(queue_size));
     }
 
     Ok(())
@@ -1610,8 +1626,10 @@ impl DiskConfig {
             ));
         }
 
+        validate_queue_size(self.queue_size)?;
+
         if self.queue_size <= MINIMUM_BLOCK_QUEUE_SIZE {
-            return Err(ValidationError::InvalidQueueSize(self.queue_size));
+            return Err(ValidationError::BlockQueueSizeTooSmall(self.queue_size));
         }
 
         if self.vhost_user && self.pci_common.iommu {
@@ -1851,6 +1869,8 @@ impl NetConfig {
             ));
         }
 
+        validate_queue_size(self.queue_size)?;
+
         if self.vhost_user && self.pci_common.iommu {
             return Err(ValidationError::IommuNotSupported);
         }
@@ -2087,6 +2107,10 @@ impl GenericVhostUserConfig {
             return Err(ValidationError::IommuNotSupported);
         }
 
+        for &queue_size in &self.queue_sizes {
+            validate_queue_size(queue_size)?;
+        }
+
         self.pci_common.validate(vm_config)
     }
 }
@@ -2140,6 +2164,8 @@ impl FsConfig {
                 vm_config.cpus.boot_vcpus as usize,
             ));
         }
+
+        validate_queue_size(self.queue_size)?;
 
         if self.pci_common.iommu {
             return Err(ValidationError::IommuNotSupported);
@@ -5566,6 +5592,42 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         }]);
         still_valid_config.memory.shared = true;
         still_valid_config.validate().unwrap();
+
+        // A block queue size that is not a power of 2 is rejected.
+        let mut invalid_config = valid_config.clone();
+        invalid_config.disks = Some(vec![DiskConfig {
+            queue_size: 100,
+            ..disk_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::InvalidQueueSize(100))
+        );
+
+        // A power-of-2 block queue size too small for a usable seg_max is
+        // rejected with the block-specific error.
+        let mut invalid_config = valid_config.clone();
+        invalid_config.disks = Some(vec![DiskConfig {
+            queue_size: MINIMUM_BLOCK_QUEUE_SIZE,
+            ..disk_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::BlockQueueSizeTooSmall(
+                MINIMUM_BLOCK_QUEUE_SIZE
+            ))
+        );
+
+        // A net queue size that is not a power of 2 is rejected.
+        let mut invalid_config = valid_config.clone();
+        invalid_config.net = Some(vec![NetConfig {
+            queue_size: 100,
+            ..net_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::InvalidQueueSize(100))
+        );
 
         let mut invalid_config = valid_config.clone();
         invalid_config.net = Some(vec![NetConfig {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2002,7 +2002,7 @@ impl GenericVhostUserConfig {
             .ok_or(Error::ParseGenericVhostUserSockMissing)?;
 
         let IntegerList(queue_sizes) = parser
-            .convert("queue_sizes")
+            .convert::<IntegerList>("queue_sizes")
             .map_err(Error::ParseGenericVhostUser)?
             .ok_or(Error::ParseGenericVhostUserQueueSizeMissing)?;
         let device_type_str = parser


### PR DESCRIPTION
Fix some configuration parsing/validation issues that can result in a panic if
the configuration is malformed.

- **option_parser: Make IntegerList generic**
- **vmm: config: Replace integer list conversion**
- **vmm: config: Reject invalid virtio queue sizes**
- **vmm: config: Check NetConfig::socket set if vhost_user is set**
