### PR TITLE
virtio-devices: Gate VIRTIO_NET_S_ANNOUNCE on feature acked

### DIFF
--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -766,7 +766,11 @@ impl Net {
         if self.common.feature_acked(VIRTIO_NET_F_STATUS.into()) {
             status |= VIRTIO_NET_S_LINK_UP as u16;
 
-            if self.announce.pending.load(Ordering::Acquire) {
+            if self
+                .common
+                .feature_acked(VIRTIO_NET_F_GUEST_ANNOUNCE.into())
+                && self.announce.pending.load(Ordering::Acquire)
+            {
                 status |= VIRTIO_NET_S_ANNOUNCE as u16;
             }
         }

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -272,7 +272,12 @@ impl Net {
         {
             status |= VIRTIO_NET_S_LINK_UP as u16;
 
-            if self.announce.pending.load(Ordering::Acquire) {
+            if self
+                .vu_common
+                .virtio_common
+                .feature_acked(VIRTIO_NET_F_GUEST_ANNOUNCE.into())
+                && self.announce.pending.load(Ordering::Acquire)
+            {
                 status |= VIRTIO_NET_S_ANNOUNCE as u16;
             }
         }


### PR DESCRIPTION
Only set the VIRTIO_NET_S_ANNOUNCE status bit if the feature
VIRTIO_NET_F_GUEST_ANNOUNCE was acknowledged.

Signed-off-by: Rob Bradford <rbradford@meta.com>
