### PR TITLE
ci: Switch to Windows Server 25H2 for AARCH64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -635,7 +635,7 @@ jobs:
           IMG_BASENAME=windows-11-iot-enterprise-aarch64.raw
           IMG_PATH=$HOME/workloads/$IMG_BASENAME
           IMG_GZ_PATH=$HOME/workloads/$IMG_BASENAME.gz
-          IMG_GZ_BLOB_NAME=windows-11-iot-enterprise-aarch64-9-min.raw.gz
+          IMG_GZ_BLOB_NAME=windows-11-iot-enterprise-aarch64-25h2-6.raw.gz
           cp "scripts/$IMG_BASENAME.sha1" "$HOME/workloads/"
           pushd "$HOME/workloads"
           if sha1sum "$IMG_BASENAME.sha1" --check; then
@@ -643,6 +643,7 @@ jobs:
           fi
           popd
           mkdir -p "$HOME/workloads"
+          rm -f "$IMG_PATH" "$IMG_GZ_PATH"
           az storage blob download --container-name private-images --file "$IMG_GZ_PATH" --name "$IMG_GZ_BLOB_NAME" --connection-string "${{ secrets.CH_PRIVATE_IMAGES }}"
           gzip -d "$IMG_GZ_PATH"
       - name: Run Windows guest integration tests

--- a/scripts/windows-11-iot-enterprise-aarch64.raw.sha1
+++ b/scripts/windows-11-iot-enterprise-aarch64.raw.sha1
@@ -1,1 +1,1 @@
-707e939654b341717d3f54b41c57eea4432978e5  windows-11-iot-enterprise-aarch64.raw
+0257666b28c659de9d9ff119288ca92f37daf76e  windows-11-iot-enterprise-aarch64.raw


### PR DESCRIPTION
The updated image is configured in a same way as before

SSH and RDP are enabled.

Includes latest stable virtio-win 0.1.285 drivers.