### PR TITLE
block: Make AlignedFile access fully positional

### DIFF
--- a/block/src/aligned_file.rs
+++ b/block/src/aligned_file.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs::{File, Metadata};
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io;
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::fs::FileExt;
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -13,7 +13,7 @@ use vmm_sys_util::seek_hole::SeekHole;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
 use crate::aligned_buffer::AlignedBuffer;
-use crate::{SECTOR_SIZE, probe_direct_alignment, query_device_size};
+use crate::{SECTOR_SIZE, probe_direct_alignment};
 
 /// True when `buf_ptr`/`len`/`offset` already satisfy `alignment`
 /// (`alignment == 0` means no O_DIRECT, so everything is "aligned").
@@ -33,7 +33,6 @@ fn is_aligned(alignment: usize, buf_ptr: usize, len: usize, offset: u64) -> bool
 pub struct AlignedFile {
     file: File,
     alignment: usize,
-    position: u64,
 }
 
 impl AlignedFile {
@@ -44,11 +43,7 @@ impl AlignedFile {
         } else {
             0
         };
-        AlignedFile {
-            file,
-            alignment,
-            position: 0,
-        }
+        AlignedFile { file, alignment }
     }
 
     pub fn alignment(&self) -> usize {
@@ -67,7 +62,6 @@ impl AlignedFile {
         Ok(AlignedFile {
             file: self.file.try_clone()?,
             alignment: self.alignment,
-            position: self.position,
         })
     }
 
@@ -105,11 +99,7 @@ impl AlignedFile {
     /// tests to force the bounce/RMW path without a real O_DIRECT fd.
     #[cfg(test)]
     pub fn with_alignment(file: File, alignment: usize) -> Self {
-        AlignedFile {
-            file,
-            alignment,
-            position: 0,
-        }
+        AlignedFile { file, alignment }
     }
 
     /// Read `len` bytes at `offset` through an aligned bounce buffer.
@@ -168,44 +158,6 @@ impl FileExt for AlignedFile {
     }
 }
 
-impl Read for AlignedFile {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let n = self.read_at(buf, self.position)?;
-        self.position += n as u64;
-        Ok(n)
-    }
-}
-
-impl Write for AlignedFile {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let n = self.write_at(buf, self.position)?;
-        self.position += n as u64;
-        Ok(n)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.file.sync_all()
-    }
-}
-
-impl Seek for AlignedFile {
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        let newpos = match pos {
-            SeekFrom::Start(o) => o,
-            SeekFrom::Current(d) => self
-                .position
-                .checked_add_signed(d)
-                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid seek"))?,
-            SeekFrom::End(d) => query_device_size(&self.file)?
-                .0
-                .checked_add_signed(d)
-                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid seek"))?,
-        };
-        self.position = newpos;
-        Ok(newpos)
-    }
-}
-
 impl WriteZeroesAt for AlignedFile {
     fn write_zeroes_at(&mut self, offset: u64, length: usize) -> io::Result<usize> {
         self.file.write_zeroes_at(offset, length)
@@ -226,27 +178,11 @@ impl FileSync for AlignedFile {
 
 impl SeekHole for AlignedFile {
     fn seek_hole(&mut self, offset: u64) -> io::Result<Option<u64>> {
-        match self.file.seek_hole(offset) {
-            Ok(pos) => {
-                if let Some(p) = pos {
-                    self.position = p;
-                }
-                Ok(pos)
-            }
-            Err(e) => Err(e),
-        }
+        self.file.seek_hole(offset)
     }
 
     fn seek_data(&mut self, offset: u64) -> io::Result<Option<u64>> {
-        match self.file.seek_data(offset) {
-            Ok(pos) => {
-                if let Some(p) = pos {
-                    self.position = p;
-                }
-                Ok(pos)
-            }
-            Err(e) => Err(e),
-        }
+        self.file.seek_data(offset)
     }
 }
 
@@ -270,7 +206,7 @@ impl AsFd for AlignedFile {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::io::Write;
     use std::os::unix::fs::FileExt;
 
     use vmm_sys_util::tempfile::TempFile;
@@ -286,11 +222,7 @@ mod tests {
     }
 
     fn forced(file: File, alignment: usize) -> AlignedFile {
-        AlignedFile {
-            file,
-            alignment,
-            position: 0,
-        }
+        AlignedFile { file, alignment }
     }
 
     #[test]
@@ -360,46 +292,20 @@ mod tests {
     }
 
     #[test]
-    fn test_unaligned_read_returns_short_read_at_eof() {
-        let file_size = 100usize;
-        let tf = pattern_file(file_size);
-        let mut af = forced(tf.as_file().try_clone().unwrap(), 512);
-        af.seek(SeekFrom::Start(10)).unwrap();
-
-        let mut buf = vec![0u8; 200];
-        let bytes_read = af.read(&mut buf).unwrap();
-
-        let expected: Vec<u8> = (10..file_size).map(|i| (i % 251) as u8).collect();
-        assert_eq!(bytes_read, expected.len());
-        assert_eq!(&buf[..bytes_read], &expected[..]);
-        assert_eq!(af.position, file_size as u64);
-    }
-
-    #[test]
     fn test_unaligned_read_beyond_eof_returns_zero() {
         let tf = pattern_file(100);
-        let mut af = forced(tf.as_file().try_clone().unwrap(), 512);
-        af.seek(SeekFrom::Start(200)).unwrap();
-
+        let af = forced(tf.as_file().try_clone().unwrap(), 512);
         let mut buf = vec![0u8; 16];
-        let bytes_read = af.read(&mut buf).unwrap();
-
-        assert_eq!(bytes_read, 0);
-        assert_eq!(af.position, 200);
+        assert_eq!(af.read_at(&mut buf, 200).unwrap(), 0);
     }
 
     #[test]
     fn test_unaligned_write_extends_at_eof() {
         let file_size = 100usize;
         let tf = pattern_file(file_size);
-        let mut af = forced(tf.as_file().try_clone().unwrap(), 512);
-        af.seek(SeekFrom::Start(file_size as u64)).unwrap();
-
+        let af = forced(tf.as_file().try_clone().unwrap(), 512);
         let data = b"xyz";
-        let bytes_written = af.write(data).unwrap();
-
-        assert_eq!(bytes_written, data.len());
-        assert_eq!(af.position, (file_size + data.len()) as u64);
+        assert_eq!(af.write_at(data, file_size as u64).unwrap(), data.len());
 
         let mut readback = vec![0u8; file_size + data.len()];
         tf.as_file().read_exact_at(&mut readback, 0).unwrap();
@@ -411,13 +317,10 @@ mod tests {
     #[test]
     fn test_empty_unaligned_io_is_noop() {
         let tf = pattern_file(100);
-        let mut af = forced(tf.as_file().try_clone().unwrap(), 512);
-        af.seek(SeekFrom::Start(1)).unwrap();
-
+        let af = forced(tf.as_file().try_clone().unwrap(), 512);
         let mut read_buf = [];
-        assert_eq!(af.read(&mut read_buf).unwrap(), 0);
-        assert_eq!(af.write(&[]).unwrap(), 0);
-        assert_eq!(af.position, 1);
+        assert_eq!(af.read_at(&mut read_buf, 1).unwrap(), 0);
+        assert_eq!(af.write_at(&[], 1).unwrap(), 0);
     }
 
     #[test]

--- a/block/src/formats/vhd/internal/footer.rs
+++ b/block/src/formats/vhd/internal/footer.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs::File;
-use std::io::{self, Read, Seek, SeekFrom};
+use std::io;
+use std::os::unix::fs::FileExt;
 
-use crate::AlignedFile;
+use crate::{AlignedFile, query_device_size};
 
 // Production code uses: cookie, file_format_version, data_offset,
 // current_size, disk_type. The remaining fields are parsed for VHD
@@ -32,10 +33,13 @@ pub struct VhdFooter {
 
 impl VhdFooter {
     pub fn new(file: &mut File) -> io::Result<VhdFooter> {
-        let mut aligned = AlignedFile::new(file.try_clone()?, true);
-        aligned.seek(SeekFrom::End(-512))?;
+        let aligned = AlignedFile::new(file.try_clone()?, true);
+        let size = query_device_size(file)?.0;
+        let footer_offset = size.checked_sub(512).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "file too small for VHD footer")
+        })?;
         let mut sector = [0u8; 512];
-        aligned.read_exact(&mut sector)?;
+        aligned.read_exact_at(&mut sector, footer_offset)?;
 
         Ok(VhdFooter {
             cookie: u64::from_be_bytes(sector[0..8].try_into().unwrap()),

--- a/block/src/io/request.rs
+++ b/block/src/io/request.rs
@@ -10,8 +10,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem;
+use std::os::unix::fs::FileExt;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -29,6 +29,7 @@ use vm_memory::{
 };
 use vm_virtio::AccessPlatform;
 use vm_virtio::checked_descriptor::DescriptorChainExt;
+use vmm_sys_util::file_traits::FileSync;
 
 use crate::async_io::{
     AsyncIo, AsyncIoCompletion, AsyncIoOperation, GuestMemoryTarget, OwnedIoBuffer,
@@ -171,7 +172,7 @@ impl Request {
         Ok(req)
     }
 
-    pub fn execute<T: Seek + Read + Write, B: Bitmap + 'static>(
+    pub fn execute<T: FileExt + FileSync, B: Bitmap + 'static>(
         &self,
         disk: &mut T,
         disk_nsectors: u64,
@@ -180,32 +181,35 @@ impl Request {
     ) -> Result<u32, ExecuteError> {
         self.check_data_bounds(disk_nsectors)?;
 
-        disk.seek(SeekFrom::Start(self.sector << SECTOR_SHIFT))
-            .map_err(ExecuteError::Seek)?;
+        let mut offset = self.sector << SECTOR_SHIFT;
         let mut len = 0;
         for (data_addr, data_len) in &self.data_descriptors {
             match self.request_type {
                 RequestType::In => {
                     let mut buf = vec![0u8; *data_len as usize];
-                    disk.read_exact(&mut buf).map_err(ExecuteError::ReadExact)?;
+                    disk.read_exact_at(&mut buf, offset)
+                        .map_err(ExecuteError::ReadExact)?;
                     mem.read_exact_volatile_from(
                         *data_addr,
                         &mut buf.as_slice(),
                         *data_len as usize,
                     )
                     .map_err(ExecuteError::Read)?;
+                    offset += u64::from(*data_len);
                     len += data_len;
                 }
                 RequestType::Out => {
                     let mut buf: Vec<u8> = Vec::new();
                     mem.write_all_volatile_to(*data_addr, &mut buf, *data_len as usize)
                         .map_err(ExecuteError::Write)?;
-                    disk.write_all(&buf).map_err(ExecuteError::WriteAll)?;
+                    disk.write_all_at(&buf, offset)
+                        .map_err(ExecuteError::WriteAll)?;
                     if !self.writeback {
-                        disk.flush().map_err(ExecuteError::Flush)?;
+                        disk.fsync().map_err(ExecuteError::Flush)?;
                     }
+                    offset += u64::from(*data_len);
                 }
-                RequestType::Flush => disk.flush().map_err(ExecuteError::Flush)?,
+                RequestType::Flush => disk.fsync().map_err(ExecuteError::Flush)?,
                 RequestType::GetDeviceId => {
                     if (*data_len as usize) < serial.len() {
                         return Err(ExecuteError::BadRequest(Error::InvalidOffset));

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -125,8 +125,6 @@ pub enum ExecuteError {
     ReadExact(#[source] io::Error),
     #[error("Can't execute an operation other than `read` or `get_id` on a read-only device")]
     ReadOnly,
-    #[error("Failed to seek")]
-    Seek(#[source] io::Error),
     #[error("Failed to write")]
     Write(#[source] GuestMemoryError),
     #[error("Failed to write_all")]
@@ -161,7 +159,6 @@ impl ExecuteError {
             ExecuteError::Read(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::ReadExact(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::ReadOnly => VIRTIO_BLK_S_IOERR,
-            ExecuteError::Seek(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::Write(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::WriteAll(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::Unsupported(_) => VIRTIO_BLK_S_UNSUPP,

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -20,13 +20,12 @@ pub mod formats;
 mod sparse;
 use std::fmt::{self, Debug};
 use std::fs::{File, OpenOptions};
-use std::io::{self, Read};
 use std::os::linux::fs::MetadataExt;
-use std::os::unix::fs::FileTypeExt;
+use std::os::unix::fs::{FileExt, FileTypeExt};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 use std::str::FromStr;
-use std::{cmp, mem, result};
+use std::{cmp, io, mem, result};
 
 pub use aligned_file::AlignedFile;
 use formats::qcow::internal as qcow;
@@ -539,10 +538,10 @@ pub fn open_disk_image(path: &Path, options: &OpenOptions) -> BlockResult<File> 
 
 /// Determine image type through file parsing.
 pub fn detect_image_type(f: &mut File) -> BlockResult<ImageType> {
-    let mut aligned = AlignedFile::new(f.try_clone()?, true);
+    let aligned = AlignedFile::new(f.try_clone()?, true);
     let mut block = vec![0u8; aligned.alignment()];
     aligned
-        .read_exact(&mut block)
+        .read_exact_at(&mut block, 0)
         .map_err(|e| BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::DetectImageType))?;
 
     // Check 4 first bytes to get the header value and determine the image type

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -9,7 +9,6 @@
 // SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 use std::fs::{File, OpenOptions};
-use std::io::{Seek, SeekFrom};
 use std::ops::Deref;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
@@ -19,7 +18,9 @@ use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
 use std::time::Instant;
 use std::{convert, io, process, result};
 
-use block::{AlignedFile, Request, RequestType, VirtioBlockConfig, build_serial};
+use block::{
+    AlignedFile, Request, RequestType, VirtioBlockConfig, build_serial, query_device_size,
+};
 use libc::EFD_NONBLOCK;
 use log::{debug, error, info, warn};
 use option_parser::{OptionParser, OptionParserError, Toggle};
@@ -234,7 +235,7 @@ impl VhostUserBlkBackend {
         let serial = build_serial(&PathBuf::from(&image_path));
         let image = Arc::new(Mutex::new(raw_img));
 
-        let nsectors = (image.lock().unwrap().seek(SeekFrom::End(0)).unwrap()) / SECTOR_SIZE;
+        let nsectors = query_device_size(image.lock().unwrap().file()).unwrap().0 / SECTOR_SIZE;
         let config = VirtioBlockConfig {
             capacity: nsectors,
             blk_size: BLK_SIZE,


### PR DESCRIPTION
Continues #8353. Converts the code that still used the `AlignedFile` `Read`, `Write`, and `Seek` cursor over to positional file access, then removes those impls and the in memory `position` field, so `AlignedFile` itself is purely positional through `FileExt`. The users of the `AlignedFile` cursor are converted one by one.

This is scoped to `AlignedFile`. The VHDx `Vhdx` type keeps its own virtual disk cursor with `Read`, `Write`, and `Seek`, but that layer already runs on positional `AlignedFile` access, so it is unaffected. Test scaffolding that seeks a plain `File` is likewise unrelated and left alone.

`Request::execute` now takes `FileExt` and `FileSync` instead of `Seek`, `Read`, and `Write`, and the now unused `ExecuteError::Seek` is dropped. The only caller is `vhost_user_block`, which passes an `AlignedFile` that satisfies the new bound.

The result is unchanged. The cursor unit tests are rewritten to use `read_at` and `write_at`.