### PR TITLE
vmm: openapi: Correct vmm.nmi endpoint to vm.nmi

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -445,7 +445,7 @@ paths:
         405:
           description: The VM instance could not be coredumped because it is not booted.
 
-  /vmm.nmi:
+  /vm.nmi:
     put:
       summary: Inject an NMI.
       responses:


### PR DESCRIPTION
This is a VM operation not a VMM operation and was wrongly recorded in
the openapi YAML file.

Signed-off-by: Rob Bradford <rbradford@meta.com>
