### PR TITLE
Harden tuple parsing

### DIFF
--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -498,17 +498,19 @@ impl<S: Parseable, T: TupleValue> Parseable for Tuple<S, T> {
         let mut in_quotes = false;
         let mut last_idx = 0;
         let mut first_val = None;
-        for (idx, c) in tuple.as_bytes().iter().enumerate() {
+        let trimmed = tuple.trim();
+        for (idx, c) in trimmed.as_bytes().iter().enumerate() {
             match c {
                 b'"' => in_quotes = !in_quotes,
                 b'@' if !in_quotes => {
                     if last_idx != 0 {
-                        return Err(TupleError::InvalidValue((*tuple).to_string()));
+                        return Err(TupleError::InvalidValue((*trimmed).to_string()));
                     }
-                    first_val = if tuple[last_idx..idx].is_empty() {
-                        return Err(TupleError::EmptyKey((*tuple).to_string()));
+                    let key = &trimmed[last_idx..idx];
+                    first_val = if key.is_empty() {
+                        return Err(TupleError::EmptyKey((*trimmed).to_string()));
                     } else {
-                        Some(&tuple[last_idx..idx])
+                        Some(key)
                     };
                     last_idx = idx + 1;
                 }
@@ -516,10 +518,10 @@ impl<S: Parseable, T: TupleValue> Parseable for Tuple<S, T> {
             }
         }
         let item1 = <S as Parseable>::from_str(
-            first_val.ok_or(TupleError::InvalidValue((*tuple).to_string()))?,
+            first_val.ok_or(TupleError::InvalidValue((*trimmed).to_string()))?,
         )
         .map_err(|_| TupleError::InvalidValue(first_val.unwrap().to_owned()))?;
-        let item2: T = TupleValue::parse_value(&tuple[last_idx..])?;
+        let item2: T = TupleValue::parse_value(&trimmed[last_idx..])?;
         Ok(Tuple(item1, item2))
     }
 }
@@ -860,6 +862,65 @@ mod unit_tests {
         assert_eq!(t, Tuple("foo".to_owned(), 42));
         let t = Tuple::<String, Vec<u64>>::from_str("foo@[42]").unwrap();
         assert_eq!(t, Tuple("foo".to_owned(), vec![42]));
+    }
+
+    #[test]
+    fn test_tuple_allowed_whitespace() {
+        let t = Tuple::<String, u64>::from_str(" foo@42").unwrap();
+        assert_eq!(t, Tuple("foo".to_owned(), 42));
+        let t = Tuple::<String, u64>::from_str("foo@42 ").unwrap();
+        assert_eq!(t, Tuple("foo".to_owned(), 42));
+        let t = Tuple::<String, u64>::from_str(" foo@42 ").unwrap();
+        assert_eq!(t, Tuple("foo".to_owned(), 42));
+        let t = Tuple::<u64, u64>::from_str(" 5@42 ").unwrap();
+        assert_eq!(t, Tuple(5, 42));
+        // Still a valid string as key, even with trailing whitespace
+        let t = Tuple::<String, u64>::from_str(" foo @42 ").unwrap();
+        assert_eq!(t, Tuple("foo ".to_owned(), 42));
+    }
+
+    #[test]
+    fn test_tuple_whitespace_surrounding_delimiter_fails() {
+        let e = Tuple::<String, u64>::from_str("foo@ 42").unwrap_err();
+        assert!(
+            matches!(e, TupleError::InvalidInteger(_)),
+            "Expected \"ParseInt\"; got \"{e:?}\"",
+        );
+        let expected_value = "42 ";
+        let e = Tuple::<u64, Vec<u64>>::from_str("42 @[]").unwrap_err();
+        assert!(
+            matches!(e, TupleError::InvalidValue(ref s) if s == expected_value),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            TupleError::InvalidValue(expected_value.to_string()),
+        );
+        // We abuse of the fact that space can be converted to a valid string as long as the
+        // string isn't empty. We use this to check the correct error for tuple value parsing.
+        let e = Tuple::<String, u64>::from_str(" foo @ 42 ").unwrap_err();
+        assert!(
+            matches!(e, TupleError::InvalidInteger(_)),
+            "Expected \"ParseInt\"; got \"{e:?}\"",
+        );
+        // Cannot parse the space into a list
+        let expected_value = "";
+        let e = Tuple::<u64, Vec<u64>>::from_str("42@ []").unwrap_err();
+        assert!(
+            matches!(
+                e,
+                TupleError::InvalidIntegerList(
+                    IntegerListParseError::InvalidValue(ref s),
+                ) if s == expected_value
+            ),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            TupleError::InvalidIntegerList(IntegerListParseError::InvalidValue(
+                expected_value.to_string()
+            ),)
+        );
+    }
+
+    #[test]
+    fn test_tuple_list_single_pair() {
+        let t = TupleList::<String, u64>::from_str("[foo@42]").unwrap();
+        assert_eq!(t, TupleList(vec![Tuple("foo".to_owned(), 42)]));
     }
 
     #[test]

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -936,6 +936,30 @@ mod unit_tests {
     }
 
     #[test]
+    fn test_tuple_list_unbalanced_brackets_in_element() {
+        let expected_value = "a@[1,2]],b@[3,4]";
+        let e = TupleList::<String, Vec<u64>>::from_str("[a@[1,2]],b@[3,4]]").unwrap_err();
+        assert!(
+            matches!(e, TupleError::SplitInsideBrackets(OptionParserError::InvalidSyntax(ref s)) if s == expected_value),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            TupleError::SplitInsideBrackets(OptionParserError::InvalidSyntax(
+                expected_value.to_string()
+            )),
+        );
+    }
+
+    #[test]
+    fn test_tuple_list_missing_brackets() {
+        let expected_value = "foo@42";
+        let e = TupleList::<String, u64>::from_str("foo@42").unwrap_err();
+        assert!(
+            matches!(e, TupleError::UnbalancedOutsideBrackets(ref s) if s == expected_value),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            TupleError::UnbalancedOutsideBrackets(expected_value.to_string()),
+        );
+    }
+
+    #[test]
     fn test_tuple_list_trim_whitespace() {
         let t = TupleList::<String, Vec<u64>>::from_str("[a@[1,2], b@[3,4] ,\tc@[5,6],\nd@[7,8]]")
             .unwrap();
@@ -947,6 +971,22 @@ mod unit_tests {
                 Tuple("c".to_owned(), vec![5, 6]),
                 Tuple("d".to_owned(), vec![7, 8]),
             ])
+        );
+    }
+
+    #[test]
+    fn test_tuple_successful_parse_quoted_at() {
+        assert_eq!(
+            Tuple::<String, u64>::from_str("\"foo@\"@42").unwrap(),
+            Tuple("foo@".to_string(), 42)
+        );
+    }
+
+    #[test]
+    fn test_tuple_successful_parse_quoted_whitespace() {
+        assert_eq!(
+            Tuple::<String, u64>::from_str("\" \"@42").unwrap(),
+            Tuple(" ".to_string(), 42)
         );
     }
 
@@ -967,6 +1007,15 @@ mod unit_tests {
     }
 
     #[test]
+    fn test_tuple_missing_value() {
+        let e = Tuple::<String, u64>::from_str("foo@").unwrap_err();
+        assert!(
+            matches!(e, TupleError::InvalidInteger(_)),
+            "Expected \"TupleError::InvalidInteger\"; got \"{e:?}\"",
+        );
+    }
+
+    #[test]
     fn test_tuple_reject_whitespace_as_empty_key() {
         let expected_value = "@42";
         let e = Tuple::<String, u64>::from_str(" @42").unwrap_err();
@@ -981,6 +1030,8 @@ mod unit_tests {
     fn test_split_commas_unbalanced_bracket() {
         split_commas("[a,b").unwrap_err();
         split_commas("a]").unwrap_err();
+        split_commas("[a]]").unwrap_err();
+        split_commas("[[[a]]").unwrap_err();
     }
 
     #[test]

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -530,7 +530,7 @@ impl<S: Parseable, T: TupleValue> Parseable for TupleList<S, T> {
             .ok_or_else(|| TupleError::UnbalancedOutsideBrackets(s.to_string()))?;
         let tuples_raw = split_commas(body).map_err(TupleError::SplitInsideBrackets)?;
         for tuple_raw in tuples_raw.iter() {
-            list.push(Tuple::from_str(tuple_raw)?);
+            list.push(Tuple::from_str(tuple_raw.trim())?);
         }
 
         Ok(TupleList(list))
@@ -864,6 +864,21 @@ mod unit_tests {
             TupleList(vec![
                 Tuple("a".to_owned(), vec![1, 2]),
                 Tuple("b".to_owned(), vec![3, 4]),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_tuple_list_trim_whitespace() {
+        let t = TupleList::<String, Vec<u64>>::from_str("[a@[1,2], b@[3,4] ,\tc@[5,6],\nd@[7,8]]")
+            .unwrap();
+        assert_eq!(
+            t,
+            TupleList(vec![
+                Tuple("a".to_owned(), vec![1, 2]),
+                Tuple("b".to_owned(), vec![3, 4]),
+                Tuple("c".to_owned(), vec![5, 6]),
+                Tuple("d".to_owned(), vec![7, 8]),
             ])
         );
     }

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -272,7 +272,7 @@ impl OptionParser {
     ///
     /// `T` can be any type that implements `FromStr` (e.g. `u32`, `String`),
     /// or one of this crate's types such as [`Toggle`], [`IntegerList`],
-    /// [`Tuple`], or [`StringList`].
+    /// [`Tuple`], [`TupleList`] or [`StringList`].
     pub fn convert<T: Parseable>(&self, option: &str) -> OptionParserResult<Option<T>> {
         match self.options.get(option).and_then(|v| v.value.as_ref()) {
             None => Ok(None),
@@ -464,62 +464,76 @@ impl TupleValue for Vec<usize> {
     }
 }
 
-/// A list of `key@value` pairs parsed from a bracket-enclosed string.
-///
-/// The format is `[key1@value1,key2@value2,...]` where `@` separates each
-/// pair's elements. `S` is the key type and `T` is the value type.
-#[derive(PartialEq, Eq, Debug)]
-pub struct Tuple<S, T>(pub Vec<(S, T)>);
-
 #[derive(Error, Debug)]
 pub enum TupleError {
     #[error("invalid value: {0}")]
     InvalidValue(String),
-    #[error("split outside brackets")]
-    SplitOutsideBrackets(#[source] OptionParserError),
+    #[error("Unbalanced brackets in one of the values")]
+    SplitInsideBrackets(#[source] OptionParserError),
+    #[error("Expected a single pair of enclosing brackets in input: {0}")]
+    UnbalancedOutsideBrackets(String),
     #[error("invalid integer list")]
     InvalidIntegerList(#[source] IntegerListParseError),
     #[error("invalid integer")]
     InvalidInteger(#[source] ParseIntError),
 }
 
+/// A tuple consisting of a `key@value` pair parsed from a string.
+#[derive(PartialEq, Eq, Debug)]
+pub struct Tuple<S, T>(pub S, pub T);
+
+/// A list of `key@value` pairs parsed from a bracket-enclosed string.
+///
+/// The format is `[key1@value1,key2@value2,...]` where `@` separates each
+/// pair's elements. `S` is the key type and `T` is the value type.
+#[derive(PartialEq, Eq, Debug)]
+pub struct TupleList<S, T>(pub Vec<Tuple<S, T>>);
+
 impl<S: Parseable, T: TupleValue> Parseable for Tuple<S, T> {
     type Err = TupleError;
 
+    fn from_str(tuple: &str) -> result::Result<Self, Self::Err> {
+        let mut in_quotes = false;
+        let mut last_idx = 0;
+        let mut first_val = None;
+        for (idx, c) in tuple.as_bytes().iter().enumerate() {
+            match c {
+                b'"' => in_quotes = !in_quotes,
+                b'@' if !in_quotes => {
+                    if last_idx != 0 {
+                        return Err(TupleError::InvalidValue((*tuple).to_string()));
+                    }
+                    first_val = Some(&tuple[last_idx..idx]);
+                    last_idx = idx + 1;
+                }
+                _ => {}
+            }
+        }
+        let item1 = <S as Parseable>::from_str(
+            first_val.ok_or(TupleError::InvalidValue((*tuple).to_string()))?,
+        )
+        .map_err(|_| TupleError::InvalidValue(first_val.unwrap().to_owned()))?;
+        let item2: T = TupleValue::parse_value(&tuple[last_idx..])?;
+        Ok(Tuple(item1, item2))
+    }
+}
+
+impl<S: Parseable, T: TupleValue> Parseable for TupleList<S, T> {
+    type Err = TupleError;
+
     fn from_str(s: &str) -> result::Result<Self, Self::Err> {
-        let mut list: Vec<(S, T)> = Vec::new();
+        let mut list: Vec<Tuple<S, T>> = Vec::new();
         let body = s
             .trim()
             .strip_prefix('[')
             .and_then(|s| s.strip_suffix(']'))
-            .ok_or_else(|| TupleError::InvalidValue(s.to_string()))?;
-        let tuples_list = split_commas(body).map_err(TupleError::SplitOutsideBrackets)?;
-        for tuple in tuples_list.iter() {
-            let mut in_quotes = false;
-            let mut last_idx = 0;
-            let mut first_val = None;
-            for (idx, c) in tuple.as_bytes().iter().enumerate() {
-                match c {
-                    b'"' => in_quotes = !in_quotes,
-                    b'@' if !in_quotes => {
-                        if last_idx != 0 {
-                            return Err(TupleError::InvalidValue((*tuple).to_string()));
-                        }
-                        first_val = Some(&tuple[last_idx..idx]);
-                        last_idx = idx + 1;
-                    }
-                    _ => {}
-                }
-            }
-            let item1 = <S as Parseable>::from_str(
-                first_val.ok_or(TupleError::InvalidValue((*tuple).to_string()))?,
-            )
-            .map_err(|_| TupleError::InvalidValue(first_val.unwrap().to_owned()))?;
-            let item2 = TupleValue::parse_value(&tuple[last_idx..])?;
-            list.push((item1, item2));
+            .ok_or_else(|| TupleError::UnbalancedOutsideBrackets(s.to_string()))?;
+        let tuples_raw = split_commas(body).map_err(TupleError::SplitInsideBrackets)?;
+        for tuple_raw in tuples_raw.iter() {
+            list.push(Tuple::from_str(tuple_raw)?);
         }
 
-        Ok(Tuple(list))
+        Ok(TupleList(list))
     }
 }
 
@@ -636,10 +650,10 @@ mod unit_tests {
         parser.parse("topology=[\"@\"\"b\"@[1,2]]").unwrap();
         assert_eq!(
             parser
-                .convert::<Tuple<String, Vec<u8>>>("topology")
+                .convert::<TupleList<String, Vec<u8>>>("topology")
                 .unwrap()
                 .unwrap(),
-            Tuple(vec![("@\"b".to_owned(), vec![1, 2])])
+            TupleList(vec![Tuple("@\"b".to_owned(), vec![1, 2])])
         );
 
         parser.parse("cmdline=\"console=ttyS0,9600n8\"").unwrap();
@@ -836,30 +850,27 @@ mod unit_tests {
 
     #[test]
     fn test_tuple_single_pair() {
-        let t = Tuple::<String, u64>::from_str("[foo@42]").unwrap();
-        assert_eq!(t, Tuple(vec![("foo".to_owned(), 42)]));
+        let t = Tuple::<String, u64>::from_str("foo@42").unwrap();
+        assert_eq!(t, Tuple("foo".to_owned(), 42));
+        let t = Tuple::<String, Vec<u64>>::from_str("foo@[42]").unwrap();
+        assert_eq!(t, Tuple("foo".to_owned(), vec![42]));
     }
 
     #[test]
-    fn test_tuple_multiple_pairs() {
-        let t = Tuple::<String, Vec<u64>>::from_str("[a@[1,2],b@[3,4]]").unwrap();
+    fn test_tuple_list_multiple_pairs() {
+        let t = TupleList::<String, Vec<u64>>::from_str("[a@[1,2],b@[3,4]]").unwrap();
         assert_eq!(
             t,
-            Tuple(vec![
-                ("a".to_owned(), vec![1, 2]),
-                ("b".to_owned(), vec![3, 4]),
+            TupleList(vec![
+                Tuple("a".to_owned(), vec![1, 2]),
+                Tuple("b".to_owned(), vec![3, 4]),
             ])
         );
     }
 
     #[test]
     fn test_tuple_missing_at_separator() {
-        Tuple::<String, u64>::from_str("[foo42]").unwrap_err();
-    }
-
-    #[test]
-    fn test_tuple_missing_brackets() {
-        Tuple::<String, u64>::from_str("foo@42").unwrap_err();
+        Tuple::<String, u64>::from_str("foo42").unwrap_err();
     }
 
     #[test]

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -71,16 +71,16 @@ struct OptionParserValue {
 #[derive(Debug, Error)]
 pub enum OptionParserError {
     /// An option name was not previously registered with [`OptionParser::add`].
-    #[error("unknown option: {0}")]
+    #[error("Unknown option: {0}")]
     UnknownOption(String),
     /// The input string has invalid syntax (unbalanced quotes/brackets, missing `=`).
-    #[error("invalid syntax: {0}")]
+    #[error("Invalid syntax: {0}")]
     InvalidSyntax(String),
     /// A value could not be converted to the requested type.
-    #[error("unable to convert {1} for {0}")]
+    #[error("Unable to convert {1} for {0}")]
     Conversion(String /* field */, String /* value */),
     /// A value was syntactically valid but semantically wrong.
-    #[error("invalid value: {0}")]
+    #[error("Invalid value: {0}")]
     InvalidValue(String),
 }
 type OptionParserResult<T> = result::Result<T, OptionParserError>;
@@ -296,7 +296,7 @@ pub struct Toggle(pub bool);
 
 #[derive(Error, Debug)]
 pub enum ToggleParseError {
-    #[error("invalid value: {0}")]
+    #[error("Invalid value: {0}")]
     InvalidValue(String),
 }
 
@@ -323,7 +323,7 @@ pub struct ByteSized(pub u64);
 
 #[derive(Error, Debug)]
 pub enum ByteSizedParseError {
-    #[error("invalid value: {0}")]
+    #[error("Invalid value: {0}")]
     InvalidValue(String),
 }
 
@@ -375,7 +375,7 @@ impl<T: Display> Display for IntegerList<T> {
 
 #[derive(Error, Debug)]
 pub enum IntegerListParseError {
-    #[error("invalid value: {0}")]
+    #[error("Invalid value: {0}")]
     InvalidValue(String),
 }
 
@@ -466,15 +466,15 @@ impl TupleValue for Vec<usize> {
 
 #[derive(Error, Debug)]
 pub enum TupleError {
-    #[error("invalid value: {0}")]
+    #[error("Invalid value: {0}")]
     InvalidValue(String),
     #[error("Unbalanced brackets in one of the values")]
     SplitInsideBrackets(#[source] OptionParserError),
     #[error("Expected a single pair of enclosing brackets in input: {0}")]
     UnbalancedOutsideBrackets(String),
-    #[error("invalid integer list")]
+    #[error("Invalid integer list")]
     InvalidIntegerList(#[source] IntegerListParseError),
-    #[error("invalid integer")]
+    #[error("Invalid integer")]
     InvalidInteger(#[source] ParseIntError),
 }
 
@@ -545,7 +545,7 @@ pub struct StringList(pub Vec<String>);
 
 #[derive(Error, Debug)]
 pub enum StringListParseError {
-    #[error("invalid value: {0}")]
+    #[error("Invalid value: {0}")]
     InvalidValue(String),
 }
 

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -967,6 +967,17 @@ mod unit_tests {
     }
 
     #[test]
+    fn test_tuple_reject_whitespace_as_empty_key() {
+        let expected_value = "@42";
+        let e = Tuple::<String, u64>::from_str(" @42").unwrap_err();
+        assert!(
+            matches!(e, TupleError::EmptyKey(ref s) if s == expected_value),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            TupleError::EmptyKey(expected_value.to_string()),
+        );
+    }
+
+    #[test]
     fn test_split_commas_unbalanced_bracket() {
         split_commas("[a,b").unwrap_err();
         split_commas("a]").unwrap_err();

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -476,6 +476,8 @@ pub enum TupleError {
     InvalidIntegerList(#[source] IntegerListParseError),
     #[error("Invalid integer")]
     InvalidInteger(#[source] ParseIntError),
+    #[error("Empty key in tuple: {0}")]
+    EmptyKey(String),
 }
 
 /// A tuple consisting of a `key@value` pair parsed from a string.
@@ -503,7 +505,11 @@ impl<S: Parseable, T: TupleValue> Parseable for Tuple<S, T> {
                     if last_idx != 0 {
                         return Err(TupleError::InvalidValue((*tuple).to_string()));
                     }
-                    first_val = Some(&tuple[last_idx..idx]);
+                    first_val = if tuple[last_idx..idx].is_empty() {
+                        return Err(TupleError::EmptyKey((*tuple).to_string()));
+                    } else {
+                        Some(&tuple[last_idx..idx])
+                    };
                     last_idx = idx + 1;
                 }
                 _ => {}
@@ -886,6 +892,17 @@ mod unit_tests {
     #[test]
     fn test_tuple_missing_at_separator() {
         Tuple::<String, u64>::from_str("foo42").unwrap_err();
+    }
+
+    #[test]
+    fn test_tuple_missing_key() {
+        let expected_value = "@42";
+        let e = Tuple::<String, u64>::from_str("@42").unwrap_err();
+        assert!(
+            matches!(e, TupleError::EmptyKey(ref s) if s == expected_value),
+            "Expected \"{:?}\"; got \"{e:?}\"",
+            TupleError::EmptyKey(expected_value.to_string()),
+        );
     }
 
     #[test]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -16,7 +16,7 @@ use block::ImageType;
 use clap::ArgMatches;
 use log::{debug, warn};
 use option_parser::{
-    ByteSized, IntegerList, OptionParser, OptionParserError, StringList, Toggle, Tuple,
+    ByteSized, IntegerList, OptionParser, OptionParserError, StringList, Toggle, Tuple, TupleList,
 };
 use pci::NUM_DEVICE_IDS;
 use serde::{Deserialize, Serialize};
@@ -744,11 +744,11 @@ impl CpusConfig {
             .map_err(Error::ParseCpus)?
             .unwrap_or(DEFAULT_MAX_PHYS_BITS);
         let affinity = parser
-            .convert::<Tuple<u32, Vec<usize>>>("affinity")
+            .convert::<TupleList<u32, Vec<usize>>>("affinity")
             .map_err(Error::ParseCpus)?
             .map(|v| {
                 v.0.iter()
-                    .map(|(e1, e2)| CpuAffinity {
+                    .map(|Tuple(e1, e2)| CpuAffinity {
                         vcpu: *e1,
                         host_cpus: e2.clone().into_boxed_slice(),
                     })
@@ -1529,11 +1529,11 @@ impl DiskConfig {
             .unwrap_or_default();
         let serial = parser.get("serial");
         let queue_affinity = parser
-            .convert::<Tuple<u16, Vec<usize>>>("queue_affinity")
+            .convert::<TupleList<u16, Vec<usize>>>("queue_affinity")
             .map_err(Error::ParseDisk)?
             .map(|v| {
                 v.0.iter()
-                    .map(|(e1, e2)| VirtQueueAffinity {
+                    .map(|Tuple(e1, e2)| VirtQueueAffinity {
                         queue_index: *e1,
                         host_cpus: e2.clone().into_boxed_slice(),
                     })
@@ -2645,11 +2645,11 @@ impl NumaConfig {
             .map_err(Error::ParseNuma)?
             .map(|v| v.0.iter().map(|e| *e as u32).collect());
         let distances = parser
-            .convert::<Tuple<u64, u64>>("distances")
+            .convert::<TupleList<u64, u64>>("distances")
             .map_err(Error::ParseNuma)?
             .map(|v| {
                 v.0.iter()
-                    .map(|(e1, e2)| NumaDistance {
+                    .map(|Tuple(e1, e2)| NumaDistance {
                         destination: *e1 as u32,
                         distance: *e2 as u8,
                     })
@@ -2841,11 +2841,11 @@ impl RestoreConfig {
             .map_err(Error::ParseRestore)?
             .unwrap_or_default();
         let net_fds = parser
-            .convert::<Tuple<String, Vec<u64>>>("net_fds")
+            .convert::<TupleList<String, Vec<u64>>>("net_fds")
             .map_err(Error::ParseRestore)?
             .map(|v| {
                 v.0.iter()
-                    .map(|(id, fds)| RestoredNetConfig {
+                    .map(|Tuple(id, fds)| RestoredNetConfig {
                         id: id.clone(),
                         num_fds: fds.len(),
                         fds: Some(fds.iter().map(|e| *e as i32).collect()),


### PR DESCRIPTION
While working on https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8370, I noticed that tuple parsing accepts some inputs that should probably be rejected. This series tightens tuple parsing and updates the affected documentation.

The first issue is that tuple parsing accepts empty keys, such as `[@42]`. A tuple element is defined as a `key@value` pair, where `@` is the delimiter. Without a key, parsing should fail.

The second issue is that tuple parsing accepts whitespace as part of tuple keys and values. This can make keys such as `ID1` and ` ID1` compare as different strings even though users likely intended the same key. To avoid pushing whitespace normalization into every consumer of parsed tuples, this series rejects whitespace in tuple elements and fails parsing early.

This intentionally makes tuple parsing stricter. I would appreciate feedback on whether rejecting all tuple whitespace is the right policy.

### Edit:
The patch series now implements the following changes:
- Splits `Tuple` up into two types; `Tuple` and `TupleList`
- Makes existing error messages adhere to coding guidelines
- Makes tuple parsing reject empty keys
- Removes whitespace from tuple and tuple list elements
- Increases overall test coverage for tuple types
