### PR TITLE
vmm: Reject snapshot/migration if on-demand restore still active

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8892,6 +8892,9 @@ mod snapshot_restore_common {
 
         let api_socket_restored = format!("{}.2", temp_api_path(&guest.tmp_dir));
         let event_path_restored = format!("{}.2", temp_event_monitor_path(&guest.tmp_dir));
+        let snapshot_dir2 =
+            String::from(guest.tmp_dir.as_path().join("snapshot2").to_str().unwrap());
+        fs::create_dir(&snapshot_dir2).unwrap();
 
         let mut child = GuestCommand::new(&guest)
             .args(["--api-socket", &api_socket_restored])
@@ -8924,6 +8927,14 @@ mod snapshot_restore_common {
                 "info",
                 None
             )));
+
+            // Snapshot the still-restoring VM: refused until prefault completes.
+            assert!(wait_until(Duration::from_secs(120), || remote_command(
+                &api_socket_restored,
+                "snapshot",
+                Some(format!("file://{snapshot_dir2}").as_str()),
+            )));
+
             assert!(remote_command(&api_socket_restored, "resume", None));
 
             let latest_events = [
@@ -8967,7 +8978,60 @@ mod snapshot_restore_common {
         });
         handle_child_output(r, &output);
 
+        // Restore the 2nd snapshot into a fresh VM to prove no guest RAM was dropped.
+        Command::new("rm")
+            .arg("-f")
+            .arg(socket.as_str())
+            .output()
+            .unwrap();
+
+        let api_socket_restored2 = format!("{}.3", temp_api_path(&guest.tmp_dir));
+        let event_path_restored2 = format!("{}.3", temp_event_monitor_path(&guest.tmp_dir));
+
+        let mut child = GuestCommand::new(&guest)
+            .args(["--api-socket", &api_socket_restored2])
+            .args([
+                "--event-monitor",
+                format!("path={event_path_restored2}").as_str(),
+            ])
+            .args([
+                "--restore",
+                format!("source_url=file://{snapshot_dir2}").as_str(),
+            ])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let latest_events = [&MetaEvent {
+            event: "restored".to_string(),
+            device_id: None,
+        }];
+        assert!(wait_for_latest_events_exact(
+            Duration::from_secs(30),
+            &latest_events,
+            &event_path_restored2
+        ));
+
+        let r = panic::catch_unwind(|| {
+            assert!(wait_until(Duration::from_secs(30), || remote_command(
+                &api_socket_restored2,
+                "info",
+                None
+            )));
+            assert!(remote_command(&api_socket_restored2, "resume", None));
+
+            assert_eq!(guest.get_cpu_count().unwrap_or_default(), 4);
+            assert!(guest.get_total_memory().unwrap_or_default() > min_total_memory_kib);
+
+            guest.check_devices_common(Some(&socket), Some(&console_text), None);
+        });
+
+        kill_child(&mut child);
+        let output = child.wait_with_output().unwrap();
+        handle_child_output(r, &output);
+
         let _ = remove_dir_all(snapshot_dir.as_str());
+        let _ = remove_dir_all(snapshot_dir2.as_str());
     }
 
     pub(crate) fn _test_snapshot_restore_devices(pvpanic: bool) {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2318,6 +2318,9 @@ impl RequestHandler for Vmm {
     fn vm_snapshot(&mut self, destination_url: &str) -> result::Result<(), VmError> {
         match self.vm {
             VmOwnership::Owned(ref mut vm) => {
+                if vm.restoring() {
+                    return Err(VmError::VmRestoring);
+                }
                 // Drain console_info so that FDs are not reused
                 let _ = self.console_info.take();
                 vm.snapshot()
@@ -3091,7 +3094,13 @@ impl RequestHandler for Vmm {
         send_data_migration: VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
         match self.vm {
-            VmOwnership::Owned(_) => (),
+            VmOwnership::Owned(ref vm) => {
+                if vm.restoring() {
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "Cannot migrate while on-demand memory restore is in progress"
+                    )));
+                }
+            }
             VmOwnership::Migration { .. } => {
                 return Err(MigratableError::MigrateSend(anyhow!(
                     "There is already an ongoing migration"

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -14,7 +14,7 @@ use std::ops::{BitAnd, Not, Sub};
 use std::os::fd::{AsFd, OwnedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{cmp, ffi, panic, result, thread, time};
@@ -71,6 +71,7 @@ struct UffdHandler {
     result_rx: Receiver<Result<(), io::Error>>,
     handle: thread::JoinHandle<()>,
     fault_socket_fd: Option<OwnedFd>,
+    prefault_complete: Arc<AtomicBool>,
 }
 
 pub const MEMORY_MANAGER_ACPI_SIZE: usize = 0x18;
@@ -1071,6 +1072,8 @@ impl MemoryManager {
         let panic_exit_evt = exit_evt.try_clone().map_err(Error::EventFdFail)?;
         let (ready_tx, ready_rx) = mpsc::sync_channel(1);
         let (result_tx, result_rx) = mpsc::sync_channel(1);
+        let prefault_complete = Arc::new(AtomicBool::new(false));
+        let thread_prefault_complete = Arc::clone(&prefault_complete);
         let handle = thread::Builder::new()
             .name("uffd-handler".to_string())
             .spawn(move || {
@@ -1081,6 +1084,7 @@ impl MemoryManager {
                         source,
                         &handler_ranges,
                         &ready_tx,
+                        &thread_prefault_complete,
                     );
 
                     if let Err(e) = &result {
@@ -1113,6 +1117,7 @@ impl MemoryManager {
             result_rx,
             handle,
             fault_socket_fd,
+            prefault_complete,
         });
 
         Ok(())
@@ -1148,6 +1153,13 @@ impl MemoryManager {
         }
     }
 
+    /// True while an on-demand (UFFD) restore is still faulting in guest RAM.
+    pub fn restoring(&self) -> bool {
+        self.uffd_handler
+            .as_ref()
+            .is_some_and(|h| !h.prefault_complete.load(Ordering::Acquire))
+    }
+
     /// Serve UFFD faults via `source`, prefaulting one page per idle
     /// iteration.
     #[expect(clippy::needless_pass_by_value)]
@@ -1157,6 +1169,7 @@ impl MemoryManager {
         mut source: Box<dyn UffdMemorySource>,
         ranges: &[UffdRange],
         ready_tx: &SyncSender<()>,
+        prefault_complete: &AtomicBool,
     ) -> Result<(), io::Error> {
         let uffd_raw_fd = uffd_fd.as_raw_fd();
 
@@ -1330,6 +1343,7 @@ impl MemoryManager {
                          prefaulted={pages_prefaulted} served={pages_served} \
                          total={total_pages}"
                     );
+                    prefault_complete.store(true, Ordering::Release);
                     return Ok(());
                 }
                 if served_bitmap[range_idx].is_bit_set(page_idx as usize) {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -201,6 +201,9 @@ pub enum Error {
     #[error("VM is currently migrating and can't be modified")]
     VmMigrating,
 
+    #[error("VM on-demand memory restore is still in progress")]
+    VmRestoring,
+
     #[error("Cannot clone EventFd")]
     EventFdClone(#[source] io::Error),
 
@@ -3039,6 +3042,10 @@ impl Vm {
 
     pub fn guest_memory(&self) -> GuestMemoryAtomic<GuestMemoryMmap> {
         self.memory_manager.lock().unwrap().guest_memory()
+    }
+
+    pub fn restoring(&self) -> bool {
+        self.memory_manager.lock().unwrap().restoring()
     }
 
     pub fn device_tree(&self) -> Arc<Mutex<DeviceTree>> {


### PR DESCRIPTION
- **vmm: Record when the on-demand memory restore is done**
- **vmm: Error out on migration & snapshot if on-demand restoring**
- **tests: Add integration tests to snapshot after/during restore**
