### PR TITLE
build: Only run MSHV integration tests on MQ

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -715,7 +715,7 @@ jobs:
     name: integration-mshv-x86-64
     needs: [preflight, dco, quality, build]
     if: >-
-      needs.preflight.outputs.full == 'true' && needs.dco.result == 'success' && needs.quality.result == 'success' && needs.build.result == 'success'
+      github.event_name == 'merge_group' && needs.preflight.outputs.full == 'true' && needs.dco.result == 'success' && needs.quality.result == 'success' && needs.build.result == 'success'
     timeout-minutes: 35
     runs-on: mshv
     steps:


### PR DESCRIPTION
There is a single runner for this so avoid overloading/queueing by
running only on MQ.

Signed-off-by: Rob Bradford <rbradford@meta.com>
