### PR TITLE
virtio-devices: restrict vhost/vsock worker socket() to AF_UNIX

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -224,7 +224,7 @@ fn virtio_vhost_fs_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_sendmsg, vec![]),
         (libc::SYS_sendto, vec![]),
-        (libc::SYS_socket, vec![]),
+        (libc::SYS_socket, create_socket_seccomp_rule()),
         (libc::SYS_timerfd_create, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
     ]
@@ -240,7 +240,7 @@ fn virtio_generic_vhost_user_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_sendmsg, vec![]),
         (libc::SYS_sendto, vec![]),
-        (libc::SYS_socket, vec![]),
+        (libc::SYS_socket, create_socket_seccomp_rule()),
         (libc::SYS_timerfd_create, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
     ]
@@ -262,7 +262,7 @@ fn virtio_vhost_net_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_sendmsg, vec![]),
         (libc::SYS_sendto, vec![]),
-        (libc::SYS_socket, vec![]),
+        (libc::SYS_socket, create_socket_seccomp_rule()),
         (libc::SYS_timerfd_create, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
         #[cfg(target_arch = "x86_64")]
@@ -279,10 +279,16 @@ fn virtio_vhost_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_nanosleep, vec![]),
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_sendmsg, vec![]),
-        (libc::SYS_socket, vec![]),
+        (libc::SYS_socket, create_socket_seccomp_rule()),
         (libc::SYS_timerfd_create, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
     ]
+}
+
+fn create_socket_seccomp_rule() -> Vec<SeccompRule> {
+    or![and![
+        Cond::new(0, ArgLen::Dword, Eq, libc::AF_UNIX as u64).unwrap()
+    ]]
 }
 
 fn create_vsock_ioctl_seccomp_rule() -> Vec<SeccompRule> {
@@ -302,7 +308,7 @@ fn virtio_vsock_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_sendto, vec![]),
         (libc::SYS_shutdown, vec![]),
-        (libc::SYS_socket, vec![]),
+        (libc::SYS_socket, create_socket_seccomp_rule()),
     ]
 }
 


### PR DESCRIPTION
The vhost-user (fs, net, block, generic) and vsock worker threads allow
`socket()` unconditionally in their seccomp rules. These threads only
ever open AF_UNIX sockets: the vhost-user transport connects/binds a
Unix socket (via the vhost crate's `Endpoint`/`Listener`), and the vsock
device's host side is a Unix socket. None of them open AF_INET/AF_INET6
sockets.

Restrict their `socket()` rule to AF_UNIX. Because these threads are
spawned by the VMM thread and inherit its filter, `socket()` was already
limited to the VMM's set (AF_UNIX/AF_INET/AF_INET6); this narrows it
further to just AF_UNIX, so each worker is confined to what it actually
uses rather than the broader inherited set.

Related to #8490 (giving each thread a more restrictive filter than the
VMM thread).