### PR TITLE
net_util: queue_pair: Use vnet_hdr_len when locating num_buffers

### DIFF
--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -239,7 +239,7 @@ impl RxVirtio {
                     .memory()
                     .checked_offset(
                         desc.addr()
-                            .translate_gva(access_platform, desc.len() as usize)
+                            .translate_gva(access_platform, vnet_hdr_len())
                             .map_err(|e| {
                                 NetQueuePairError::GuestMemory(
                                     vm_memory::GuestMemoryError::IOError(e),


### PR DESCRIPTION
Follow up split out, as per review in https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8512#issuecomment-4898044439

`num_buffers` sits at offset 10 of the virtio net header, so only `vnet_hdr_len()` bytes need to translate contiguously to compute its host address. Shrink the `translate_gva` length from `desc.len()` to `vnet_hdr_len()` so the request matches what is actually read.