### PR TITLE
virtio-devices: net: offer VIRTIO_NET_F_GUEST_ANNOUNCE to guests

### DIFF
--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -599,6 +599,7 @@ impl Net {
 
                 avail_features |= 1 << VIRTIO_NET_F_CTRL_VQ;
                 avail_features |= 1 << VIRTIO_NET_F_STATUS;
+                avail_features |= 1 << VIRTIO_NET_F_GUEST_ANNOUNCE;
                 let queue_num = num_queues + 1;
 
                 let mut config = VirtioNetConfig::default();


### PR DESCRIPTION
This restores `VIRTIO_NET_F_GUEST_ANNOUNCE` in virtio-net feature advertisement. The bit was accidentally dropped during https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8263, so guest never saw it offered.

@phip1611 noticed the missing line (big thanks to him!)

We backported https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8263 onto our Cyberus branch and ran our tests to make sure everything works.