### PR TITLE
build: Mark vfio runner as required for MQ

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -870,8 +870,7 @@ jobs:
       - hadolint
       - integration-arm64
       - integration-sev-snp
-      # VFIO worker is failing #8160
-      # - integration-vfio
+      - integration-vfio
       - integration-mshv-x86-64
       - integration-windows
       - integration-x86-64-mq

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -12030,6 +12030,7 @@ mod vfio {
     }
 
     #[test]
+    #[ignore = "See #8548"]
     fn test_iommufd_nvidia_card_pci_hotplug() {
         test_nvidia_card_pci_hotplug_common(true);
     }
@@ -12276,6 +12277,7 @@ mod vfio {
     }
 
     #[test]
+    #[ignore = "See #8549"]
     fn test_iommufd_nvidia_card_x_exclude_mmap_bars() {
         test_nvidia_card_x_exclude_mmap_bars_common(true);
     }


### PR DESCRIPTION
Across the last 20 MQ runs, all 13 vfio runner failures came from two
flaky tests. Both are now skipped and tracked in https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8548 and https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8549.