### PR TITLE
build: Exclude the qcow2 block tests from the metrics runner

### DIFF
--- a/.github/workflows/integration-metrics.yaml
+++ b/.github/workflows/integration-metrics.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Tests (Metrics)
-    runs-on: bare-metal-9950x
+    runs-on: garm-jammy-16
     env:
       METRICS_PUBLISH_KEY: ${{ secrets.METRICS_PUBLISH_KEY }}
     steps:
@@ -15,8 +15,18 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      - name: Install Docker
+        run: |
+          set -eufo pipefail
+          sudo apt-get update
+          sudo apt-get -y install ca-certificates curl gnupg
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          sudo chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt install -y docker-ce docker-ce-cli
       - name: Run metrics tests
         timeout-minutes: 60
-        run: scripts/dev_cli.sh tests --metrics -- --test-exclude micro_ -- --report-file /root/workloads/metrics.json
+        run: scripts/dev_cli.sh tests --metrics -- --test-exclude micro_,block_qcow2 -- --report-file /root/workloads/metrics.json
       - name: Upload metrics report
         run: 'curl -X PUT https://ch-metrics.azurewebsites.net/api/publishmetrics -H "x-functions-key: $METRICS_PUBLISH_KEY" -T ~/workloads/metrics.json'

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -23,6 +23,9 @@ exclude = [
   '^tcp://192\.168\.1\.10',
   # Slack invite endpoints reject automated GETs and return 403.
   '^https://join\.slack\.com/t/',
+  # Metrics publish endpoint only answers authenticated PUTs; a plain GET
+  # returns 404.
+  '^https://ch-metrics\.azurewebsites\.net/api/publishmetrics',
 ]
 
 # Exclude loopback addresses

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -1783,15 +1783,17 @@ fn main() {
         .arg(
             Arg::new("test-filter")
                 .long("test-filter")
-                .help("Filter metrics tests to run based on provided keywords")
+                .help("Filter metrics tests to run based on provided keywords (comma-separated)")
                 .num_args(1)
+                .value_delimiter(',')
                 .required(false),
         )
         .arg(
             Arg::new("test-exclude")
                 .long("test-exclude")
-                .help("Exclude metrics tests matching the provided keywords")
+                .help("Exclude metrics tests matching the provided keywords (comma-separated)")
                 .num_args(1)
+                .value_delimiter(',')
                 .required(false),
         )
         .arg(


### PR DESCRIPTION
The metrics test list has grown significantly and no longer finishes
even within the 60-minute timeout. Exclude the block_qcow2 group (30
tests) in addition to the micro benchmarks, leaving a 30-test set that
completes meaningfully (~41 minutes in my testing). Trimming and
re-tuning the metrics test list is tracked in https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8551.

Since the underlying bare-metal system is also retired, run the metrics
tests on the garm-jammy-16 (Azure VM) runner instead.