### PR TITLE
block: vhdx: fix sector size and restrict to 512-byte sectors

### DIFF
--- a/block/src/formats/vhdx/io.rs
+++ b/block/src/formats/vhdx/io.rs
@@ -19,6 +19,8 @@ pub enum VhdxIoError {
     InvalidBatEntryState,
     #[error("Invalid BAT entry count")]
     InvalidBatIndex,
+    #[error("Buffer length does not match the requested sector count")]
+    InvalidBufferLength,
     #[error("Invalid disk size")]
     InvalidDiskSize,
     #[error("Failed reading sector blocks from file {0}")]
@@ -95,6 +97,12 @@ pub(super) fn read(
     if disk_spec.has_parent {
         return Err(VhdxIoError::UnsupportedMode);
     }
+    let expected_len = sector_count
+        .checked_mul(disk_spec.logical_sector_size as u64)
+        .ok_or(VhdxIoError::InvalidBufferLength)?;
+    if buf.len() as u64 != expected_len {
+        return Err(VhdxIoError::InvalidBufferLength);
+    }
 
     let mut read_count: usize = 0;
     while sector_count > 0 {
@@ -146,6 +154,12 @@ pub(super) fn write(
 ) -> Result<usize> {
     if disk_spec.has_parent {
         return Err(VhdxIoError::UnsupportedMode);
+    }
+    let expected_len = sector_count
+        .checked_mul(disk_spec.logical_sector_size as u64)
+        .ok_or(VhdxIoError::InvalidBufferLength)?;
+    if buf.len() as u64 != expected_len {
+        return Err(VhdxIoError::InvalidBufferLength);
     }
 
     let mut write_count: usize = 0;
@@ -273,5 +287,25 @@ mod tests {
         let mut readback = vec![0u8; SECTOR_SIZE as usize];
         f.file().read_exact_at(&mut readback, DATA_OFFSET).unwrap();
         assert_eq!(readback, data);
+    }
+
+    #[test]
+    fn read_short_buffer_is_rejected() {
+        let (f, disk_spec, bat) = fixture();
+
+        let mut buf = vec![0u8; SECTOR_SIZE as usize - 1];
+        let err = read(&f, &mut buf, &disk_spec, &bat, 0, 1).unwrap_err();
+
+        assert!(matches!(err, VhdxIoError::InvalidBufferLength));
+    }
+
+    #[test]
+    fn write_short_buffer_is_rejected() {
+        let (f, mut disk_spec, mut bat) = fixture();
+
+        let data = vec![0xCDu8; SECTOR_SIZE as usize - 1];
+        let err = write(&f, &data, &mut disk_spec, 0, &mut bat, 0, 1).unwrap_err();
+
+        assert!(matches!(err, VhdxIoError::InvalidBufferLength));
     }
 }

--- a/block/src/formats/vhdx/io.rs
+++ b/block/src/formats/vhdx/io.rs
@@ -12,8 +12,6 @@ use super::bat::{self, BatEntry, VhdxBatError};
 use super::metadata::{self, DiskSpec};
 use crate::aligned_file::AlignedFile;
 
-const SECTOR_SIZE: u64 = 512;
-
 #[sorted]
 #[derive(Error, Debug)]
 pub enum VhdxIoError {
@@ -116,8 +114,7 @@ pub(super) fn read(
             | bat::PAYLOAD_BLOCK_ZERO => {}
             bat::PAYLOAD_BLOCK_FULLY_PRESENT => {
                 f.read_exact_at(
-                    &mut buf
-                        [read_count..(read_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
+                    &mut buf[read_count..(read_count + sector.free_bytes as usize)],
                     sector.file_offset,
                 )
                 .map_err(VhdxIoError::ReadSectorBlock)?;
@@ -187,7 +184,7 @@ pub(super) fn write(
                 }
 
                 f.write_all_at(
-                    &buf[write_count..(write_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
+                    &buf[write_count..(write_count + sector.free_bytes as usize)],
                     file_offset,
                 )
                 .map_err(VhdxIoError::ReadSectorBlock)?;
@@ -198,7 +195,7 @@ pub(super) fn write(
                 }
 
                 f.write_all_at(
-                    &buf[write_count..(write_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
+                    &buf[write_count..(write_count + sector.free_bytes as usize)],
                     sector.file_offset,
                 )
                 .map_err(VhdxIoError::ReadSectorBlock)?;
@@ -215,4 +212,66 @@ pub(super) fn write(
         write_count += sector.free_bytes as usize;
     }
     Ok(write_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+
+    // 512 is the only sector size read/write allowed by metadata::parse_metadata.
+    // [MS-VHDX] allows 4096, but it's not currently implemented
+    const SECTOR_SIZE: u64 = 512;
+
+    // The first BLOCK_SIZE_MIN bytes of a VHDx file are always headers, so
+    // write() treats a file offset below BLOCK_SIZE_MIN as malformed and skips
+    // the writing operation.
+    // Use a DATA_OFFSET greater than BLOCK_SIZE_MIN to bypass that early exit.
+    const DATA_OFFSET: u64 = 2 * metadata::BLOCK_SIZE_MIN as u64;
+
+    fn fixture() -> (AlignedFile, DiskSpec, Vec<BatEntry>) {
+        let disk_spec = DiskSpec {
+            // One block == one sector, so there's exactly one BAT entry.
+            sectors_per_block: 1,
+            logical_sector_size: SECTOR_SIZE as u32,
+            virtual_disk_size: SECTOR_SIZE,
+            image_size: DATA_OFFSET + SECTOR_SIZE,
+            block_size: SECTOR_SIZE as u32,
+            ..Default::default()
+        };
+
+        let file = TempFile::new().unwrap().into_file();
+        file.set_len(DATA_OFFSET + SECTOR_SIZE).unwrap();
+        file.write_all_at(&vec![0xABu8; SECTOR_SIZE as usize], DATA_OFFSET)
+            .unwrap();
+        // A BAT entry saying "this block's data is already written to the
+        // file at `file_offset`".
+        let bat = vec![BatEntry(DATA_OFFSET | bat::PAYLOAD_BLOCK_FULLY_PRESENT)];
+        (AlignedFile::new(file, false), disk_spec, bat)
+    }
+
+    #[test]
+    fn read_sector() {
+        let (f, disk_spec, bat) = fixture();
+
+        let mut buf = vec![0u8; SECTOR_SIZE as usize];
+        let n = read(&f, &mut buf, &disk_spec, &bat, 0, 1).unwrap();
+
+        assert_eq!(n, SECTOR_SIZE as usize);
+        assert!(buf.iter().all(|&b| b == 0xAB));
+    }
+
+    #[test]
+    fn write_sector() {
+        let (f, mut disk_spec, mut bat) = fixture();
+
+        let data = vec![0xCDu8; SECTOR_SIZE as usize];
+        let n = write(&f, &data, &mut disk_spec, 0, &mut bat, 0, 1).unwrap();
+        assert_eq!(n, SECTOR_SIZE as usize);
+
+        let mut readback = vec![0u8; SECTOR_SIZE as usize];
+        f.file().read_exact_at(&mut readback, DATA_OFFSET).unwrap();
+        assert_eq!(readback, data);
+    }
 }

--- a/block/src/formats/vhdx/metadata.rs
+++ b/block/src/formats/vhdx/metadata.rs
@@ -175,8 +175,7 @@ impl DiskSpec {
                 f.read_exact_at(&mut item, item_offset)
                     .map_err(VhdxMetadataError::ReadMetadata)?;
                 disk_spec.logical_sector_size = LittleEndian::read_u32(&item);
-                if !(disk_spec.logical_sector_size == 512 || disk_spec.logical_sector_size == 4096)
-                {
+                if disk_spec.logical_sector_size != 512 {
                     return Err(VhdxMetadataError::InvalidLogicalSectorSize);
                 }
 

--- a/block/src/formats/vhdx/parser.rs
+++ b/block/src/formats/vhdx/parser.rs
@@ -98,8 +98,18 @@ impl Read for Vhdx {
     /// Wrapper function to satisfy Read trait implementation for VHDx disk.
     /// Convert the offset to sector index and buffer length to sector count.
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
-        let sector_count = (buf.len() as u64).div_ceil(self.disk_spec.logical_sector_size as u64);
-        let sector_index = self.current_offset / self.disk_spec.logical_sector_size as u64;
+        let sector_size = self.disk_spec.logical_sector_size as u64;
+        if !(buf.len() as u64).is_multiple_of(sector_size) {
+            return Err(IoError::new(
+                IoErrorKind::InvalidInput,
+                format!(
+                    "Read buffer length {} is not a multiple of the {sector_size}-byte logical sector size",
+                    buf.len()
+                ),
+            ));
+        }
+        let sector_count = buf.len() as u64 / sector_size;
+        let sector_index = self.current_offset / sector_size;
 
         let result = io::read(
             &self.aligned,
@@ -129,8 +139,18 @@ impl Write for Vhdx {
     /// Wrapper function to satisfy Write trait implementation for VHDx disk.
     /// Convert the offset to sector index and buffer length to sector count.
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
-        let sector_count = (buf.len() as u64).div_ceil(self.disk_spec.logical_sector_size as u64);
-        let sector_index = self.current_offset / self.disk_spec.logical_sector_size as u64;
+        let sector_size = self.disk_spec.logical_sector_size as u64;
+        if !(buf.len() as u64).is_multiple_of(sector_size) {
+            return Err(IoError::new(
+                IoErrorKind::InvalidInput,
+                format!(
+                    "Write buffer length {} is not a multiple of the {sector_size}-byte logical sector size",
+                    buf.len()
+                ),
+            ));
+        }
+        let sector_count = buf.len() as u64 / sector_size;
+        let sector_index = self.current_offset / sector_size;
 
         if self.first_write {
             self.first_write = false;
@@ -304,5 +324,43 @@ mod tests {
         vhdx.seek(SeekFrom::Start(0)).unwrap();
         assert_eq!(vhdx.read(&mut readback).unwrap(), readback.len());
         assert_eq!(readback, data);
+    }
+
+    #[test]
+    fn read_misaligned_buffer_is_rejected() {
+        let Some(tf) = create_dynamic_vhdx(16) else {
+            eprintln!("skipping read_misaligned_buffer_is_rejected: qemu-img unavailable");
+            return;
+        };
+
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(tf.as_path())
+            .unwrap();
+        let mut vhdx = Vhdx::new(file, false).unwrap();
+
+        let mut buf = vec![0u8; vhdx.disk_spec.logical_sector_size as usize - 1];
+        let err = vhdx.read(&mut buf).unwrap_err();
+        assert_eq!(err.kind(), IoErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn write_misaligned_buffer_is_rejected() {
+        let Some(tf) = create_dynamic_vhdx(16) else {
+            eprintln!("skipping write_misaligned_buffer_is_rejected: qemu-img unavailable");
+            return;
+        };
+
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(tf.as_path())
+            .unwrap();
+        let mut vhdx = Vhdx::new(file, false).unwrap();
+
+        let buf = vec![0u8; vhdx.disk_spec.logical_sector_size as usize - 1];
+        let err = vhdx.write(&buf).unwrap_err();
+        assert_eq!(err.kind(), IoErrorKind::InvalidInput);
     }
 }


### PR DESCRIPTION
io::read/write computed the per-iteration slice length as sector.free_sectors * SECTOR_SIZE, a hardcoded 512-byte constant instead of the file's real logical sector size.

Per [MS-VHDX], LogicalSectorSize can be 512 or 4,096:
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-vhdx/e45dcf18-f45b-4507-8760-e76fa538a61b
On a 4096-byte sector, the hardcoded 512 didn't cover the real sector size: the slice could exceed the request's buffer, and only the first
512 bytes of each sector were transferred while the full 4096 was reported as done.

4096-byte sectors were accepted at metadata parse time but never worked correctly. cloud-hypervisor always advertises a 512-byte logical block size to the guest over virtio-blk regardless of the VHDx file's real sector size, so a 4096-byte-sector image could never be addressed correctly.

1. Reject 4096-byte logical sectors at metadata parse time, matching QEMU's VHDx support and virtio-blk's fixed 512-byte sector convention.
2. Use sector.free_bytes consistently for the I/O slice (removing the hardcoded SECTOR_SIZE constant).
3. Reject read/write calls with the new VhdxIoError::InvalidBufferLength when buf.len() doesn't equal sector_count * logical_sector_size, as a defense-in-depth check.
4. Validate buf.len() against the logical sector size directly in Vhdx's Read/Write impl (parser.rs).