### PR TITLE
build: Bump vm-memory and dependents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
+checksum = "d54207cb617cd75b10c57ad20235c914ab62b180ceeff2ef3111983670d3b321"
 dependencies = [
  "vm-memory",
 ]
@@ -2555,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "vfio-ioctls"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b1110f3ab5703a0f788d569b1b4a2436e8cc434f384b3ef5d77283f8ee03d8"
+checksum = "a22f93a7f6cc51b8671b9282ed6487b0c905890be20ffa4a26835d2652a7c638"
 dependencies = [
  "byteorder",
  "iommufd-bindings",
@@ -2576,11 +2587,12 @@ dependencies = [
 
 [[package]]
 name = "vfio_user"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731c2582dd43f4f174ab47b4c933a1a9bb872d9d1b7f54c5867e12dbc1491b75"
+checksum = "d39bb422ac00cd1d670dc0135c7b32f0a17125b47317d26e442931908c8dbf4a"
 dependencies = [
  "bitflags 2.13.0",
+ "enumn",
  "libc",
  "log",
  "serde",
@@ -2594,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee90657203a8644e9a0860a0db6a7887d8ef0c7bc09fc22dfa4ae75df65bac86"
+checksum = "1c63c14485260662b4257bd929d5fd4aaf96bbecbe61d2224bad8807849f5f8f"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
@@ -2607,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5925983d8fb537752ad3e26604c0a17abfa5de77cb6773a096c8a959c9eca0f"
+checksum = "555753b65bc33837bd011f981e2c6d52d8ddc330d92c2deb9aa3f0b378a58bcc"
 dependencies = [
  "libc",
  "log",
@@ -2699,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e358084f32ed165fddb41d98ff1b7ff3c08b9611d8d6114a1b422e2e85688baf"
+checksum = "f631bfd09362a9b17f0cfd5ca3b0a1b179d153fa276f9ce86919d560891e61d6"
 dependencies = [
  "libc",
  "log",
@@ -2740,9 +2752,9 @@ checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
 
 [[package]]
 name = "vm-memory"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
+checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,19 +57,19 @@ acpi_tables = "0.2.1"
 iommufd-ioctls = "0.2.0"
 kvm-bindings = "0.14.1"
 kvm-ioctls = "0.25.0"
-linux-loader = "0.13.2"
+linux-loader = "0.14.0"
 mshv-bindings = "0.6.9"
 mshv-ioctls = "0.6.9"
 seccompiler = "0.5.0"
 vfio-bindings = { version = "0.6.2", default-features = false }
-vfio-ioctls = { version = "0.7.0", default-features = false }
-vfio_user = { version = "0.1.3", default-features = false }
-vhost = { version = "0.16.0", default-features = false }
-vhost-user-backend = { version = "0.22.0", default-features = false }
+vfio-ioctls = { version = "0.8.0", default-features = false }
+vfio_user = { version = "0.1.4", default-features = false }
+vhost = { version = "0.17.0", default-features = false }
+vhost-user-backend = { version = "0.23.0", default-features = false }
 virtio-bindings = "0.2.6"
-virtio-queue = "0.17.0"
+virtio-queue = "0.18.0"
 vm-fdt = "0.3.0"
-vm-memory = "0.17.1"
+vm-memory = "0.18.0"
 vmm-sys-util = "0.15.0"
 
 # igvm crates

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -23,7 +23,7 @@ use hypervisor::arch::aarch64::regs::{
 use log::{debug, info};
 use thiserror::Error;
 use vm_fdt::{FdtWriter, FdtWriterResult};
-use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError, GuestMemoryRegion};
+use vm_memory::{Address, Bytes, GuestMemoryBackend, GuestMemoryError, GuestMemoryRegion};
 
 use super::super::{DeviceType, GuestMemoryMmap, InitramfsConfig};
 use super::cache::{CacheTopologyInfo, read_cache_topology};
@@ -397,14 +397,14 @@ fn create_memory_node(
             }
         }
     } else {
-        // Note: memory regions from "GuestMemory" are sorted and non-zero sized.
+        // Note: memory regions from "GuestMemoryBackend" are sorted and non-zero sized.
         let ram_regions = {
             let mut ram_regions = Vec::new();
             let mut current_start = guest_mem
                 .iter()
                 .next()
                 .map(GuestMemoryRegion::start_addr)
-                .expect("GuestMemory must have one memory region at least")
+                .expect("GuestMemoryBackend must have one memory region at least")
                 .raw_value();
             let mut current_end = current_start;
 

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -20,7 +20,7 @@ use hypervisor::arch::aarch64::gic::Vgic;
 use hypervisor::arch::aarch64::regs::MPIDR_EL1;
 use log::{Level, log_enabled};
 use thiserror::Error;
-use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryAtomic};
+use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryBackend};
 
 pub use self::fdt::DeviceInfoForFdt;
 use crate::{DeviceType, GuestMemoryMmap, NumaNodes, PciSpaceInfo, RegionType};

--- a/arch/src/riscv64/fdt.rs
+++ b/arch/src/riscv64/fdt.rs
@@ -18,7 +18,7 @@ use hypervisor::arch::riscv64::aia::Vaia;
 use log::debug;
 use thiserror::Error;
 use vm_fdt::{FdtWriter, FdtWriterResult};
-use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError, GuestMemoryRegion};
+use vm_memory::{Address, Bytes, GuestMemoryBackend, GuestMemoryError, GuestMemoryRegion};
 
 use super::super::{DeviceType, GuestMemoryMmap, InitramfsConfig};
 use super::layout::{
@@ -151,14 +151,14 @@ fn create_cpu_nodes(
 }
 
 fn create_memory_node(fdt: &mut FdtWriter, guest_mem: &GuestMemoryMmap) -> FdtWriterResult<()> {
-    // Note: memory regions from "GuestMemory" are sorted and non-zero sized.
+    // Note: memory regions from "GuestMemoryBackend" are sorted and non-zero sized.
     let ram_regions = {
         let mut ram_regions = Vec::new();
         let mut current_start = guest_mem
             .iter()
             .next()
             .map(GuestMemoryRegion::start_addr)
-            .expect("GuestMemory must have one memory region at least")
+            .expect("GuestMemoryBackend must have one memory region at least")
             .raw_value();
         let mut current_end = current_start;
 

--- a/arch/src/riscv64/mod.rs
+++ b/arch/src/riscv64/mod.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex};
 use hypervisor::arch::riscv64::aia::Vaia;
 use log::{Level, log_enabled};
 use thiserror::Error;
-use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryAtomic};
+use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryBackend};
 
 pub use self::fdt::DeviceInfoForFdt;
 use crate::{DeviceType, GuestMemoryMmap, PciSpaceInfo, RegionType};

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -33,7 +33,7 @@ use log::{debug, error, info};
 pub use smbios::{SmbiosChassisConfig, SmbiosConfig, SmbiosSystem};
 use thiserror::Error;
 use vm_memory::{
-    Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
+    Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend,
     GuestMemoryRegion,
 };
 use vmm_sys_util::fam;
@@ -1030,9 +1030,9 @@ pub fn configure_vcpu(
 
 /// Returns a Vec of the valid memory addresses.
 ///
-/// These should be used to configure the GuestMemory structure for the platform.
-/// For x86_64 all addresses are valid from the start of the kernel except a
-/// carve out at the end of 32bit address space.
+/// These should be used to configure the GuestMemoryBackend structure for the
+/// platform. For x86_64 all addresses are valid from the start of the kernel
+/// except a carve out at the end of 32bit address space.
 pub fn arch_memory_regions() -> Vec<(GuestAddress, usize, RegionType)> {
     vec![
         // 0 GiB ~ 3GiB: memory before the gap
@@ -1116,14 +1116,14 @@ type RamRange = (u64, u64);
 /// These should be used to create e820_RAM memory maps
 pub fn generate_ram_ranges(guest_mem: &GuestMemoryMmap) -> super::Result<Vec<RamRange>> {
     // Merge continuous memory regions into one region.
-    // Note: memory regions from "GuestMemory" are sorted and non-zero sized.
+    // Note: memory regions from "GuestMemoryBackend" are sorted and non-zero sized.
     let ram_regions = {
         let mut ram_regions = Vec::new();
         let mut current_start = guest_mem
             .iter()
             .next()
             .map(GuestMemoryRegion::start_addr)
-            .expect("GuestMemory must have one memory region at least")
+            .expect("GuestMemoryBackend must have one memory region at least")
             .raw_value();
         let mut current_end = current_start;
 
@@ -1392,7 +1392,7 @@ fn add_e820_entry(
 
     params.e820_table[params.e820_entries as usize].addr = addr;
     params.e820_table[params.e820_entries as usize].size = size;
-    params.e820_table[params.e820_entries as usize].type_ = mem_type;
+    params.e820_table[params.e820_entries as usize].r#type = mem_type;
     params.e820_entries += 1;
 
     Ok(())
@@ -1688,7 +1688,7 @@ mod unit_tests {
         let e820_table = [(boot_e820_entry {
             addr: 0x1,
             size: 4,
-            type_: 1,
+            r#type: 1,
         }); 128];
 
         let expected_params = boot_params {
@@ -1702,7 +1702,7 @@ mod unit_tests {
             &mut params,
             e820_table[0].addr,
             e820_table[0].size,
-            e820_table[0].type_,
+            e820_table[0].r#type,
         )
         .unwrap();
         assert_eq!(
@@ -1718,7 +1718,7 @@ mod unit_tests {
             &mut params,
             e820_table[0].addr,
             e820_table[0].size,
-            e820_table[0].type_,
+            e820_table[0].r#type,
         )
         .unwrap_err();
     }

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -10,7 +10,7 @@ use std::result;
 use libc::c_uchar;
 use log::{info, warn};
 use thiserror::Error;
-use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError};
+use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryError};
 
 use super::MAX_SUPPORTED_CPUS_LEGACY;
 use crate::GuestMemoryMmap;

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -12,7 +12,7 @@ use hypervisor::arch::x86::gdt::{gdt_entry, segment_from_gdt};
 use hypervisor::arch::x86::regs::CR0_PE;
 use hypervisor::arch::x86::{FpuState, SpecialRegisters};
 use thiserror::Error;
-use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError};
+use vm_memory::{Address, Bytes, GuestMemoryBackend, GuestMemoryError};
 
 use crate::layout::{
     BOOT_GDT_START, BOOT_IDT_START, BOOT_STACK_POINTER, PVH_INFO_START, ZERO_PAGE_START,

--- a/block/src/io/async_io/guest_memory_target.rs
+++ b/block/src/io/async_io/guest_memory_target.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 
 use smallvec::SmallVec;
 use vm_memory::bitmap::Bitmap;
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
+use vm_memory::{
+    Address, Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryError, GuestMemoryMmap,
+};
 
 trait GuestMemoryTargetOwner: Send + Sync {
     fn iovec_for_range(

--- a/block/src/io/request.rs
+++ b/block/src/io/request.rs
@@ -24,7 +24,7 @@ use virtio_bindings::virtio_blk::{
 use virtio_queue::DescriptorChain;
 use vm_memory::bitmap::Bitmap;
 use vm_memory::{
-    Address as _, Bytes as _, GuestAddress, GuestMemory as _, GuestMemoryError,
+    Address as _, Bytes as _, GuestAddress, GuestMemoryBackend as _, GuestMemoryError,
     GuestMemoryLoadGuard,
 };
 use vm_virtio::AccessPlatform;

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -41,7 +41,7 @@ pub use sparse::{BLKDISCARD, BLKZEROOUT};
 use thiserror::Error;
 use virtio_bindings::virtio_blk::*;
 use vm_memory::bitmap::Bitmap;
-use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError};
+use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryError};
 use vmm_sys_util::{aio, ioctl_io_nr, ioctl_ior_nr};
 
 use crate::async_io::AsyncIoError;

--- a/devices/src/pvmemcontrol.rs
+++ b/devices/src/pvmemcontrol.rs
@@ -21,8 +21,8 @@ use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::{BusDeviceSync, Resource};
 use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::{
-    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
-    GuestMemoryError, GuestMemoryMmap, Le32, Le64,
+    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
+    GuestMemoryBackend, GuestMemoryError, GuestMemoryMmap, Le32, Le64,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -430,6 +430,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "epoll"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
+checksum = "d54207cb617cd75b10c57ad20235c914ab62b180ceeff2ef3111983670d3b321"
 dependencies = [
  "vm-memory",
 ]
@@ -1460,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "vfio-ioctls"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b1110f3ab5703a0f788d569b1b4a2436e8cc434f384b3ef5d77283f8ee03d8"
+checksum = "a22f93a7f6cc51b8671b9282ed6487b0c905890be20ffa4a26835d2652a7c638"
 dependencies = [
  "byteorder",
  "iommufd-bindings",
@@ -1479,11 +1490,12 @@ dependencies = [
 
 [[package]]
 name = "vfio_user"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731c2582dd43f4f174ab47b4c933a1a9bb872d9d1b7f54c5867e12dbc1491b75"
+checksum = "d39bb422ac00cd1d670dc0135c7b32f0a17125b47317d26e442931908c8dbf4a"
 dependencies = [
  "bitflags 2.13.0",
+ "enumn",
  "libc",
  "log",
  "serde",
@@ -1497,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee90657203a8644e9a0860a0db6a7887d8ef0c7bc09fc22dfa4ae75df65bac86"
+checksum = "1c63c14485260662b4257bd929d5fd4aaf96bbecbe61d2224bad8807849f5f8f"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
@@ -1548,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e358084f32ed165fddb41d98ff1b7ff3c08b9611d8d6114a1b422e2e85688baf"
+checksum = "f631bfd09362a9b17f0cfd5ca3b0a1b179d153fa276f9ce86919d560891e61d6"
 dependencies = [
  "libc",
  "log",
@@ -1589,9 +1601,9 @@ checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
 
 [[package]]
 name = "vm-memory"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
+checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
 dependencies = [
  "arc-swap",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -23,15 +23,15 @@ epoll = "4.4.0"
 hypervisor = { path = "../hypervisor", features = ["mshv_emulator"] }
 libc = "0.2.186"
 libfuzzer-sys = "0.4.12"
-linux-loader = { version = "0.13.2", features = ["bzimage", "elf", "pe"] }
+linux-loader = { version = "0.14.0", features = ["bzimage", "elf", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 mshv-bindings = "0.6.9"
 net_util = { path = "../net_util" }
 seccompiler = "0.5.0"
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.17.0"
+virtio-queue = "0.18.0"
 vm-device = { path = "../vm-device" }
-vm-memory = "0.17.1"
+vm-memory = "0.18.0"
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm = { path = "../vmm", features = ["guest_debug"] }

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -14,7 +14,7 @@ use rate_limiter::{RateLimiter, TokenType};
 use thiserror::Error;
 use virtio_queue::{Queue, QueueOwnedT, QueueT};
 use vm_memory::bitmap::Bitmap;
-use vm_memory::{Bytes, GuestAddress, GuestMemory};
+use vm_memory::{Bytes, GuestAddress, GuestMemoryBackend};
 use vm_virtio::{AccessPlatform, Translatable};
 
 use super::{Tap, register_listener, unregister_listener, vnet_hdr_len};

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -45,8 +45,8 @@ use vm_device::interrupt::{
 use vm_device::{BusDevice, Resource};
 use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::{
-    Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryRegion,
-    GuestUsize,
+    Address, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend,
+    GuestMemoryRegion, GuestUsize,
 };
 
 type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
@@ -2612,7 +2612,10 @@ impl<M: GuestAddressSpace> VfioDmaMapping<M> {
     }
 }
 
-impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M> {
+impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M>
+where
+    M::M: GuestMemoryBackend,
+{
     fn map(&self, iova: u64, gpa: u64, size: u64) -> result::Result<(), io::Error> {
         let Ok(usize_size): Result<usize, _> = size.try_into() else {
             return Err(io::Error::other(format!("size {size} overflows usize")));
@@ -2648,7 +2651,7 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M
         };
 
         // vfio_dma_map is unsound and ought to be marked as unsafe
-        // SAFETY: find_user_address and GuestMemory::get_slice() guarantee that
+        // SAFETY: find_user_address and GuestMemoryBackend::get_slice() guarantee that
         // the returned pointer is valid for up to `usize_size` bytes.
         // `usize_size` is always equal to `size` due to the above `try_into()` call.
         unsafe { self.vfio_ops.vfio_dma_map(iova, size as usize, user_addr) }.map_err(|e| {

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -21,7 +21,8 @@ use vm_device::interrupt::{InterruptManager, InterruptSourceGroup, MsiIrqGroupCo
 use vm_device::{BusDevice, Resource};
 use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::{
-    Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryRegion, GuestRegionMmap,
+    Address, GuestAddress, GuestAddressSpace, GuestMemoryBackend, GuestMemoryRegion,
+    GuestRegionMmap,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
@@ -540,7 +541,10 @@ impl<M: GuestAddressSpace> VfioUserDmaMapping<M> {
     }
 }
 
-impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioUserDmaMapping<M> {
+impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioUserDmaMapping<M>
+where
+    M::M: GuestMemoryBackend,
+{
     fn map(&self, iova: u64, gpa: u64, size: u64) -> result::Result<(), io::Error> {
         let mem = self.memory.memory();
         let guest_addr = GuestAddress(gpa);

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -30,8 +30,8 @@ use thiserror::Error;
 use virtio_queue::{Queue, QueueT};
 use vm_allocator::page_size::{align_page_size_down, get_page_size};
 use vm_memory::{
-    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
-    GuestMemoryError, GuestMemoryRegion,
+    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
+    GuestMemoryBackend, GuestMemoryError, GuestMemoryRegion,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vm_virtio::AccessPlatform;

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -17,8 +17,8 @@ use thiserror::Error;
 use virtio_queue::{DescriptorChain, Queue, QueueT};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
-    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
-    GuestMemoryError, GuestMemoryLoadGuard,
+    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
+    GuestMemoryBackend, GuestMemoryError, GuestMemoryLoadGuard,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vm_virtio::AccessPlatform;

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -38,7 +38,7 @@ pub mod vsock;
 pub mod watchdog;
 
 use vm_memory::bitmap::AtomicBitmap;
-use vm_memory::{GuestAddress, GuestMemory};
+use vm_memory::{GuestAddress, GuestMemoryBackend};
 use vm_virtio::VirtioDeviceType;
 
 pub use self::balloon::Balloon;
@@ -180,12 +180,12 @@ impl TryInto<rate_limiter::RateLimiter> for RateLimiterConfig {
 
 /// Return the host virtual address corresponding to the given guest address range
 ///
-/// Convert an absolute address into an address space (GuestMemory)
+/// Convert an absolute address into an address space (GuestMemoryBackend)
 /// to a host pointer and verify that the provided size defines a valid
 /// range within a single memory region.
 /// Return None if it is out of bounds, spans multiple regions, or has
 /// zero size at an unmapped GPA.
-pub fn get_host_address_range<M: GuestMemory + ?Sized>(
+pub fn get_host_address_range<M: GuestMemoryBackend + ?Sized>(
     mem: &M,
     addr: GuestAddress,
     size: usize,

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -29,8 +29,8 @@ use thiserror::Error;
 use virtio_queue::{DescriptorChain, Queue, QueueT};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
-    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
-    GuestMemoryError, GuestMemoryLoadGuard, GuestMemoryRegion,
+    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
+    GuestMemoryBackend, GuestMemoryError, GuestMemoryLoadGuard, GuestMemoryRegion,
 };
 use vm_migration::protocol::MemoryRangeTable;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -21,7 +21,7 @@ use vhost::{VhostBackend, VringConfigData};
 use virtio_queue::desc::RawDescriptor;
 use virtio_queue::{Queue, QueueT};
 use vm_device::dma_mapping::ExternalDmaMapping;
-use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic};
+use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vm_virtio::{AccessPlatform, Translatable};
 use vmm_sys_util::eventfd::EventFd;
@@ -564,7 +564,10 @@ impl<M: GuestAddressSpace> VdpaDmaMapping<M> {
     }
 }
 
-impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VdpaDmaMapping<M> {
+impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VdpaDmaMapping<M>
+where
+    M::M: GuestMemoryBackend,
+{
     fn map(&self, iova: u64, gpa: u64, size: u64) -> result::Result<(), io::Error> {
         let usize_size = size.try_into().unwrap();
         let mem = self.memory.memory();

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -23,7 +23,7 @@ use vhost::vhost_user::{Error as VhostUserError, FrontendReqHandler, VhostUserFr
 use virtio_queue::{Error as QueueError, Queue};
 use vm_memory::guest_memory::Error as MmapError;
 use vm_memory::mmap::MmapRegionError;
-use vm_memory::{Address, GuestAddressSpace, GuestMemory, GuestMemoryAtomic};
+use vm_memory::{Address, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend};
 use vm_migration::protocol::MemoryRangeTable;
 use vm_migration::{MigratableError, Pausable, Snapshot};
 use vmm_sys_util::eventfd::EventFd;

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -27,7 +27,7 @@ use vhost::{
 use virtio_queue::desc::RawDescriptor;
 use virtio_queue::{Queue, QueueT};
 use vm_memory::guest_memory::Error as MmapError;
-use vm_memory::{Address, FileOffset, GuestAddress, GuestMemory, GuestMemoryRegion};
+use vm_memory::{Address, FileOffset, GuestAddress, GuestMemoryBackend, GuestMemoryRegion};
 use vm_migration::protocol::MemoryRangeTable;
 use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 use vmm_sys_util::eventfd::EventFd;

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -22,7 +22,8 @@ use std::ops::Deref;
 use byteorder::{ByteOrder, LittleEndian};
 use virtio_queue::DescriptorChain;
 use vm_memory::{
-    Address, Bytes, GuestAddress, GuestMemory, ReadVolatile, VolatileMemoryError, WriteVolatile,
+    Address, Bytes, GuestAddress, GuestMemoryBackend, ReadVolatile, VolatileMemoryError,
+    WriteVolatile,
 };
 use vm_virtio::AccessPlatform;
 use vm_virtio::checked_descriptor::DescriptorChainExt;
@@ -502,7 +503,7 @@ impl VsockPacket {
 
     /// Writes the local copy of the packet header to the guest memory.
     ///
-    pub fn commit_hdr<M: GuestMemory>(&mut self, guest_mem: &M) -> Result<()> {
+    pub fn commit_hdr<M: GuestMemoryBackend>(&mut self, guest_mem: &M) -> Result<()> {
         self.validate_len()?;
 
         guest_mem

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -15,7 +15,7 @@ use std::ops::Deref;
 use log::warn;
 use virtio_queue::DescriptorChain;
 use virtio_queue::desc::split::Descriptor;
-use vm_memory::{GuestAddress, GuestMemory};
+use vm_memory::{GuestAddress, GuestMemoryBackend};
 
 use crate::{AccessPlatform, Translatable};
 
@@ -65,7 +65,7 @@ pub struct CheckedDescriptorIter<'a, M> {
 impl<'a, M> CheckedDescriptorIter<'a, M>
 where
     M: Deref,
-    M::Target: GuestMemory,
+    M::Target: GuestMemoryBackend,
 {
     pub fn new(
         chain: &'a mut DescriptorChain<M>,
@@ -82,7 +82,7 @@ where
 impl<M> Iterator for CheckedDescriptorIter<'_, M>
 where
     M: Deref,
-    M::Target: GuestMemory,
+    M::Target: GuestMemoryBackend,
 {
     type Item = Result<CheckedDescriptor, GuestAddress>;
 
@@ -156,7 +156,7 @@ pub trait DescriptorChainExt<M> {
 impl<M> DescriptorChainExt<M> for DescriptorChain<M>
 where
     M: Deref,
-    M::Target: GuestMemory,
+    M::Target: GuestMemoryBackend,
 {
     fn checked_iter<'a>(
         &'a mut self,

--- a/vmm/src/coredump.rs
+++ b/vmm/src/coredump.rs
@@ -194,16 +194,16 @@ const EM_X86_64: u16 = 62;
 pub trait Elf64Writable {
     fn write_header(&mut self, dump_state: &DumpState) -> result::Result<(), GuestDebuggableError> {
         let e_ident = [
-            elf::ELFMAG0 as u8, // magic
+            elf::ELFMAG0, // magic
             elf::ELFMAG1,
             elf::ELFMAG2,
             elf::ELFMAG3,
-            ELFCLASS64,             // class
-            elf::ELFDATA2LSB as u8, //data
-            EV_CURRENT,             // version
-            0,                      // os_abi
-            0,                      // abi_version
-            0,                      // padding
+            ELFCLASS64,       // class
+            elf::ELFDATA2LSB, // data
+            EV_CURRENT,       // version
+            0,                // os_abi
+            0,                // abi_version
+            0,                // padding
             0,
             0,
             0,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -114,7 +114,7 @@ use vm_memory::{
     Address, GuestAddress, GuestMemoryRegion, GuestUsize, MmapRegion, VolatileMemory, mmap,
 };
 #[cfg(target_arch = "x86_64")]
-use vm_memory::{GuestAddressSpace, GuestMemory};
+use vm_memory::{GuestAddressSpace, GuestMemoryBackend};
 use vm_migration::protocol::MemoryRangeTable;
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, SnapshotData, Snapshottable, Transportable,

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -37,7 +37,7 @@ use thiserror::Error;
 #[cfg(all(feature = "kvm", feature = "sev_snp"))]
 use vm_memory::Bytes;
 #[cfg(feature = "sev_snp")]
-use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemory};
+use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryBackend};
 #[cfg(all(feature = "kvm", feature = "sev_snp"))]
 use vm_migration::Snapshottable;
 #[cfg(all(feature = "kvm", feature = "sev_snp", feature = "fw_cfg"))]

--- a/vmm/src/igvm/loader.rs
+++ b/vmm/src/igvm/loader.rs
@@ -7,7 +7,7 @@ use range_map_vec::{Entry, RangeMap};
 use thiserror::Error;
 use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::{
-    Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap,
+    Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend, GuestMemoryMmap,
     GuestMemoryRegion,
 };
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -40,7 +40,7 @@ use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::guest_memory::{Error as MmapError, FileOffset};
 use vm_memory::mmap::MmapRegionError;
 use vm_memory::{
-    Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
+    Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend,
     GuestMemoryError, GuestMemoryRegion, GuestUsize, MmapRegion,
 };
 use vm_migration::protocol::{MemoryRange, MemoryRangeTable};
@@ -768,7 +768,7 @@ impl MemoryManager {
         Ok((mem_regions, memory_zones))
     }
 
-    // Restore both GuestMemory regions along with MemoryZone zones.
+    // Restore both GuestMemoryBackend regions along with MemoryZone zones.
     fn restore_memory_regions_and_zones(
         guest_ram_mappings: &[GuestRamMapping],
         zones_config: &[MemoryZoneConfig],
@@ -1585,7 +1585,7 @@ impl MemoryManager {
         for region in self.arch_mem_regions.iter() {
             if region.r_type == RegionType::Ram {
                 // Ignore the RAM type since ranges have already been allocated
-                // based on the GuestMemory regions.
+                // based on the GuestMemoryBackend regions.
                 continue;
             }
             self.ram_allocator

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -78,7 +78,7 @@ use thiserror::Error;
 use tracer::trace_scoped;
 use vm_device::Bus;
 #[cfg(feature = "tdx")]
-use vm_memory::GuestMemory;
+use vm_memory::GuestMemoryBackend;
 #[cfg(feature = "tdx")]
 use vm_memory::{Address, ByteValued, GuestMemoryRegion, ReadVolatile};
 use vm_memory::{Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic};
@@ -3905,7 +3905,7 @@ mod unit_tests {
     #[test]
     pub fn test_vm() {
         use hypervisor::VmExit;
-        use vm_memory::{Address, GuestMemory, GuestMemoryRegion};
+        use vm_memory::{Address, GuestMemoryBackend, GuestMemoryRegion};
         // This example based on https://lwn.net/Articles/658511/
         let code = [
             0xba, 0xf8, 0x03, /* mov $0x3f8, %dx */
@@ -4043,7 +4043,7 @@ mod unit_tests {
 #[test]
 pub fn test_vm() {
     use hypervisor::VmExit;
-    use vm_memory::{Address, GuestMemory, GuestMemoryRegion};
+    use vm_memory::{Address, GuestMemoryBackend, GuestMemoryRegion};
     // This example based on https://lwn.net/Articles/658511/
     let code = [
         0xba, 0xf8, 0x03, /* mov $0x3f8, %dx */


### PR DESCRIPTION
Draft because:

- We'll need my [vfio PR](https://github.com/rust-vmm/vfio/pull/163) merged and ideally released first.
- I've only tested aarch64 so far.
- but I want to spare anybody else duplicating the work.

vm-memory 0.18 has renamed GuestMemory to GuestMemoryBackend, and made GuestMemory refer to something less specific.  For simplicity, we keep using GuestMemoryBackend (formerly GuestMemory) everywhere for now.  We can adjust bounds to be less specific later if we find ourselves needing the newly enabled flexibility.