### PR TITLE
block: Make the sparse-file size test portable across filesystems

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -678,7 +678,7 @@ mod unit_tests {
     use std::fs::OpenOptions;
     use std::io::Write;
     use std::os::unix::fs::OpenOptionsExt;
-    use std::{ptr, slice};
+    use std::{mem, ptr, slice};
 
     use vmm_sys_util::tempfile::TempFile;
 
@@ -809,6 +809,25 @@ mod unit_tests {
         assert!(physical > 0);
     }
 
+    // A mode-0 fallocate() is not eagerly accounted in st_blocks on every
+    // filesystem: zfs reserves the range but accounts blocks lazily at
+    // transaction-group commit, and FUSE-based filesystems such as virtiofs
+    // report preallocated files as sparse. Identify those by filesystem type
+    // so a skipped physical-size check always names a proven platform
+    // limitation instead of being inferred from the value under test.
+    fn fs_defers_fallocate_block_accounting(f: &File) -> bool {
+        // SAFETY: a zeroed statfs is a valid output buffer for fstatfs and it
+        // is only read after the call succeeds.
+        let mut sfs: libc::statfs = unsafe { mem::zeroed() };
+        // SAFETY: the fd is valid and sfs outlives the call.
+        let ret = unsafe { libc::fstatfs(f.as_raw_fd(), &mut sfs) };
+        assert_eq!(ret, 0, "fstatfs failed: {}", io::Error::last_os_error());
+        // ZFS_SUPER_MAGIC and FUSE_SUPER_MAGIC (statfs(2)), as untyped
+        // literals because the width and signedness of f_type differ
+        // between libc targets.
+        matches!(sfs.f_type, 0x2fc1_2fc1 | 0x6573_5546)
+    }
+
     #[test]
     fn test_query_device_size_sparse_file_punch_hole() {
         let temp_file = TempFile::new().unwrap();
@@ -825,11 +844,25 @@ mod unit_tests {
                 size,
             )
         };
-        assert_eq!(ret, 0, "fallocate failed: {}", io::Error::last_os_error());
+        if ret != 0 {
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EOPNOTSUPP) {
+                eprintln!("Skipping test: fallocate() is not supported: {err}");
+                return;
+            }
+            panic!("fallocate failed: {err}");
+        }
         f.sync_all().unwrap();
 
         let (log_before, phys_before) = query_device_size(f).unwrap();
         assert_eq!(log_before, size as u64);
+        if fs_defers_fallocate_block_accounting(f) {
+            eprintln!(
+                "Skipping physical size checks: the filesystem defers \
+                 fallocate() block accounting"
+            );
+            return;
+        }
         assert_eq!(phys_before, size as u64);
 
         // Punch a hole in the middle 512 KiB
@@ -842,7 +875,16 @@ mod unit_tests {
                 size / 2,
             )
         };
-        assert_eq!(ret, 0, "punch hole failed: {}", io::Error::last_os_error());
+        if ret != 0 {
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EOPNOTSUPP) {
+                eprintln!(
+                    "Skipping punch-hole checks: FALLOC_FL_PUNCH_HOLE is not supported: {err}"
+                );
+                return;
+            }
+            panic!("punch hole failed: {err}");
+        }
         f.sync_all().unwrap();
 
         let (logical, physical) = query_device_size(f).unwrap();


### PR DESCRIPTION
## Problem

`test_query_device_size_sparse_file_punch_hole` assumes a mode-0 `fallocate()` is immediately reflected in `st_blocks` and that the filesystem supports hole punching. Neither is guaranteed: zfs accounts `st_blocks` lazily (#8296) and virtiofs reports preallocated files as fully sparse, so the test fails on those filesystems even though `query_device_size()` itself behaves correctly there.

## Fix

Identify the filesystems that defer `fallocate()` block accounting explicitly, through a small `fstatfs()` helper matching `ZFS_SUPER_MAGIC` and `FUSE_SUPER_MAGIC` (virtiofs), and skip the physical-size checks only there. Everywhere else, including unknown filesystems, every original assertion runs unconditionally, so a skip always names a proven platform limitation and a real `st_blocks` reporting bug still fails loudly. Hole punching support is likewise detected explicitly, via the `EOPNOTSUPP` errno. Writing real data instead of preallocating (tried in #8479) would not be enough, since zfs does not guarantee `st_blocks` is up to date right after `fsync()` either.

## Verification

Tested in the dev container with `/tmp` backed by overlayfs, tmpfs and virtiofs: the first two run the full assertions before and after; virtiofs fails before (`left: 0, right: 1048576`) and is detected and skipped after. No zfs environment was available; the zfs super magic is taken from the OpenZFS `statfs` implementation and the #8296 report.

Fixes #8296
