### PR TITLE
vfio: Support live migration of VFIO devices

### DIFF
--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -531,18 +531,19 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                 .map_err(Error::HttpApiClient)
         }
         Some("receive-migration") => {
-            let receive_migration_data = receive_migration_data(
+            let (receive_migration_data, fds) = receive_migration_data(
                 matches
                     .subcommand_matches("receive-migration")
                     .unwrap()
                     .get_one::<String>("receive_migration_config")
                     .unwrap(),
             )?;
-            simple_api_command(
+            simple_api_command_with_fds(
                 socket,
                 "PUT",
                 "receive-migration",
                 Some(&receive_migration_data),
+                &fds,
             )
             .map_err(Error::HttpApiClient)
         }
@@ -750,7 +751,7 @@ fn dbus_api_do_command(matches: &ArgMatches, proxy: &DBusApi1ProxyBlocking<'_>) 
             proxy.api_vm_send_migration(&send_migration_data)
         }
         Some("receive-migration") => {
-            let receive_migration_data = receive_migration_data(
+            let (receive_migration_data, _fds) = receive_migration_data(
                 matches
                     .subcommand_matches("receive-migration")
                     .unwrap()
@@ -962,10 +963,21 @@ fn coredump_config(destination_url: &str) -> String {
     serde_json::to_string(&coredump_config).unwrap()
 }
 
-fn receive_migration_data(config: &str) -> Result<String, Error> {
-    let receive_migration_data =
+fn receive_migration_data(config: &str) -> Result<(String, Vec<i32>), Error> {
+    let mut data =
         api::VmReceiveMigrationData::parse(config).map_err(Error::ReceiveMigrationConfig)?;
-    Ok(serde_json::to_string(&receive_migration_data).unwrap())
+
+    // The FDs are passed to the server side process via SCM_RIGHTS, in the
+    // order vfio_fds then the iommufd FD, matching the server's split.
+    let mut fds: Vec<i32> = match data.vfio_fds.as_mut() {
+        Some(vfio_fds) => vfio_fds.iter_mut().filter_map(|v| v.fd.take()).collect(),
+        None => Vec::new(),
+    };
+    if let Some(iommufd_fd) = data.iommufd_fd.take() {
+        fds.push(iommufd_fd);
+    }
+
+    Ok((serde_json::to_string(&data).unwrap(), fds))
 }
 
 fn send_migration_data(config: &str) -> Result<String, Error> {

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -933,14 +933,22 @@ fn snapshot_config(url: &str) -> String {
 fn restore_config(config: &str) -> Result<(String, Vec<i32>), Error> {
     let mut restore_config = RestoreConfig::parse(config).map_err(Error::Restore)?;
     // RestoreConfig is modified on purpose to take out the file descriptors.
-    // These fds are passed to the server side process via SCM_RIGHTS
-    let fds = match &mut restore_config.net_fds {
+    // These fds are passed to the server side process via SCM_RIGHTS, in the
+    // order net_fds, then vfio_fds, then the iommufd FD, matching the
+    // server's split.
+    let mut fds: Vec<i32> = match &mut restore_config.net_fds {
         Some(net_fds) => net_fds
             .iter_mut()
             .flat_map(|net| net.fds.take().unwrap_or_default())
             .collect(),
         None => Vec::new(),
     };
+    if let Some(vfio_fds) = restore_config.vfio_fds.as_mut() {
+        fds.extend(vfio_fds.iter_mut().filter_map(|v| v.fd.take()));
+    }
+    if let Some(iommufd_fd) = restore_config.iommufd_fd.take() {
+        fds.push(iommufd_fd);
+    }
     let restore_config = serde_json::to_string(&restore_config).unwrap();
 
     Ok((restore_config, fds))

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -382,6 +382,17 @@ migration process. Via the API or `ch-remote`, you may specify:
   Memory transfer mode. `postcopy` resumes the destination first and faults
   guest pages in on demand over a dedicated connection. Defaults to `precopy`.
 
+## Migrating VMs with VFIO Devices
+
+VMs with migratable VFIO devices, for example NIC VFs bound to
+`mlx5_vfio_pci`, can be live migrated. The opaque device state is captured
+during the downtime window and the destination receives new device file
+descriptors through the `vfio_fds` and `iommufd_fd` options of
+`receive-migration`.
+
+See [Live Migration of VFIO Devices](vfio.md#live-migration-of-vfio-devices)
+for the requirements, the dirty tracking behavior, and an example.
+
 ## Version Compatibility
 
 Cloud Hypervisor live migration compatibility has two dimensions: the

--- a/docs/vfio.md
+++ b/docs/vfio.md
@@ -198,9 +198,9 @@ mmio address space is available for use by devices on PCI segment 1.
 ## Snapshot and Restore of VFIO Devices
 
 Cloud Hypervisor supports snapshotting and restoring VFIO devices that advertise
-the kernel VFIO migration v2 protocol. Live migration of VFIO devices, where the
-guest keeps running while its state transfers, is a separate effort not covered
-by this section.
+the kernel VFIO migration v2 protocol. Live migration of VFIO devices builds on
+the same protocol and is covered in
+[Live Migration of VFIO Devices](#live-migration-of-vfio-devices).
 
 ### Requirements
 
@@ -238,3 +238,70 @@ INFO  vfio: VFIO device 0000:01:00.0 supports migration v2 (flags=0x7, ...)
 The current snapshot format stores the blob as base64 inside the snapshot
 JSON. Very large blobs may benefit from a binary transport path in the
 future.
+
+## Live Migration of VFIO Devices
+
+Cloud Hypervisor can live migrate a VM with a migratable VFIO device. Guest
+memory moves according to the selected memory mode while the guest runs. The
+opaque device state is captured through STOP_COPY during the downtime window,
+after the guest is paused, and is loaded on the destination through RESUMING
+before the guest resumes. There is no iterative device state transfer, so a
+large device state extends the downtime accordingly.
+
+### Requirements
+
+All the snapshot and restore requirements apply, plus the following.
+
+- **Dirty tracking.** The variant driver must implement VFIO DMA logging so
+  the pages the device writes to guest memory are tracked during the memory
+  transfer. Without it a precopy migration fails at the start.
+- **iommufd.** The destination receives the device as file descriptors, which
+  requires the config to carry `iommufd=on`. The iommufd itself arrives as a
+  file descriptor with the receive request, see below.
+- **BAR mapping.** `vfio_p2p_dma=off` is needed on older Linux kernels
+  (pre 6.19) that cannot map VFIO BAR MMIO into iommufd.
+- **No virtual IOMMU.** Live migration of a VFIO device behind a virtual
+  IOMMU is not supported and is refused at migration start. Assign the
+  device without a virtual IOMMU.
+
+### Dirty Tracking
+
+When the migration starts, Cloud Hypervisor programs the device with the IOVA
+ranges to track and merges the reported dirty pages into the memory transfer.
+The device sees an identity mapping of guest memory, so the tracked ranges are
+the guest memory layout with iova equal to gpa. Devices behind a virtual IOMMU
+are out of scope, see the requirement above.
+
+### Destination File Descriptors
+
+The device paths and file descriptors in the source configuration are
+meaningless on the destination host. The receive migration request therefore
+carries replacements. Each `vfio_fds` entry pairs a device id with a cdev
+file descriptor opened on the destination, and `iommufd_fd` carries a freshly
+opened iommufd. Both travel over the ch-remote UNIX socket via SCM_RIGHTS.
+
+The destination VF can live at a different BDF than the source's, and the
+kernel assigns its cdev name independently of the device id. The `vfio-dev`
+directory under the VF's sysfs node names the cdev to open.
+
+```console
+dst $ ls /sys/bus/pci/devices/0000:41:00.3/vfio-dev/
+vfio12
+dst $ exec 5<>/dev/vfio/devices/vfio12
+dst $ exec 6<>/dev/iommu
+dst $ ch-remote --api-socket=/tmp/api receive-migration \
+          receiver_url=tcp:0.0.0.0:{port},vfio_fds=[vfio0@5],iommufd_fd=6
+```
+
+The id in each `vfio_fds` entry must match the `id` of the corresponding
+device in the source VM configuration. The same substitution is available on
+snapshot restore through the `vfio_fds` and `iommufd_fd` parameters of the
+restore request, for restoring onto a different VF or host.
+
+### Failure Recovery
+
+A failed migration state transition can leave the device in an indeterminate
+state, including ERROR. Cloud Hypervisor first attempts to return the device
+to a known state and resets it as a last resort, so a failed snapshot or
+migration leaves the guest with a functional device. The original error is
+reported either way.

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -30,7 +30,9 @@ use vfio_bindings::bindings::vfio::{
     vfio_device_mig_state_VFIO_DEVICE_STATE_STOP as VFIO_DEV_STATE_STOP,
     vfio_device_mig_state_VFIO_DEVICE_STATE_STOP_COPY as VFIO_DEV_STATE_STOP_COPY, *,
 };
-use vfio_ioctls::{VfioDevice, VfioIrq, VfioOps, VfioRegionInfoCap, VfioRegionSparseMmapArea};
+use vfio_ioctls::{
+    DmaLoggingRange, VfioDevice, VfioIrq, VfioOps, VfioRegionInfoCap, VfioRegionSparseMmapArea,
+};
 use vm_allocator::page_size::{
     align_page_size_down, align_page_size_up, get_page_size, is_4k_aligned, is_4k_multiple,
     is_page_size_aligned,
@@ -41,7 +43,14 @@ use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig,
 };
 use vm_device::{BusDevice, Resource};
-use vm_memory::{Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestUsize};
+use vm_memory::bitmap::AtomicBitmap;
+use vm_memory::{
+    Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryRegion,
+    GuestUsize,
+};
+
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
+use vm_migration::protocol::MemoryRangeTable;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -518,6 +527,26 @@ pub(crate) trait Vfio: Send + Sync {
     }
 
     fn reset(&self) {}
+
+    fn start_dma_logging(
+        &self,
+        _page_size: u64,
+        _ranges: &[DmaLoggingRange],
+    ) -> Result<u64, VfioError> {
+        Err(VfioError::NoMigrationSupport)
+    }
+
+    fn stop_dma_logging(&self) -> Result<(), VfioError> {
+        Err(VfioError::NoMigrationSupport)
+    }
+
+    fn report_dma_logging(
+        &self,
+        _range: DmaLoggingRange,
+        _page_size: u64,
+    ) -> Result<MemoryRangeTable, VfioError> {
+        Err(VfioError::NoMigrationSupport)
+    }
 }
 
 struct VfioDeviceWrapper {
@@ -588,6 +617,38 @@ impl Vfio for VfioDeviceWrapper {
     fn reset(&self) {
         self.device.reset();
     }
+
+    fn start_dma_logging(
+        &self,
+        page_size: u64,
+        ranges: &[DmaLoggingRange],
+    ) -> Result<u64, VfioError> {
+        self.device
+            .start_dma_logging(page_size, ranges)
+            .map_err(VfioError::KernelVfio)
+    }
+
+    fn stop_dma_logging(&self) -> Result<(), VfioError> {
+        self.device
+            .stop_dma_logging()
+            .map_err(VfioError::KernelVfio)
+    }
+
+    // Wrap the kernel dirty bitmap into a MemoryRangeTable at the trait
+    // boundary so callers work with guest memory ranges directly.
+    fn report_dma_logging(
+        &self,
+        range: DmaLoggingRange,
+        page_size: u64,
+    ) -> Result<MemoryRangeTable, VfioError> {
+        let bitmap = self
+            .device
+            .report_dma_logging(range, page_size)
+            .map_err(VfioError::KernelVfio)?;
+        Ok(MemoryRangeTable::from_dirty_bitmap(
+            bitmap, range.iova, page_size,
+        ))
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -618,6 +679,8 @@ pub(crate) struct VfioCommon {
     x_nv_gpudirect_clique: Option<u8>,
     x_exclude_mmap_bars: Vec<u8>,
     pub(crate) migration_flags: Option<u64>,
+    // Negotiated dirty bitmap granularity while DMA logging is active.
+    dma_logging_page_size: Option<u64>,
 }
 
 #[derive(Default)]
@@ -693,6 +756,7 @@ impl VfioCommon {
             x_nv_gpudirect_clique: config.x_nv_gpudirect_clique,
             x_exclude_mmap_bars: config.x_exclude_mmap_bars,
             migration_flags,
+            dma_logging_page_size: None,
         };
 
         let state: Option<VfioCommonState> = snapshot
@@ -1735,6 +1799,58 @@ impl VfioCommon {
         }
         Ok(())
     }
+
+    // No op without ranges to track. page_size is a hint, the device reports
+    // back the granularity it actually applied, kept for the report calls.
+    pub(crate) fn start_dirty_log(
+        &mut self,
+        ranges: &[DmaLoggingRange],
+        page_size: u64,
+    ) -> Result<(), MigratableError> {
+        if ranges.is_empty() {
+            return Ok(());
+        }
+        let negotiated = self
+            .vfio_wrapper
+            .start_dma_logging(page_size, ranges)
+            .map_err(|e| MigratableError::StartDirtyLog(anyhow!("VFIO start_dma_logging: {e}")))?;
+        debug!(
+            "VFIO DMA logging started over {} range(s), requested page size {page_size:#x}, device granularity {negotiated:#x}",
+            ranges.len()
+        );
+        self.dma_logging_page_size = Some(negotiated);
+        Ok(())
+    }
+
+    pub(crate) fn stop_dirty_log(&mut self) -> Result<(), MigratableError> {
+        if self.dma_logging_page_size.take().is_none() {
+            return Ok(());
+        }
+        self.vfio_wrapper
+            .stop_dma_logging()
+            .map_err(|e| MigratableError::StopDirtyLog(anyhow!("VFIO stop_dma_logging: {e}")))
+    }
+
+    // Reports per range dirty bitmaps from the kernel, merged into a single
+    // MemoryRangeTable. Returns an empty table when logging is not active so
+    // the caller can splice it into the union without a special case.
+    pub(crate) fn dirty_log(
+        &self,
+        ranges: &[DmaLoggingRange],
+    ) -> Result<MemoryRangeTable, MigratableError> {
+        let Some(page_size) = self.dma_logging_page_size else {
+            return Ok(MemoryRangeTable::default());
+        };
+        let mut tables = Vec::with_capacity(ranges.len());
+        for range in ranges {
+            let table = self
+                .vfio_wrapper
+                .report_dma_logging(*range, page_size)
+                .map_err(|e| MigratableError::DirtyLog(anyhow!("VFIO report_dma_logging: {e}")))?;
+            tables.push(table);
+        }
+        Ok(MemoryRangeTable::new_from_tables(tables))
+    }
 }
 
 impl Pausable for VfioCommon {}
@@ -1792,6 +1908,9 @@ pub struct VfioPciDevice {
     // Required for peer-to-peer DMA between VFIO devices.
     p2p_dma: bool,
     memory_slot_allocator: MemorySlotAllocator,
+    // Guest memory layout, used to enumerate the IOVA ranges to track when
+    // programming VFIO DMA logging.
+    memory: GuestMemoryAtomic<GuestMemoryMmap>,
     bdf: PciBdf,
     device_path: PathBuf,
 }
@@ -1810,6 +1929,7 @@ impl VfioPciDevice {
         p2p_dma: bool,
         bdf: PciBdf,
         memory_slot_allocator: MemorySlotAllocator,
+        memory: GuestMemoryAtomic<GuestMemoryMmap>,
         snapshot: Option<&Snapshot>,
         x_nv_gpudirect_clique: Option<u8>,
         x_exclude_mmap_bars: Vec<u8>,
@@ -1842,6 +1962,7 @@ impl VfioPciDevice {
             iommu_attached,
             p2p_dma,
             memory_slot_allocator,
+            memory,
             bdf,
             device_path,
         };
@@ -2163,6 +2284,20 @@ impl VfioPciDevice {
     pub fn mmio_regions(&self) -> Vec<MmioRegion> {
         self.common.mmio_regions.clone()
     }
+
+    // IOVA ranges for DMA logging. Without a virtual IOMMU the device sees an
+    // identity mapping of guest memory (iova == gpa), so these are the guest
+    // memory regions. A virtual IOMMU is refused in start_migration, see
+    // issue #8567.
+    fn dirty_log_iova_ranges(&self) -> Vec<DmaLoggingRange> {
+        let mem = self.memory.memory();
+        mem.iter()
+            .map(|region| DmaLoggingRange {
+                iova: region.start_addr().raw_value(),
+                length: region.len(),
+            })
+            .collect()
+    }
 }
 
 impl Drop for VfioPciDevice {
@@ -2413,7 +2548,41 @@ impl Snapshottable for VfioPciDevice {
 }
 
 impl Transportable for VfioPciDevice {}
-impl Migratable for VfioPciDevice {}
+
+impl Migratable for VfioPciDevice {
+    fn start_migration(&mut self) -> result::Result<(), MigratableError> {
+        // Reject a device that does not implement migration v2 up front,
+        // rather than silently skipping its state and dirty tracking.
+        if self.common.migration_flags.is_none() {
+            return Err(MigratableError::MigrateSend(anyhow!(
+                "VFIO device does not support migration"
+            )));
+        }
+        // Dirty tracking behind a virtual IOMMU needs IOVA to GPA translation
+        // and would have to follow mappings the guest changes mid migration,
+        // neither of which is implemented, see issue #8567.
+        if self.iommu_attached {
+            return Err(MigratableError::MigrateSend(anyhow!(
+                "VFIO device live migration is not supported behind a virtual IOMMU"
+            )));
+        }
+        Ok(())
+    }
+
+    fn start_dirty_log(&mut self) -> result::Result<(), MigratableError> {
+        let ranges = self.dirty_log_iova_ranges();
+        self.common.start_dirty_log(&ranges, get_page_size())
+    }
+
+    fn stop_dirty_log(&mut self) -> result::Result<(), MigratableError> {
+        self.common.stop_dirty_log()
+    }
+
+    fn dirty_log(&mut self) -> result::Result<MemoryRangeTable, MigratableError> {
+        let ranges = self.dirty_log_iova_ranges();
+        self.common.dirty_log(&ranges)
+    }
+}
 
 /// This structure implements the ExternalDmaMapping trait. It is meant to
 /// be used when the caller tries to provide a way to update the mappings
@@ -2551,6 +2720,26 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn default_dma_logging_methods_error() {
+        let range = DmaLoggingRange {
+            iova: 0,
+            length: 0x1000,
+        };
+        assert!(matches!(
+            DefaultVfio.start_dma_logging(0x1000, &[range]),
+            Err(VfioError::NoMigrationSupport)
+        ));
+        assert!(matches!(
+            DefaultVfio.stop_dma_logging(),
+            Err(VfioError::NoMigrationSupport)
+        ));
+        assert!(matches!(
+            DefaultVfio.report_dma_logging(range, 0x1000),
+            Err(VfioError::NoMigrationSupport)
+        ));
+    }
+
     // Save and load state machine flows, driven through a mock Vfio wrapper
     // that records state transitions and stores the migration data in memory.
 
@@ -2563,6 +2752,11 @@ mod tests {
         fail_read: bool,
         fail_write: bool,
         resets: u32,
+        dma_logging_started: bool,
+        dma_logging_page_size: u64,
+        dma_logging_ranges: Vec<DmaLoggingRange>,
+        dma_logging_bitmap: Vec<u64>,
+        dma_logging_negotiated: Option<u64>,
     }
 
     struct MockVfio {
@@ -2601,6 +2795,13 @@ mod tests {
             })
         }
 
+        fn for_dma_logging(bitmap: Vec<u64>) -> Arc<Self> {
+            Self::with_state(MockVfioState {
+                dma_logging_bitmap: bitmap,
+                ..Default::default()
+            })
+        }
+
         fn transitions(&self) -> Vec<VfioMigrationState> {
             self.state.lock().unwrap().transitions.clone()
         }
@@ -2611,6 +2812,15 @@ mod tests {
 
         fn resets(&self) -> u32 {
             self.state.lock().unwrap().resets
+        }
+
+        fn dma_logging_started(&self) -> bool {
+            self.state.lock().unwrap().dma_logging_started
+        }
+
+        fn dma_logging_recorded(&self) -> (u64, Vec<DmaLoggingRange>) {
+            let s = self.state.lock().unwrap();
+            (s.dma_logging_page_size, s.dma_logging_ranges.clone())
         }
     }
 
@@ -2643,6 +2853,34 @@ mod tests {
 
         fn reset(&self) {
             self.state.lock().unwrap().resets += 1;
+        }
+
+        fn start_dma_logging(
+            &self,
+            page_size: u64,
+            ranges: &[DmaLoggingRange],
+        ) -> Result<u64, VfioError> {
+            let mut s = self.state.lock().unwrap();
+            s.dma_logging_started = true;
+            s.dma_logging_page_size = page_size;
+            s.dma_logging_ranges = ranges.to_vec();
+            Ok(s.dma_logging_negotiated.unwrap_or(page_size))
+        }
+
+        fn stop_dma_logging(&self) -> Result<(), VfioError> {
+            self.state.lock().unwrap().dma_logging_started = false;
+            Ok(())
+        }
+
+        fn report_dma_logging(
+            &self,
+            range: DmaLoggingRange,
+            page_size: u64,
+        ) -> Result<MemoryRangeTable, VfioError> {
+            let bitmap = self.state.lock().unwrap().dma_logging_bitmap.clone();
+            Ok(MemoryRangeTable::from_dirty_bitmap(
+                bitmap, range.iova, page_size,
+            ))
         }
 
         fn region_write(&self, _index: u32, _offset: u64, _data: &[u8]) {}
@@ -2688,6 +2926,7 @@ mod tests {
             x_nv_gpudirect_clique: None,
             x_exclude_mmap_bars: Vec::new(),
             migration_flags,
+            dma_logging_page_size: None,
         }
     }
 
@@ -2815,6 +3054,148 @@ mod tests {
         // resets directly rather than attempting STOP.
         assert_eq!(mock.transitions(), vec![VfioMigrationState::Resuming]);
         assert_eq!(mock.resets(), 1);
+    }
+
+    #[test]
+    fn mock_dma_logging_start_records_and_negotiates() {
+        let mock = MockVfio::with_state(MockVfioState {
+            dma_logging_negotiated: Some(0x2000),
+            ..Default::default()
+        });
+        let ranges = [
+            DmaLoggingRange {
+                iova: 0,
+                length: 0x1000,
+            },
+            DmaLoggingRange {
+                iova: 0x4000,
+                length: 0x2000,
+            },
+        ];
+        // The device may apply a different granularity than requested, so
+        // the negotiated page size flows back through the trait.
+        let negotiated = mock.start_dma_logging(0x1000, &ranges).unwrap();
+        assert_eq!(negotiated, 0x2000);
+        assert!(mock.dma_logging_started());
+        let (page_size, recorded) = mock.dma_logging_recorded();
+        assert_eq!(page_size, 0x1000);
+        assert_eq!(recorded, ranges);
+    }
+
+    #[test]
+    fn mock_dma_logging_stop_clears_started_flag() {
+        let mock = MockVfio::for_dma_logging(Vec::new());
+        let range = DmaLoggingRange {
+            iova: 0,
+            length: 0x1000,
+        };
+        mock.start_dma_logging(0x1000, &[range]).unwrap();
+        assert!(mock.dma_logging_started());
+        mock.stop_dma_logging().unwrap();
+        assert!(!mock.dma_logging_started());
+    }
+
+    #[test]
+    fn mock_dma_logging_report_converts_bitmap_to_ranges() {
+        // Bits 0, 1, 4 set means three dirty pages with a one page gap.
+        // Expect two ranges, [iova .. iova+2*ps) and [iova+4*ps .. iova+5*ps).
+        let bitmap = vec![0b10011_u64];
+        let mock = MockVfio::for_dma_logging(bitmap);
+        let page_size: u64 = 0x1000;
+        let range = DmaLoggingRange {
+            iova: 0x1_0000_0000,
+            length: page_size * 64,
+        };
+        let table = mock.report_dma_logging(range, page_size).unwrap();
+        let ranges = table.regions();
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].gpa, 0x1_0000_0000);
+        assert_eq!(ranges[0].length, page_size * 2);
+        assert_eq!(ranges[1].gpa, 0x1_0000_0000 + 4 * page_size);
+        assert_eq!(ranges[1].length, page_size);
+    }
+
+    #[test]
+    fn start_dirty_log_skips_empty_ranges() {
+        let mock = MockVfio::for_dma_logging(Vec::new());
+        let mut common = test_vfio_common(mock.clone(), Some(1));
+
+        // No ranges to track, so no logging session is opened and the
+        // stop is a no op rather than an unbalanced kernel call.
+        common.start_dirty_log(&[], 0x1000).unwrap();
+        assert!(!mock.dma_logging_started());
+        common.stop_dirty_log().unwrap();
+    }
+
+    #[test]
+    fn start_stop_dirty_log_drives_mock_when_migration_enabled() {
+        let mock = MockVfio::for_dma_logging(Vec::new());
+        let mut common = test_vfio_common(mock.clone(), Some(1));
+        let ranges = [DmaLoggingRange {
+            iova: 0x4000,
+            length: 0x2000,
+        }];
+
+        common.start_dirty_log(&ranges, 0x1000).unwrap();
+        assert!(mock.dma_logging_started());
+        let (page_size, recorded) = mock.dma_logging_recorded();
+        assert_eq!(page_size, 0x1000);
+        assert_eq!(recorded, ranges);
+
+        common.stop_dirty_log().unwrap();
+        assert!(!mock.dma_logging_started());
+    }
+
+    #[test]
+    fn dirty_log_uses_negotiated_page_size() {
+        // The mock negotiates 0x2000 against a requested 0x1000. With bit 0
+        // set the reported range length equals the negotiated granularity.
+        let mock = MockVfio::with_state(MockVfioState {
+            dma_logging_bitmap: vec![0b1_u64],
+            dma_logging_negotiated: Some(0x2000),
+            ..Default::default()
+        });
+        let mut common = test_vfio_common(mock, Some(1));
+        let ranges = [DmaLoggingRange {
+            iova: 0x1_0000_0000,
+            length: 0x2000 * 64,
+        }];
+
+        common.start_dirty_log(&ranges, 0x1000).unwrap();
+        let table = common.dirty_log(&ranges).unwrap();
+        let merged = table.ranges();
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].gpa, 0x1_0000_0000);
+        assert_eq!(merged[0].length, 0x2000);
+    }
+
+    #[test]
+    fn dirty_log_merges_ranges_into_one_table() {
+        // Mock returns the same canned bitmap for each report call. With
+        // bit 0 set, each range contributes its first page.
+        let bitmap = vec![0b1_u64];
+        let mock = MockVfio::for_dma_logging(bitmap);
+        let mut common = test_vfio_common(mock, Some(1));
+        let page_size: u64 = 0x1000;
+        let ranges = [
+            DmaLoggingRange {
+                iova: 0x1_0000_0000,
+                length: page_size * 64,
+            },
+            DmaLoggingRange {
+                iova: 0x2_0000_0000,
+                length: page_size * 64,
+            },
+        ];
+
+        common.start_dirty_log(&ranges, page_size).unwrap();
+        let table = common.dirty_log(&ranges).unwrap();
+        let merged = table.ranges();
+        assert_eq!(merged.len(), 2);
+        let mut starts: Vec<u64> = merged.iter().map(|r| r.gpa).collect();
+        starts.sort();
+        assert_eq!(starts, vec![0x1_0000_0000, 0x2_0000_0000]);
+        assert!(merged.iter().all(|r| r.length == page_size));
     }
 
     // pause() and resume() name no recovery state, so a failed transition

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -17,7 +17,7 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use byteorder::{ByteOrder, LittleEndian};
 use hypervisor::HypervisorVmError;
 use libc::{_SC_PAGESIZE, sysconf};
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vfio_bindings::bindings::vfio::{
@@ -516,6 +516,8 @@ pub(crate) trait Vfio: Send + Sync {
     fn write_migration_data(&self, _data: &[u8]) -> Result<(), VfioError> {
         Err(VfioError::NoMigrationSupport)
     }
+
+    fn reset(&self) {}
 }
 
 struct VfioDeviceWrapper {
@@ -581,6 +583,10 @@ impl Vfio for VfioDeviceWrapper {
         self.device
             .write_migration_data(data)
             .map_err(VfioError::KernelVfio)
+    }
+
+    fn reset(&self) {
+        self.device.reset();
     }
 }
 
@@ -1618,6 +1624,12 @@ impl VfioCommon {
                 .map_err(|e| VfioPciError::RestoreMigration(anyhow!("{e}")))?;
         }
 
+        self.sync_command_and_interrupts()?;
+
+        Ok(())
+    }
+
+    fn sync_command_and_interrupts(&self) -> Result<(), VfioPciError> {
         // Push PCI_COMMAND to the device. State replay updates the shadow config
         // space but not the device, so memory decode and bus mastering would
         // otherwise stay disabled after restore.
@@ -1642,28 +1654,60 @@ impl VfioCommon {
         Ok(())
     }
 
-    pub(crate) fn transition_migration_state(
-        &self,
-        target: VfioMigrationState,
-    ) -> anyhow::Result<()> {
+    fn transition_migration_state(&self, target: VfioMigrationState) -> anyhow::Result<()> {
         debug!("VFIO migration transition -> {target:?}");
         self.vfio_wrapper
             .set_migration_state(target)
             .map_err(|e| anyhow!("VFIO set_migration_state({target:?}) failed: {e}"))
     }
 
+    fn reset_and_rearm(&self) {
+        self.vfio_wrapper.reset();
+        // The reset returns the device to RUNNING. Reapply PCI_COMMAND and the
+        // interrupt eventfds the same way the restore path does.
+        if let Err(e) = self.sync_command_and_interrupts() {
+            error!("VFIO device rearm after reset failed: {e}");
+        }
+    }
+
+    // A failed set can leave the device anywhere along the transition path
+    // including ERROR, where only a reset recovers. Attempt the recovery
+    // state first when the caller names one, otherwise reset directly.
+    // The original error is propagated either way.
+    pub(crate) fn transition_migration_state_with_recovery(
+        &self,
+        target: VfioMigrationState,
+        recover: Option<VfioMigrationState>,
+    ) -> anyhow::Result<()> {
+        let Err(err) = self.transition_migration_state(target) else {
+            return Ok(());
+        };
+
+        if let Some(state) = recover
+            && self.transition_migration_state(state).is_ok()
+        {
+            return Err(err);
+        }
+
+        warn!("VFIO device in indeterminate migration state, resetting");
+        self.reset_and_rearm();
+        Err(err)
+    }
+
     pub(crate) fn save_migration_data(&self) -> Result<Vec<u8>, MigratableError> {
-        self.transition_migration_state(VfioMigrationState::StopCopy)
-            .map_err(MigratableError::Snapshot)?;
+        self.transition_migration_state_with_recovery(
+            VfioMigrationState::StopCopy,
+            Some(VfioMigrationState::Stop),
+        )
+        .map_err(MigratableError::Snapshot)?;
 
         let data = self.vfio_wrapper.read_migration_data();
 
         // We entered STOP_COPY successfully, so the STOP_COPY to STOP arc is
         // valid whether or not the read succeeded. Return the device to STOP
-        // either way, since a failed transition into STOP_COPY would have
-        // returned above and a STOP from ERROR cannot help.
+        // either way and reset it if even that fails.
         let stop = self
-            .transition_migration_state(VfioMigrationState::Stop)
+            .transition_migration_state_with_recovery(VfioMigrationState::Stop, None)
             .map_err(MigratableError::Snapshot);
 
         let data = data.map_err(|e| {
@@ -1675,20 +1719,21 @@ impl VfioCommon {
 
     pub(crate) fn load_migration_data(&self, data: &[u8]) -> Result<(), MigratableError> {
         // Leave the device in RESUMING and resume() drives it back to RUNNING.
-        let result = (|| -> Result<(), MigratableError> {
-            self.transition_migration_state(VfioMigrationState::Resuming)
-                .map_err(MigratableError::Restore)?;
+        self.transition_migration_state_with_recovery(
+            VfioMigrationState::Resuming,
+            Some(VfioMigrationState::Stop),
+        )
+        .map_err(MigratableError::Restore)?;
 
-            self.vfio_wrapper.write_migration_data(data).map_err(|e| {
-                MigratableError::Restore(anyhow!("VFIO migration data write failed: {e}"))
-            })?;
-            Ok(())
-        })();
-
-        if result.is_err() {
-            let _ = self.transition_migration_state(VfioMigrationState::Stop);
+        // A failed write leaves an incomplete RESUMING session, which the uAPI
+        // only allows aborting with a reset, so reset directly.
+        if let Err(e) = self.vfio_wrapper.write_migration_data(data) {
+            self.reset_and_rearm();
+            return Err(MigratableError::Restore(anyhow!(
+                "VFIO migration data write failed: {e}"
+            )));
         }
-        result
+        Ok(())
     }
 }
 
@@ -2336,7 +2381,7 @@ impl Pausable for VfioPciDevice {
     fn pause(&mut self) -> result::Result<(), MigratableError> {
         if self.common.migration_flags.is_some() {
             self.common
-                .transition_migration_state(VfioMigrationState::Stop)
+                .transition_migration_state_with_recovery(VfioMigrationState::Stop, None)
                 .map_err(MigratableError::Pause)?;
         }
         Ok(())
@@ -2345,7 +2390,7 @@ impl Pausable for VfioPciDevice {
     fn resume(&mut self) -> result::Result<(), MigratableError> {
         if self.common.migration_flags.is_some() {
             self.common
-                .transition_migration_state(VfioMigrationState::Running)
+                .transition_migration_state_with_recovery(VfioMigrationState::Running, None)
                 .map_err(MigratableError::Resume)?;
         }
         Ok(())
@@ -2514,8 +2559,10 @@ mod tests {
         transitions: Vec<VfioMigrationState>,
         save_blob: Vec<u8>,
         loaded: Vec<u8>,
-        fail_at: Option<VfioMigrationState>,
+        fail_at: Vec<VfioMigrationState>,
         fail_read: bool,
+        fail_write: bool,
+        resets: u32,
     }
 
     struct MockVfio {
@@ -2523,36 +2570,34 @@ mod tests {
     }
 
     impl MockVfio {
-        fn for_save(blob: Vec<u8>) -> Arc<Self> {
+        fn with_state(state: MockVfioState) -> Arc<Self> {
             Arc::new(Self {
-                state: Mutex::new(MockVfioState {
-                    save_blob: blob,
-                    ..Default::default()
-                }),
+                state: Mutex::new(state),
+            })
+        }
+
+        fn for_save(blob: Vec<u8>) -> Arc<Self> {
+            Self::with_state(MockVfioState {
+                save_blob: blob,
+                ..Default::default()
             })
         }
 
         fn for_load() -> Arc<Self> {
-            Arc::new(Self {
-                state: Mutex::new(MockVfioState::default()),
-            })
+            Self::with_state(MockVfioState::default())
         }
 
-        fn failing_at(target: VfioMigrationState) -> Arc<Self> {
-            Arc::new(Self {
-                state: Mutex::new(MockVfioState {
-                    fail_at: Some(target),
-                    ..Default::default()
-                }),
+        fn failing_at(targets: &[VfioMigrationState]) -> Arc<Self> {
+            Self::with_state(MockVfioState {
+                fail_at: targets.to_vec(),
+                ..Default::default()
             })
         }
 
         fn failing_read() -> Arc<Self> {
-            Arc::new(Self {
-                state: Mutex::new(MockVfioState {
-                    fail_read: true,
-                    ..Default::default()
-                }),
+            Self::with_state(MockVfioState {
+                fail_read: true,
+                ..Default::default()
             })
         }
 
@@ -2563,13 +2608,17 @@ mod tests {
         fn loaded(&self) -> Vec<u8> {
             self.state.lock().unwrap().loaded.clone()
         }
+
+        fn resets(&self) -> u32 {
+            self.state.lock().unwrap().resets
+        }
     }
 
     impl Vfio for MockVfio {
         fn set_migration_state(&self, state: VfioMigrationState) -> Result<(), VfioError> {
             let mut s = self.state.lock().unwrap();
             s.transitions.push(state);
-            if s.fail_at == Some(state) {
+            if s.fail_at.contains(&state) {
                 return Err(VfioError::NoMigrationSupport);
             }
             Ok(())
@@ -2584,8 +2633,16 @@ mod tests {
         }
 
         fn write_migration_data(&self, data: &[u8]) -> Result<(), VfioError> {
-            self.state.lock().unwrap().loaded.extend_from_slice(data);
+            let mut s = self.state.lock().unwrap();
+            if s.fail_write {
+                return Err(VfioError::NoMigrationSupport);
+            }
+            s.loaded.extend_from_slice(data);
             Ok(())
+        }
+
+        fn reset(&self) {
+            self.state.lock().unwrap().resets += 1;
         }
 
         fn region_write(&self, _index: u32, _offset: u64, _data: &[u8]) {}
@@ -2648,13 +2705,31 @@ mod tests {
     }
 
     #[test]
-    fn save_migration_data_stop_copy_failure_does_not_attempt_stop() {
-        let mock = MockVfio::failing_at(VfioMigrationState::StopCopy);
+    fn save_migration_data_stop_copy_failure_recovers_to_stop() {
+        let mock = MockVfio::failing_at(&[VfioMigrationState::StopCopy]);
         let common = test_vfio_common(mock.clone(), Some(1));
         let err = common.save_migration_data().unwrap_err();
         assert!(matches!(err, MigratableError::Snapshot(_)));
-        // Entering STOP_COPY failed, so no STOP is attempted afterwards.
-        assert_eq!(mock.transitions(), vec![VfioMigrationState::StopCopy]);
+        // Entering STOP_COPY failed, so STOP is attempted as recovery.
+        assert_eq!(
+            mock.transitions(),
+            vec![VfioMigrationState::StopCopy, VfioMigrationState::Stop]
+        );
+        assert_eq!(mock.resets(), 0);
+    }
+
+    #[test]
+    fn save_migration_data_stop_copy_and_stop_failure_resets() {
+        let mock = MockVfio::failing_at(&[VfioMigrationState::StopCopy, VfioMigrationState::Stop]);
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let err = common.save_migration_data().unwrap_err();
+        assert!(matches!(err, MigratableError::Snapshot(_)));
+        // The recovery STOP failed too, so the device is reset.
+        assert_eq!(
+            mock.transitions(),
+            vec![VfioMigrationState::StopCopy, VfioMigrationState::Stop]
+        );
+        assert_eq!(mock.resets(), 1);
     }
 
     #[test]
@@ -2668,6 +2743,26 @@ mod tests {
             mock.transitions(),
             vec![VfioMigrationState::StopCopy, VfioMigrationState::Stop]
         );
+        assert_eq!(mock.resets(), 0);
+    }
+
+    #[test]
+    fn save_migration_data_read_and_stop_failure_resets() {
+        let mock = MockVfio::with_state(MockVfioState {
+            fail_read: true,
+            fail_at: vec![VfioMigrationState::Stop],
+            ..Default::default()
+        });
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let err = common.save_migration_data().unwrap_err();
+        assert!(matches!(err, MigratableError::Snapshot(_)));
+        // The return to STOP after the failed read has no recovery state,
+        // so its failure resets the device directly.
+        assert_eq!(
+            mock.transitions(),
+            vec![VfioMigrationState::StopCopy, VfioMigrationState::Stop]
+        );
+        assert_eq!(mock.resets(), 1);
     }
 
     #[test]
@@ -2683,7 +2778,7 @@ mod tests {
 
     #[test]
     fn load_migration_data_recovers_on_failure() {
-        let mock = MockVfio::failing_at(VfioMigrationState::Resuming);
+        let mock = MockVfio::failing_at(&[VfioMigrationState::Resuming]);
         let common = test_vfio_common(mock.clone(), Some(1));
         let err = common.load_migration_data(b"ignored").unwrap_err();
         assert!(matches!(err, MigratableError::Restore(_)));
@@ -2691,6 +2786,49 @@ mod tests {
             mock.transitions(),
             vec![VfioMigrationState::Resuming, VfioMigrationState::Stop]
         );
+        assert_eq!(mock.resets(), 0);
+    }
+
+    #[test]
+    fn load_migration_data_resuming_and_stop_failure_resets() {
+        let mock = MockVfio::failing_at(&[VfioMigrationState::Resuming, VfioMigrationState::Stop]);
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let err = common.load_migration_data(b"ignored").unwrap_err();
+        assert!(matches!(err, MigratableError::Restore(_)));
+        assert_eq!(
+            mock.transitions(),
+            vec![VfioMigrationState::Resuming, VfioMigrationState::Stop]
+        );
+        assert_eq!(mock.resets(), 1);
+    }
+
+    #[test]
+    fn load_migration_data_write_failure_resets() {
+        let mock = MockVfio::with_state(MockVfioState {
+            fail_write: true,
+            ..Default::default()
+        });
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let err = common.load_migration_data(b"ignored").unwrap_err();
+        assert!(matches!(err, MigratableError::Restore(_)));
+        // A RESUMING session can only be aborted by a reset, so a failed write
+        // resets directly rather than attempting STOP.
+        assert_eq!(mock.transitions(), vec![VfioMigrationState::Resuming]);
+        assert_eq!(mock.resets(), 1);
+    }
+
+    // pause() and resume() name no recovery state, so a failed transition
+    // resets the device directly.
+    #[test]
+    fn transition_without_recovery_state_resets() {
+        let mock = MockVfio::failing_at(&[VfioMigrationState::Running]);
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let err = common
+            .transition_migration_state_with_recovery(VfioMigrationState::Running, None)
+            .unwrap_err();
+        assert!(err.to_string().contains("Running"));
+        assert_eq!(mock.transitions(), vec![VfioMigrationState::Running]);
+        assert_eq!(mock.resets(), 1);
     }
 
     // A snapshot with migration state restored onto a device without migration

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -52,8 +52,8 @@ use crate::api::{
     AddDisk, ApiAction, ApiError, ApiRequest, DeviceConfig, NetConfig, VmAddDevice, VmAddFs,
     VmAddGenericVhostUser, VmAddNet, VmAddPmem, VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot,
     VmConfig, VmCounters, VmDelete, VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration,
-    VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration,
-    VmShutdown, VmSnapshot,
+    VmReceiveMigrationData, VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore,
+    VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::config::RestoreConfig;
 use crate::cpu::Error as CpuError;
@@ -484,7 +484,6 @@ vm_action_put_handler_body!(VmRemoveDevice);
 vm_action_put_handler_body!(VmResizeDisk);
 vm_action_put_handler_body!(VmResizeZone);
 vm_action_put_handler_body!(VmSnapshot);
-vm_action_put_handler_body!(VmReceiveMigration);
 vm_action_put_handler_body!(VmSendMigration);
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -625,6 +624,54 @@ impl PutHandler for VmRestore {
 }
 
 impl GetHandler for VmRestore {}
+
+// Custom handler so the SCM_RIGHTS file pool can be split the same way
+// VmRestore does, cdev FDs for the vfio_fds entries then the iommufd FD.
+impl PutHandler for VmReceiveMigration {
+    fn handle_request(
+        &'static self,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+        body: &Option<Body>,
+        files: Vec<File>,
+    ) -> result::Result<Option<Body>, HttpError> {
+        if let Some(body) = body {
+            let mut data: VmReceiveMigrationData = serde_json::from_slice(body.raw())?;
+
+            let vfio_total = data.vfio_fds.as_ref().map_or(0, |c| c.len());
+            let expected = if data.vfio_fds.is_some() {
+                vfio_total + 1
+            } else {
+                0
+            };
+            if files.len() != expected {
+                error!(
+                    "Expected {expected} FDs in VmReceiveMigration request, received {}",
+                    files.len()
+                );
+                return Err(HttpError::BadRequest);
+            }
+
+            // Split in the order vfio_fds, then the iommufd FD.
+            let mut files = files;
+            if let Some(cfgs) = data.vfio_fds.as_mut() {
+                let vfio_files: Vec<File> = files.drain(..vfio_total).collect();
+                let mut cfgs = cfgs.iter_mut().collect::<Vec<&mut _>>();
+                attach_fds_to_cfgs(vfio_files, cfgs.as_mut_slice())?;
+            }
+            if data.vfio_fds.is_some() {
+                data.iommufd_fd = Some(files.remove(0).into_raw_fd());
+            }
+
+            self.send(api_notifier, api_sender, data)
+                .map_err(HttpError::ApiError)
+        } else {
+            Err(HttpError::BadRequest)
+        }
+    }
+}
+
+impl GetHandler for VmReceiveMigration {}
 
 // Common handler for boot, shutdown and reboot
 pub struct VmActionHandler {

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -35,9 +35,11 @@
 //! [special HTTP library]: https://github.com/firecracker-microvm/micro-http
 
 use std::fs::File;
+use std::os::fd::IntoRawFd;
 use std::result;
 use std::sync::mpsc::Sender;
 
+use log::error;
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -120,7 +122,7 @@ mod fds_helper {
         use std::slice::from_ref;
 
         use super::{ConfigWithFDs, ConfigWithVariableFDs};
-        use crate::config::RestoredNetConfig;
+        use crate::config::{RestoredNetConfig, RestoredVfioConfig};
         use crate::vm_config::{DeviceConfig, NetConfig};
 
         impl ConfigWithFDs for NetConfig {
@@ -172,6 +174,26 @@ mod fds_helper {
         impl ConfigWithVariableFDs for RestoredNetConfig {
             fn expected_num_fds(&self) -> usize {
                 self.num_fds
+            }
+        }
+
+        impl ConfigWithFDs for RestoredVfioConfig {
+            fn id(&self) -> Option<&str> {
+                Some(self.id.as_str())
+            }
+
+            fn fds_from_http_body(&self) -> Option<&[RawFd]> {
+                self.fd.as_ref().map(from_ref)
+            }
+
+            fn set_fds(&mut self, fds: Option<Vec<RawFd>>) {
+                self.fd = fds.and_then(|mut v| v.pop());
+            }
+        }
+
+        impl ConfigWithVariableFDs for RestoredVfioConfig {
+            fn expected_num_fds(&self) -> usize {
+                1
             }
         }
     }
@@ -561,10 +583,37 @@ impl PutHandler for VmRestore {
         if let Some(body) = body {
             let mut restore_cfg: RestoreConfig = serde_json::from_slice(body.raw())?;
 
+            let net_total: usize = restore_cfg
+                .net_fds
+                .iter()
+                .flatten()
+                .map(|c| c.num_fds)
+                .sum();
+            let vfio_total = restore_cfg.vfio_fds.as_ref().map_or(0, |c| c.len());
+            let iommufd_total = usize::from(restore_cfg.vfio_fds.is_some());
+            let expected = net_total + vfio_total + iommufd_total;
+            if files.len() != expected {
+                error!(
+                    "Expected {expected} FDs in VmRestore request, received {}",
+                    files.len()
+                );
+                return Err(HttpError::BadRequest);
+            }
+
+            // Split in the order net_fds, then vfio_fds, then the iommufd FD.
+            let mut files = files;
             if let Some(cfgs) = restore_cfg.net_fds.as_mut() {
+                let net_files: Vec<File> = files.drain(..net_total).collect();
                 let mut cfgs = cfgs.iter_mut().collect::<Vec<&mut _>>();
-                let cfgs = cfgs.as_mut_slice();
-                attach_fds_to_cfgs(files, cfgs)?;
+                attach_fds_to_cfgs(net_files, cfgs.as_mut_slice())?;
+            }
+            if let Some(cfgs) = restore_cfg.vfio_fds.as_mut() {
+                let vfio_files: Vec<File> = files.drain(..vfio_total).collect();
+                let mut cfgs = cfgs.iter_mut().collect::<Vec<&mut _>>();
+                attach_fds_to_cfgs(vfio_files, cfgs.as_mut_slice())?;
+            }
+            if restore_cfg.vfio_fds.is_some() {
+                restore_cfg.iommufd_fd = Some(files.remove(0).into_raw_fd());
             }
 
             self.send(api_notifier, api_sender, restore_cfg)

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -33,6 +33,7 @@
 pub mod dbus;
 pub mod http;
 
+use std::collections::HashSet;
 use std::io;
 use std::num::{NonZeroU32, NonZeroU64};
 use std::path::PathBuf;
@@ -42,7 +43,7 @@ use std::time::Duration;
 
 use log::info;
 use micro_http::Body;
-use option_parser::{OptionParser, OptionParserError, Toggle};
+use option_parser::{OptionParser, OptionParserError, Toggle, Tuple, TupleList};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vm_migration::MigratableError;
@@ -53,7 +54,7 @@ use vmm_sys_util::eventfd::EventFd;
 pub use self::dbus::start_dbus_thread;
 pub use self::http::{start_http_fd_thread, start_http_path_thread};
 use crate::Error as VmmError;
-use crate::config::RestoreConfig;
+use crate::config::{RestoreConfig, RestoredVfioConfig, deserialize_restored_fd};
 use crate::device_tree::DeviceTree;
 use crate::migration::transport::{
     MAX_MIGRATION_CONNECTIONS, TcpAddressParseError, tcp_address_to_server_name,
@@ -311,6 +312,13 @@ pub struct VmReceiveMigrationData {
     /// Memory transfer mode.
     #[serde(default)]
     pub memory_mode: MigrationMode,
+    /// Optional VFIO device id to cdev FD pairs, used to substitute each
+    /// device's saved path or stale FD in the received VmConfig.
+    #[serde(default)]
+    pub vfio_fds: Option<Vec<RestoredVfioConfig>>,
+    // FDs are not serialized and any deserialized value is invalid; see NetConfig::fds.
+    #[serde(default, deserialize_with = "deserialize_restored_fd")]
+    pub iommufd_fd: Option<i32>,
 }
 
 #[derive(Debug, Error)]
@@ -324,11 +332,17 @@ pub enum VmReceiveMigrationConfigError {
 
 impl VmReceiveMigrationData {
     pub const SYNTAX: &'static str = "VM receive migration parameters \
-        \"<receiver_url>\" or \"receiver_url=<url>[,tls_dir=<path>][,memory_mode=precopy|postcopy]\"";
+        \"<receiver_url>\" or \"receiver_url=<url>[,tls_dir=<path>][,memory_mode=precopy|postcopy]\
+        [,vfio_fds=<list_of_vfio_ids_with_their_associated_fd>][,iommufd_fd=<fd>]\"";
 
     pub fn parse(migration: &str) -> Result<Self, VmReceiveMigrationConfigError> {
         let mut parser = OptionParser::new();
-        parser.add("receiver_url").add("tls_dir").add("memory_mode");
+        parser
+            .add("receiver_url")
+            .add("tls_dir")
+            .add("memory_mode")
+            .add("vfio_fds")
+            .add("iommufd_fd");
         parser
             .parse(migration)
             .map_err(VmReceiveMigrationConfigError::ParseError)?;
@@ -346,11 +360,27 @@ impl VmReceiveMigrationData {
             .convert::<MigrationMode>("memory_mode")
             .map_err(VmReceiveMigrationConfigError::ParseError)?
             .unwrap_or_default();
+        let vfio_fds = parser
+            .convert::<TupleList<String, u64>>("vfio_fds")
+            .map_err(VmReceiveMigrationConfigError::ParseError)?
+            .map(|v| {
+                v.0.iter()
+                    .map(|Tuple(id, fd)| RestoredVfioConfig {
+                        id: id.clone(),
+                        fd: Some(*fd as i32),
+                    })
+                    .collect()
+            });
+        let iommufd_fd = parser
+            .convert::<i32>("iommufd_fd")
+            .map_err(VmReceiveMigrationConfigError::ParseError)?;
 
         let data = Self {
             receiver_url,
             tls_dir,
             memory_mode,
+            vfio_fds,
+            iommufd_fd,
         };
 
         data.validate()?;
@@ -387,6 +417,75 @@ impl VmReceiveMigrationData {
                     "invalid TLS configuration for receive-migration: {e}"
                 ))
             })?;
+        }
+
+        Ok(())
+    }
+
+    pub fn validate_vfio_fds(
+        &self,
+        vm_config: &VmConfig,
+    ) -> Result<(), VmReceiveMigrationConfigError> {
+        let vfio_fds = self.vfio_fds.as_deref().unwrap_or_default();
+
+        // A migrated VFIO device cannot reuse its source handle. Its fd is
+        // invalid across the migration and its path names the source host's
+        // topology, so every device needs a replacement in vfio_fds. This
+        // holds even when no vfio_fds are supplied at all.
+        let substituted: HashSet<&str> = vfio_fds.iter().map(|v| v.id.as_str()).collect();
+        for d in vm_config.devices.iter().flatten() {
+            if !d
+                .pci_common
+                .id
+                .as_deref()
+                .is_some_and(|id| substituted.contains(id))
+            {
+                return Err(VmReceiveMigrationConfigError::ValidationError(format!(
+                    "VFIO device '{}' has no replacement in vfio_fds, its source path or fd is not usable on the destination",
+                    d.pci_common.id.as_deref().unwrap_or_default()
+                )));
+            }
+        }
+
+        if vfio_fds.is_empty() {
+            return Ok(());
+        }
+
+        // The supplied vfio_fds must be usable against the received VmConfig.
+        if self.iommufd_fd.is_none() {
+            return Err(VmReceiveMigrationConfigError::ValidationError(
+                "vfio_fds requires iommufd_fd".to_string(),
+            ));
+        }
+        if !vm_config.platform.as_ref().is_some_and(|p| p.iommufd) {
+            return Err(VmReceiveMigrationConfigError::ValidationError(
+                "vfio_fds requires platform iommufd=on in the received VmConfig".to_string(),
+            ));
+        }
+
+        let mut seen = HashSet::new();
+        for v in vfio_fds {
+            if !seen.insert(v.id.as_str()) {
+                return Err(VmReceiveMigrationConfigError::ValidationError(format!(
+                    "duplicate vfio_fds id '{}'",
+                    v.id
+                )));
+            }
+        }
+
+        let known_ids: HashSet<&str> = vm_config
+            .devices
+            .iter()
+            .flatten()
+            .filter_map(|d| d.pci_common.id.as_deref())
+            .collect();
+        for v in vfio_fds {
+            if !known_ids.contains(v.id.as_str()) {
+                return Err(VmReceiveMigrationConfigError::ValidationError(format!(
+                    "vfio_fds id '{}' does not match any device in the received VmConfig",
+                    v.id
+                )));
+            }
         }
 
         Ok(())
@@ -1988,6 +2087,8 @@ mod unit_tests {
                 receiver_url: "tcp:192.168.1.1:8080".to_string(),
                 tls_dir: None,
                 memory_mode: MigrationMode::Precopy,
+                vfio_fds: None,
+                iommufd_fd: None,
             }
         );
 
@@ -2015,6 +2116,8 @@ mod unit_tests {
                 receiver_url: "tcp:192.168.1.1:8080".to_string(),
                 tls_dir: Some(tls_dir_path),
                 memory_mode: MigrationMode::Precopy,
+                vfio_fds: None,
+                iommufd_fd: None,
             }
         );
 
@@ -2038,6 +2141,8 @@ mod unit_tests {
                 receiver_url: "tcp:127.0.0.1:1234".to_string(),
                 tls_dir: None,
                 memory_mode: MigrationMode::Precopy,
+                vfio_fds: None,
+                iommufd_fd: None,
             }
         );
 
@@ -2051,11 +2156,33 @@ mod unit_tests {
                 receiver_url: "unix:/tmp/sock".to_string(),
                 tls_dir: None,
                 memory_mode: MigrationMode::Postcopy,
+                vfio_fds: None,
+                iommufd_fd: None,
             }
         );
 
         // Missing receiver_url in keyed form must fail.
         VmReceiveMigrationData::parse("memory_mode=postcopy").unwrap_err();
+
+        // vfio_fds without iommufd_fd parses fine now, the pairing is checked
+        // later against the received VmConfig by validate_vfio_fds.
+        let data =
+            VmReceiveMigrationData::parse("receiver_url=tcp:127.0.0.1:1234,vfio_fds=[vfio0@5]")
+                .unwrap();
+        assert!(data.iommufd_fd.is_none());
+
+        // vfio_fds entries with the iommufd FD.
+        let data = VmReceiveMigrationData::parse(
+            "receiver_url=tcp:127.0.0.1:1234,vfio_fds=[vfio0@5,vfio1@7],iommufd_fd=9",
+        )
+        .unwrap();
+        let fds = data.vfio_fds.expect("vfio_fds populated");
+        assert_eq!(fds.len(), 2);
+        assert_eq!(fds[0].id, "vfio0");
+        assert_eq!(fds[0].fd, Some(5));
+        assert_eq!(fds[1].id, "vfio1");
+        assert_eq!(fds[1].fd, Some(7));
+        assert_eq!(data.iommufd_fd, Some(9));
     }
 
     #[test]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -390,6 +390,12 @@ pub enum ValidationError {
     /// Number of FDs passed during Restore are incorrect to the NetConfig
     #[error("Number of Net FDs passed for '{0}' during Restore: {1}. Expected: {2}")]
     RestoreNetFdCountMismatch(String, usize, usize),
+    /// vfio_fds entry does not match any DeviceConfig.id in the snapshot
+    #[error("VFIO device id '{0}' in 'vfio_fds' does not match any device in the snapshot")]
+    RestoreUnknownVfioId(String),
+    /// A device saved with an FD has no replacement FD for the restore
+    #[error("VFIO device '{0}' was FD backed and needs a new fd in 'vfio_fds'")]
+    RestoreMissingVfioFd(String),
     /// Prefault cannot be combined with on-demand restore
     #[error("'prefault' cannot be combined with 'memory_restore_mode=ondemand'")]
     InvalidRestorePrefaultWithOnDemand,
@@ -2803,6 +2809,26 @@ impl FromStr for MemoryRestoreMode {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct RestoredVfioConfig {
+    pub id: String,
+    // FDs are not serialized and any deserialized value is invalid; see NetConfig::fds.
+    #[serde(default, deserialize_with = "deserialize_restored_fd")]
+    pub fd: Option<i32>,
+}
+
+fn deserialize_restored_fd<'de, D>(d: D) -> result::Result<Option<i32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let invalid_fd: Option<i32> = Option::deserialize(d)?;
+    if invalid_fd.is_some() {
+        Ok(Some(-1))
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct RestoreConfig {
     pub source_url: PathBuf,
     #[serde(default)]
@@ -2812,18 +2838,29 @@ pub struct RestoreConfig {
     #[serde(default)]
     pub net_fds: Option<Vec<RestoredNetConfig>>,
     #[serde(default)]
+    pub vfio_fds: Option<Vec<RestoredVfioConfig>>,
+    // FDs are not serialized and any deserialized value is invalid; see NetConfig::fds.
+    #[serde(default, deserialize_with = "deserialize_restored_fd")]
+    pub iommufd_fd: Option<i32>,
+    #[serde(default)]
     pub resume: bool,
 }
 
 impl RestoreConfig {
     pub const SYNTAX: &'static str = "Restore from a VM snapshot. \
         \nRestore parameters \"source_url=<source_url>,prefault=on|off,memory_restore_mode=copy|ondemand,\
-        net_fds=<list_of_net_ids_with_their_associated_fds>,resume=true|false\" \
+        net_fds=<list_of_net_ids_with_their_associated_fds>,\
+        vfio_fds=<list_of_vfio_ids_with_their_associated_fd>,iommufd_fd=<fd>,resume=true|false\" \
         \n`source_url` should be a valid URL (e.g file:///foo/bar or tcp://192.168.1.10/foo) \
         \n`prefault` controls eager prefaulting for the copy-based restore path (disabled by default) \
         \n`memory_restore_mode=copy` preserves the existing eager read-copy restore behavior, while `memory_restore_mode=ondemand` enables lazy demand paging and fails restore if userfaultfd support is unavailable \
         \n`net_fds` is a list of net ids with new file descriptors. \
         Only net devices backed by FDs directly are needed as input.\
+        \n`vfio_fds` is a list of VFIO device ids each paired with a new cdev file descriptor, \
+        e.g. vfio_fds=[vfio0@5,vfio1@6]. Use this to restore a VFIO device onto a different \
+        sysfs path or host. Requires `iommufd_fd`.\
+        \n`iommufd_fd` is a new iommufd file descriptor for the restored VM. \
+        The one saved in the snapshot does not survive serialization.\
         \n `resume` controls whether the VM will be directly resumed after restore ";
 
     pub fn parse(restore: &str) -> Result<Self> {
@@ -2833,6 +2870,8 @@ impl RestoreConfig {
             .add("prefault")
             .add("memory_restore_mode")
             .add("net_fds")
+            .add("vfio_fds")
+            .add("iommufd_fd")
             .add("resume");
         parser.parse(restore).map_err(Error::ParseRestore)?;
 
@@ -2861,6 +2900,20 @@ impl RestoreConfig {
                     })
                     .collect()
             });
+        let vfio_fds = parser
+            .convert::<TupleList<String, u64>>("vfio_fds")
+            .map_err(Error::ParseRestore)?
+            .map(|v| {
+                v.0.iter()
+                    .map(|Tuple(id, fd)| RestoredVfioConfig {
+                        id: id.clone(),
+                        fd: Some(*fd as i32),
+                    })
+                    .collect()
+            });
+        let iommufd_fd = parser
+            .convert::<i32>("iommufd_fd")
+            .map_err(Error::ParseRestore)?;
         let resume = parser
             .convert::<Toggle>("resume")
             .map_err(Error::ParseRestore)?
@@ -2872,6 +2925,8 @@ impl RestoreConfig {
             prefault,
             memory_restore_mode,
             net_fds,
+            vfio_fds,
+            iommufd_fd,
             resume,
         })
     }
@@ -2921,6 +2976,54 @@ impl RestoreConfig {
 
         if !restored_net_with_fds.is_empty() {
             warn!("Ignoring unused 'net_fds' for VM restore.");
+        }
+
+        let vfio_fds = self.vfio_fds.as_deref().unwrap_or_default();
+        if !vfio_fds.is_empty() {
+            // Substituted devices become FD backed, which requires an
+            // externally supplied iommufd FD and the iommufd backend.
+            if self.iommufd_fd.is_none() {
+                return Err(ValidationError::VfioFdRequiresIommufdFd);
+            }
+            if !vm_config.platform.as_ref().is_some_and(|p| p.iommufd) {
+                return Err(ValidationError::IommufdFdRequiresIommufd);
+            }
+
+            let mut seen = HashSet::new();
+            for v in vfio_fds {
+                if !seen.insert(v.id.as_str()) {
+                    return Err(ValidationError::IdentifierNotUnique(v.id.clone()));
+                }
+            }
+
+            let known_ids: HashSet<&str> = vm_config
+                .devices
+                .iter()
+                .flatten()
+                .filter_map(|d| d.pci_common.id.as_deref())
+                .collect();
+            for v in vfio_fds {
+                if !known_ids.contains(v.id.as_str()) {
+                    return Err(ValidationError::RestoreUnknownVfioId(v.id.clone()));
+                }
+            }
+        }
+
+        // A device saved with an FD cannot reuse it, the snapshot carries no
+        // live descriptor. Each one needs a replacement in vfio_fds.
+        let substituted: HashSet<&str> = vfio_fds.iter().map(|v| v.id.as_str()).collect();
+        for d in vm_config.devices.iter().flatten() {
+            if d.fd.is_some()
+                && !d
+                    .pci_common
+                    .id
+                    .as_deref()
+                    .is_some_and(|id| substituted.contains(id))
+            {
+                return Err(ValidationError::RestoreMissingVfioFd(
+                    d.pci_common.id.clone().unwrap_or_default(),
+                ));
+            }
         }
 
         Ok(())
@@ -5090,6 +5193,8 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 prefault: false,
                 memory_restore_mode: MemoryRestoreMode::Copy,
                 net_fds: None,
+                vfio_fds: None,
+                iommufd_fd: None,
                 resume: false,
             }
         );
@@ -5113,6 +5218,8 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                         fds: Some(vec![5, 6, 7, 8]),
                     }
                 ]),
+                vfio_fds: None,
+                iommufd_fd: None,
                 resume: false,
             }
         );
@@ -5123,6 +5230,8 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 prefault: false,
                 memory_restore_mode: MemoryRestoreMode::OnDemand,
                 net_fds: None,
+                vfio_fds: None,
+                iommufd_fd: None,
                 resume: false,
             }
         );
@@ -5133,7 +5242,32 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 prefault: false,
                 memory_restore_mode: MemoryRestoreMode::Copy,
                 net_fds: None,
+                vfio_fds: None,
+                iommufd_fd: None,
                 resume: true,
+            }
+        );
+        assert_eq!(
+            RestoreConfig::parse(
+                "source_url=/path/to/snapshot,vfio_fds=[vfio0@5,vfio1@6],iommufd_fd=7"
+            )?,
+            RestoreConfig {
+                source_url: PathBuf::from("/path/to/snapshot"),
+                prefault: false,
+                memory_restore_mode: MemoryRestoreMode::Copy,
+                net_fds: None,
+                vfio_fds: Some(vec![
+                    RestoredVfioConfig {
+                        id: "vfio0".to_string(),
+                        fd: Some(5),
+                    },
+                    RestoredVfioConfig {
+                        id: "vfio1".to_string(),
+                        fd: Some(6),
+                    },
+                ]),
+                iommufd_fd: Some(7),
+                resume: false,
             }
         );
         // Parsing should fail as source_url is a required field
@@ -5245,6 +5379,8 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                     fds: Some(vec![7, 8]),
                 },
             ]),
+            vfio_fds: None,
+            iommufd_fd: None,
             resume: false,
         };
         valid_config.validate(&snapshot_vm_config).unwrap();
@@ -5310,6 +5446,8 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             prefault: false,
             memory_restore_mode: MemoryRestoreMode::Copy,
             net_fds: None,
+            vfio_fds: None,
+            iommufd_fd: None,
             resume: false,
         };
         snapshot_vm_config.net = Some(vec![NetConfig {
@@ -5327,11 +5465,142 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             prefault: true,
             memory_restore_mode: MemoryRestoreMode::OnDemand,
             net_fds: None,
+            vfio_fds: None,
+            iommufd_fd: None,
             resume: false,
         };
         assert_eq!(
             invalid_restore_mode.validate(&snapshot_vm_config),
             Err(ValidationError::InvalidRestorePrefaultWithOnDemand)
+        );
+    }
+
+    #[test]
+    fn test_restore_config_vfio_fds_validation() {
+        // interested in only VmConfig.devices and platform, so set rest to
+        // default values
+        let mut snapshot_vm_config = VmConfig {
+            cpus: CpusConfig::default(),
+            memory: MemoryConfig::default(),
+            payload: None,
+            rate_limit_groups: None,
+            disks: None,
+            rng: RngConfig::default(),
+            generic_vhost_user: None,
+            balloon: None,
+            fs: None,
+            pmem: None,
+            serial: SerialConfig::default(),
+            console: ConsoleConfig::default(),
+            #[cfg(target_arch = "x86_64")]
+            debug_console: DebugConsoleConfig::default(),
+            devices: Some(vec![DeviceConfig {
+                pci_common: PciDeviceCommonConfig {
+                    id: Some("vfio0".to_owned()),
+                    ..Default::default()
+                },
+                path: Some(PathBuf::from("/sys/bus/pci/devices/0000:01:00.0")),
+                fd: None,
+                x_nv_gpudirect_clique: None,
+                x_exclude_mmap_bars: Vec::new(),
+            }]),
+            user_devices: None,
+            vdpa: None,
+            vsock: None,
+            #[cfg(feature = "pvmemcontrol")]
+            pvmemcontrol: None,
+            pvpanic: false,
+            iommu: false,
+            numa: None,
+            watchdog: false,
+            rtc: None,
+            #[cfg(feature = "guest_debug")]
+            gdb: false,
+            pci_segments: None,
+            platform: Some(PlatformConfig {
+                iommufd: true,
+                ..platform_fixture()
+            }),
+            tpm: None,
+            preserved_fds: None,
+            net: None,
+            landlock_enable: false,
+            landlock_rules: None,
+            #[cfg(feature = "ivshmem")]
+            ivshmem: None,
+        };
+
+        let valid_config = RestoreConfig {
+            source_url: PathBuf::from("/path/to/snapshot"),
+            prefault: false,
+            memory_restore_mode: MemoryRestoreMode::Copy,
+            net_fds: None,
+            vfio_fds: Some(vec![RestoredVfioConfig {
+                id: "vfio0".to_string(),
+                fd: Some(5),
+            }]),
+            iommufd_fd: Some(6),
+            resume: false,
+        };
+        valid_config.validate(&snapshot_vm_config).unwrap();
+
+        let missing_iommufd = RestoreConfig {
+            iommufd_fd: None,
+            ..valid_config.clone()
+        };
+        assert_eq!(
+            missing_iommufd.validate(&snapshot_vm_config),
+            Err(ValidationError::VfioFdRequiresIommufdFd)
+        );
+
+        let unknown_id = RestoreConfig {
+            vfio_fds: Some(vec![RestoredVfioConfig {
+                id: "missing".to_string(),
+                fd: Some(5),
+            }]),
+            ..valid_config.clone()
+        };
+        assert_eq!(
+            unknown_id.validate(&snapshot_vm_config),
+            Err(ValidationError::RestoreUnknownVfioId("missing".to_string()))
+        );
+
+        let duplicate_id = RestoreConfig {
+            vfio_fds: Some(vec![
+                RestoredVfioConfig {
+                    id: "vfio0".to_string(),
+                    fd: Some(5),
+                },
+                RestoredVfioConfig {
+                    id: "vfio0".to_string(),
+                    fd: Some(6),
+                },
+            ]),
+            ..valid_config.clone()
+        };
+        assert_eq!(
+            duplicate_id.validate(&snapshot_vm_config),
+            Err(ValidationError::IdentifierNotUnique("vfio0".to_string()))
+        );
+
+        // A device saved with an FD must get a replacement FD.
+        snapshot_vm_config.devices.as_mut().unwrap()[0].path = None;
+        snapshot_vm_config.devices.as_mut().unwrap()[0].fd = Some(-1);
+        let no_substitution = RestoreConfig {
+            vfio_fds: None,
+            iommufd_fd: None,
+            ..valid_config.clone()
+        };
+        assert_eq!(
+            no_substitution.validate(&snapshot_vm_config),
+            Err(ValidationError::RestoreMissingVfioFd("vfio0".to_string()))
+        );
+
+        // The iommufd backend must be enabled in the snapshot config.
+        snapshot_vm_config.platform = Some(platform_fixture());
+        assert_eq!(
+            valid_config.validate(&snapshot_vm_config),
+            Err(ValidationError::IommufdFdRequiresIommufd)
         );
     }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2816,7 +2816,7 @@ pub struct RestoredVfioConfig {
     pub fd: Option<i32>,
 }
 
-fn deserialize_restored_fd<'de, D>(d: D) -> result::Result<Option<i32>, D::Error>
+pub(crate) fn deserialize_restored_fd<'de, D>(d: D) -> result::Result<Option<i32>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4152,6 +4152,11 @@ impl DeviceManager {
             .as_ref()
             .is_none_or(|p| p.vfio_p2p_dma);
 
+        let (memory_slot_allocator, guest_memory) = {
+            let mut mm = memory_manager.lock().unwrap();
+            (mm.memory_slot_allocator(), mm.guest_memory())
+        };
+
         let vfio_pci_device = VfioPciDevice::new(
             vfio_name.clone(),
             self.address_manager.vm.clone(),
@@ -4162,7 +4167,8 @@ impl DeviceManager {
             device_cfg.pci_common.iommu,
             vfio_p2p_dma,
             pci_device_bdf,
-            memory_manager.lock().unwrap().memory_slot_allocator(),
+            memory_slot_allocator,
+            guest_memory,
             vm_migration::snapshot_from_id(snapshot, vfio_name.as_str()),
             device_cfg.x_nv_gpudirect_clique,
             device_cfg

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -962,13 +962,13 @@ impl Vmm {
             )))
         };
 
-        let mode = receive_data_migration.memory_mode;
         let mut configure_vm =
             |socket: &mut SocketStream,
              memory_files: HashMap<u32, File>|
              -> result::Result<ReceiveMigrationConfiguredData, MigratableError> {
                 let shared_backing = !memory_files.is_empty();
-                let memory_manager = self.vm_receive_config(req, socket, memory_files, mode)?;
+                let memory_manager =
+                    self.vm_receive_config(req, socket, memory_files, receive_data_migration)?;
                 let guest_memory = memory_manager.lock().unwrap().guest_memory();
                 // Create the additional-connection receiver even in the single-connection case.
                 // At this point the receiver does not know whether the sender will use extra TCP
@@ -1148,11 +1148,13 @@ impl Vmm {
         req: &Request,
         socket: &mut T,
         existing_memory_files: HashMap<u32, File>,
-        mode: MigrationMode,
+        receive_data_migration: &VmReceiveMigrationData,
     ) -> result::Result<Arc<Mutex<MemoryManager>>, MigratableError>
     where
         T: Read,
     {
+        let mode = receive_data_migration.memory_mode;
+
         // Read in config data along with memory manager data
         let mut data: Vec<u8> = Vec::new();
         data.resize_with(req.length() as usize, Default::default);
@@ -1163,6 +1165,14 @@ impl Vmm {
         let vm_migration_config: VmMigrationConfig = serde_json::from_slice(&data)
             .context("Error deserialising config")
             .map_err(MigratableError::MigrateReceive)?;
+
+        // Mirrors the vm_restore handling of RestoreConfig.vfio_fds. The
+        // received VmConfig carries the source's device paths or stale FDs,
+        // neither of which is usable on this host.
+        receive_data_migration
+            .validate_vfio_fds(&vm_migration_config.vm_config.lock().unwrap())
+            .map_err(|e| MigratableError::MigrateReceive(e.into()))?;
+        apply_vfio_fds_to_vm_config(receive_data_migration, &vm_migration_config.vm_config);
 
         // Eager prefault populates memory before UFFD is registered, so those
         // pages never fault and are never served. Reject postcopy+prefault
@@ -2191,6 +2201,44 @@ impl Vmm {
 fn apply_landlock(vm_config: &mut VmConfig) -> result::Result<(), LandlockError> {
     vm_config.apply_landlock()?;
     Ok(())
+}
+
+// For each matched DeviceConfig.id, swap the saved path or stale FD for the
+// cdev FD received with the request, and install the fresh iommufd FD backing
+// them. The values in the migrated VmConfig are stale. validate_vfio_fds has
+// already confirmed the ids match and the iommufd FD is present.
+fn apply_vfio_fds_to_vm_config(
+    receive_data_migration: &VmReceiveMigrationData,
+    vm_config: &Arc<Mutex<VmConfig>>,
+) {
+    let vfio_fds = receive_data_migration
+        .vfio_fds
+        .as_deref()
+        .unwrap_or_default();
+    if vfio_fds.is_empty() {
+        return;
+    }
+
+    let mut config = vm_config.lock().unwrap();
+    if let Some(devices) = config.devices.as_mut() {
+        for v in vfio_fds {
+            for device in devices.iter_mut() {
+                if device.pci_common.id.as_deref() == Some(v.id.as_str()) {
+                    device.path = None;
+                    device.fd = v.fd;
+                }
+            }
+        }
+    }
+
+    let iommufd_fd = receive_data_migration
+        .iommufd_fd
+        .expect("receive-migration validated an iommufd FD accompanies vfio_fds");
+    config
+        .platform
+        .as_mut()
+        .expect("receive-migration validated iommufd=on, so a platform exists")
+        .iommufd_fd = Some(iommufd_fd);
 }
 
 impl RequestHandler for Vmm {
@@ -3299,12 +3347,13 @@ mod unit_tests {
     use arch::CpuProfile;
 
     use super::*;
+    use crate::config::RestoredVfioConfig;
     #[cfg(target_arch = "x86_64")]
     use crate::vm_config::DebugConsoleConfig;
     use crate::vm_config::{
         CommonConsoleConfig, ConsoleConfig, ConsoleOutputMode, CoreScheduling, CpuFeatures,
-        CpusConfig, HotplugMethod, MemoryConfig, PayloadConfig, PciDeviceCommonConfig, RngConfig,
-        SerialConfig,
+        CpusConfig, DeviceConfig, HotplugMethod, MemoryConfig, PayloadConfig,
+        PciDeviceCommonConfig, PlatformConfig, RngConfig, SerialConfig,
     };
 
     fn create_dummy_vmm() -> Vmm {
@@ -3842,5 +3891,141 @@ mod unit_tests {
                 .unwrap(),
             vsock_config
         );
+    }
+
+    fn vm_config_with_vfio_devices(ids: &[&str], iommufd: bool) -> Arc<Mutex<VmConfig>> {
+        let mut config = *create_dummy_vm_config();
+        let platform = if iommufd { "iommufd=on" } else { "iommufd=off" };
+        config.platform = Some(PlatformConfig::parse(platform).unwrap());
+        config.devices = Some(
+            ids.iter()
+                .map(|id| DeviceConfig {
+                    pci_common: PciDeviceCommonConfig {
+                        id: Some((*id).to_owned()),
+                        ..Default::default()
+                    },
+                    path: Some(PathBuf::from(format!("/sys/bus/pci/devices/{id}"))),
+                    fd: None,
+                    x_nv_gpudirect_clique: None,
+                    x_exclude_mmap_bars: Vec::new(),
+                })
+                .collect(),
+        );
+        Arc::new(Mutex::new(config))
+    }
+
+    fn receive_data(
+        vfio_fds: Option<Vec<RestoredVfioConfig>>,
+        iommufd_fd: Option<i32>,
+    ) -> VmReceiveMigrationData {
+        VmReceiveMigrationData {
+            receiver_url: "tcp:127.0.0.1:4321".to_string(),
+            tls_dir: None,
+            memory_mode: MigrationMode::default(),
+            vfio_fds,
+            iommufd_fd,
+        }
+    }
+
+    fn vfio_fd(id: &str, fd: i32) -> RestoredVfioConfig {
+        RestoredVfioConfig {
+            id: id.to_owned(),
+            fd: Some(fd),
+        }
+    }
+
+    #[test]
+    fn test_apply_vfio_fds_empty_is_noop() {
+        let vm_config = vm_config_with_vfio_devices(&["vfio0"], true);
+        apply_vfio_fds_to_vm_config(&receive_data(None, None), &vm_config);
+        let config = vm_config.lock().unwrap();
+        let device = &config.devices.as_ref().unwrap()[0];
+        assert!(device.path.is_some());
+        assert!(device.fd.is_none());
+    }
+
+    #[test]
+    fn test_apply_vfio_fds_swaps_path_for_fd() {
+        let vm_config = vm_config_with_vfio_devices(&["vfio0", "vfio1"], true);
+        let data = receive_data(Some(vec![vfio_fd("vfio1", 5)]), Some(6));
+        apply_vfio_fds_to_vm_config(&data, &vm_config);
+        let config = vm_config.lock().unwrap();
+        let devices = config.devices.as_ref().unwrap();
+        assert!(devices[0].path.is_some());
+        assert!(devices[0].fd.is_none());
+        assert!(devices[1].path.is_none());
+        assert_eq!(devices[1].fd, Some(5));
+        assert_eq!(config.platform.as_ref().unwrap().iommufd_fd, Some(6));
+    }
+
+    #[test]
+    fn test_validate_vfio_fds_requires_iommufd_fd() {
+        let vm_config = vm_config_with_vfio_devices(&["vfio0"], true);
+        let data = receive_data(Some(vec![vfio_fd("vfio0", 5)]), None);
+        data.validate_vfio_fds(&vm_config.lock().unwrap())
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_validate_vfio_fds_unknown_id_fails() {
+        // vfio0 is covered so coverage passes, the extra bogus id is what the
+        // id match must reject.
+        let vm_config = vm_config_with_vfio_devices(&["vfio0"], true);
+        let data = receive_data(
+            Some(vec![vfio_fd("vfio0", 5), vfio_fd("missing", 6)]),
+            Some(7),
+        );
+        data.validate_vfio_fds(&vm_config.lock().unwrap())
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_validate_vfio_fds_duplicate_id_fails() {
+        let vm_config = vm_config_with_vfio_devices(&["vfio0"], true);
+        let data = receive_data(
+            Some(vec![vfio_fd("vfio0", 5), vfio_fd("vfio0", 6)]),
+            Some(7),
+        );
+        data.validate_vfio_fds(&vm_config.lock().unwrap())
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_validate_vfio_fds_requires_iommufd_backend() {
+        let vm_config = vm_config_with_vfio_devices(&["vfio0"], false);
+        let data = receive_data(Some(vec![vfio_fd("vfio0", 5)]), Some(6));
+        data.validate_vfio_fds(&vm_config.lock().unwrap())
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_validate_vfio_fds_stale_fd_needs_replacement() {
+        let vm_config = vm_config_with_vfio_devices(&["vfio0"], true);
+        {
+            let mut config = vm_config.lock().unwrap();
+            let device = &mut config.devices.as_mut().unwrap()[0];
+            device.path = None;
+            device.fd = Some(-1);
+        }
+        receive_data(None, None)
+            .validate_vfio_fds(&vm_config.lock().unwrap())
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_validate_vfio_fds_path_based_needs_replacement() {
+        // A path based device carries its source path, which is unusable on
+        // the destination, so it must be replaced in vfio_fds as well.
+        let vm_config = vm_config_with_vfio_devices(&["vfio0"], true);
+        receive_data(None, None)
+            .validate_vfio_fds(&vm_config.lock().unwrap())
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_validate_vfio_fds_all_substituted_ok() {
+        let vm_config = vm_config_with_vfio_devices(&["vfio0"], true);
+        let data = receive_data(Some(vec![vfio_fd("vfio0", 5)]), Some(6));
+        data.validate_vfio_fds(&vm_config.lock().unwrap()).unwrap();
     }
 }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2374,6 +2374,32 @@ impl RequestHandler for Vmm {
                     }
                 }
 
+                // Swap each VFIO device's saved path or stale FD for the cdev
+                // FD received with the restore request, and install the fresh
+                // iommufd FD backing them. The one saved in the snapshot is
+                // stale, and validate() has confirmed both accompany vfio_fds.
+                if let Some(restored_vfios) = restore_cfg.vfio_fds {
+                    let mut config = vm_config.lock().unwrap();
+                    if let Some(vm_device_configs) = config.devices.as_mut() {
+                        for v in restored_vfios.iter() {
+                            for device_config in vm_device_configs.iter_mut() {
+                                if device_config.pci_common.id.as_ref() == Some(&v.id) {
+                                    device_config.path = None;
+                                    device_config.fd = v.fd;
+                                }
+                            }
+                        }
+                    }
+                    let iommufd_fd = restore_cfg
+                        .iommufd_fd
+                        .expect("restore validated an iommufd FD accompanies vfio_fds");
+                    config
+                        .platform
+                        .as_mut()
+                        .expect("restore validated iommufd=on, so a platform exists")
+                        .iommufd_fd = Some(iommufd_fd);
+                }
+
                 self.vm_restore(
                     source_url,
                     vm_config,


### PR DESCRIPTION
## Summary

Adds live migration support for VFIO devices that implement the kernel VFIO migration v2 protocol. This builds on the snapshot and restore support merged in #8303. The opaque device state moves through stop and copy during the downtime window. Guest memory dirtied by device DMA is tracked with VFIO DMA logging during the memory transfer. 

**Note** : VFIO device state PRE_COPY is not covered in this PR. Live Migration of a VFIO device behind a virtual IOMMU is refused in `start_migration`.

The series also implements the transition failure recovery deferred from the #8303 review. On a failed migration state set the named recovery state is attempted first and the device is reset as a last resort. After the reset the device gets the same `PCI_COMMAND` write and interrupt rearm that a restored device gets, so a failed snapshot or migration leaves the guest with a functional device.

### Migration flow with a VFIO device

| # | Side | Phase | VFIO action |
|---|---|---|---|
| 1 | destination | Receive request | `vfio_fds` and `iommufd_fd` arrive over SCM_RIGHTS with the receive migration request |
| 2 | destination | Config received | the source's device paths and stale FDs in the incoming VmConfig are replaced with the received FDs |
| 3 | source | Migration start | `start_dirty_log()` programs VFIO DMA logging with the IOVA ranges to track |
| 4 | source | Memory precopy | `dirty_log()` merges device dirtied pages into each memory pass |
| 5 | source | Downtime | `pause()` drives RUNNING to STOP, snapshot captures the STOP_COPY blob and returns the device to STOP |
| 6 | destination | State received | the device is created from the substituted FDs and the blob loads through RESUMING |
| 7 | destination | Resume | `resume()` drives the device from RESUMING to RUNNING |

### Source invocation

```console
src $ cloud-hypervisor \
        --api-socket /tmp/api \
        --cpus boot=2 --memory size=4G \
        --kernel /var/images/linux --initramfs /var/images/initrd \
        --cmdline "console=ttyS0" \
        --platform iommufd=on,vfio_p2p_dma=off \
        --device path=/sys/bus/pci/devices/0000:42:00.2,id=vfio0
```

The device carries an explicit id and each `vfio_fds` entry on the destination references that id. The source must run with `iommufd=on`, since the destination validates the received config before substituting the FDs. `vfio_p2p_dma=off` is needed on older Linux kernels (pre 6.19) that cannot map VFIO BAR MMIO into `iommufd`.

### Destination invocation

The destination VF can live at a different BDF than the source's, and the kernel assigns its cdev name independently. The `vfio-dev` directory under the VF's sysfs node names the cdev to open. Start a bare VMM, open the cdev and a fresh iommufd, then hand both to `receive-migration`, which blocks until the source connects.

```console
dst $ cloud-hypervisor --api-socket /tmp/api
```

```console
dst $ ls /sys/bus/pci/devices/0000:41:00.3/vfio-dev/
vfio12
dst $ exec 5<>/dev/vfio/devices/vfio12
dst $ exec 6<>/dev/iommu
dst $ ch-remote --api-socket=/tmp/api receive-migration \
          receiver_url=tcp:0.0.0.0:6000,vfio_fds=[vfio0@5],iommufd_fd=6
```

### Performing the migration

With the receiver listening, trigger the migration from the source.

```console
src $ ch-remote --api-socket=/tmp/api send-migration destination_url=tcp:{dst}:6000
```

### Test

- Unit tests

```
cargo test -p pci --lib vfio::tests
test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out

cargo test -p vmm --lib -- restore vfio_fds apply_vfio receive_migration_data_parse
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 83 filtered out
```



https://github.com/user-attachments/assets/43a8b168-6eb5-4749-802f-a9eb76ab4357




- Live migration validated across two hosts with a Mellanox ConnectX 7 VF (`mlx5_vfio_pci`, firmware 28.43.1014). The guest sent one UDP heartbeat per second out the migrated VF for the whole run and did not miss a second across the cutover. Both VMMs ran with the default seccomp enforcement. 

The source reported for the 4GiB  guest. 
```
  Migration completed after 4.3s with a downtime of 693ms (goal was 500ms)
```
The overshoot against the goal is dominated by the VFIO stop and copy device state, which the precopy downtime estimator does not model.