### PR TITLE
vmm: add guest_block_size disk option

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -637,6 +637,18 @@ enum BlockSize {
 }
 
 impl DiskTopology {
+    /// Overrides the logical block size advertised to the guest with `block_size`.
+    /// The physical block size and minimum I/O size are raised to `block_size`
+    /// when smaller, since neither can be below one logical block.
+    pub fn with_block_size(self, block_size: u64) -> Self {
+        Self {
+            logical_block_size: block_size,
+            physical_block_size: self.physical_block_size.max(block_size),
+            minimum_io_size: self.minimum_io_size.max(block_size),
+            ..self
+        }
+    }
+
     // libc::ioctl() takes different types on different architectures
     fn query_block_size(f: &File, block_size_type: BlockSize) -> io::Result<u64> {
         let mut block_size = 0;
@@ -696,6 +708,38 @@ mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
+
+    #[test]
+    fn with_block_size_raises_physical_and_min_io() {
+        let topology = DiskTopology {
+            logical_block_size: 512,
+            physical_block_size: 512,
+            minimum_io_size: 512,
+            optimal_io_size: 0,
+        }
+        .with_block_size(4096);
+        assert_eq!(topology.logical_block_size, 4096);
+        // Neither can sit below one logical block.
+        assert_eq!(topology.physical_block_size, 4096);
+        assert_eq!(topology.minimum_io_size, 4096);
+        // optimal_io_size is a hint and left untouched.
+        assert_eq!(topology.optimal_io_size, 0);
+    }
+
+    #[test]
+    fn with_block_size_keeps_larger_probed_fields() {
+        let topology = DiskTopology {
+            logical_block_size: 512,
+            physical_block_size: 8192,
+            minimum_io_size: 8192,
+            optimal_io_size: 65536,
+        }
+        .with_block_size(4096);
+        assert_eq!(topology.logical_block_size, 4096);
+        assert_eq!(topology.physical_block_size, 8192);
+        assert_eq!(topology.minimum_io_size, 8192);
+        assert_eq!(topology.optimal_io_size, 65536);
+    }
 
     #[test]
     fn validate_short_file_is_not_eof_error() {

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -1707,6 +1707,125 @@ mod common_parallel {
         _test_virtio_block_direct_io_data_disk_4k(ImageType::FlatVmdk);
     }
 
+    fn _test_virtio_block_guest_block_size(image_type: ImageType, direct: bool) {
+        let (qemu_fmt, ext): (&str, &str) = match image_type {
+            ImageType::Raw => ("raw", "raw"),
+            ImageType::Qcow2 => ("qcow2", "qcow2"),
+            _ => panic!("unsupported image_type {image_type}"),
+        };
+        let image_type_str = image_type.to_string();
+
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+
+        // The advertised 4096 geometry comes entirely from the override and
+        // not from the backend. Direct I/O needs an O_DIRECT capable
+        // backing, so place it on the workloads filesystem rather than the
+        // default tmpfs.
+        let workloads_dir = direct.then(|| {
+            let mut workloads_path = dirs::home_dir().unwrap();
+            workloads_path.push("workloads");
+            TempDir::new_in(workloads_path.as_path()).unwrap()
+        });
+        let test_disk = match &workloads_dir {
+            Some(dir) => dir.as_path().join(format!("lbs-test.{ext}")),
+            None => guest.tmp_dir.as_path().join(format!("lbs-test.{ext}")),
+        };
+        let test_disk_path = test_disk.to_str().unwrap().to_owned();
+        let res = run_qemu_img(&test_disk, &["create", "-f", qemu_fmt], Some(&["64M"]));
+        assert!(res.status.success(), "qemu-img create failed: {res:?}");
+
+        let direct_opt = if direct { ",direct=on" } else { "" };
+
+        let mut child = GuestCommand::new(&guest)
+            .default_cpus()
+            .default_memory()
+            .default_kernel_cmdline()
+            .default_disks()
+            .args([
+                "--disk",
+                format!(
+                    "path={test_disk_path},image_type={image_type_str},\
+                     guest_block_size=4096{direct_opt}"
+                )
+                .as_str(),
+            ])
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+
+            // LOG-SEC column
+            assert_eq!(
+                guest
+                    .ssh_command("lsblk -t | grep vdc | awk '{print $6}'")
+                    .unwrap()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default(),
+                4096
+            );
+
+            // MIN-IO column
+            assert_eq!(
+                guest
+                    .ssh_command("lsblk -t | grep vdc | awk '{print $3}'")
+                    .unwrap()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default(),
+                4096
+            );
+
+            // PHY-SEC column
+            assert_eq!(
+                guest
+                    .ssh_command("lsblk -t | grep vdc | awk '{print $5}'")
+                    .unwrap()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default(),
+                4096
+            );
+
+            // Guest direct I/O aligns to the advertised block size while
+            // the host side stays buffered.
+            guest
+                .ssh_command(
+                    "sudo dd if=/dev/urandom of=/tmp/pattern bs=4096 count=8 && \
+                     sudo dd if=/tmp/pattern of=/dev/vdc bs=4096 count=8 seek=1 \
+                         oflag=direct conv=fsync && \
+                     sudo dd if=/dev/vdc of=/tmp/readback bs=4096 count=8 skip=1 \
+                         iflag=direct && \
+                     cmp /tmp/pattern /tmp/readback",
+                )
+                .expect("4k logical block size round trip failed");
+        });
+
+        kill_child(&mut child);
+        let output = child.wait_with_output().unwrap();
+
+        handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_virtio_block_guest_block_size_raw() {
+        _test_virtio_block_guest_block_size(ImageType::Raw, false);
+    }
+
+    #[test]
+    fn test_virtio_block_guest_block_size_qcow2() {
+        _test_virtio_block_guest_block_size(ImageType::Qcow2, false);
+    }
+
+    #[test]
+    fn test_virtio_block_guest_block_size_raw_direct() {
+        _test_virtio_block_guest_block_size(ImageType::Raw, true);
+    }
+
     #[test]
     fn test_virtio_block_qcow2_dirty_bit_unclean_shutdown() {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2.to_string());

--- a/docs/device_model.md
+++ b/docs/device_model.md
@@ -102,6 +102,16 @@ usually used to boot the operating system running in the VM.
 This device is always built-in, and it is enabled based on the presence of the
 flag `--disk`.
 
+The `guest_block_size` parameter of `--disk` overrides the logical block size
+advertised to the guest, so an image keeps the geometry it was built for
+regardless of the backing storage. It applies to every image format backend and
+must be a power of 2 between 512 and 64KiB.
+
+With buffered I/O the host page cache absorbs any alignment difference. Under
+`direct=on` a value below the backing block size is not supported, because the
+sub block writes it produces need a read modify write serialized against
+concurrent requests, which the block layer does not do.
+
 ### virtio-console
 
 `cloud-hypervisor` exposes a `virtio-console` device to the guest. Although

--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -216,6 +216,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
         queue_affinity,
         false,
         LockGranularityChoice::default(),
+        None,
     )
     .unwrap();
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -790,6 +790,7 @@ impl Block {
         queue_affinity: BTreeMap<u16, Box<[usize]>>,
         sparse: bool,
         lock_granularity: LockGranularityChoice,
+        guest_block_size: Option<u32>,
     ) -> io::Result<Self> {
         let (disk_nsectors, avail_features, acked_features, config, paused) =
             if let Some(state) = state {
@@ -845,7 +846,10 @@ impl Block {
                     avail_features |= 1u64 << VIRTIO_BLK_F_RO;
                 }
 
-                let topology = disk_image.topology();
+                let mut topology = disk_image.topology();
+                if let Some(block_size) = guest_block_size {
+                    topology = topology.with_block_size(block_size as u64);
+                }
                 info!("Disk topology: {topology:?}");
 
                 let logical_block_size = if topology.logical_block_size > 512 {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1237,6 +1237,8 @@ components:
           $ref: "#/components/schemas/ImageType"
         lock_granularity:
           $ref: "#/components/schemas/LockGranularity"
+        guest_block_size:
+          type: integer
 
     NetConfig:
       type: object

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -277,6 +277,9 @@ pub enum ValidationError {
     /// Block queue size too small to advertise a usable seg_max
     #[error("Block queue size must be greater than {MINIMUM_BLOCK_QUEUE_SIZE}: {0}")]
     BlockQueueSizeTooSmall(u16),
+    /// Disk guest_block_size is not a power of 2 within the supported range
+    #[error("Disk guest_block_size must be a power of 2 between 512 and 65536: {0}")]
+    InvalidGuestBlockSize(u32),
     /// Need shared memory for vfio-user
     #[error("Using user devices requires using shared memory or huge pages")]
     UserDevicesRequireSharedMemory,
@@ -352,6 +355,9 @@ pub enum ValidationError {
     /// Rate limiting is not supported with vhost-user
     #[error("Rate limiting is not supported with vhost-user")]
     VhostUserRateLimiterNotSupported,
+    /// The vhost-user backend provides the virtio config space
+    #[error("guest_block_size is not supported with vhost-user")]
+    VhostUserGuestBlockSizeNotSupported,
     /// The specified I/O port was invalid. It should be provided in hex, such as `0xe9`.
     #[cfg(target_arch = "x86_64")]
     #[error("The IO port was not properly provided in hex or a `0x` prefix is missing: {0}")]
@@ -1460,7 +1466,8 @@ impl DiskConfig {
          rate_limit_group=<group_id>,\
          queue_affinity=<list_of_queue_indices_with_their_associated_cpuset>,\
          serial=<serial_number>,backing_files=on|off,sparse=on|off,\
-         image_type=<raw,qcow2,vhd,vhdx,vmdk>,lock_granularity=byte-range|full";
+         image_type=<raw,qcow2,vhd,vhdx,vmdk>,lock_granularity=byte-range|full,\
+         guest_block_size=<size_in_bytes>";
 
     pub fn parse(disk: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -1487,6 +1494,7 @@ impl DiskConfig {
             .add("sparse")
             .add("image_type")
             .add("lock_granularity")
+            .add("guest_block_size")
             .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
 
         parser.parse(disk).map_err(Error::ParseDisk)?;
@@ -1584,6 +1592,10 @@ impl DiskConfig {
             .map_err(Error::ParseDisk)?
             .unwrap_or_default();
 
+        let guest_block_size = parser
+            .convert::<u32>("guest_block_size")
+            .map_err(Error::ParseDisk)?;
+
         let bw_tb_config = if bw_size != 0 && bw_refill_time != 0 {
             Some(TokenBucketConfig {
                 size: bw_size,
@@ -1637,6 +1649,7 @@ impl DiskConfig {
             sparse,
             image_type,
             lock_granularity,
+            guest_block_size,
         })
     }
 
@@ -1668,6 +1681,10 @@ impl DiskConfig {
             return Err(ValidationError::VhostUserRateLimiterNotSupported);
         }
 
+        if self.vhost_user && self.guest_block_size.is_some() {
+            return Err(ValidationError::VhostUserGuestBlockSizeNotSupported);
+        }
+
         if self.rate_limiter_config.is_some() && self.rate_limit_group.is_some() {
             return Err(ValidationError::InvalidRateLimiterGroup);
         }
@@ -1684,6 +1701,12 @@ impl DiskConfig {
 
         if !self.vhost_user && self.image_type == ImageType::Unknown {
             return Err(ValidationError::ImageTypeRequired);
+        }
+
+        if let Some(guest_block_size) = self.guest_block_size
+            && (!guest_block_size.is_power_of_two() || !(512..=65536).contains(&guest_block_size))
+        {
+            return Err(ValidationError::InvalidGuestBlockSize(guest_block_size));
         }
 
         Ok(())
@@ -4454,6 +4477,7 @@ mod tests {
             sparse: true,
             image_type: ImageType::Unknown,
             lock_granularity: LockGranularityChoice::default(),
+            guest_block_size: None,
         }
     }
 
@@ -4582,6 +4606,14 @@ mod tests {
                 ..disk_fixture()
             }
         );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,guest_block_size=4096")?,
+            DiskConfig {
+                guest_block_size: Some(4096),
+                ..disk_fixture()
+            }
+        );
+        DiskConfig::parse("path=/path/to_file,guest_block_size=abc").unwrap_err();
         Ok(())
     }
 
@@ -6141,6 +6173,22 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         still_valid_config.memory.shared = true;
         still_valid_config.validate().unwrap();
 
+        // guest_block_size cannot take effect when the vhost-user backend
+        // provides the virtio config space.
+        let mut invalid_config = valid_config.clone();
+        invalid_config.memory.shared = true;
+        invalid_config.disks = Some(vec![DiskConfig {
+            path: None,
+            vhost_user: true,
+            vhost_socket: Some("/path/to/sock".to_owned()),
+            guest_block_size: Some(4096),
+            ..disk_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::VhostUserGuestBlockSizeNotSupported)
+        );
+
         // A block queue size that is not a power of 2 is rejected.
         let mut invalid_config = valid_config.clone();
         invalid_config.disks = Some(vec![DiskConfig {
@@ -6165,6 +6213,55 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 MINIMUM_BLOCK_QUEUE_SIZE
             ))
         );
+
+        // A disk logical block size that is not a power of 2 is rejected.
+        let mut invalid_config = valid_config.clone();
+        invalid_config.disks = Some(vec![DiskConfig {
+            guest_block_size: Some(1000),
+            ..raw_disk_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::InvalidGuestBlockSize(1000))
+        );
+
+        // A disk logical block size below 512 is rejected.
+        let mut invalid_config = valid_config.clone();
+        invalid_config.disks = Some(vec![DiskConfig {
+            guest_block_size: Some(256),
+            ..raw_disk_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::InvalidGuestBlockSize(256))
+        );
+
+        // A disk logical block size above the 64KiB limit is rejected.
+        let mut invalid_config = valid_config.clone();
+        invalid_config.disks = Some(vec![DiskConfig {
+            guest_block_size: Some(131072),
+            ..raw_disk_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::InvalidGuestBlockSize(131072))
+        );
+
+        let mut still_valid_config = valid_config.clone();
+        still_valid_config.disks = Some(vec![DiskConfig {
+            guest_block_size: Some(4096),
+            ..raw_disk_fixture()
+        }]);
+        still_valid_config.validate().unwrap();
+
+        // The override is backend agnostic and accepted for non raw images.
+        let mut still_valid_config = valid_config.clone();
+        still_valid_config.disks = Some(vec![DiskConfig {
+            image_type: ImageType::Qcow2,
+            guest_block_size: Some(4096),
+            ..disk_fixture()
+        }]);
+        still_valid_config.validate().unwrap();
 
         // A net queue size that is not a power of 2 is rejected.
         let mut invalid_config = valid_config.clone();

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -197,6 +197,10 @@ pub enum DeviceManagerError {
     #[error("Cannot create virtio-blk device")]
     CreateVirtioBlock(#[source] io::Error),
 
+    /// Unsupported under direct I/O
+    #[error("Disk guest_block_size is below the required backend block size")]
+    GuestBlockSizeBelowBackend,
+
     /// Cannot create virtio-net device
     #[error("Cannot create virtio-net device")]
     CreateVirtioNet(#[source] net::Error),
@@ -2666,6 +2670,14 @@ impl DeviceManager {
             )
             .map_err(DeviceManagerError::Disk)?;
 
+            if let Some(guest_block_size) = disk_cfg.guest_block_size
+                && disk_cfg.direct
+                && !disk_cfg.readonly
+                && u64::from(guest_block_size) < disk.topology().logical_block_size
+            {
+                return Err(DeviceManagerError::GuestBlockSizeBelowBackend);
+            }
+
             if disk_cfg.image_type != ImageType::Qcow2 && disk_cfg.backing_files {
                 warn!("Enabling backing_files option only applies for QCOW2 files");
             }
@@ -2734,6 +2746,7 @@ impl DeviceManager {
                 queue_affinity,
                 disk_cfg.sparse,
                 disk_cfg.lock_granularity,
+                disk_cfg.guest_block_size,
             )
             .map_err(DeviceManagerError::CreateVirtioBlock)?;
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -416,6 +416,8 @@ pub struct DiskConfig {
     pub image_type: ImageType,
     #[serde(default)]
     pub lock_granularity: LockGranularityChoice,
+    #[serde(default)]
+    pub guest_block_size: Option<u32>,
 }
 
 impl ApplyLandlock for DiskConfig {


### PR DESCRIPTION
Cloud disk images (ubuntu) authored with 512 byte sectors cannot boot when they are advertised over the network (NVMe-oF) and attached to the host as a native 4096 block storage device (when nvmet advertises the block size of the target filesystem). With a configurable block size capability, an operator can inject the block geometry of the disk and buffered I/O on the host absorbs the alignment difference.

An image authored at 512 byte sectors places its GPT at byte offset 512, and a guest kernel that reads the logical block sector size to be 4096 looks at byte offset 4096, finds no partition table, and exposes no partitions to boot from. This is observable on the host with a loop device, no VM needed, where the advertised logical block sector size is the only variable.

```
$ curl -sSLO https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
$ qemu-img convert -O raw noble-server-cloudimg-amd64.img noble.raw

$ LOOP=$(sudo losetup --show -f --sector-size 4096 -P noble.raw)
$ lsblk -o NAME,SIZE,LOG-SEC "$LOOP"
NAME   SIZE LOG-SEC
loop6  3.5G    4096          # no partitions, boot has nothing to mount

$ LOOP=$(sudo losetup --show -f --sector-size 512 -P noble.raw)
$ lsblk -o NAME,SIZE,LOG-SEC "$LOOP"
NAME        SIZE LOG-SEC
loop6       3.5G     512
├─loop6p1   2.5G     512     # partitions appear
├─loop6p14    4M     512
├─loop6p15  106M     512
└─loop6p16  913M     512
```

Add a `guest_block_size` option to `--disk` that overrides the block size virtio-block advertises to the guest. It shapes the advertised topology where virtio-block builds its config, so it applies to every disk backend, including the case of a 4096 byte GPT inside a qcow2 file. The physical block size and minimum I/O are raised alongside it to stay consistent, and no read modify write emulation is added.

With buffered I/O the host page cache absorbs the alignment difference between guest requests and the backing storage. With `direct=on` there is no such absorption. Cloud Hypervisor can read modify write a single unaligned request through a bounce buffer, but it does not serialize that against other in flight requests to the same block, so two overlapping writes could lose an update. A value below the backing block size is therefore not supported under `direct=on`, while one at or above it is accepted. vhost-user disks are rejected because the external backend provides the virtio config space. The value must be a power of 2 between 512 and 2^31.

Documentation is added to the virtio-block section of `docs/device_model.md`.

## Testing

Unit tests

```bash
cargo test -p virtio-devices --features kvm override_block_size
cargo test -p vmm --features kvm -- test_disk_parsing test_config_validation
```

Integration test boots a guest advertising 4096 on raw and qcow2 backings, and once with `direct=on`, checking the guest visible geometry and a direct I/O round trip.

```bash
scripts/dev_cli.sh tests --integration -- --test-filter test_virtio_block_guest_block_size
```
