### PR TITLE
ci: Exclude flaky villain tests S0094 and PCI0006

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -899,6 +899,7 @@ jobs:
             --vmm "${GITHUB_WORKSPACE}/target/release/cloud-hypervisor" \
             --blk-queues 2 --net-queues 2 --cpus 2 --memory 256M \
             --order=fast \
+            --exclude S0094 --exclude PCI0006 \
             --jobs 4 --batch 10 --timeout 45 --log-dir villain-logs \
             --format junit --output villain-logs/results.xml \
             | tee villain-logs/run.out


### PR DESCRIPTION
Both tests intermittently report WEDGED because the villain harness can lose the guest verdict marker when the VM exits before the VMM drains the console virtqueue, so the host reads a console with no marker under load. This is a harness race, not a CH defect, and it lands on a random test each run. Exclude the two most affected until the harness drains the console on shutdown.