### PR TITLE
block: Check request total length is a multiple of SECTOR_SIZE

### DIFF
--- a/block/src/io/request.rs
+++ b/block/src/io/request.rs
@@ -644,7 +644,10 @@ impl Request {
         if total_bytes == 0 {
             return Ok(());
         }
-        let total_sectors = total_bytes.div_ceil(SECTOR_SIZE);
+        if !total_bytes.is_multiple_of(SECTOR_SIZE) {
+            return Err(ExecuteError::BadRequest(Error::InvalidDataLength));
+        }
+        let total_sectors = total_bytes / SECTOR_SIZE;
         let end_sector = self
             .sector
             .checked_add(total_sectors)

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -71,6 +71,8 @@ pub enum Error {
     GetFileMetadata(#[source] io::Error),
     #[error("The requested operation would cause a seek beyond disk end")]
     InvalidOffset,
+    #[error("Request data length is not a multiple of the 512-byte sector size")]
+    InvalidDataLength,
     #[error("Failure in qcow")]
     QcowError(#[source] qcow::Error),
     #[error("The requested operation does not support multiple descriptors")]


### PR DESCRIPTION
The request can be spread over multiple descriptors but the virtio-block
specification (and this code) expects that is a whole number of sectors
(512 bytes).

Signed-off-by: Rob Bradford <rbradford@meta.com>
