### PR TITLE
vmm: Gate tpm import for riscv64

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -67,7 +67,9 @@ use devices::legacy::{
 };
 #[cfg(feature = "pvmemcontrol")]
 use devices::pvmemcontrol::{self, PvmemcontrolBusDevice, PvmemcontrolPciDevice};
-use devices::{AcpiNotificationFlags, acpi, interrupt_controller, legacy, pvpanic, tpm};
+#[cfg(not(target_arch = "riscv64"))]
+use devices::tpm;
+use devices::{AcpiNotificationFlags, acpi, interrupt_controller, legacy, pvpanic};
 use event_monitor::event;
 use hypervisor::IoEventAddress;
 #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
The `tpm` module in the `devices` crate is disabled on riscv64 (see commit 0042447fb "devices: Disable tpm module for riscv64"), and every use of `tpm` in the device manager is already gated behind `#[cfg(not(target_arch = "riscv64"))]`. However, the import itself was merged into the unconditional `use devices::{...}` line in commit 025e782e5 "vmm: trim qualified paths", which broke the riscv64 build:

    error[E0432]: unresolved import `devices::tpm`
      --> vmm/src/device_manager.rs:70:83

Split the `tpm` import out into its own line gated with `#[cfg(not(target_arch = "riscv64"))]`, matching all of its usages.