### PR TITLE
ci: Bump virtio-villain to v0.5.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -854,7 +854,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VILLAIN_REPO: https://github.com/weltling/virtio-villain.git
-      VILLAIN_REF: v0.5.0
+      VILLAIN_REF: v0.5.2
     steps:
       - name: Code checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
The S0094 state test could be reported as WEDGED when the host per test timeout killed the VM before the guest finished its wait, dropping the verdict marker. v0.5.2 accepts that timeout case as a pass since the device does not consume the buffer before DRIVER_OK.

Other changes since v0.5.0 reduce unrelated flakes in the suite through test timing fixes for V0038, T0097 and N0130 and by excluding XFAIL tests from batching.