### PR TITLE
vmm: add copyonwrite memory restore mode

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8269,6 +8269,17 @@ mod ivshmem {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
+    fn test_snapshot_restore_copyonwrite() {
+        snapshot_restore_common::_test_snapshot_restore(
+            snapshot_restore_common::SnapshotRestoreTest {
+                memory_restore_mode: Some("copyonwrite"),
+                ..Default::default()
+            },
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "mshv"))]
     fn test_snapshot_check_guest_time() {
         snapshot_restore_common::_test_snapshot_restore(
             snapshot_restore_common::SnapshotRestoreTest {
@@ -8386,7 +8397,7 @@ mod ivshmem {
 }
 
 mod snapshot_restore_common {
-    use std::fs::remove_dir_all;
+    use std::fs::{read_to_string, remove_dir_all};
     use std::process::Command;
 
     use crate::*;
@@ -8452,6 +8463,7 @@ mod snapshot_restore_common {
         pub use_hotplug: bool,
         pub use_resume_option: bool,
         pub check_clock: bool,
+        pub memory_restore_mode: Option<&'static str>,
     }
 
     pub(crate) fn _test_snapshot_restore(cfg: SnapshotRestoreTest) {
@@ -8459,6 +8471,7 @@ mod snapshot_restore_common {
             use_hotplug,
             use_resume_option,
             check_clock,
+            memory_restore_mode,
         } = cfg;
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -8606,7 +8619,13 @@ mod snapshot_restore_common {
             ])
             .args([
                 "--restore",
-                format!("source_url=file://{snapshot_dir},resume={use_resume_option}").as_str(),
+                format!(
+                    "source_url=file://{snapshot_dir},resume={use_resume_option}{}",
+                    memory_restore_mode
+                        .map(|m| format!(",memory_restore_mode={m}"))
+                        .unwrap_or_default()
+                )
+                .as_str(),
             ])
             .capture_output()
             .spawn()
@@ -8674,8 +8693,16 @@ mod snapshot_restore_common {
             None
         )));
 
-        // Remove the snapshot dir
-        let _ = remove_dir_all(snapshot_dir.as_str());
+        if memory_restore_mode == Some("copyonwrite") {
+            // Copy-on-write restore must map the snapshot file itself (a silent
+            // fallback to copy keeps RAM anonymous), and the mapped file must
+            // outlive the VM.
+            let maps = read_to_string(format!("/proc/{}/maps", child.id())).unwrap();
+            assert!(maps.contains(&format!("{snapshot_dir}/memory-ranges")));
+        } else {
+            // Remove the snapshot dir
+            let _ = remove_dir_all(snapshot_dir.as_str());
+        }
 
         let r = panic::catch_unwind(|| {
             if use_resume_option {

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -143,6 +143,47 @@ Setting `vm.unprivileged_userfaultfd=1` also works, but it enables
 `userfaultfd(2)` for every process on the host, whereas the ACL grants access
 to one user.
 
+### Copy-on-write restore
+
+With `memory_restore_mode=copyonwrite`, guest RAM is created by mapping the snapshot
+memory file copy-on-write before any KVM memslot or device consumes the
+mapping: nothing is copied up front, pages fault in from the page cache — so
+many VMs restored from the same snapshot share it — and guest writes stay
+private to each VM.
+
+Current constraints for `memory_restore_mode=copyonwrite`:
+
+- Plain private guest RAM only. Anything else falls back to the eager copy
+  (logged): `shared=on` or hugepages (global or per-zone), zones with
+  `host_numa_node`, `reserve`, `mergeable` or hotplug fields (a purely static
+  `id`+`size` zone is fine), resizable RAM (`hotplug_size`, virtio-mem), KSM
+  (`mergeable=on`), `--pvmemcontrol`, device passthrough
+  (`--device`/`--user-device`/`--vdpa`), and snapshot ranges that are not
+  page-aligned single-region extents. Each region's `reserve` policy and the
+  THP policy are re-applied to the mapped region.
+- A snapshot memory file shorter than the saved ranges is rejected up front (it
+  would otherwise fault `SIGBUS` at run time).
+- `prefault` is rejected.
+- The snapshot memory file must remain on disk **and unchanged** for the
+  entire lifetime of the VM. This is stronger than `ondemand`: UFFD copies each
+  page into the original anonymous mapping and stops needing the file once every
+  page is populated, and a read error there is a controlled VM exit; the
+  copy-on-write region stays file-backed forever, so truncating it delivers a
+  synchronous `SIGBUS` and any in-place edit corrupts the guest. The length
+  check only rejects a file that is already short at restore time.
+- `virtio-balloon` operates normally. Balloon inflation uses `MADV_DONTNEED`,
+  which is valid on the private file mapping: the kernel releases the private
+  page copies and the host reclaims the memory. A released page reads from the
+  snapshot file again on the next access. The guest must not expect specific
+  content in a page that returns from the balloon, so this is correct.
+  (`pvmemcontrol` differs: it issues operations that are only valid on
+  anonymous memory, which is why it is on the fallback list above.)
+- A device that is hot-plugged after the restore and that pins guest memory
+  (VFIO, vfio-user, vDPA) write-faults every guest page when its IOMMU mapping
+  is created. Every page becomes a private copy: the VM stays correct, but the
+  page-cache sharing is lost for that VM and host memory use grows to the
+  eager-copy level. The same applies to `ondemand` restores.
+
 ## Restore a VM with new Net FDs
 For a VM created with FDs explicitly passed to NetConfig, a set of valid FDs
 need to be provided along with the VM restore command in the following syntax:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1546,7 +1546,7 @@ components:
 
     MemoryRestoreMode:
       type: string
-      enum: [Copy, OnDemand]
+      enum: [Copy, OnDemand, CopyOnWrite]
       default: Copy
 
     RestoreConfig:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -396,8 +396,8 @@ pub enum ValidationError {
     /// A device saved with an FD has no replacement FD for the restore
     #[error("VFIO device '{0}' was FD backed and needs a new fd in 'vfio_fds'")]
     RestoreMissingVfioFd(String),
-    /// Prefault cannot be combined with on-demand restore
-    #[error("'prefault' cannot be combined with 'memory_restore_mode=ondemand'")]
+    /// Prefault requires the eager-copy restore mode
+    #[error("'prefault' requires 'memory_restore_mode=copy'")]
     InvalidRestorePrefaultWithOnDemand,
     /// Path provided in landlock-rules doesn't exist
     #[error("Path {0:?} provided in landlock-rules does not exist")]
@@ -2791,6 +2791,9 @@ pub enum MemoryRestoreMode {
     Copy,
     /// Restore lazily by faulting snapshot pages into guest RAM on demand.
     OnDemand,
+    /// Restore by mapping the snapshot memory file copy-on-write, sharing the
+    /// page cache across VMs restored from the same snapshot.
+    CopyOnWrite,
 }
 
 #[derive(Debug, Error)]
@@ -2806,6 +2809,7 @@ impl FromStr for MemoryRestoreMode {
         match s.to_lowercase().as_str() {
             "copy" => Ok(Self::Copy),
             "ondemand" => Ok(Self::OnDemand),
+            "copyonwrite" => Ok(Self::CopyOnWrite),
             _ => Err(MemoryRestoreModeParseError::InvalidValue(s.to_owned())),
         }
     }
@@ -2862,13 +2866,13 @@ pub struct RestoreConfig {
 
 impl RestoreConfig {
     pub const SYNTAX: &'static str = "Restore from a VM snapshot. \
-        \nRestore parameters \"source_url=<source_url>,prefault=on|off,memory_restore_mode=copy|ondemand,\
+        \nRestore parameters \"source_url=<source_url>,prefault=on|off,memory_restore_mode=copy|ondemand|copyonwrite,\
         net_fds=<list_of_net_ids_with_their_associated_fds>,\
         vfio_fds=<list_of_vfio_ids_with_their_associated_fd>,iommufd_fd=<fd>,resume=true|false,\
         zone_updates=<list_of_updates>\"
         \n`source_url` should be a valid URL (e.g file:///foo/bar or tcp://192.168.1.10/foo) \
         \n`prefault` controls eager prefaulting for the copy-based restore path (disabled by default) \
-        \n`memory_restore_mode=copy` preserves the existing eager read-copy restore behavior, while `memory_restore_mode=ondemand` enables lazy demand paging and fails restore if userfaultfd support is unavailable \
+        \n`memory_restore_mode=copy` preserves the existing eager read-copy restore behavior, `memory_restore_mode=ondemand` enables lazy demand paging and fails restore if userfaultfd support is unavailable, and `memory_restore_mode=copyonwrite` maps the snapshot file copy-on-write (plain private RAM only; falls back to copy otherwise) \
         \n`net_fds` is a list of net ids with new file descriptors. \
         Only net devices backed by FDs directly are needed as input.\
         \n`vfio_fds` is a list of VFIO device ids each paired with a new cdev file descriptor, \
@@ -2965,7 +2969,7 @@ impl RestoreConfig {
     // corresponding 'RestoreNetConfig' with a matched 'id' and expected
     // number of FDs.
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        if self.memory_restore_mode == MemoryRestoreMode::OnDemand && self.prefault {
+        if self.memory_restore_mode != MemoryRestoreMode::Copy && self.prefault {
             return Err(ValidationError::InvalidRestorePrefaultWithOnDemand);
         }
 
@@ -5608,6 +5612,21 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             invalid_config_zone_updates.validate(&snapshot_vm_config),
             Err(ValidationError::MemoryZoneUpdatesEmptyId)
+        );
+
+        let invalid_cow_prefault = RestoreConfig {
+            source_url: PathBuf::from("/path/to/snapshot"),
+            prefault: true,
+            memory_restore_mode: MemoryRestoreMode::CopyOnWrite,
+            net_fds: None,
+            vfio_fds: None,
+            iommufd_fd: None,
+            resume: false,
+            zone_updates: vec![],
+        };
+        assert_eq!(
+            invalid_cow_prefault.validate(&snapshot_vm_config),
+            Err(ValidationError::InvalidRestorePrefaultWithOnDemand)
         );
     }
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -399,6 +399,10 @@ pub enum Error {
     #[error("Error copying snapshot into region")]
     SnapshotCopy(#[source] GuestMemoryError),
 
+    /// Error mapping snapshot file over guest RAM
+    #[error("Error mapping snapshot file over guest RAM")]
+    SnapshotMmap(#[source] io::Error),
+
     /// Failed to allocate MMIO address
     #[error("Failed to allocate MMIO address")]
     AllocateMmioAddress,
@@ -923,6 +927,40 @@ impl MemoryManager {
         }
 
         Ok(())
+    }
+
+    // Restore guest memory by mapping the snapshot file copy-on-write over
+    // the anonymous guest mappings — before any KVM memslot or device
+    // consumes them, so overlay identity concerns do not apply. Falls back
+    // to the eager copy whenever a range cannot be mapped safely. The
+    // snapshot file must remain on disk for the VM lifetime.
+    fn mmap_cow_saved_regions(
+        &mut self,
+        file_path: PathBuf,
+        saved_regions: &MemoryRangeTable,
+    ) -> Result<(), Error> {
+        if saved_regions.is_empty() {
+            return Ok(());
+        }
+        let guest_memory = self.guest_memory.memory();
+        if !is_restore_cow_compatible(&guest_memory, saved_regions) {
+            info!("Restore (mode=copyonwrite): guest RAM unsuitable, falling back to copy");
+            return self.fill_saved_regions(file_path, saved_regions);
+        }
+        let memory_file = OpenOptions::new()
+            .read(true)
+            .open(file_path)
+            .map_err(Error::SnapshotOpen)?;
+        // A range mapped past EOF faults SIGBUS at run time, not restore time.
+        let mapped_len: u64 = saved_regions.regions().iter().map(|r| r.length).sum();
+        let file_len = memory_file.metadata().map_err(Error::SnapshotOpen)?.len();
+        if file_len < mapped_len {
+            return Err(Error::SnapshotMmap(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "snapshot memory file is shorter than the saved ranges",
+            )));
+        }
+        do_mmap_cow_saved_regions(&guest_memory, &memory_file, saved_regions, self.thp)
     }
 
     /// Restore guest memory using userfaultfd for lazy demand paging.
@@ -1950,16 +1988,20 @@ impl MemoryManager {
                 Default::default(),
             )?;
 
-            if memory_restore_mode == MemoryRestoreMode::OnDemand {
-                mm.lock().unwrap().restore_by_uffd(
+            match memory_restore_mode {
+                MemoryRestoreMode::OnDemand => mm.lock().unwrap().restore_by_uffd(
                     &memory_file_path,
                     &mem_snapshot.memory_ranges,
                     exit_evt,
-                )?;
-            } else {
-                mm.lock()
+                )?,
+                MemoryRestoreMode::CopyOnWrite => mm
+                    .lock()
                     .unwrap()
-                    .fill_saved_regions(memory_file_path, &mem_snapshot.memory_ranges)?;
+                    .mmap_cow_saved_regions(memory_file_path, &mem_snapshot.memory_ranges)?,
+                MemoryRestoreMode::Copy => mm
+                    .lock()
+                    .unwrap()
+                    .fill_saved_regions(memory_file_path, &mem_snapshot.memory_ranges)?,
             }
 
             Ok(mm)
@@ -3494,5 +3536,219 @@ impl Migratable for MemoryManager {
             table.extend(sub_table);
         }
         Ok(table)
+    }
+}
+
+// Reports whether every saved range is page-aligned and lies wholly inside a
+// single plain private-anonymous guest region — the MAP_FIXED overlay
+// preconditions. File-backed regions are rejected: their stale mapping
+// metadata would misdirect a later snapshot or fd consumer.
+fn is_restore_cow_compatible(
+    guest_memory: &GuestMemoryMmap,
+    saved_regions: &MemoryRangeTable,
+) -> bool {
+    // SAFETY: sysconf(_SC_PAGESIZE) has no failure mode relevant here.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
+    let mut file_offset: u64 = 0;
+    for range in saved_regions.regions() {
+        if !file_offset.is_multiple_of(page_size)
+            || !range.gpa.is_multiple_of(page_size)
+            || !range.length.is_multiple_of(page_size)
+        {
+            return false;
+        }
+        let Some(end) = range.gpa.checked_add(range.length) else {
+            return false;
+        };
+        let ok = guest_memory
+            .find_region(GuestAddress(range.gpa))
+            .is_some_and(|r| {
+                r.file_offset().is_none() && end <= r.start_addr().raw_value() + r.len()
+            });
+        if !ok {
+            return false;
+        }
+        let Some(next) = file_offset.checked_add(range.length) else {
+            return false;
+        };
+        file_offset = next;
+    }
+    true
+}
+
+// Maps each saved range over its guest RAM window, re-applying the owning
+// region's reserve policy and the THP policy. Ranges must have passed
+// `is_restore_cow_compatible`.
+fn do_mmap_cow_saved_regions(
+    guest_memory: &GuestMemoryMmap,
+    memory_file: &File,
+    saved_regions: &MemoryRangeTable,
+    thp: bool,
+) -> Result<(), Error> {
+    let mut file_offset: u64 = 0;
+    for range in saved_regions.regions() {
+        // Zones map with their own reserve setting, so take MAP_NORESERVE
+        // from the region actually backing this range rather than from the
+        // global memory config.
+        let reserve_flag = guest_memory
+            .find_region(GuestAddress(range.gpa))
+            .map(|region| region.flags() & libc::MAP_NORESERVE)
+            .ok_or_else(|| {
+                Error::SnapshotMmap(io::Error::other("saved range outside guest memory"))
+            })?;
+        let host_addr = guest_memory
+            .get_host_address(GuestAddress(range.gpa))
+            .map_err(|e| Error::SnapshotMmap(io::Error::other(e)))?;
+        let length = range.length as usize;
+        // SAFETY: the window is page-aligned, wholly inside a live private
+        // anonymous region nothing consumes yet, so the MAP_FIXED replacement
+        // cannot clobber foreign mappings. The fd stays valid for the call.
+        let ret = unsafe {
+            libc::mmap(
+                host_addr.cast(),
+                length,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_FIXED | reserve_flag,
+                memory_file.as_raw_fd(),
+                file_offset as libc::off_t,
+            )
+        };
+        if ret == libc::MAP_FAILED {
+            return Err(Error::SnapshotMmap(io::Error::last_os_error()));
+        }
+        if thp {
+            // SAFETY: ret/length name the private mapping just installed above.
+            let adv = unsafe { libc::madvise(ret, length, libc::MADV_HUGEPAGE) };
+            if adv != 0 {
+                warn!(
+                    "Restore (mode=copyonwrite): MADV_HUGEPAGE failed: {}",
+                    io::Error::last_os_error()
+                );
+            }
+        }
+        file_offset = file_offset.checked_add(range.length).ok_or_else(|| {
+            Error::SnapshotMmap(io::Error::other("snapshot range file offset overflow"))
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    use vm_migration::protocol::{MemoryRange, MemoryRangeTable};
+
+    use super::*;
+
+    fn page_size() -> u64 {
+        // SAFETY: sysconf(_SC_PAGESIZE) has no failure mode relevant here.
+        unsafe { libc::sysconf(libc::_SC_PAGESIZE) as u64 }
+    }
+
+    #[test]
+    fn cow_restore_maps_data_and_reads_holes_as_zero() {
+        let page = page_size();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), (2 * page) as usize)]).unwrap();
+
+        let mut file = tempfile::tempfile().unwrap();
+        file.write_all(&vec![0xabu8; page as usize]).unwrap();
+        file.set_len(2 * page).unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+
+        let mut table = MemoryRangeTable::default();
+        table.push(MemoryRange {
+            gpa: 0,
+            length: 2 * page,
+        });
+
+        assert!(is_restore_cow_compatible(&gm, &table));
+        do_mmap_cow_saved_regions(&gm, &file, &table, false).unwrap();
+
+        assert_eq!(gm.read_obj::<u8>(GuestAddress(0)).unwrap(), 0xab);
+        assert_eq!(gm.read_obj::<u8>(GuestAddress(page - 1)).unwrap(), 0xab);
+        assert_eq!(gm.read_obj::<u8>(GuestAddress(page)).unwrap(), 0);
+        assert_eq!(gm.read_obj::<u8>(GuestAddress(2 * page - 1)).unwrap(), 0);
+
+        // Copy-on-write: guest writes must not reach the file.
+        gm.write_obj::<u8>(0x5a, GuestAddress(0)).unwrap();
+        let mut back = [0u8; 1];
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.read_exact(&mut back).unwrap();
+        assert_eq!(back[0], 0xab);
+    }
+
+    #[test]
+    fn cow_restore_rejects_unaligned_or_out_of_region_ranges() {
+        let page = page_size();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), page as usize)]).unwrap();
+
+        let mut unaligned = MemoryRangeTable::default();
+        unaligned.push(MemoryRange {
+            gpa: 1,
+            length: page,
+        });
+        assert!(!is_restore_cow_compatible(&gm, &unaligned));
+
+        let mut spanning = MemoryRangeTable::default();
+        spanning.push(MemoryRange {
+            gpa: 0,
+            length: 2 * page,
+        });
+        assert!(!is_restore_cow_compatible(&gm, &spanning));
+    }
+
+    #[test]
+    fn cow_restore_rejects_file_backed_region() {
+        let page = page_size();
+        let backing = tempfile::tempfile().unwrap();
+        backing.set_len(page).unwrap();
+        let region = MmapRegion::build(
+            Some(FileOffset::new(backing, 0)),
+            page as usize,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED,
+        )
+        .unwrap();
+        let gm = GuestMemoryMmap::from_regions(vec![
+            GuestRegionMmap::new(region, GuestAddress(0)).unwrap(),
+        ])
+        .unwrap();
+
+        let mut table = MemoryRangeTable::default();
+        table.push(MemoryRange {
+            gpa: 0,
+            length: page,
+        });
+        assert!(!is_restore_cow_compatible(&gm, &table));
+    }
+
+    #[test]
+    fn cow_restore_honors_region_reserve_and_thp() {
+        let page = page_size();
+        let mut file = tempfile::tempfile().unwrap();
+        file.write_all(&vec![0xcdu8; page as usize]).unwrap();
+
+        for extra_flags in [0, libc::MAP_NORESERVE] {
+            let region = MmapRegion::build(
+                None,
+                page as usize,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | extra_flags,
+            )
+            .unwrap();
+            let gm = GuestMemoryMmap::from_regions(vec![
+                GuestRegionMmap::new(region, GuestAddress(0)).unwrap(),
+            ])
+            .unwrap();
+
+            let mut table = MemoryRangeTable::default();
+            table.push(MemoryRange {
+                gpa: 0,
+                length: page,
+            });
+            do_mmap_cow_saved_regions(&gm, &file, &table, true).unwrap();
+            assert_eq!(gm.read_obj::<u8>(GuestAddress(0)).unwrap(), 0xcd);
+        }
     }
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -529,6 +529,38 @@ pub fn physical_bits(hypervisor: &dyn hypervisor::Hypervisor, max_phys_bits: u8)
     cmp::min(host_phys_bits, max_phys_bits)
 }
 
+// Whether the VM configuration supports the copy-on-write restore path at
+// runtime. Consumers that rely on guest RAM staying anonymous (DMA pinning,
+// MADV_DONTNEED zeroing, KSM, per-zone reserve/NUMA replay) keep the eager
+// copy. Shared and hugepage zones are already rejected per region.
+fn is_restore_cow_supported(config: &VmConfig) -> bool {
+    let mem = &config.memory;
+    // vDPA dma-maps guest RAM into the vhost-vdpa IOTLB, pinning host pages the
+    // same way VFIO does, so it also needs the anonymous eager-copy mapping.
+    let passthrough = config.devices.as_ref().is_some_and(|d| !d.is_empty())
+        || config.user_devices.as_ref().is_some_and(|d| !d.is_empty())
+        || config.vdpa.as_ref().is_some_and(|d| !d.is_empty());
+    // pvmemcontrol madvises guest RAM as if anonymous.
+    #[cfg(feature = "pvmemcontrol")]
+    let pvmemcontrol = config.pvmemcontrol.is_some();
+    #[cfg(not(feature = "pvmemcontrol"))]
+    let pvmemcontrol = false;
+    let unsupported_zone = mem.zones.as_ref().is_some_and(|zones| {
+        zones.iter().any(|z| {
+            z.host_numa_node.is_some()
+                || z.hotplug_size.is_some()
+                || z.hotplugged_size.is_some()
+                || z.reserve
+                || z.mergeable
+        })
+    });
+    !(passthrough
+        || pvmemcontrol
+        || mem.mergeable
+        || mem.hotplug_size.is_some()
+        || unsupported_zone)
+}
+
 /// Guest clock baseline captured for snapshot/restore, plus how it must be
 /// re-established on the next resume. `mode` is runtime-only (`SnapshotRestore`
 /// after restore/migration-receive, `SameHostResume` for a live same-host capture)
@@ -1400,6 +1432,16 @@ impl Vm {
             vm_config.lock().unwrap().cpus.max_phys_bits,
         );
 
+        let mut memory_restore_mode = memory_restore_mode.unwrap_or_default();
+        if memory_restore_mode == MemoryRestoreMode::CopyOnWrite
+            && !is_restore_cow_supported(&vm_config.lock().unwrap())
+        {
+            warn!(
+                "Restore (mode=copyonwrite): requires non-resizable private RAM without passthrough, NUMA binding or KSM, falling back to copy"
+            );
+            memory_restore_mode = MemoryRestoreMode::Copy;
+        }
+
         let memory_manager =
             if let Some(snapshot) = snapshot_from_id(snapshot, MEMORY_MANAGER_SNAPSHOT_ID) {
                 MemoryManager::new_from_snapshot(
@@ -1408,7 +1450,7 @@ impl Vm {
                     &vm_config.lock().unwrap().memory.clone(),
                     source_url,
                     prefault.unwrap_or(false),
-                    memory_restore_mode.unwrap_or_default(),
+                    memory_restore_mode,
                     phys_bits,
                     &exit_evt,
                 )


### PR DESCRIPTION
## What

Adds a third `memory_restore_mode` value, `mmap`: restore guest RAM by mapping the snapshot memory file copy-on-write over the still-unconsumed private anonymous guest mappings. Nothing is copied up front, pages fault in from the page cache — so VMs restored from the same snapshot share it — and guest writes stay private per VM (MAP_PRIVATE). Opt-in; the default `copy` path is byte-for-byte unchanged.

The target workload is fleet-style restore: many VMs brought up concurrently from one snapshot. There the eager copy is bandwidth-bound (N full copies of guest RAM), and `ondemand` shifts the cost to serialized userfaultfd page service; a CoW mapping keeps a single copy of the snapshot in page cache across all restored VMs.

## Relation to the earlier decisions about mmap restore

Two prior decisions rejected mmap-based restore, both for concrete reasons that this implementation does not trigger:

1. **Removal of the original CoW restore (a60b437f8, 2020)** gave two reasons:
   - *The snapshot file stays pinned by the mapping.* This mode makes that an explicit, documented, opt-in contract — the same shape as the `ondemand` mode's existing "snapshot file must remain on disk" requirement, with the stronger "and unchanged" clause documented.
   - *A second snapshot could silently skip file-backed regions.* The sparse-writer skip in today's code requires a MAP_SHARED mapping whose backing file identity matches; the MAP_PRIVATE overlay never satisfies it, so a re-snapshot of an mmap-restored VM densely copies actual guest memory (CoW view) — the 2020 failure mechanism no longer exists in the current writer.

2. **The mmap alternative considered during the on-demand restore work (#7800)** was rejected because an mmap *replacement* breaks mapping identity for consumers that already hold the original mapping — KVM memslots, VFIO DMA pinning, vhost-user shared memory. This implementation does not overlay an already-consumed mapping: the overlay happens in `MemoryManager::new_from_snapshot`, before any KVM memslot is registered and before any device is constructed, so at that point nothing holds the mapping. Consumers that later rely on guest RAM being anonymous or fd-identified are excluded up front and fall back to the eager copy:
   - per region: anything file/memfd-backed (shared or hugepage RAM, global or per-zone) is rejected via `file_offset()`;
   - per config: device passthrough (`--device`/`--user-device`), `--pvmemcontrol`, KSM (`mergeable=on`), resizable RAM (`hotplug_size`), and zones with numa/reserve/mergeable/hotplug attributes. A purely static `id`+`size` zone takes the mmap path.

`ondemand` and `mmap` are complementary rather than competing: `ondemand` preserves anonymous mappings (device-passthrough-compatible) for lazy single-VM restore; `mmap` targets many-VMs-from-one-snapshot density where page cache sharing is the win.

## Safety details

- A snapshot memory file shorter than the saved ranges is rejected before any mapping (a range mapped past EOF would otherwise SIGBUS at run time, not restore time).
- Ranges must be page-aligned single-region extents (validated; falls back to copy otherwise).
- `reserve` and THP policy are re-applied to the overlaid region; `prefault` is rejected (as for `ondemand`).
- Arithmetic on range offsets is checked.
- Documented in `docs/snapshot_restore.md`, including that the file-immutability requirement is stronger than `ondemand`'s.

## Measurements

16-core x86_64 host, 512 MiB guests, same binary with only `memory_restore_mode` switched, 3 interleaved rounds:

| | `copy` | `mmap` |
|---|---|---|
| single restore p50 | 54–58 ms | 22–35 ms |
| 16 concurrent restores from one snapshot, per-restore p50 | 443–463 ms | 72–82 ms |
| 16 concurrent restores, wall | 456–478 ms | 87–108 ms |

Restored VMs boot and run normally in all modes.

## Tests

Four unit tests in `memory_manager.rs`: CoW mapping content + holes read as zero + writes do not reach the file; file-backed regions rejected; unaligned/region-spanning ranges rejected; reserve/THP path. `cargo fmt`, `cargo clippy --all-targets -- -D warnings` (with and without `pvmemcontrol`) and `cargo test -p vmm` are clean on this branch. Happy to add an integration test in the CI framework if that is preferred for merging.
