### PR TITLE
virtio-devices: Replay in-order vhost-user queues after reconnect

### DIFF
--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -143,6 +143,10 @@ pub enum Error {
     MissingIrqFd,
     #[error("Failed getting the available index")]
     GetAvailableIndex(#[source] QueueError),
+    #[error("Failed getting the used index")]
+    GetUsedIndex(#[source] QueueError),
+    #[error("Failed to kick vhost-user vring")]
+    VhostUserKickVring(#[source] io::Error),
     #[error("Migration is not supported by this vhost-user device")]
     MigrationNotSupported,
     #[error("Failed creating memfd")]

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -32,8 +32,8 @@ use vmm_sys_util::timerfd::TimerFd;
 use super::{Error, Result, VhostUserState};
 use crate::vhost_user::Inflight;
 use crate::{
-    GuestMemoryMmap, GuestRegionMmap, MmapRegion, VirtioInterrupt, VirtioInterruptType,
-    get_host_address_range,
+    GuestMemoryMmap, GuestRegionMmap, MmapRegion, VIRTIO_F_IN_ORDER, VirtioInterrupt,
+    VirtioInterruptType, get_host_address_range,
 };
 
 // Size of a dirty page for vhost-user.
@@ -365,6 +365,30 @@ impl VhostUserHandle {
     ) -> Result<()> {
         self.set_protocol_features_vhost_user(acked_features, acked_protocol_features)?;
 
+        let (vring_bases, notification_needed) =
+            if inflight.is_none() && acked_features & (1u64 << VIRTIO_F_IN_ORDER) != 0 {
+                // With in-order processing, used_idx is a contiguous completion
+                // boundary. Replay descriptors after it when inflight tracking is
+                // not available to recover them more precisely.
+                let mut vring_bases = Vec::with_capacity(queues.len());
+                let mut notification_needed = Vec::with_capacity(queues.len());
+                for (_, queue, _) in queues {
+                    let used_idx = queue
+                        .used_idx(mem, Ordering::Acquire)
+                        .map_err(Error::GetUsedIndex)?
+                        .0;
+                    let avail_idx = queue
+                        .avail_idx(mem, Ordering::Acquire)
+                        .map_err(Error::GetAvailableIndex)?
+                        .0;
+                    vring_bases.push(u64::from(used_idx));
+                    notification_needed.push(used_idx != avail_idx);
+                }
+                (Some(vring_bases), notification_needed)
+            } else {
+                (None, vec![false; queues.len()])
+            };
+
         self.setup_vhost_user(
             mem,
             queues,
@@ -372,8 +396,16 @@ impl VhostUserHandle {
             acked_features,
             backend_req_handler,
             inflight,
-            None,
-        )
+            vring_bases.as_deref(),
+        )?;
+
+        for ((_, _, queue_evt), notification_needed) in queues.iter().zip(notification_needed) {
+            if notification_needed {
+                queue_evt.write(1).map_err(Error::VhostUserKickVring)?;
+            }
+        }
+
+        Ok(())
     }
 
     pub fn connect_vhost_user(


### PR DESCRIPTION
## Summary

When reconnecting to a vhost-user backend, Cloud Hypervisor keeps the same
queues and currently restarts them from `avail_idx`.

That can skip descriptors that the guest made available but the old backend did
not complete before it disconnected.

This change replays from `used_idx` only when that is safe:

- `VIRTIO_F_IN_ORDER` was negotiated, so `used_idx` is a contiguous completion
  boundary.
- Inflight tracking is not active, so there is no more precise backend recovery
  state.

Queues with inflight tracking, or without `VIRTIO_F_IN_ORDER`, keep the existing
`avail_idx` behavior.

In testing, the replacement backend could reconnect and the VM could remain
`RUNNING`, but guest traffic still stopped making progress. A simple SSH command
kept timing out during connection setup after the backend restart. That matches
the queue state this replay path targets when the negotiated features make
`used_idx` replay safe.

This reconnect path dates back to [`6bce7f79371b`](https://github.com/cloud-hypervisor/cloud-hypervisor/commit/6bce7f79371b3fa507e0c44d5fb3299d8319309b), which added backend reconnect support, and [`058946772af7`](https://github.com/cloud-hypervisor/cloud-hypervisor/commit/058946772af7d142af9dc3a6aa22b08807ce5d60), which changed reconnect setup to resume from `avail_idx`. That avoided replaying from zero, but skipped work between `used_idx` and `avail_idx` after a backend crash.

## Testing

```bash
cargo fmt --all -- --check
cargo check -p virtio-devices --all-targets --tests --locked
cargo clippy -p virtio-devices --all-targets --tests --locked -- -D warnings
cargo test -p virtio-devices --all-targets --tests --locked
```