### PR TITLE
build: disallow building `tdx` feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -448,14 +448,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           args: --locked --all --all-targets --no-default-features --tests --examples --features "mshv,igvm" -- -D warnings
-      - name: Clippy (kvm + tdx)
-        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
-        uses: houseabsolute/actions-rust-cross@v1
-        with:
-          command: clippy
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          args: --locked --all --all-targets --no-default-features --tests --examples --features "tdx,kvm" -- -D warnings
       - name: Clippy (kvm + igvm + sev_snp + fw_cfg)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: houseabsolute/actions-rust-cross@v1
@@ -508,8 +500,6 @@ jobs:
         run: cargo build --locked --bin cloud-hypervisor
       - name: Build (kvm)
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "kvm"
-      - name: Build (default features + tdx)
-        run: cargo build --locked --bin cloud-hypervisor --features "tdx"
       - name: Build (default features + dbus_api)
         run: cargo build --locked --bin cloud-hypervisor --features "dbus_api"
       - name: Build (default features + guest_debug)

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -894,6 +894,8 @@ fn expand_fdtable() -> Result<(), FdTableError> {
 }
 
 fn main() {
+    #[cfg(feature = "tdx")]
+    compile_error!("Feature 'tdx' is broken.");
     #[cfg(all(feature = "tdx", feature = "sev_snp"))]
     compile_error!("Feature 'tdx' and 'sev_snp' are mutually exclusive.");
     #[cfg(all(feature = "sev_snp", not(target_arch = "x86_64")))]

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -12,8 +12,6 @@ cargo_args=("")
 # shellcheck disable=SC2154
 if [[ $hypervisor = "mshv" ]]; then
     cargo_args+=("--features $hypervisor")
-elif [[ $(uname -m) = "x86_64" ]]; then
-    cargo_args+=("--features tdx")
 fi
 
 export RUST_BACKTRACE=1


### PR DESCRIPTION
It is broken. There is no use in producing something that doesn't work.