### PR TITLE
[RFC] Allow TDX and SEV-SNP to be built into the same binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -465,6 +465,15 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           args: --locked --all --all-targets --no-default-features --tests --examples --features "kvm,igvm,sev_snp,fw_cfg" -- -D warnings
+      - name: Clippy (kvm + tdx + igvm + sev_snp + fw_cfg)
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        uses: houseabsolute/actions-rust-cross@v1
+        with:
+          command: clippy
+          cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          args: --locked --all --all-targets --no-default-features --tests --examples --features "kvm,tdx,igvm,sev_snp,fw_cfg" -- -D warnings
       - name: Clippy (default features + sev_snp + igvm + fw_cfg)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: houseabsolute/actions-rust-cross@v1
@@ -532,6 +541,8 @@ jobs:
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "kvm,sev_snp"
       - name: Build (kvm + igvm + sev_snp + fw_cfg)
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "kvm,igvm,sev_snp,fw_cfg"
+      - name: Build (kvm + tdx + igvm + sev_snp + fw_cfg)
+        run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "kvm,tdx,igvm,sev_snp,fw_cfg"
       - name: Build (kvm + igvm)
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "kvm,igvm"
       - name: Build (mshv + kvm)

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -894,8 +894,6 @@ fn expand_fdtable() -> Result<(), FdTableError> {
 }
 
 fn main() {
-    #[cfg(all(feature = "tdx", feature = "sev_snp"))]
-    compile_error!("Feature 'tdx' and 'sev_snp' are mutually exclusive.");
     #[cfg(all(feature = "sev_snp", not(target_arch = "x86_64")))]
     compile_error!("Feature 'sev_snp' needs target 'x86_64'");
     #[cfg(all(feature = "fw_cfg", target_arch = "riscv64"))]

--- a/docs/amd_sev_snp.md
+++ b/docs/amd_sev_snp.md
@@ -24,7 +24,9 @@ Change `mshv` to `kvm` for the KVM backend. You can enable both at the same
 time.
 
 **Note**
-Please note that `sev_snp` cannot be enabled in conjunction with the `tdx` feature flag.
+The `sev_snp` and `tdx` feature flags can be enabled together in the same
+build. A single VM cannot enable both at once; the confidential-computing mode
+is selected per VM at runtime.
 
 SEV-SNP is also supported on KVM with an IGVM stage0 image and a guest kernel
 provided through `fw_cfg`. Build that configuration with:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -290,6 +290,10 @@ pub enum ValidationError {
     #[cfg(feature = "tdx")]
     #[error("No TDX firmware specified")]
     TdxFirmwareMissing,
+    /// TDX and SEV-SNP cannot be enabled on the same VM
+    #[cfg(all(feature = "tdx", feature = "sev_snp"))]
+    #[error("TDX and SEV-SNP cannot be enabled on the same VM")]
+    TdxSevSnpIncompatible,
     /// Insufficient vCPUs for queues
     #[error("Queue count ({0}) must not exceed boot vCPUs ({1})")]
     TooManyQueues(usize /* queues */, usize /* vCPUs */),
@@ -3072,6 +3076,15 @@ impl VmConfig {
             ))?
             .validate()?;
 
+        #[cfg(all(feature = "tdx", feature = "sev_snp"))]
+        {
+            let tdx_enabled = self.platform.as_ref().is_some_and(|p| p.tdx);
+            let sev_snp_enabled = self.platform.as_ref().is_some_and(|p| p.sev_snp);
+            if tdx_enabled && sev_snp_enabled {
+                return Err(ValidationError::TdxSevSnpIncompatible);
+            }
+        }
+
         #[cfg(feature = "tdx")]
         {
             let tdx_enabled = self.platform.as_ref().is_some_and(|p| p.tdx);
@@ -5533,6 +5546,19 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             packages: 1,
         });
         still_valid_config.validate().unwrap();
+
+        #[cfg(all(feature = "tdx", feature = "sev_snp"))]
+        {
+            let mut invalid_config = valid_config.clone();
+            let mut platform = platform_fixture();
+            platform.tdx = true;
+            platform.sev_snp = true;
+            invalid_config.platform = Some(platform);
+            assert_eq!(
+                invalid_config.validate(),
+                Err(ValidationError::TdxSevSnpIncompatible)
+            );
+        }
 
         #[cfg(target_arch = "x86_64")]
         {


### PR DESCRIPTION
Do runtime check to make sure they are not enabled at the same time. Add CI build configuration.

Note that TDX support has rotten, so this alone isn't very useful.

Cc: @gjolly 