### PR TITLE
vmm, hypervisor: Clean up KVM SEV-SNP page type logic

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -785,11 +785,6 @@ impl vm::Vm for KvmVm {
             return Ok(());
         }
         assert_eq!(pfns.len(), uaddrs.len());
-        // VMSA pages are not supported by launch_update
-        // https://elixir.bootlin.com/linux/v6.11/source/arch/x86/kvm/svm/sev.c#L2377
-        if page_type == sev::SNP_PAGE_TYPE_VMSA {
-            return Ok(());
-        }
         for i in 0..pfns.len() {
             self.fd
                 .set_memory_attributes(kvm_memory_attributes {

--- a/hypervisor/src/kvm/x86_64/sev.rs
+++ b/hypervisor/src/kvm/x86_64/sev.rs
@@ -23,8 +23,6 @@ const KVM_SEV_INIT2: u32 = 22;
 const KVM_SEV_SNP_LAUNCH_START: u32 = 100;
 const KVM_SEV_SNP_LAUNCH_UPDATE: u32 = 101;
 const KVM_SEV_SNP_LAUNCH_FINISH: u32 = 102;
-// SNP_LAUNCH_UPDATE page types — linux/arch/x86/include/uapi/asm/sev-guest.h
-pub const SNP_PAGE_TYPE_VMSA: u32 = 2;
 
 // See AMD Spec Section 8.17 — SNP_LAUNCH_UPDATE
 // The last 12 bits are metadata about the guest context

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -12,6 +12,11 @@ use std::sync::{Arc, Mutex};
 use std::{ffi, io};
 
 use hypervisor::HypervisorType;
+#[cfg(feature = "kvm")]
+use hypervisor::kvm::kvm_bindings::{
+    KVM_SEV_SNP_PAGE_TYPE_CPUID, KVM_SEV_SNP_PAGE_TYPE_NORMAL, KVM_SEV_SNP_PAGE_TYPE_SECRETS,
+    KVM_SEV_SNP_PAGE_TYPE_UNMEASURED, KVM_SEV_SNP_PAGE_TYPE_ZERO,
+};
 #[cfg(feature = "sev_snp")]
 use igvm::IgvmInitializationHeader;
 use igvm::snp_defs::SevVmsa;
@@ -123,18 +128,6 @@ pub enum Error {
         hash_end: u64,
     },
 }
-
-// KVM SNP page types — linux/arch/x86/include/uapi/asm/sev-guest.h
-#[cfg(feature = "kvm")]
-const KVM_SNP_PAGE_TYPE_NORMAL: u32 = 1;
-#[cfg(feature = "kvm")]
-const KVM_SNP_PAGE_TYPE_ZERO: u32 = 3;
-#[cfg(feature = "kvm")]
-const KVM_SNP_PAGE_TYPE_UNMEASURED: u32 = 4;
-#[cfg(feature = "kvm")]
-const KVM_SNP_PAGE_TYPE_SECRETS: u32 = 5;
-#[cfg(feature = "kvm")]
-const KVM_SNP_PAGE_TYPE_CPUID: u32 = 6;
 
 // Consolidated page type/size configuration per hypervisor.
 struct PageTypeConfig {
@@ -289,11 +282,11 @@ pub fn load_igvm(
         #[cfg(feature = "kvm")]
         HypervisorType::Kvm => PageTypeConfig {
             isolated_page_size_4kb: HV_PAGE_SIZE as u32,
-            normal: KVM_SNP_PAGE_TYPE_NORMAL,
-            zero: KVM_SNP_PAGE_TYPE_ZERO,
-            unmeasured: KVM_SNP_PAGE_TYPE_UNMEASURED,
-            cpuid: KVM_SNP_PAGE_TYPE_CPUID,
-            secrets: KVM_SNP_PAGE_TYPE_SECRETS,
+            normal: KVM_SEV_SNP_PAGE_TYPE_NORMAL,
+            zero: KVM_SEV_SNP_PAGE_TYPE_ZERO,
+            unmeasured: KVM_SEV_SNP_PAGE_TYPE_UNMEASURED,
+            cpuid: KVM_SEV_SNP_PAGE_TYPE_CPUID,
+            secrets: KVM_SEV_SNP_PAGE_TYPE_SECRETS,
             // KVM doesn't import a VMSA page, it instead constructs it internally
             vmsa: None,
         },

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -128,8 +128,6 @@ pub enum Error {
 #[cfg(feature = "kvm")]
 const KVM_SNP_PAGE_TYPE_NORMAL: u32 = 1;
 #[cfg(feature = "kvm")]
-const KVM_SNP_PAGE_TYPE_VMSA: u32 = 2;
-#[cfg(feature = "kvm")]
 const KVM_SNP_PAGE_TYPE_ZERO: u32 = 3;
 #[cfg(feature = "kvm")]
 const KVM_SNP_PAGE_TYPE_UNMEASURED: u32 = 4;
@@ -147,7 +145,7 @@ struct PageTypeConfig {
     unmeasured: u32,
     cpuid: u32,
     secrets: u32,
-    vmsa: u32,
+    vmsa: Option<u32>,
 }
 
 #[derive(Copy, Clone)]
@@ -277,7 +275,7 @@ pub fn load_igvm(
     #[cfg(feature = "sev_snp")] host_data: &Option<String>,
 ) -> Result<Box<IgvmLoadedInfo>, Error> {
     let hypervisor_type = cpu_manager.lock().unwrap().hypervisor_type();
-    let page_types = match hypervisor_type {
+    let page_types: PageTypeConfig = match hypervisor_type {
         #[cfg(feature = "mshv")]
         HypervisorType::Mshv => PageTypeConfig {
             isolated_page_size_4kb: mshv_bindings::hv_isolated_page_size_HV_ISOLATED_PAGE_SIZE_4KB,
@@ -286,7 +284,7 @@ pub fn load_igvm(
             unmeasured: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_UNMEASURED,
             cpuid: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_CPUID,
             secrets: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_SECRETS,
-            vmsa: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_VMSA,
+            vmsa: Some(mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_VMSA),
         },
         #[cfg(feature = "kvm")]
         HypervisorType::Kvm => PageTypeConfig {
@@ -296,7 +294,8 @@ pub fn load_igvm(
             unmeasured: KVM_SNP_PAGE_TYPE_UNMEASURED,
             cpuid: KVM_SNP_PAGE_TYPE_CPUID,
             secrets: KVM_SNP_PAGE_TYPE_SECRETS,
-            vmsa: KVM_SNP_PAGE_TYPE_VMSA,
+            // KVM doesn't import a VMSA page, it instead constructs it internally
+            vmsa: None,
         },
     };
 
@@ -627,11 +626,13 @@ pub fn load_igvm(
                     }
                 }
 
-                gpas.push(GpaPages {
-                    gpa: *gpa,
-                    page_type: page_types.vmsa,
-                    page_size: page_types.isolated_page_size_4kb,
-                });
+                if let Some(vmsa_page_type) = page_types.vmsa {
+                    gpas.push(GpaPages {
+                        gpa: *gpa,
+                        page_type: vmsa_page_type,
+                        page_size: page_types.isolated_page_size_4kb,
+                    });
+                }
             }
             IgvmDirectiveHeader::SnpIdBlock {
                 compatibility_mask,


### PR DESCRIPTION
#### Summary
This PR adds some small improvements to the page type logic for KVM SEV-SNP implementation:
1. First, we clean up the logic with the VMSA page type. KVM sets up VMSA itself, and the logic we have for passing it around from igvm_loader is misleading. So we just make vmsa optional and use it in the MSHV path only.
2. kvm-bindings already specifies the page types, so we don't need to hardcode these.

#### Testing
```
scripts/dev_cli.sh tests --integration-cvm --hypervisor kvm
...
Summary [ 323.456s] 39 tests run: 39 passed (2 slow), 292 skipped
```