### PR TITLE
virtio-devices: Reconcile sparse external IOMMU unmaps

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -31,14 +31,15 @@ use vfio_bindings::bindings::vfio::{
     vfio_device_mig_state_VFIO_DEVICE_STATE_STOP_COPY as VFIO_DEV_STATE_STOP_COPY, *,
 };
 use vfio_ioctls::{
-    DmaLoggingRange, VfioDevice, VfioIrq, VfioOps, VfioRegionInfoCap, VfioRegionSparseMmapArea,
+    DmaLoggingRange, VfioDevice, VfioError as VfioIoctlError, VfioIrq, VfioOps, VfioRegionInfoCap,
+    VfioRegionSparseMmapArea,
 };
 use vm_allocator::page_size::{
     align_page_size_down, align_page_size_up, get_page_size, is_4k_aligned, is_4k_multiple,
     is_page_size_aligned,
 };
 use vm_allocator::{AddressAllocator, MemorySlotAllocator, SystemAllocator};
-use vm_device::dma_mapping::ExternalDmaMapping;
+use vm_device::dma_mapping::{ExternalDmaMapping, ExternalDmaMappingUnmap};
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig,
 };
@@ -2612,6 +2613,24 @@ impl<M: GuestAddressSpace> VfioDmaMapping<M> {
     }
 }
 
+fn external_unmap_outcome(
+    result: result::Result<(), VfioIoctlError>,
+    iova: u64,
+    size: u64,
+) -> io::Result<ExternalDmaMappingUnmap> {
+    match result {
+        Ok(()) => Ok(ExternalDmaMappingUnmap::Full),
+        // VFIO type1 v2 and iommufd report the number of mapped bytes removed.
+        // A short result means the request contained holes; the successful ioctl
+        // still removed every mapping in the requested range.
+        Err(VfioIoctlError::InvalidDmaUnmapSize) => Ok(ExternalDmaMappingUnmap::Sparse),
+        Err(e) => Err(io::Error::other(format!(
+            "failed to unmap memory from the host IOMMU address space, \
+             iova 0x{iova:x}, size 0x{size:x}: {e:?}"
+        ))),
+    }
+}
+
 impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M> {
     fn map(&self, iova: u64, gpa: u64, size: u64) -> result::Result<(), io::Error> {
         let Ok(usize_size): Result<usize, _> = size.try_into() else {
@@ -2659,15 +2678,12 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M
         })
     }
 
-    fn unmap(&self, iova: u64, size: u64) -> result::Result<(), io::Error> {
-        self.vfio_ops
-            .vfio_dma_unmap(iova, size as usize)
-            .map_err(|e| {
-                io::Error::other(format!(
-                    "failed to unmap memory from the host IOMMU address space, \
-                     iova 0x{iova:x}, size 0x{size:x}: {e:?}"
-                ))
-            })
+    fn unmap(&self, iova: u64, size: u64) -> result::Result<ExternalDmaMappingUnmap, io::Error> {
+        external_unmap_outcome(
+            self.vfio_ops.vfio_dma_unmap(iova, size as usize),
+            iova,
+            size,
+        )
     }
 }
 
@@ -2676,6 +2692,20 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
+
+    #[test]
+    fn classify_vfio_unmap_outcomes() {
+        assert_eq!(
+            external_unmap_outcome(Ok(()), 0x1000, 0x2000).unwrap(),
+            ExternalDmaMappingUnmap::Full
+        );
+        assert_eq!(
+            external_unmap_outcome(Err(VfioIoctlError::InvalidDmaUnmapSize), 0x1000, 0x2000,)
+                .unwrap(),
+            ExternalDmaMappingUnmap::Sparse
+        );
+        external_unmap_outcome(Err(VfioIoctlError::VfioInvalidType), 0x1000, 0x2000).unwrap_err();
+    }
 
     // Trait default behavior and state enum round trip.
 

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -16,7 +16,7 @@ use vfio_bindings::bindings::vfio::*;
 use vfio_ioctls::VfioIrq;
 use vfio_user::{Client, Error as VfioUserError};
 use vm_allocator::{AddressAllocator, MemorySlotAllocator, SystemAllocator};
-use vm_device::dma_mapping::ExternalDmaMapping;
+use vm_device::dma_mapping::{ExternalDmaMapping, ExternalDmaMappingUnmap};
 use vm_device::interrupt::{InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig};
 use vm_device::{BusDevice, Resource};
 use vm_memory::bitmap::AtomicBitmap;
@@ -575,11 +575,12 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioUserDmaMappi
             .map_err(|e| io::Error::other(format!("Error mapping region: {e}")))
     }
 
-    fn unmap(&self, iova: u64, size: u64) -> result::Result<(), io::Error> {
+    fn unmap(&self, iova: u64, size: u64) -> result::Result<ExternalDmaMappingUnmap, io::Error> {
         self.client
             .lock()
             .unwrap()
             .dma_unmap(iova, size)
-            .map_err(|e| io::Error::other(format!("Error unmapping region: {e}")))
+            .map_err(|e| io::Error::other(format!("Error unmapping region: {e}")))?;
+        Ok(ExternalDmaMappingUnmap::Full)
     }
 }

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -15,7 +15,7 @@ use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use virtio_queue::{DescriptorChain, Queue, QueueT};
-use vm_device::dma_mapping::ExternalDmaMapping;
+use vm_device::dma_mapping::{ExternalDmaMapping, ExternalDmaMappingUnmap};
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
     GuestMemoryError, GuestMemoryLoadGuard,
@@ -323,8 +323,14 @@ enum Error {
     InvalidProbeRequest,
     #[error("Failed to performing external mapping")]
     ExternalMapping(#[source] io::Error),
-    #[error("Failed to performing external unmapping")]
+    #[error("Failed to perform external unmapping")]
     ExternalUnmapping(#[source] io::Error),
+    #[error("Failed to roll back external unmapping after {unmap_error}")]
+    ExternalUnmappingRollback {
+        unmap_error: io::Error,
+        #[source]
+        rollback_error: io::Error,
+    },
     #[error("Failed adding used index")]
     QueueAddUsed(#[source] virtio_queue::Error),
 }
@@ -670,14 +676,15 @@ impl Request {
                         return Err(Error::InvalidUnmapRequestMissingDomain);
                     }
 
-                    let Some(size) = req
+                    if req
                         .virt_end
                         .checked_sub(virt_start)
                         .and_then(|d| d.checked_add(1))
-                    else {
+                        .is_none()
+                    {
                         status = VIRTIO_IOMMU_S_RANGE;
                         return Err(Error::InvalidUnmapRequest);
-                    };
+                    }
 
                     // An UNMAP that would split an existing mapping must be
                     // rejected with VIRTIO_IOMMU_S_RANGE without removing
@@ -702,33 +709,13 @@ impl Request {
                         }
                     }
 
-                    // Find the list of endpoints attached to the given domain.
-                    let endpoints: Vec<u32> = mapping
-                        .endpoints
-                        .write()
-                        .unwrap()
-                        .iter()
-                        .filter(|&(_, &d)| d == domain_id)
-                        .map(|(&e, _)| e)
-                        .collect();
-
-                    // Trigger external unmapping if necessary.
-                    for endpoint in endpoints {
-                        if let Some(ext_map) = ext_mapping.get(&endpoint) {
-                            ext_map
-                                .unmap(virt_start, size)
-                                .map_err(Error::ExternalUnmapping)?;
+                    match unmap_range(mapping, domain_id, virt_start, req.virt_end, ext_mapping) {
+                        Ok(outcome) => debug!("External unmap completed: {outcome:?}"),
+                        Err(e) => {
+                            status = VIRTIO_IOMMU_S_DEVERR;
+                            return Err(e);
                         }
                     }
-
-                    let mut domains = mapping.domains.write().unwrap();
-                    let Some(domain) = domains.get_mut(&domain_id) else {
-                        status = VIRTIO_IOMMU_S_NOENT;
-                        return Err(Error::InvalidUnmapRequestMissingDomain);
-                    };
-                    domain
-                        .mappings
-                        .retain(|&x, _| x < req.virt_start || x > req.virt_end);
                 }
                 VIRTIO_IOMMU_T_PROBE => {
                     if desc_size_left != size_of::<VirtioIommuReqProbe>() {
@@ -813,6 +800,97 @@ impl Request {
 
         Ok(reply_len)
     }
+}
+
+fn rollback_external_unmap(
+    mappings: &[(u64, Mapping)],
+    completed: &[Arc<dyn ExternalDmaMapping>],
+) -> io::Result<()> {
+    let mut first_error = None;
+    for ext_map in completed.iter().rev() {
+        for (iova, mapping) in mappings {
+            if let Err(e) = ext_map.map(*iova, mapping.gpa, mapping.size) {
+                first_error.get_or_insert(e);
+            }
+        }
+    }
+
+    match first_error {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+fn unmap_range(
+    mapping: &IommuMapping,
+    domain_id: u32,
+    virt_start: u64,
+    virt_end: u64,
+    ext_mapping: &BTreeMap<u32, Arc<dyn ExternalDmaMapping>>,
+) -> result::Result<ExternalDmaMappingUnmap, Error> {
+    let size = virt_end
+        .checked_sub(virt_start)
+        .and_then(|delta| delta.checked_add(1))
+        .ok_or(Error::InvalidUnmapRequest)?;
+
+    let mappings: Vec<(u64, Mapping)> = {
+        let domains = mapping.domains.read().unwrap();
+        let domain = domains
+            .get(&domain_id)
+            .ok_or(Error::InvalidUnmapRequestMissingDomain)?;
+        domain
+            .mappings
+            .range(virt_start..=virt_end)
+            .map(|(&iova, &mapping)| (iova, mapping))
+            .collect()
+    };
+    let endpoints: Vec<Arc<dyn ExternalDmaMapping>> = mapping
+        .endpoints
+        .read()
+        .unwrap()
+        .iter()
+        .filter(|&(_, &domain)| domain == domain_id)
+        .filter_map(|(endpoint, _)| ext_mapping.get(endpoint).cloned())
+        .collect();
+
+    let mut outcome = ExternalDmaMappingUnmap::Full;
+    let mut completed = Vec::new();
+    for ext_map in endpoints {
+        match ext_map.unmap(virt_start, size) {
+            Ok(ExternalDmaMappingUnmap::Full) => {}
+            Ok(ExternalDmaMappingUnmap::Sparse) => {
+                outcome = ExternalDmaMappingUnmap::Sparse;
+            }
+            Err(unmap_error) => {
+                if let Err(rollback_error) = rollback_external_unmap(&mappings, &completed) {
+                    return Err(Error::ExternalUnmappingRollback {
+                        unmap_error,
+                        rollback_error,
+                    });
+                }
+                return Err(Error::ExternalUnmapping(unmap_error));
+            }
+        }
+        completed.push(ext_map);
+    }
+
+    let mut domains = mapping.domains.write().unwrap();
+    let Some(domain) = domains.get_mut(&domain_id) else {
+        drop(domains);
+        let missing_domain = io::Error::other("IOMMU domain disappeared during external unmap");
+        if let Err(rollback_error) = rollback_external_unmap(&mappings, &completed) {
+            return Err(Error::ExternalUnmappingRollback {
+                unmap_error: missing_domain,
+                rollback_error,
+            });
+        }
+        return Err(Error::InvalidUnmapRequestMissingDomain);
+    };
+    for (iova, _) in mappings {
+        domain.mappings.remove(&iova);
+    }
+
+    Ok(outcome)
 }
 
 fn detach_endpoint_from_domain(
@@ -1396,13 +1474,13 @@ mod tests {
     use std::collections::BTreeMap;
     use std::io;
     use std::sync::atomic::AtomicBool;
-    use std::sync::{Arc, RwLock, Weak};
+    use std::sync::{Arc, Mutex, RwLock, Weak};
 
     use seccompiler::SeccompAction;
-    use vm_device::dma_mapping::ExternalDmaMapping;
+    use vm_device::dma_mapping::{ExternalDmaMapping, ExternalDmaMappingUnmap};
     use vmm_sys_util::eventfd::{EFD_NONBLOCK, EventFd};
 
-    use super::{Domain, Iommu, IommuMapping, Mapping};
+    use super::{Domain, Error, Iommu, IommuMapping, Mapping, unmap_range};
     use crate::DmaRemapping;
 
     /// Test stub for VfioDmaMapping.
@@ -1413,8 +1491,57 @@ mod tests {
             Ok(())
         }
 
-        fn unmap(&self, _iova: u64, _size: u64) -> Result<(), io::Error> {
+        fn unmap(&self, _iova: u64, _size: u64) -> Result<ExternalDmaMappingUnmap, io::Error> {
+            Ok(ExternalDmaMappingUnmap::Full)
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum UnmapBehavior {
+        Full,
+        Sparse,
+        Fail,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum MappingCall {
+        Map { iova: u64, gpa: u64, size: u64 },
+        Unmap { iova: u64, size: u64 },
+    }
+
+    struct RecordingMapping {
+        behavior: UnmapBehavior,
+        calls: Mutex<Vec<MappingCall>>,
+    }
+
+    impl RecordingMapping {
+        fn new(behavior: UnmapBehavior) -> Self {
+            Self {
+                behavior,
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ExternalDmaMapping for RecordingMapping {
+        fn map(&self, iova: u64, gpa: u64, size: u64) -> Result<(), io::Error> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(MappingCall::Map { iova, gpa, size });
             Ok(())
+        }
+
+        fn unmap(&self, iova: u64, size: u64) -> Result<ExternalDmaMappingUnmap, io::Error> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(MappingCall::Unmap { iova, size });
+            match self.behavior {
+                UnmapBehavior::Full => Ok(ExternalDmaMappingUnmap::Full),
+                UnmapBehavior::Sparse => Ok(ExternalDmaMappingUnmap::Sparse),
+                UnmapBehavior::Fail => Err(io::Error::other("unmap failed")),
+            }
         }
     }
 
@@ -1465,7 +1592,10 @@ mod tests {
 
     /// Build an IommuMapping with endpoint 0 attached to a single domain whose
     /// mappings are the given `(iova, gpa, size)` tuples.
-    fn iommu_mapping(entries: &[(u64, u64, u64)]) -> IommuMapping {
+    fn iommu_mapping_with_endpoints(
+        entries: &[(u64, u64, u64)],
+        endpoint_ids: &[u32],
+    ) -> IommuMapping {
         let mut mappings = BTreeMap::new();
         for &(iova, gpa, size) in entries {
             mappings.insert(iova, Mapping { gpa, size });
@@ -1478,13 +1608,128 @@ mod tests {
                 bypass: false,
             },
         );
-        let mut endpoints = BTreeMap::new();
-        endpoints.insert(0, 0);
+        let endpoints = endpoint_ids
+            .iter()
+            .copied()
+            .map(|endpoint| (endpoint, 0))
+            .collect();
         IommuMapping {
             endpoints: Arc::new(RwLock::new(endpoints)),
             domains: Arc::new(RwLock::new(domains)),
             bypass: AtomicBool::new(false),
         }
+    }
+
+    fn iommu_mapping(entries: &[(u64, u64, u64)]) -> IommuMapping {
+        iommu_mapping_with_endpoints(entries, &[0])
+    }
+
+    fn domain_mappings(mapping: &IommuMapping) -> BTreeMap<u64, Mapping> {
+        mapping.domains.read().unwrap()[&0].mappings.clone()
+    }
+
+    #[test]
+    fn unmap_removes_bookkeeping_after_full_external_unmap() {
+        let mapping = iommu_mapping(&[(0x1000, 0x4000, 0x1000)]);
+        let external = Arc::new(RecordingMapping::new(UnmapBehavior::Full));
+        let ext_mapping: BTreeMap<u32, Arc<dyn ExternalDmaMapping>> =
+            BTreeMap::from([(0, external.clone() as Arc<dyn ExternalDmaMapping>)]);
+
+        let outcome = unmap_range(&mapping, 0, 0x1000, 0x1fff, &ext_mapping).unwrap();
+
+        assert_eq!(outcome, ExternalDmaMappingUnmap::Full);
+        assert!(domain_mappings(&mapping).is_empty());
+        assert_eq!(
+            *external.calls.lock().unwrap(),
+            [MappingCall::Unmap {
+                iova: 0x1000,
+                size: 0x1000,
+            }]
+        );
+    }
+
+    #[test]
+    fn unmap_reconciles_hole_spanning_external_unmap() {
+        let mapping = iommu_mapping(&[(0x1000, 0x4000, 0x1000), (0x3000, 0x6000, 0x1000)]);
+        let external = Arc::new(RecordingMapping::new(UnmapBehavior::Sparse));
+        let ext_mapping: BTreeMap<u32, Arc<dyn ExternalDmaMapping>> =
+            BTreeMap::from([(0, external.clone() as Arc<dyn ExternalDmaMapping>)]);
+
+        let outcome = unmap_range(&mapping, 0, 0x1000, 0x3fff, &ext_mapping).unwrap();
+
+        assert_eq!(outcome, ExternalDmaMappingUnmap::Sparse);
+        assert!(domain_mappings(&mapping).is_empty());
+        assert_eq!(
+            *external.calls.lock().unwrap(),
+            [MappingCall::Unmap {
+                iova: 0x1000,
+                size: 0x3000,
+            }]
+        );
+    }
+
+    #[test]
+    fn unmap_total_failure_keeps_bookkeeping() {
+        let entries = [(0x1000, 0x4000, 0x1000)];
+        let mapping = iommu_mapping(&entries);
+        let external = Arc::new(RecordingMapping::new(UnmapBehavior::Fail));
+        let ext_mapping: BTreeMap<u32, Arc<dyn ExternalDmaMapping>> =
+            BTreeMap::from([(0, external.clone() as Arc<dyn ExternalDmaMapping>)]);
+
+        let error = unmap_range(&mapping, 0, 0x1000, 0x1fff, &ext_mapping).unwrap_err();
+
+        assert!(matches!(error, Error::ExternalUnmapping(_)));
+        assert_eq!(domain_mappings(&mapping).len(), 1);
+        assert_eq!(
+            *external.calls.lock().unwrap(),
+            [MappingCall::Unmap {
+                iova: 0x1000,
+                size: 0x1000,
+            }]
+        );
+    }
+
+    #[test]
+    fn unmap_mixed_endpoint_failure_rolls_back_completed_endpoint() {
+        let entries = [(0x1000, 0x4000, 0x1000), (0x2000, 0x5000, 0x1000)];
+        let mapping = iommu_mapping_with_endpoints(&entries, &[0, 1]);
+        let completed = Arc::new(RecordingMapping::new(UnmapBehavior::Full));
+        let failed = Arc::new(RecordingMapping::new(UnmapBehavior::Fail));
+        let ext_mapping: BTreeMap<u32, Arc<dyn ExternalDmaMapping>> = BTreeMap::from([
+            (0, completed.clone() as Arc<dyn ExternalDmaMapping>),
+            (1, failed.clone() as Arc<dyn ExternalDmaMapping>),
+        ]);
+
+        let error = unmap_range(&mapping, 0, 0x1000, 0x2fff, &ext_mapping).unwrap_err();
+
+        assert!(matches!(error, Error::ExternalUnmapping(_)));
+        assert_eq!(domain_mappings(&mapping).len(), entries.len());
+        assert_eq!(
+            *completed.calls.lock().unwrap(),
+            [
+                MappingCall::Unmap {
+                    iova: 0x1000,
+                    size: 0x2000,
+                },
+                MappingCall::Map {
+                    iova: 0x1000,
+                    gpa: 0x4000,
+                    size: 0x1000,
+                },
+                MappingCall::Map {
+                    iova: 0x2000,
+                    gpa: 0x5000,
+                    size: 0x1000,
+                },
+            ]
+        );
+        assert_eq!(
+            *failed.calls.lock().unwrap(),
+            [MappingCall::Unmap {
+                iova: 0x1000,
+                size: 0x2000,
+            }]
+        );
     }
 
     #[test]

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -20,7 +20,7 @@ use vhost::vhost_kern::vhost_binding::VHOST_BACKEND_F_SUSPEND;
 use vhost::{VhostBackend, VringConfigData};
 use virtio_queue::desc::RawDescriptor;
 use virtio_queue::{Queue, QueueT};
-use vm_device::dma_mapping::ExternalDmaMapping;
+use vm_device::dma_mapping::{ExternalDmaMapping, ExternalDmaMappingUnmap};
 use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vm_virtio::{AccessPlatform, Translatable};
@@ -596,7 +596,7 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VdpaDmaMapping<M
         }
     }
 
-    fn unmap(&self, iova: u64, size: u64) -> io::Result<()> {
+    fn unmap(&self, iova: u64, size: u64) -> io::Result<ExternalDmaMappingUnmap> {
         debug!("DMA unmap iova 0x{iova:x} size 0x{size:x}");
         self.device
             .lock()
@@ -607,6 +607,7 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VdpaDmaMapping<M
                     "failed to unmap memory for vDPA device, \
                      iova 0x{iova:x}, size 0x{size:x}: {e:?}"
                 ))
-            })
+            })?;
+        Ok(ExternalDmaMappingUnmap::Full)
     }
 }

--- a/vm-device/src/dma_mapping/mod.rs
+++ b/vm-device/src/dma_mapping/mod.rs
@@ -4,6 +4,15 @@
 
 use std::io;
 
+/// Result of a successful external DMA unmap operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExternalDmaMappingUnmap {
+    /// The entire requested range was mapped and has been unmapped.
+    Full,
+    /// The request covered unmapped holes, but all mappings in the range were removed.
+    Sparse,
+}
+
 /// Trait to trigger DMA mapping updates for devices managed by virtio-iommu
 ///
 /// Trait meant for triggering the DMA mapping update related to an external
@@ -15,5 +24,5 @@ pub trait ExternalDmaMapping: Send + Sync {
     fn map(&self, iova: u64, gpa: u64, size: u64) -> io::Result<()>;
 
     /// Unmap a memory range
-    fn unmap(&self, iova: u64, size: u64) -> io::Result<()>;
+    fn unmap(&self, iova: u64, size: u64) -> io::Result<ExternalDmaMappingUnmap>;
 }


### PR DESCRIPTION
## Problem

A virtio-IOMMU `UNMAP` request may cover several mappings separated by
unmapped holes. VFIO type1 v2 and iommufd complete that operation and report
the number of mapped bytes they actually removed. `vfio-ioctls` represents a
short byte count as `InvalidDmaUnmapSize`, which Cloud Hypervisor previously
converted into a generic error.

The request handler then returned before removing the corresponding entries
from `domain.mappings`. It also left the reply status at `S_OK`. A later `MAP`
of the same IOVA could therefore be rejected against stale bookkeeping even
though the external mappings were gone.

There is a second consistency case for domains with multiple endpoints: if an
early endpoint completes the unmap and a later endpoint fails, returning
immediately leaves their external address spaces different.

## Fix

- Add a structured external-unmap outcome that distinguishes a fully mapped
  interval from a successfully unmapped sparse interval.
- Classify VFIO's short successful unmap as sparse instead of as a failure.
- Reconcile the domain table after every endpoint completes successfully.
- On a true failure, remap the affected ranges on endpoints that already
  completed, retain the bookkeeping, and return `S_DEVERR` to the guest.
- Surface a distinct error if the compensating remap itself fails.

## Testing

The new tests cover:

- a fully mapped successful unmap;
- a hole-spanning sparse unmap;
- a total external failure with unchanged bookkeeping;
- a later-endpoint failure with call-order and rollback assertions; and
- VFIO full, sparse, and failed outcome classification.

Commands run:

```text
cargo +nightly fmt --all -- --check
cargo check --locked --all-targets --tests
cargo clippy --locked --all-targets --tests -- -D warnings
cargo test --locked --all-targets --tests
gitlint --commits 'HEAD~1..HEAD'
```

---

Assisted-by: Codex:GPT-5
