### PR TITLE
block: Implement backend for Virtual Machine DisK (VMDK)

### DIFF
--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -24,6 +24,7 @@ use crate::formats::qcow::QcowDisk;
 use crate::formats::raw::{RawBackend, RawDisk};
 use crate::formats::vhd::VhdDisk;
 use crate::formats::vhdx::VhdxDisk;
+use crate::formats::vmdk::VmdkDisk;
 use crate::{
     ImageType, block_aio_is_supported, detect_image_type, open_disk_image, preallocate_disk,
 };
@@ -98,6 +99,7 @@ pub fn open_disk(options: &DiskOpenOptions<'_>) -> BlockResult<OpenedDisk> {
         ImageType::Raw => open_raw(file, options)?,
         ImageType::Qcow2 => open_qcow2(file, options)?,
         ImageType::Vhdx => open_vhdx(file, options)?,
+        ImageType::FlatVmdk => open_flat_vmdk(file, options)?,
         ImageType::Unknown => {
             return Err(
                 BlockError::from_kind(BlockErrorKind::UnsupportedFeature).with_path(options.path)
@@ -212,6 +214,16 @@ fn open_qcow2(
             false,
         )
         .map_err(|e| e.with_path(options.path))?,
+    ))
+}
+
+fn open_flat_vmdk(
+    file: fs::File,
+    options: &DiskOpenOptions<'_>,
+) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+    info!("Opening VMDK disk file with synchronous backend");
+    Ok(Box::new(
+        VmdkDisk::new(file, options.path, options.direct).map_err(|e| e.with_path(options.path))?,
     ))
 }
 

--- a/block/src/formats/mod.rs
+++ b/block/src/formats/mod.rs
@@ -11,3 +11,4 @@ pub mod qcow;
 pub mod raw;
 pub mod vhd;
 pub mod vhdx;
+pub mod vmdk;

--- a/block/src/formats/vhd/footer.rs
+++ b/block/src/formats/vhd/footer.rs
@@ -119,7 +119,11 @@ impl VhdFooter {
 
 /// Determine image type through file parsing.
 pub fn is_fixed_vhd(f: &mut File) -> io::Result<bool> {
-    let footer = VhdFooter::new(f)?;
+    let footer = match VhdFooter::new(f) {
+        Ok(footer) => footer,
+        Err(e) if e.kind() == io::ErrorKind::InvalidInput => return Ok(false),
+        Err(e) => return Err(e),
+    };
 
     // "conectix" => 0x636f6e6563746978
     Ok(footer.cookie() == 0x636f6e6563746978
@@ -228,5 +232,12 @@ mod unit_tests {
         with_file(&valid_dynamic_vhd_footer(), |mut file: File| {
             assert!(!(is_fixed_vhd(&mut file).unwrap()));
         });
+    }
+
+    #[test]
+    fn test_is_fixed_vhd_short_file_is_not_vhd() {
+        let mut file: File = TempFile::new().unwrap().into_file();
+        file.write_all(b"# Disk DescriptorFile\n").unwrap();
+        assert!(!is_fixed_vhd(&mut file).unwrap());
     }
 }

--- a/block/src/formats/vmdk/descriptor.rs
+++ b/block/src/formats/vmdk/descriptor.rs
@@ -8,10 +8,10 @@
 //! of `FLAT` extent lines, and a disk database (DDB). Only the `monolithicFlat`
 //! and `twoGbMaxExtentFlat` create types are recognized.
 
-use std::collections::HashMap;
 use std::fs::File;
 use std::io;
 use std::os::unix::fs::FileExt;
+use std::path::Path;
 use std::str::Lines;
 
 use crate::AlignedFile;
@@ -33,7 +33,6 @@ pub enum VMDKDiskType {
 /// Flat VMDK extent line fields.
 /// Format of each extent line:
 /// `<access> <sectors> <type> "<file>" [offset]`.
-#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct VmdkExtentHeader {
     pub access: String,
@@ -44,14 +43,9 @@ pub struct VmdkExtentHeader {
 }
 
 /// Descriptor header fields.
-#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct VmdkDescriptorHeader {
-    pub version: u32,
-    pub cid: u32,
-    pub parent_cid: u32,
     pub create_type: VMDKDiskType,
-    pub parent_filename_hint: String,
 }
 
 /// Ordered list of extents.
@@ -59,11 +53,49 @@ pub struct VmdkDescriptorHeader {
 pub struct VmdkDescriptorExtents {
     pub extents: Vec<VmdkExtentHeader>,
 }
-/// Disk database.
-#[allow(dead_code)]
+
+/// Parsed flat VMDK descriptor
+///
+/// extents_list: ordered extent list
+/// base_path: descriptor file's parent directory
 #[derive(Debug, Default)]
-pub struct VmdkDescriptorDdb {
-    pub entries: HashMap<String, String>,
+pub struct VmdkDescriptor {
+    pub base_path: String,
+    pub extents_list: VmdkDescriptorExtents,
+}
+
+impl VmdkDescriptor {
+    pub fn new(file: &File, path: &Path) -> io::Result<Self> {
+        // The descriptor's directory anchors the relative extent filenames.
+        let base_path = path
+            .parent()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Cannot retrieve parent directory of the file",
+                )
+            })?
+            .to_string_lossy()
+            .to_string();
+
+        // Valid descriptor file must be much larger than 4 bytes.
+        if file.metadata()?.len() < 4 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid VMDK descriptor file: file is empty or too small",
+            ));
+        }
+
+        let content = read_descriptor(file)?;
+        let mut lines = content.lines();
+        let (_header, last_line) = parse_header(&mut lines)?;
+        let extents_list = parse_extents(&mut lines, last_line)?;
+
+        Ok(Self {
+            base_path,
+            extents_list,
+        })
+    }
 }
 
 // Read the whole descriptor into memory through an `AlignedFile` and return it
@@ -115,35 +147,24 @@ pub(crate) fn parse_header<'a>(
             break;
         }
         let parts: Vec<&str> = line.split('=').map(|s| s.trim()).collect();
-        if parts.len() == 2 {
-            match parts[0] {
-                "version" => header.version = parts[1].parse().unwrap_or(0),
-                "CID" => header.cid = u32::from_str_radix(parts[1], 16).unwrap_or(0),
-                "parentCID" => header.parent_cid = u32::from_str_radix(parts[1], 16).unwrap_or(0),
-                "createType" => {
-                    // Tools such as qemu-img quote the value, e.g.
-                    // createType="monolithicFlat", strip the quotes.
-                    header.create_type = match parts[1].trim_matches('"') {
-                        "monolithicFlat" => VMDKDiskType::MonolithicFlat,
-                        "twoGbMaxExtentFlat" => VMDKDiskType::TwoGbMaxExtentFlat,
-                        _ => VMDKDiskType::CreateTypeUnsupported,
-                    }
-                }
-                "parentFileNameHint" => header.parent_filename_hint = parts[1].to_string(),
-                _ => {}
-            }
+        if parts.len() == 2 && parts[0] == "createType" {
+            // Tools such as qemu-img quote the value, strip quotes for comparison.
+            header.create_type = match parts[1].trim_matches('"') {
+                "monolithicFlat" => VMDKDiskType::MonolithicFlat,
+                "twoGbMaxExtentFlat" => VMDKDiskType::TwoGbMaxExtentFlat,
+                _ => VMDKDiskType::CreateTypeUnsupported,
+            };
         }
     }
 
     Ok((header, last_comment_line))
 }
 
-pub(crate) fn parse_extents_and_ddb(
+pub(crate) fn parse_extents(
     lines: &mut Lines<'_>,
     last_comment_line: &str,
-) -> io::Result<(VmdkDescriptorExtents, VmdkDescriptorDdb)> {
+) -> io::Result<VmdkDescriptorExtents> {
     let mut extents = VmdkDescriptorExtents::default();
-    let mut ddb = VmdkDescriptorDdb::default();
 
     if last_comment_line != VMDK_DESCRIPTOR_EXTENTS {
         return Err(io::Error::new(
@@ -152,66 +173,55 @@ pub(crate) fn parse_extents_and_ddb(
         ));
     }
 
-    let mut in_extents_section = true;
     for line in lines.by_ref() {
         if line.trim().is_empty() {
             continue;
         }
         if line.starts_with('#') {
             if line == VMDK_DESCRIPTOR_DDB || line == VMDK_DESCRIPTOR_DDB_2 {
-                in_extents_section = false;
-                continue;
+                break;
             }
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Expected the DDB section comment line",
             ));
         }
-        if in_extents_section {
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() == 4 || parts.len() == 5 {
-                let size_in_sectors = parts[1].parse::<u64>().map_err(|_| {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() == 4 || parts.len() == 5 {
+            let size_in_sectors = parts[1].parse::<u64>().map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "VMDK extent size '{}' is not a valid sector count",
+                        parts[1]
+                    ),
+                )
+            })?;
+            let offset_in_sectors = match parts.get(4) {
+                Some(offset) => offset.parse::<u64>().map_err(|_| {
                     io::Error::new(
                         io::ErrorKind::InvalidData,
-                        format!(
-                            "VMDK extent size '{}' is not a valid sector count",
-                            parts[1]
-                        ),
+                        format!("VMDK extent offset '{offset}' is not a valid sector count"),
                     )
-                })?;
-                let offset_in_sectors = match parts.get(4) {
-                    Some(offset) => offset.parse::<u64>().map_err(|_| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!("VMDK extent offset '{offset}' is not a valid sector count"),
-                        )
-                    })?,
-                    None => 0,
-                };
-                let extent = VmdkExtentHeader {
-                    access: parts[0].to_string(),
-                    size_in_sectors,
-                    extent_type: parts[2].to_string(),
-                    filename: parts[3].trim_matches('"').to_string(),
-                    offset_in_sectors,
-                };
-                extents.extents.push(extent);
-            } else {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "Malformed VMDK extent line",
-                ));
-            }
+                })?,
+                None => 0,
+            };
+            extents.extents.push(VmdkExtentHeader {
+                access: parts[0].to_string(),
+                size_in_sectors,
+                extent_type: parts[2].to_string(),
+                filename: parts[3].trim_matches('"').to_string(),
+                offset_in_sectors,
+            });
         } else {
-            let parts: Vec<&str> = line.split('=').map(|s| s.trim()).collect();
-            if parts.len() == 2 {
-                ddb.entries
-                    .insert(parts[0].to_string(), parts[1].to_string());
-            }
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Malformed VMDK extent line",
+            ));
         }
     }
 
-    Ok((extents, ddb))
+    Ok(extents)
 }
 
 /// Returns true when `prefix` begins with the `# Disk DescriptorFile` header.
@@ -240,8 +250,8 @@ pub fn is_flat_vmdk(f: &mut File) -> io::Result<bool> {
         _ => return Ok(false),
     }
 
-    let extents = match parse_extents_and_ddb(&mut lines, last_line) {
-        Ok((extents, _ddb)) => extents,
+    let extents = match parse_extents(&mut lines, last_line) {
+        Ok(extents) => extents,
         Err(e) if e.kind() == io::ErrorKind::InvalidData => return Ok(false),
         Err(e) => return Err(e),
     };
@@ -265,26 +275,54 @@ mod tests {
         Ok((header, last.to_string()))
     }
 
-    fn parse_body(
-        last_comment: &str,
-        body: &str,
-    ) -> io::Result<(VmdkDescriptorExtents, VmdkDescriptorDdb)> {
+    fn parse_body(last_comment: &str, body: &str) -> io::Result<VmdkDescriptorExtents> {
         let mut lines = body.lines();
-        parse_extents_and_ddb(&mut lines, last_comment)
+        parse_extents(&mut lines, last_comment)
     }
 
     // Two-stage parse, as `VmdkDescriptor::new` chains it.
-    fn parse_full(
-        input: &str,
-    ) -> io::Result<(
-        VmdkDescriptorHeader,
-        VmdkDescriptorExtents,
-        VmdkDescriptorDdb,
-    )> {
+    fn parse_full(input: &str) -> io::Result<(VmdkDescriptorHeader, VmdkDescriptorExtents)> {
         let mut lines = input.lines();
         let (header, last) = parse_header(&mut lines)?;
-        let (extents, ddb) = parse_extents_and_ddb(&mut lines, last)?;
-        Ok((header, extents, ddb))
+        let extents = parse_extents(&mut lines, last)?;
+        Ok((header, extents))
+    }
+
+    #[test]
+    fn new_is_unaffected_by_shared_file_offset() {
+        use std::io::{Read, Seek, SeekFrom, Write};
+
+        use vmm_sys_util::tempfile::TempFile;
+
+        // A minimal but complete monolithicFlat descriptor.
+        let descriptor_text = "# Disk DescriptorFile\n\
+                               version=1\n\
+                               createType=monolithicFlat\n\
+                               # Extent description\n\
+                               RW 2097152 FLAT \"disk-flat.vmdk\"\n\
+                               # The Disk Data Base\n\
+                               ddb.adapterType = \"ide\"\n";
+
+        let tmp = TempFile::new().unwrap();
+        let mut file: &File = tmp.as_file();
+        file.write_all(descriptor_text.as_bytes()).unwrap();
+
+        // Advance the shared OS file offset off zero, mimicking an earlier
+        // image-type probe. `&File` is `Copy`, so this moves the same fd's
+        // offset that `VmdkDescriptor::new` will see.
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let mut scratch = [0u8; 8];
+        file.read_exact(&mut scratch).unwrap();
+        assert_ne!(file.stream_position().unwrap(), 0);
+
+        // `read_descriptor` reads positionally (anchored at offset 0), so the
+        // advanced offset must not affect the parse.
+        let descriptor = VmdkDescriptor::new(file, tmp.as_path()).unwrap();
+        assert_eq!(descriptor.extents_list.extents.len(), 1);
+        assert_eq!(
+            descriptor.extents_list.extents[0].filename,
+            "disk-flat.vmdk"
+        );
     }
 
     #[test]
@@ -294,7 +332,7 @@ mod tests {
                           ddb.adapterType = \"ide\"\n\
                           ddb.geometry.sectors = \"63\"\n";
 
-        let (extents, ddb) = parse_body("# Extent description", body).unwrap();
+        let extents = parse_body("# Extent description", body).unwrap();
 
         assert_eq!(extents.extents.len(), 1);
         let e = &extents.extents[0];
@@ -302,15 +340,6 @@ mod tests {
         assert_eq!(e.size_in_sectors, 2_097_152);
         assert_eq!(e.extent_type, "FLAT");
         assert_eq!(e.filename, "disk-flat.vmdk");
-
-        assert_eq!(
-            ddb.entries.get("ddb.adapterType").map(String::as_str),
-            Some("\"ide\"")
-        );
-        assert_eq!(
-            ddb.entries.get("ddb.geometry.sectors").map(String::as_str),
-            Some("\"63\"")
-        );
     }
 
     #[test]
@@ -321,7 +350,7 @@ mod tests {
                           # The Disk Data Base\n\
                           ddb.adapterType = \"lsilogic\"\n";
 
-        let (extents, _ddb) = parse_body("# Extent description", body).unwrap();
+        let extents = parse_body("# Extent description", body).unwrap();
 
         assert_eq!(extents.extents.len(), 3);
         assert_eq!(extents.extents[0].filename, "disk-s001.vmdk");
@@ -334,7 +363,7 @@ mod tests {
         // 5-field form: <access> <sectors> <type> <file> <offset>
         let body: &str = "RW 2097152 FLAT \"disk-flat.vmdk\" 0\n";
 
-        let (extents, _ddb) = parse_body("# Extent description", body).unwrap();
+        let extents = parse_body("# Extent description", body).unwrap();
 
         assert_eq!(extents.extents.len(), 1);
         assert_eq!(extents.extents[0].filename, "disk-flat.vmdk");
@@ -345,7 +374,7 @@ mod tests {
         let body: &str = "RDONLY 2097152 FLAT \"ro.vmdk\"\n\
                           NOACCESS 1048576 FLAT \"noaccess.vmdk\"\n";
 
-        let (extents, _ddb) = parse_body("# Extent description", body).unwrap();
+        let extents = parse_body("# Extent description", body).unwrap();
 
         assert_eq!(extents.extents.len(), 2);
         assert_eq!(extents.extents[0].access, "RDONLY");
@@ -394,7 +423,7 @@ mod tests {
         let body: &str = "RW 2097152 FLAT \"disk-flat.vmdk\"\n\
                           \n\
                           # The Disk Data Base\n";
-        let (extents, _ddb) = parse_body("# Extent description", body).unwrap();
+        let extents = parse_body("# Extent description", body).unwrap();
         assert_eq!(extents.extents.len(), 1);
         assert_eq!(extents.extents[0].filename, "disk-flat.vmdk");
     }
@@ -416,9 +445,6 @@ mod tests {
 
         let (header, last) = parse_hdr(input).unwrap();
 
-        assert_eq!(header.version, 1);
-        assert_eq!(header.cid, 0xffff_fffe);
-        assert_eq!(header.parent_cid, 0xffff_ffff);
         assert!(matches!(header.create_type, VMDKDiskType::MonolithicFlat));
         assert_eq!(last, "# Extent description");
     }
@@ -447,15 +473,11 @@ mod tests {
                            # The Disk Data Base\n\
                            ddb.adapterType = \"ide\"\n";
 
-        let (header, extents, ddb) = parse_full(input).unwrap();
+        let (header, extents) = parse_full(input).unwrap();
 
         assert!(matches!(header.create_type, VMDKDiskType::MonolithicFlat));
         assert_eq!(extents.extents.len(), 1);
         assert_eq!(extents.extents[0].access, "RW");
-        assert_eq!(
-            ddb.entries.get("ddb.adapterType").map(String::as_str),
-            Some("\"ide\"")
-        );
     }
 
     #[test]
@@ -468,7 +490,7 @@ mod tests {
                            RW 4192256 FLAT \"disk-s002.vmdk\"\n\
                            # The Disk Data Base\n";
 
-        let (header, extents, _ddb) = parse_full(input).unwrap();
+        let (header, extents) = parse_full(input).unwrap();
 
         assert!(matches!(
             header.create_type,
@@ -497,7 +519,7 @@ mod tests {
                            ddb.virtualHWVersion = \"4\"\n\
                            ddb.adapterType = \"ide\"\n";
 
-        let (header, extents, ddb) = parse_full(input).unwrap();
+        let (header, extents) = parse_full(input).unwrap();
 
         assert!(matches!(header.create_type, VMDKDiskType::MonolithicFlat));
         assert_eq!(extents.extents.len(), 1);
@@ -505,9 +527,5 @@ mod tests {
         assert_eq!(extents.extents[0].size_in_sectors, 6_291_456);
         assert_eq!(extents.extents[0].extent_type, "FLAT");
         assert_eq!(extents.extents[0].filename, "t-flat.vmdk");
-        assert_eq!(
-            ddb.entries.get("ddb.adapterType").map(String::as_str),
-            Some("\"ide\"")
-        );
     }
 }

--- a/block/src/formats/vmdk/descriptor.rs
+++ b/block/src/formats/vmdk/descriptor.rs
@@ -1,0 +1,513 @@
+// Copyright © 2026, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parser for the flat VMDK text descriptor.
+//!
+//! A flat VMDK stores its layout in a small text descriptor: a header, a list
+//! of `FLAT` extent lines, and a disk database (DDB). Only the `monolithicFlat`
+//! and `twoGbMaxExtentFlat` create types are recognized.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io;
+use std::os::unix::fs::FileExt;
+use std::str::Lines;
+
+use crate::AlignedFile;
+
+const VMDK_DESCRIPTOR_HEADER: &str = "# Disk DescriptorFile";
+const VMDK_DESCRIPTOR_EXTENTS: &str = "# Extent description";
+const VMDK_DESCRIPTOR_DDB: &str = "# The Disk Data Base";
+const VMDK_DESCRIPTOR_DDB_2: &str = "#DDB";
+
+/// Flat VMDK create types.
+#[derive(Debug, Default)]
+pub enum VMDKDiskType {
+    #[default]
+    CreateTypeUnsupported,
+    MonolithicFlat,
+    TwoGbMaxExtentFlat,
+}
+
+/// Flat VMDK extent line fields.
+/// Format of each extent line:
+/// `<access> <sectors> <type> "<file>" [offset]`.
+#[allow(dead_code)]
+#[derive(Debug, Default)]
+pub struct VmdkExtentHeader {
+    pub access: String,
+    pub size_in_sectors: u64,
+    pub extent_type: String,
+    pub filename: String,
+    pub offset_in_sectors: u64,
+}
+
+/// Descriptor header fields.
+#[allow(dead_code)]
+#[derive(Debug, Default)]
+pub struct VmdkDescriptorHeader {
+    pub version: u32,
+    pub cid: u32,
+    pub parent_cid: u32,
+    pub create_type: VMDKDiskType,
+    pub parent_filename_hint: String,
+}
+
+/// Ordered list of extents.
+#[derive(Debug, Default)]
+pub struct VmdkDescriptorExtents {
+    pub extents: Vec<VmdkExtentHeader>,
+}
+/// Disk database.
+#[allow(dead_code)]
+#[derive(Debug, Default)]
+pub struct VmdkDescriptorDdb {
+    pub entries: HashMap<String, String>,
+}
+
+// Read the whole descriptor into memory through an `AlignedFile` and return it
+// as a `String`.
+fn read_descriptor(file: &File) -> io::Result<String> {
+    let aligned = AlignedFile::new(file.try_clone()?, true);
+    let len = file.metadata()?.len() as usize;
+    let mut buf = vec![0u8; len];
+    let mut filled = 0;
+    while filled < buf.len() {
+        match aligned.read_at(&mut buf[filled..], filled as u64) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    buf.truncate(filled);
+    // A descriptor is ASCII text, so invalid UTF-8 means "not a descriptor".
+    String::from_utf8(buf).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "VMDK descriptor is not valid UTF-8",
+        )
+    })
+}
+
+pub(crate) fn parse_header<'a>(
+    lines: &mut Lines<'a>,
+) -> io::Result<(VmdkDescriptorHeader, &'a str)> {
+    let header_line = lines.next().unwrap_or_default();
+
+    // Reject actual disk data (or an embedded descriptor, which is
+    // unsupported): a flat descriptor must start with the header line.
+    if header_line.trim_end() != VMDK_DESCRIPTOR_HEADER {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Not a VMDK descriptor file: missing header: {header_line}"),
+        ));
+    }
+
+    let mut header = VmdkDescriptorHeader::default();
+    let mut last_comment_line = "";
+
+    for line in lines.by_ref() {
+        if line.starts_with('#') {
+            // End of the header section.
+            last_comment_line = line;
+            break;
+        }
+        let parts: Vec<&str> = line.split('=').map(|s| s.trim()).collect();
+        if parts.len() == 2 {
+            match parts[0] {
+                "version" => header.version = parts[1].parse().unwrap_or(0),
+                "CID" => header.cid = u32::from_str_radix(parts[1], 16).unwrap_or(0),
+                "parentCID" => header.parent_cid = u32::from_str_radix(parts[1], 16).unwrap_or(0),
+                "createType" => {
+                    // Tools such as qemu-img quote the value, e.g.
+                    // createType="monolithicFlat", strip the quotes.
+                    header.create_type = match parts[1].trim_matches('"') {
+                        "monolithicFlat" => VMDKDiskType::MonolithicFlat,
+                        "twoGbMaxExtentFlat" => VMDKDiskType::TwoGbMaxExtentFlat,
+                        _ => VMDKDiskType::CreateTypeUnsupported,
+                    }
+                }
+                "parentFileNameHint" => header.parent_filename_hint = parts[1].to_string(),
+                _ => {}
+            }
+        }
+    }
+
+    Ok((header, last_comment_line))
+}
+
+pub(crate) fn parse_extents_and_ddb(
+    lines: &mut Lines<'_>,
+    last_comment_line: &str,
+) -> io::Result<(VmdkDescriptorExtents, VmdkDescriptorDdb)> {
+    let mut extents = VmdkDescriptorExtents::default();
+    let mut ddb = VmdkDescriptorDdb::default();
+
+    if last_comment_line != VMDK_DESCRIPTOR_EXTENTS {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Expected the extents section comment line",
+        ));
+    }
+
+    let mut in_extents_section = true;
+    for line in lines.by_ref() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if line.starts_with('#') {
+            if line == VMDK_DESCRIPTOR_DDB || line == VMDK_DESCRIPTOR_DDB_2 {
+                in_extents_section = false;
+                continue;
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Expected the DDB section comment line",
+            ));
+        }
+        if in_extents_section {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() == 4 || parts.len() == 5 {
+                let size_in_sectors = parts[1].parse::<u64>().map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "VMDK extent size '{}' is not a valid sector count",
+                            parts[1]
+                        ),
+                    )
+                })?;
+                let offset_in_sectors = match parts.get(4) {
+                    Some(offset) => offset.parse::<u64>().map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("VMDK extent offset '{offset}' is not a valid sector count"),
+                        )
+                    })?,
+                    None => 0,
+                };
+                let extent = VmdkExtentHeader {
+                    access: parts[0].to_string(),
+                    size_in_sectors,
+                    extent_type: parts[2].to_string(),
+                    filename: parts[3].trim_matches('"').to_string(),
+                    offset_in_sectors,
+                };
+                extents.extents.push(extent);
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Malformed VMDK extent line",
+                ));
+            }
+        } else {
+            let parts: Vec<&str> = line.split('=').map(|s| s.trim()).collect();
+            if parts.len() == 2 {
+                ddb.entries
+                    .insert(parts[0].to_string(), parts[1].to_string());
+            }
+        }
+    }
+
+    Ok((extents, ddb))
+}
+
+/// Returns true when `prefix` begins with the `# Disk DescriptorFile` header.
+pub fn has_descriptor_header(prefix: &[u8]) -> bool {
+    prefix.starts_with(VMDK_DESCRIPTOR_HEADER.as_bytes())
+}
+
+/// Returns true for a supported flat VMDK: create type `monolithicFlat` or
+/// `twoGbMaxExtentFlat` with only `FLAT` extents.
+pub fn is_flat_vmdk(f: &mut File) -> io::Result<bool> {
+    let content = match read_descriptor(f) {
+        Ok(content) => content,
+        Err(e) if e.kind() == io::ErrorKind::InvalidData => return Ok(false),
+        Err(e) => return Err(e),
+    };
+    let mut lines = content.lines();
+
+    let (header, last_line) = match parse_header(&mut lines) {
+        Ok(parsed) => parsed,
+        Err(e) if e.kind() == io::ErrorKind::InvalidData => return Ok(false),
+        Err(e) => return Err(e),
+    };
+
+    match header.create_type {
+        VMDKDiskType::MonolithicFlat | VMDKDiskType::TwoGbMaxExtentFlat => {}
+        _ => return Ok(false),
+    }
+
+    let extents = match parse_extents_and_ddb(&mut lines, last_line) {
+        Ok((extents, _ddb)) => extents,
+        Err(e) if e.kind() == io::ErrorKind::InvalidData => return Ok(false),
+        Err(e) => return Err(e),
+    };
+
+    for extent in &extents.extents {
+        if extent.extent_type != "FLAT" {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_hdr(input: &str) -> io::Result<(VmdkDescriptorHeader, String)> {
+        let mut lines = input.lines();
+        let (header, last) = parse_header(&mut lines)?;
+        Ok((header, last.to_string()))
+    }
+
+    fn parse_body(
+        last_comment: &str,
+        body: &str,
+    ) -> io::Result<(VmdkDescriptorExtents, VmdkDescriptorDdb)> {
+        let mut lines = body.lines();
+        parse_extents_and_ddb(&mut lines, last_comment)
+    }
+
+    // Two-stage parse, as `VmdkDescriptor::new` chains it.
+    fn parse_full(
+        input: &str,
+    ) -> io::Result<(
+        VmdkDescriptorHeader,
+        VmdkDescriptorExtents,
+        VmdkDescriptorDdb,
+    )> {
+        let mut lines = input.lines();
+        let (header, last) = parse_header(&mut lines)?;
+        let (extents, ddb) = parse_extents_and_ddb(&mut lines, last)?;
+        Ok((header, extents, ddb))
+    }
+
+    #[test]
+    fn single_flat_extent_with_ddb() {
+        let body: &str = "RW 2097152 FLAT \"disk-flat.vmdk\"\n\
+                          # The Disk Data Base\n\
+                          ddb.adapterType = \"ide\"\n\
+                          ddb.geometry.sectors = \"63\"\n";
+
+        let (extents, ddb) = parse_body("# Extent description", body).unwrap();
+
+        assert_eq!(extents.extents.len(), 1);
+        let e = &extents.extents[0];
+        assert_eq!(e.access, "RW");
+        assert_eq!(e.size_in_sectors, 2_097_152);
+        assert_eq!(e.extent_type, "FLAT");
+        assert_eq!(e.filename, "disk-flat.vmdk");
+
+        assert_eq!(
+            ddb.entries.get("ddb.adapterType").map(String::as_str),
+            Some("\"ide\"")
+        );
+        assert_eq!(
+            ddb.entries.get("ddb.geometry.sectors").map(String::as_str),
+            Some("\"63\"")
+        );
+    }
+
+    #[test]
+    fn multiple_extents_two_gb_max() {
+        let body: &str = "RW 4192256 FLAT \"disk-s001.vmdk\"\n\
+                          RW 4192256 FLAT \"disk-s002.vmdk\"\n\
+                          RW 2097152 FLAT \"disk-s003.vmdk\"\n\
+                          # The Disk Data Base\n\
+                          ddb.adapterType = \"lsilogic\"\n";
+
+        let (extents, _ddb) = parse_body("# Extent description", body).unwrap();
+
+        assert_eq!(extents.extents.len(), 3);
+        assert_eq!(extents.extents[0].filename, "disk-s001.vmdk");
+        assert_eq!(extents.extents[2].filename, "disk-s003.vmdk");
+        assert!(extents.extents.iter().all(|e| e.extent_type == "FLAT"));
+    }
+
+    #[test]
+    fn extent_line_with_optional_offset_field() {
+        // 5-field form: <access> <sectors> <type> <file> <offset>
+        let body: &str = "RW 2097152 FLAT \"disk-flat.vmdk\" 0\n";
+
+        let (extents, _ddb) = parse_body("# Extent description", body).unwrap();
+
+        assert_eq!(extents.extents.len(), 1);
+        assert_eq!(extents.extents[0].filename, "disk-flat.vmdk");
+    }
+
+    #[test]
+    fn extent_access_modes_are_preserved() {
+        let body: &str = "RDONLY 2097152 FLAT \"ro.vmdk\"\n\
+                          NOACCESS 1048576 FLAT \"noaccess.vmdk\"\n";
+
+        let (extents, _ddb) = parse_body("# Extent description", body).unwrap();
+
+        assert_eq!(extents.extents.len(), 2);
+        assert_eq!(extents.extents[0].access, "RDONLY");
+        assert_eq!(extents.extents[1].access, "NOACCESS");
+    }
+
+    #[test]
+    fn rejects_wrong_leading_comment() {
+        let body: &str = "RW 2097152 FLAT \"disk-flat.vmdk\"\n";
+        // Must be told we are at "# Extent description", anything else errors.
+        parse_body("# The Disk Data Base", body).unwrap_err();
+    }
+
+    #[test]
+    fn rejects_malformed_extent_line() {
+        // Only three fields -> malformed.
+        let body: &str = "RW 2097152 FLAT\n";
+        parse_body("# Extent description", body).unwrap_err();
+    }
+
+    #[test]
+    fn rejects_non_numeric_extent_size() {
+        // A non-numeric sector count must be rejected, not coerced to 0.
+        let body: &str = "RW notanumber FLAT \"disk-flat.vmdk\"\n";
+        parse_body("# Extent description", body).unwrap_err();
+    }
+
+    #[test]
+    fn rejects_non_numeric_extent_offset() {
+        // A non-numeric trailing offset must be rejected too.
+        let body: &str = "RW 2097152 FLAT \"disk-flat.vmdk\" xyz\n";
+        parse_body("# Extent description", body).unwrap_err();
+    }
+
+    #[test]
+    fn rejects_unexpected_comment_in_body() {
+        let body: &str = "RW 2097152 FLAT \"disk-flat.vmdk\"\n\
+                          # Some other comment\n";
+        parse_body("# Extent description", body).unwrap_err();
+    }
+
+    #[test]
+    fn skips_blank_line_inside_extent_section() {
+        // qemu-img emits a blank line between the last extent and the
+        // "# The Disk Data Base" marker, it must be skipped, not rejected.
+        let body: &str = "RW 2097152 FLAT \"disk-flat.vmdk\"\n\
+                          \n\
+                          # The Disk Data Base\n";
+        let (extents, _ddb) = parse_body("# Extent description", body).unwrap();
+        assert_eq!(extents.extents.len(), 1);
+        assert_eq!(extents.extents[0].filename, "disk-flat.vmdk");
+    }
+
+    #[test]
+    fn rejects_missing_descriptor_header() {
+        let input: &str = "NOT_A_DESCRIPTOR\nversion=1\n";
+        parse_hdr(input).unwrap_err();
+    }
+
+    #[test]
+    fn parses_header_fields() {
+        let input: &str = "# Disk DescriptorFile\n\
+                           version=1\n\
+                           CID=fffffffe\n\
+                           parentCID=ffffffff\n\
+                           createType=monolithicFlat\n\
+                           # Extent description\n";
+
+        let (header, last) = parse_hdr(input).unwrap();
+
+        assert_eq!(header.version, 1);
+        assert_eq!(header.cid, 0xffff_fffe);
+        assert_eq!(header.parent_cid, 0xffff_ffff);
+        assert!(matches!(header.create_type, VMDKDiskType::MonolithicFlat));
+        assert_eq!(last, "# Extent description");
+    }
+
+    #[test]
+    fn parses_quoted_create_type() {
+        let input: &str = "# Disk DescriptorFile\n\
+                           version=1\n\
+                           createType=\"twoGbMaxExtentFlat\"\n\
+                           # Extent description\n";
+
+        let (header, _last) = parse_hdr(input).unwrap();
+        assert!(matches!(
+            header.create_type,
+            VMDKDiskType::TwoGbMaxExtentFlat
+        ));
+    }
+
+    #[test]
+    fn full_monolithic_flat_descriptor() {
+        let input: &str = "# Disk DescriptorFile\n\
+                           version=1\n\
+                           createType=monolithicFlat\n\
+                           # Extent description\n\
+                           RW 2097152 FLAT \"disk-flat.vmdk\"\n\
+                           # The Disk Data Base\n\
+                           ddb.adapterType = \"ide\"\n";
+
+        let (header, extents, ddb) = parse_full(input).unwrap();
+
+        assert!(matches!(header.create_type, VMDKDiskType::MonolithicFlat));
+        assert_eq!(extents.extents.len(), 1);
+        assert_eq!(extents.extents[0].access, "RW");
+        assert_eq!(
+            ddb.entries.get("ddb.adapterType").map(String::as_str),
+            Some("\"ide\"")
+        );
+    }
+
+    #[test]
+    fn full_two_gb_max_extent_flat_descriptor() {
+        let input: &str = "# Disk DescriptorFile\n\
+                           version=1\n\
+                           createType=twoGbMaxExtentFlat\n\
+                           # Extent description\n\
+                           RW 4192256 FLAT \"disk-s001.vmdk\"\n\
+                           RW 4192256 FLAT \"disk-s002.vmdk\"\n\
+                           # The Disk Data Base\n";
+
+        let (header, extents, _ddb) = parse_full(input).unwrap();
+
+        assert!(matches!(
+            header.create_type,
+            VMDKDiskType::TwoGbMaxExtentFlat
+        ));
+        assert_eq!(extents.extents.len(), 2);
+    }
+
+    #[test]
+    fn full_qemu_style_descriptor() {
+        // Mirrors a real qemu-img monolithicFlat descriptor: quoted createType,
+        // blank lines between sections, 5-field extent line with a trailing
+        // offset, and the "#DDB" marker form.
+        let input: &str = "# Disk DescriptorFile\n\
+                           version=1\n\
+                           CID=eb2295a4\n\
+                           parentCID=ffffffff\n\
+                           createType=\"monolithicFlat\"\n\
+                           \n\
+                           # Extent description\n\
+                           RW 6291456 FLAT \"t-flat.vmdk\" 0\n\
+                           \n\
+                           # The Disk Data Base\n\
+                           #DDB\n\
+                           \n\
+                           ddb.virtualHWVersion = \"4\"\n\
+                           ddb.adapterType = \"ide\"\n";
+
+        let (header, extents, ddb) = parse_full(input).unwrap();
+
+        assert!(matches!(header.create_type, VMDKDiskType::MonolithicFlat));
+        assert_eq!(extents.extents.len(), 1);
+        assert_eq!(extents.extents[0].access, "RW");
+        assert_eq!(extents.extents[0].size_in_sectors, 6_291_456);
+        assert_eq!(extents.extents[0].extent_type, "FLAT");
+        assert_eq!(extents.extents[0].filename, "t-flat.vmdk");
+        assert_eq!(
+            ddb.entries.get("ddb.adapterType").map(String::as_str),
+            Some("\"ide\"")
+        );
+    }
+}

--- a/block/src/formats/vmdk/engine_sync.rs
+++ b/block/src/formats/vmdk/engine_sync.rs
@@ -1,0 +1,293 @@
+// Copyright © 2026, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::os::unix::fs::FileExt;
+use std::sync::Arc;
+use std::{cmp, io};
+
+use vmm_sys_util::eventfd::EventFd;
+
+use crate::AlignedFile;
+use crate::async_io::{
+    AsyncIo, AsyncIoCompletion, AsyncIoError, AsyncIoOperation, AsyncIoResult, CompletionCommon,
+};
+use crate::formats::vmdk::flat::{ExtentAccess, VmdkExtent};
+
+/// Synchronous, extent-aware I/O worker for flat VMDK images.
+///
+/// Maps each guest I/O request to one or more backing extents.
+///
+/// Async backends (io_uring/AIO) are not supported.
+pub(crate) struct FlatVmdkSync {
+    extents: Arc<Vec<VmdkExtent>>,
+    size: u64,
+    completions: CompletionCommon,
+}
+
+impl FlatVmdkSync {
+    pub fn new(extents: Arc<Vec<VmdkExtent>>, size: u64) -> Self {
+        FlatVmdkSync {
+            extents,
+            size,
+            completions: CompletionCommon::new(),
+        }
+    }
+
+    // Returns the extent containing virtual `offset`, or `None` if out of range.
+    fn extent_at(&self, offset: u64) -> Option<&VmdkExtent> {
+        self.extents
+            .iter()
+            .find(|e| offset >= e.virtual_start && offset < e.virtual_start + e.length)
+    }
+
+    fn check_access(&self, start: u64, total: u64, is_read: bool) -> io::Result<()> {
+        let end = start + total;
+        let mut cur = start;
+        while cur < end {
+            let extent = self.extent_at(cur).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "offset outside any VMDK extent")
+            })?;
+            match extent.access {
+                ExtentAccess::NoAccess => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("VMDK extent at offset {cur} is NOACCESS; request rejected"),
+                    ));
+                }
+                ExtentAccess::ReadOnly if !is_read => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("write to read-only VMDK extent at offset {cur} rejected"),
+                    ));
+                }
+                _ => {}
+            }
+            cur = extent.virtual_start + extent.length;
+        }
+        Ok(())
+    }
+
+    // Reads or writes a single contiguous segment of one extent through the
+    // extent's `AlignedFile`.
+    fn segment_io(
+        file: &AlignedFile,
+        file_offset: u64,
+        op: &mut AsyncIoOperation,
+        buf_start: usize,
+        seg_len: usize,
+        is_read: bool,
+    ) -> io::Result<usize> {
+        // O_DIRECT unaligned
+        if file.alignment() != 0 {
+            return if is_read {
+                file.read_unaligned(file_offset, seg_len, |data| {
+                    op.write_bytes_at(buf_start, data)
+                })
+            } else {
+                file.write_unaligned(file_offset, seg_len, |data| {
+                    op.read_bytes_at(buf_start, data)
+                })
+            };
+        }
+
+        // Aligned & Buffered
+        let mut buf = vec![0u8; seg_len];
+        let mut done = 0usize;
+        if is_read {
+            while done < seg_len {
+                match file.read_at(&mut buf[done..], file_offset + done as u64) {
+                    Ok(0) => break, // EOF: nothing more to read
+                    Ok(n) => done += n,
+                    Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(e) => return Err(e),
+                }
+            }
+            op.write_bytes_at(buf_start, &buf[..done])?;
+            Ok(done)
+        } else {
+            op.read_bytes_at(buf_start, &mut buf)?;
+            while done < seg_len {
+                match file.write_at(&buf[done..], file_offset + done as u64) {
+                    Ok(0) => break, // no progress: avoid spinning forever
+                    Ok(n) => done += n,
+                    Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(e) => return Err(e),
+                }
+            }
+            Ok(done)
+        }
+    }
+
+    // Single-extent path: the whole request lives in `extent`.
+    //
+    // The guest iovecs are handed to `AlignedFile::{read,write}_vectored_at`
+    fn single_extent_io(
+        &self,
+        extent: &VmdkExtent,
+        op: &mut AsyncIoOperation,
+    ) -> io::Result<usize> {
+        let file = extent.file.as_ref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "VMDK extent is not accessible",
+            )
+        })?;
+        let file_offset = extent.file_base_offset + (op.offset() as u64 - extent.virtual_start);
+        let iovecs = op.iovecs();
+
+        // SAFETY: the iovec buffers are owned by `op` and remain valid for the
+        // duration of this call.
+        unsafe {
+            if op.is_read() {
+                file.read_vectored_at(iovecs, file_offset)
+            } else {
+                file.write_vectored_at(iovecs, file_offset)
+            }
+        }
+    }
+
+    // Slow path: the request straddles >= 2 extents.
+    //
+    // A single guest request here maps onto several different backing files,
+    // Every segment goes through `segment_io` regardless of
+    // alignment.
+    fn spanning_io(&self, op: &mut AsyncIoOperation) -> io::Result<usize> {
+        let start = op.offset() as u64;
+        let total = op.total_len() as u64;
+        let is_read = op.is_read();
+
+        let mut done: u64 = 0;
+        while done < total {
+            let cur = start + done;
+            let extent = self.extent_at(cur).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "offset outside any VMDK extent")
+            })?;
+            let extent_end = extent.virtual_start + extent.length;
+            // Bytes handled in this extent before reaching its boundary.
+            let seg_len = cmp::min(total - done, extent_end - cur) as usize;
+            let file = extent.file.as_ref().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "VMDK extent is not accessible",
+                )
+            })?;
+            let file_offset = extent.file_base_offset + (cur - extent.virtual_start);
+
+            let n = Self::segment_io(file, file_offset, op, done as usize, seg_len, is_read)?;
+            done += n as u64;
+            if n < seg_len {
+                break; // short read/write
+            }
+        }
+
+        Ok(done as usize)
+    }
+}
+
+impl AsyncIo for FlatVmdkSync {
+    fn notifier(&self) -> &EventFd {
+        self.completions.notifier()
+    }
+
+    fn submit_data_operation(&mut self, mut op: AsyncIoOperation) -> AsyncIoResult<()> {
+        let start = op.offset() as u64;
+        let total = op.total_len() as u64;
+        let is_read = op.is_read();
+
+        // Bounds check against the virtual disk size (overflow-safe: `start`
+        // is checked before subtracting it from `size`).
+        if start > self.size || total > self.size - start {
+            let error = io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "VMDK request [{start}, {}) exceeds virtual size {}",
+                    start + total,
+                    self.size
+                ),
+            );
+            return Err(if is_read {
+                AsyncIoError::ReadVectored(error)
+            } else {
+                AsyncIoError::WriteVectored(error)
+            });
+        }
+
+        // Reject the request up front if any extent it touches forbids it:
+        // NOACCESS extents reject all I/O.
+        if total != 0
+            && let Err(error) = self.check_access(start, total, is_read)
+        {
+            return Err(if is_read {
+                AsyncIoError::ReadVectored(error)
+            } else {
+                AsyncIoError::WriteVectored(error)
+            });
+        }
+
+        let result = if total == 0 {
+            Ok(0)
+        } else if let Some(extent) = self.extent_at(start) {
+            if start + total <= extent.virtual_start + extent.length {
+                // Entire request fits in one extent
+                self.single_extent_io(extent, &mut op)
+            } else {
+                // Request crosses an extent boundary
+                self.spanning_io(&mut op)
+            }
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "offset outside any VMDK extent",
+            ))
+        };
+
+        let bytes = result.map_err(|e| {
+            if is_read {
+                AsyncIoError::ReadVectored(e)
+            } else {
+                AsyncIoError::WriteVectored(e)
+            }
+        })?;
+
+        self.completions
+            .complete(AsyncIoCompletion::from_operation(op, bytes as i32));
+        Ok(())
+    }
+
+    fn fsync(&mut self, user_data: Option<u64>) -> AsyncIoResult<()> {
+        // Flush every extent: a single guest flush must durably persist data
+        // that may have been written across multiple extent files.
+        for extent in self.extents.iter() {
+            // Skip NoAccess extents, which have no open file.
+            if let Some(file) = extent.file.as_ref() {
+                file.sync_all().map_err(AsyncIoError::Fsync)?;
+            }
+        }
+
+        if let Some(user_data) = user_data {
+            self.completions
+                .complete(AsyncIoCompletion::new(user_data, 0, None));
+        }
+
+        Ok(())
+    }
+
+    fn next_completed_request(&mut self) -> Option<AsyncIoCompletion> {
+        self.completions.next_completed()
+    }
+
+    fn punch_hole(&mut self, _offset: u64, _length: u64, _user_data: u64) -> AsyncIoResult<()> {
+        // Flat VMDK is not sparse-capable (see `SparseCapable` impl), so this
+        // should never be negotiated by the guest.
+        Err(AsyncIoError::PunchHole(io::Error::other(
+            "punch_hole not supported for flat VMDK",
+        )))
+    }
+
+    fn write_zeroes(&mut self, _offset: u64, _length: u64, _user_data: u64) -> AsyncIoResult<()> {
+        Err(AsyncIoError::WriteZeroes(io::Error::other(
+            "write_zeroes not supported for flat VMDK",
+        )))
+    }
+}

--- a/block/src/formats/vmdk/flat.rs
+++ b/block/src/formats/vmdk/flat.rs
@@ -5,8 +5,6 @@
 //! Flat VMDK extent layout: opens the data extents referenced by the
 //! descriptor and maps the virtual disk onto them.
 
-#![allow(dead_code)]
-
 use std::ffi::{CString, OsStr};
 use std::fs::{File, OpenOptions};
 use std::io;
@@ -19,7 +17,7 @@ use std::sync::Arc;
 use log::warn;
 
 use crate::formats::vmdk::descriptor::VmdkDescriptor;
-use crate::{AlignedFile, DiskTopology};
+use crate::{AlignedFile, DiskTopology, query_device_size};
 
 const VMDK_SECTOR_SIZE: u64 = 512;
 
@@ -346,18 +344,16 @@ impl FlatVmdk {
         Arc::clone(&self.extents)
     }
 
-    /// Host allocation size: the sum of every opened extent file's size.
-    /// `NoAccess` extents contribute 0 to the total.
+    /// Host allocation size: the sum of every opened extent's actually
+    /// allocated storage (`st_blocks * 512` for regular files, device size for
+    /// block devices), so sparse extents are reported correctly. `NoAccess`
+    /// extents (no open file) contribute 0, as does any extent whose size
+    /// cannot be queried.
     pub fn physical_block_size(&self) -> u64 {
         self.extents
             .iter()
-            .map(|extent| {
-                extent
-                    .file
-                    .as_ref()
-                    .and_then(|f| f.metadata().ok())
-                    .map_or(0, |m| m.len())
-            })
+            .filter_map(|extent| extent.file.as_ref())
+            .map(|f| query_device_size(f.file()).map_or(0, |(_, physical)| physical))
             .sum()
     }
 

--- a/block/src/formats/vmdk/flat.rs
+++ b/block/src/formats/vmdk/flat.rs
@@ -1,0 +1,637 @@
+// Copyright © 2026, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Flat VMDK extent layout: opens the data extents referenced by the
+//! descriptor and maps the virtual disk onto them.
+
+#![allow(dead_code)]
+
+use std::ffi::{CString, OsStr};
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::path::{Component, Path};
+use std::sync::Arc;
+
+use log::warn;
+
+use crate::formats::vmdk::descriptor::VmdkDescriptor;
+use crate::{AlignedFile, DiskTopology};
+
+const VMDK_SECTOR_SIZE: u64 = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExtentAccess {
+    /// "RW": readable and writable.
+    ReadWrite,
+    /// "RDONLY": readable only, writes must be rejected.
+    ReadOnly,
+    /// "NOACCESS": cannot be accessed, reads and writes must be rejected.
+    NoAccess,
+}
+
+/// A single Flat VMDK extent
+///
+/// `twoGbMaxExtentFlat` images concatenate several of these to form the full
+/// virtual disk, `monolithicFlat` images have exactly one.
+#[derive(Debug)]
+pub(crate) struct VmdkExtent {
+    /// Open, alignment-aware handle to this extent's data file. `None` for
+    /// `NoAccess` extents, which are never opened because they cannot be
+    /// accessed.
+    ///
+    /// The handle is wrapped in an [`AlignedFile`]
+    pub file: Option<AlignedFile>,
+    /// Access mode declared for this extent in the descriptor.
+    pub access: ExtentAccess,
+    /// First virtual-disk offset (in bytes) backed by this extent.
+    pub virtual_start: u64,
+    /// Length (in bytes) of the virtual-disk range backed by this extent.
+    pub length: u64,
+    /// Starting offset (in bytes) within the backing file for this extent.
+    /// Non-zero when several extents reference the same file at growing
+    /// offsets (e.g. a >2GB file split under `twoGbMaxExtentFlat`).
+    pub file_base_offset: u64,
+}
+
+#[derive(Debug)]
+pub struct FlatVmdk {
+    descriptor: Arc<VmdkDescriptor>,
+    // Open handle to the VMDK descriptor file.
+    descriptor_file: Arc<File>,
+    // All opened data extents, in virtual-disk order.
+    extents: Arc<Vec<VmdkExtent>>,
+    size: u64,
+}
+
+#[repr(C)]
+struct OpenHow {
+    flags: u64,
+    mode: u64,
+    resolve: u64,
+}
+
+// Splits an untrusted extent `filename` into its `Normal` path components for
+// the fallback walk, rejecting any `..`/`.` traversal.
+fn extent_components(filename: &str) -> io::Result<Vec<&OsStr>> {
+    let mut components = Vec::new();
+    for component in Path::new(filename).components() {
+        match component {
+            Component::Normal(name) => components.push(name),
+            Component::RootDir => {}
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "VMDK extent filename '{filename}' must not contain '..' or '.' path \
+                         components"
+                    ),
+                ));
+            }
+        }
+    }
+    if components.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("VMDK extent filename '{filename}' is empty"),
+        ));
+    }
+    Ok(components)
+}
+
+// Opens a single VMDK data extent for the descriptor whose directory is
+// base_path.
+//
+// The extent name may be relative to the descriptor or an absolute path. The
+// only difference between the two is:
+//   - relative -> colocated with descriptor file
+//   - absolute -> the filesystem root
+// The symlink policy rejects the final component if it is a symlink (O_NOFOLLOW).
+//
+// Resolution prefers openat2(2). On kernels without it (< 5.6, ENOSYS) or
+// where it is blocked (EPERM, e.g. a seccomp filter), it falls back to a
+// per-component openat walk.
+fn open_extent(
+    base_path: &str,
+    filename: &str,
+    writable: bool,
+    direct: bool,
+) -> io::Result<AlignedFile> {
+    let anchor = if Path::new(filename).is_absolute() {
+        "/"
+    } else {
+        base_path
+    };
+
+    let dir = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
+        .open(anchor)?;
+
+    match open_extent_openat2(dir.as_raw_fd(), filename, writable, direct) {
+        Ok(file) => Ok(AlignedFile::new(file, direct)),
+        Err(e) if matches!(e.raw_os_error(), Some(libc::ENOSYS) | Some(libc::EPERM)) => {
+            let components = extent_components(filename)?;
+            open_extent_walk(dir, &components, writable, direct)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn open_extent_openat2(
+    dir_fd: RawFd,
+    filename: &str,
+    writable: bool,
+    direct: bool,
+) -> io::Result<File> {
+    let cname = CString::new(filename).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "VMDK extent filename contains an interior NUL byte",
+        )
+    })?;
+
+    let access = if writable {
+        libc::O_RDWR
+    } else {
+        libc::O_RDONLY
+    };
+
+    let mut flags = access | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+    if direct {
+        flags |= libc::O_DIRECT;
+    }
+    let how = OpenHow {
+        flags: flags as u64,
+        mode: 0,
+        resolve: 0,
+    };
+
+    // SAFETY: FFI syscall. `cname` is NUL-terminated and outlives the call,
+    // `how` is a correctly sized `open_how` passed by pointer, and `dir_fd` is a
+    // valid directory fd.
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_openat2,
+            dir_fd,
+            cname.as_ptr(),
+            &how as *const OpenHow,
+            size_of::<OpenHow>(),
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `openat2` returned a fresh descriptor we now own exclusively.
+    Ok(unsafe { File::from_raw_fd(ret as RawFd) })
+}
+
+fn open_extent_walk(
+    mut dir: File,
+    components: &[&OsStr],
+    writable: bool,
+    direct: bool,
+) -> io::Result<AlignedFile> {
+    let last = components.len() - 1;
+    for (i, name) in components.iter().enumerate() {
+        let cname = CString::new(name.as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "VMDK extent filename contains an interior NUL byte",
+            )
+        })?;
+
+        let flags = if i < last {
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC
+        } else {
+            // Final component: the extent file, opened with the declared access
+            // and cache mode, and O_NOFOLLOW so it may not be a symlink either.
+            let access = if writable {
+                libc::O_RDWR
+            } else {
+                libc::O_RDONLY
+            };
+            let mut flags = access | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+            if direct {
+                flags |= libc::O_DIRECT;
+            }
+            flags
+        };
+
+        // SAFETY: `dir` is a valid open directory fd and `cname` is a
+        // NUL-terminated C string that outlives the call.
+        let fd = unsafe { libc::openat(dir.as_raw_fd(), cname.as_ptr(), flags) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: `fd` is a freshly opened descriptor we now own exclusively.
+        let opened = unsafe { File::from_raw_fd(fd) };
+
+        if i < last {
+            // Reassignment drops the previous directory `File`, closing that fd.
+            dir = opened;
+        } else {
+            return Ok(AlignedFile::new(opened, direct));
+        }
+    }
+
+    unreachable!("extent_components guarantees at least one component")
+}
+
+// Builds the error returned when a sector count/offset from the (untrusted)
+// descriptor, scaled to bytes, does not fit in a u64.
+fn overflow_error(what: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("VMDK {what} overflows a 64-bit byte count"),
+    )
+}
+
+impl FlatVmdk {
+    /// Opens a flat VMDK image from its already-open descriptor file.
+    pub fn new(file: File, path: &Path, direct: bool) -> io::Result<Self> {
+        let descriptor = VmdkDescriptor::new(&file, path)?;
+
+        if descriptor.extents_list.extents.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "VMDK descriptor lists no extents",
+            ));
+        }
+
+        // Open every data extent and record the virtual-disk byte range it
+        // backs.
+        let mut extents: Vec<VmdkExtent> =
+            Vec::with_capacity(descriptor.extents_list.extents.len());
+        let mut virtual_start: u64 = 0;
+        for extent in &descriptor.extents_list.extents {
+            // A flat extent is a fixed, pre-allocated region, a zero-sector
+            // extent would back an empty virtual range that can never be read
+            // or written
+            if extent.size_in_sectors == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "VMDK flat extent has zero size",
+                ));
+            }
+
+            let length = extent
+                .size_in_sectors
+                .checked_mul(VMDK_SECTOR_SIZE)
+                .ok_or_else(|| overflow_error("extent size"))?;
+            let file_base_offset = extent
+                .offset_in_sectors
+                .checked_mul(VMDK_SECTOR_SIZE)
+                .ok_or_else(|| overflow_error("extent file offset"))?;
+            file_base_offset
+                .checked_add(length)
+                .ok_or_else(|| overflow_error("extent file range"))?;
+
+            // Open the backing file using exactly the access declared for this
+            // extent. The VMDK spec defines three values:
+            //   "RW"       -> read + write
+            //   "RDONLY"   -> read only
+            //   "NOACCESS" -> not accessible, do not open the file at all
+            let (access, extent_file) = match extent.access.as_str() {
+                "RW" => {
+                    let f = open_extent(&descriptor.base_path, &extent.filename, true, direct)?;
+                    (ExtentAccess::ReadWrite, Some(f))
+                }
+                "RDONLY" => {
+                    let f = open_extent(&descriptor.base_path, &extent.filename, false, direct)?;
+                    (ExtentAccess::ReadOnly, Some(f))
+                }
+                "NOACCESS" => (ExtentAccess::NoAccess, None),
+                other => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("unsupported VMDK extent access mode '{other}'"),
+                    ));
+                }
+            };
+
+            extents.push(VmdkExtent {
+                file: extent_file,
+                access,
+                virtual_start,
+                length,
+                file_base_offset,
+            });
+
+            virtual_start = virtual_start
+                .checked_add(length)
+                .ok_or_else(|| overflow_error("total virtual size"))?;
+        }
+
+        // The virtual disk size is the end offset of the last extent.
+        let total_disk_size = virtual_start;
+
+        Ok(Self {
+            descriptor: Arc::new(descriptor),
+            descriptor_file: Arc::new(file),
+            extents: Arc::new(extents),
+            size: total_disk_size,
+        })
+    }
+
+    pub fn virtual_block_size(&self) -> u64 {
+        self.size
+    }
+
+    /// Shared handle to the opened data extents, used to build the I/O worker.
+    pub fn extents(&self) -> Arc<Vec<VmdkExtent>> {
+        Arc::clone(&self.extents)
+    }
+
+    /// Host allocation size: the sum of every opened extent file's size.
+    /// `NoAccess` extents contribute 0 to the total.
+    pub fn physical_block_size(&self) -> u64 {
+        self.extents
+            .iter()
+            .map(|extent| {
+                extent
+                    .file
+                    .as_ref()
+                    .and_then(|f| f.metadata().ok())
+                    .map_or(0, |m| m.len())
+            })
+            .sum()
+    }
+
+    /// Sector/cluster geometry reported to the guest.
+    pub fn topology(&self) -> DiskTopology {
+        self.extents
+            .iter()
+            .find_map(|extent| extent.file.as_ref())
+            .map(|f| {
+                DiskTopology::probe(f.file()).unwrap_or_else(|_| {
+                    warn!("Unable to get VMDK extent topology. Using default topology");
+                    DiskTopology::default()
+                })
+            })
+            .unwrap_or_default()
+    }
+}
+
+// Expose the descriptor file's fd as the disk's representative fd.
+impl AsRawFd for FlatVmdk {
+    fn as_raw_fd(&self) -> RawFd {
+        self.descriptor_file.as_raw_fd()
+    }
+}
+
+impl Clone for FlatVmdk {
+    fn clone(&self) -> Self {
+        Self {
+            descriptor: Arc::clone(&self.descriptor),
+            descriptor_file: Arc::clone(&self.descriptor_file),
+            extents: Arc::clone(&self.extents),
+            size: self.size,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn extent_components_allows_bare_name() {
+        // The common flat-VMDK case: a single co-located extent file.
+        let comps = extent_components("disk-flat.vmdk").unwrap();
+        assert_eq!(comps, [OsStr::new("disk-flat.vmdk")]);
+    }
+
+    #[test]
+    fn extent_components_rejects_traversal_and_empty() {
+        // `..`/`.` traversal and empty names are refused. (An absolute path is
+        // decomposed into its Normal components, the leading `/` is skipped and
+        // the caller anchors the walk at the filesystem root.)
+        extent_components("../../etc/passwd").unwrap_err();
+        extent_components("sub/../../escape").unwrap_err();
+        extent_components("extent-1.vmdk/../../").unwrap_err();
+        extent_components("./s001.vmdk").unwrap_err();
+        extent_components("").unwrap_err();
+    }
+
+    #[test]
+    fn extent_components_decomposes_absolute_path() {
+        // A leading `/` is skipped, the remaining Normal components are walked
+        // from the filesystem root by the caller.
+        let comps = extent_components("/var/lib/layer.erofs").unwrap();
+        assert_eq!(
+            comps,
+            [
+                OsStr::new("var"),
+                OsStr::new("lib"),
+                OsStr::new("layer.erofs")
+            ]
+        );
+    }
+
+    // Opens `path` as a directory anchor fd, mirroring how `open_extent` opens
+    // its anchor.
+    fn open_dir(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
+            .open(path)
+            .unwrap()
+    }
+
+    // Returns false when `openat2(2)` is unavailable.
+    fn openat2_available(res: &io::Result<File>) -> bool {
+        !matches!(
+            res.as_ref().err().and_then(|e| e.raw_os_error()),
+            Some(libc::ENOSYS) | Some(libc::EPERM)
+        )
+    }
+
+    // Opens the same anchor + `filename` with BOTH extent-open implementations
+    // so a single scenario asserts they behave identically:
+    fn open_both(
+        base_path: &Path,
+        filename: &str,
+        writable: bool,
+        direct: bool,
+    ) -> (io::Result<File>, io::Result<AlignedFile>) {
+        let anchor: &Path = if Path::new(filename).is_absolute() {
+            Path::new("/")
+        } else {
+            base_path
+        };
+
+        let openat2_dir = open_dir(anchor);
+        let openat2_res = open_extent_openat2(openat2_dir.as_raw_fd(), filename, writable, direct);
+
+        let walk_dir = open_dir(anchor);
+        let walk_res = match extent_components(filename) {
+            Ok(components) => open_extent_walk(walk_dir, &components, writable, direct),
+            Err(e) => Err(e),
+        };
+
+        (openat2_res, walk_res)
+    }
+
+    // Asserts openat2.
+    fn check_openat2(res: &io::Result<File>, expect_ok: bool) {
+        if !openat2_available(res) {
+            return;
+        }
+        assert_eq!(
+            res.is_ok(),
+            expect_ok,
+            "openat2 result did not match expectation (expected ok = {expect_ok})"
+        );
+    }
+
+    // Asserts the per-component walk result.
+    fn check_walk(res: &io::Result<AlignedFile>, expect_ok: bool) {
+        assert_eq!(
+            res.is_ok(),
+            expect_ok,
+            "walk result did not match expectation (expected ok = {expect_ok})"
+        );
+    }
+
+    #[test]
+    fn open_extent_opens_regular_file() {
+        use vmm_sys_util::tempdir::TempDir;
+
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-regular-test").unwrap();
+        let base = dir.as_path();
+        fs::write(base.join("disk-flat.vmdk"), b"data").unwrap();
+
+        let (openat2_res, walk_res) = open_both(base, "disk-flat.vmdk", false, false);
+        check_openat2(&openat2_res, true);
+        check_walk(&walk_res, true);
+    }
+
+    #[test]
+    fn open_extent_opens_file_in_subdirectory() {
+        use vmm_sys_util::tempdir::TempDir;
+
+        // A relative sub-path resolves beneath the descriptor directory.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-subdir-test").unwrap();
+        let base = dir.as_path();
+        fs::create_dir(base.join("extents")).unwrap();
+        fs::write(base.join("extents").join("s001.vmdk"), b"data").unwrap();
+
+        let (openat2_res, walk_res) = open_both(base, "extents/s001.vmdk", false, false);
+        check_openat2(&openat2_res, true);
+        check_walk(&walk_res, true);
+    }
+
+    #[test]
+    fn open_extent_opens_absolute_path_within_descriptor_dir() {
+        use vmm_sys_util::tempdir::TempDir;
+
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-abs-in-test").unwrap();
+        let base = dir.as_path();
+        fs::write(base.join("gpt_meta_head.img"), b"data").unwrap();
+        let abs = base.join("gpt_meta_head.img");
+
+        let (openat2_res, walk_res) = open_both(base, abs.to_str().unwrap(), false, false);
+        check_openat2(&openat2_res, true);
+        check_walk(&walk_res, true);
+    }
+
+    #[test]
+    fn open_extent_opens_absolute_path_outside_descriptor_dir() {
+        use vmm_sys_util::tempdir::TempDir;
+
+        let desc_dir = TempDir::new_with_prefix("/tmp/vmdk-desc-test").unwrap();
+        let layer_dir = TempDir::new_with_prefix("/tmp/vmdk-layer-test").unwrap();
+        fs::write(layer_dir.as_path().join("layer.erofs"), b"data").unwrap();
+        let abs = layer_dir.as_path().join("layer.erofs");
+
+        let (openat2_res, walk_res) =
+            open_both(desc_dir.as_path(), abs.to_str().unwrap(), false, false);
+        check_openat2(&openat2_res, true);
+        check_walk(&walk_res, true);
+    }
+
+    #[test]
+    fn open_extent_rejects_symlinked_final_component_relative() {
+        use std::os::unix::fs::symlink;
+
+        use vmm_sys_util::tempdir::TempDir;
+
+        // A bare-named extent that is actually a symlink to a file the guest
+        // must never reach. Both implementations refuse it via O_NOFOLLOW.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-symlink-test").unwrap();
+        let base = dir.as_path();
+        let target = base.join("target-secret");
+        fs::write(&target, b"secret").unwrap();
+        symlink(&target, base.join("disk-flat.vmdk")).unwrap();
+
+        let (openat2_res, walk_res) = open_both(base, "disk-flat.vmdk", true, false);
+        check_openat2(&openat2_res, false);
+        check_walk(&walk_res, false);
+    }
+
+    #[test]
+    fn open_extent_rejects_symlinked_final_component_absolute() {
+        use std::os::unix::fs::symlink;
+
+        use vmm_sys_util::tempdir::TempDir;
+
+        // Even for absolute paths, the extent file itself may not be a symlink.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-abs-finalsym-test").unwrap();
+        let base = dir.as_path();
+        let target = base.join("target-secret");
+        fs::write(&target, b"secret").unwrap();
+        let link = base.join("extent-link.vmdk");
+        symlink(&target, &link).unwrap();
+
+        let (openat2_res, walk_res) = open_both(base, link.to_str().unwrap(), true, false);
+        check_openat2(&openat2_res, false);
+        check_walk(&walk_res, false);
+    }
+
+    #[test]
+    fn open_extent_follows_symlinked_intermediate_directory_relative() {
+        use std::os::unix::fs::symlink;
+
+        use vmm_sys_util::tempdir::TempDir;
+
+        // A relative path may traverse a symlinked intermediate directory
+        // (only the final component is guarded).
+        let real = TempDir::new_with_prefix("/tmp/vmdk-rel-real-test").unwrap();
+        fs::write(real.as_path().join("s001.vmdk"), b"data").unwrap();
+
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-rel-symdir-test").unwrap();
+        let base = dir.as_path();
+        symlink(real.as_path(), base.join("sub")).unwrap();
+
+        let (openat2_res, walk_res) = open_both(base, "sub/s001.vmdk", false, false);
+        check_openat2(&openat2_res, true);
+        check_walk(&walk_res, true);
+    }
+
+    #[test]
+    fn open_extent_follows_symlinked_intermediate_directory_absolute() {
+        use std::os::unix::fs::symlink;
+
+        use vmm_sys_util::tempdir::TempDir;
+
+        // An absolute path may likewise traverse a symlinked intermediate
+        // directory (common in container deployments).
+        let real = TempDir::new_with_prefix("/tmp/vmdk-abs-realdir-test").unwrap();
+        fs::write(real.as_path().join("layer.erofs"), b"data").unwrap();
+
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-abs-linkdir-test").unwrap();
+        let base = dir.as_path();
+        symlink(real.as_path(), base.join("link")).unwrap();
+
+        let via_symlink = base.join("link").join("layer.erofs");
+        let (openat2_res, walk_res) = open_both(base, via_symlink.to_str().unwrap(), false, false);
+        check_openat2(&openat2_res, true);
+        check_walk(&walk_res, true);
+    }
+}

--- a/block/src/formats/vmdk/mod.rs
+++ b/block/src/formats/vmdk/mod.rs
@@ -8,5 +8,6 @@
 //! synchronous, extent-aware I/O.
 
 mod descriptor;
+mod flat;
 
 pub use descriptor::{has_descriptor_header, is_flat_vmdk};

--- a/block/src/formats/vmdk/mod.rs
+++ b/block/src/formats/vmdk/mod.rs
@@ -1,0 +1,12 @@
+// Copyright 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Flat VMDK block backend.
+//!
+//! Supports the `monolithicFlat` and `twoGbMaxExtentFlat` create types with
+//! synchronous, extent-aware I/O.
+
+mod descriptor;
+
+pub use descriptor::{has_descriptor_header, is_flat_vmdk};

--- a/block/src/formats/vmdk/mod.rs
+++ b/block/src/formats/vmdk/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 The Cloud Hypervisor Authors. All rights reserved.
+// Copyright © 2026, Microsoft Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,6 +8,377 @@
 //! synchronous, extent-aware I/O.
 
 mod descriptor;
+mod engine_sync;
 mod flat;
 
+use std::fs::File;
+use std::io;
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
+
 pub use descriptor::{has_descriptor_header, is_flat_vmdk};
+
+use self::engine_sync::FlatVmdkSync;
+use self::flat::FlatVmdk;
+use crate::async_io::{AsyncIo, BorrowedDiskFd, DiskFileError};
+use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
+use crate::{DiskTopology, disk_file};
+
+#[derive(Debug)]
+pub struct VmdkDisk {
+    inner: FlatVmdk,
+}
+
+impl VmdkDisk {
+    /// Builds a Flat VMDK disk backend.
+    pub fn new(file: File, path: &Path, direct: bool) -> Result<Self, BlockError> {
+        let inner = FlatVmdk::new(file, path, direct)?;
+        Ok(VmdkDisk { inner })
+    }
+}
+
+impl disk_file::DiskSize for VmdkDisk {
+    fn logical_size(&self) -> BlockResult<u64> {
+        Ok(self.inner.virtual_block_size())
+    }
+}
+
+impl disk_file::PhysicalSize for VmdkDisk {
+    fn physical_size(&self) -> BlockResult<u64> {
+        Ok(self.inner.physical_block_size())
+    }
+}
+
+// Expose the descriptor file's fd for advisory image locking.
+impl disk_file::DiskFd for VmdkDisk {
+    fn fd(&self) -> BorrowedDiskFd<'_> {
+        BorrowedDiskFd::new(self.inner.as_raw_fd())
+    }
+}
+
+impl disk_file::Geometry for VmdkDisk {
+    fn topology(&self) -> DiskTopology {
+        self.inner.topology()
+    }
+}
+
+impl disk_file::SparseCapable for VmdkDisk {}
+
+// Flat VMDK keeps no in-memory format metadata, so no-op.
+impl disk_file::MetadataSync for VmdkDisk {}
+
+impl disk_file::Resizable for VmdkDisk {
+    fn resize(&mut self, _size: u64) -> BlockResult<()> {
+        Err(BlockError::new(
+            BlockErrorKind::UnsupportedFeature,
+            DiskFileError::ResizeError(io::Error::other("resize not supported for flat VMDK")),
+        )
+        .with_op(ErrorOp::Resize))
+    }
+}
+
+impl disk_file::DiskFile for VmdkDisk {}
+
+impl disk_file::AsyncDiskFile for VmdkDisk {
+    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
+        Ok(Box::new(VmdkDisk {
+            inner: self.inner.clone(),
+        }))
+    }
+
+    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+        // VMDK provides a synchronous, extent-aware worker, so the io_uring ring
+        // depth is unused here.
+        let _ = ring_depth;
+
+        Ok(Box::new(FlatVmdkSync::new(
+            self.inner.extents(),
+            self.inner.virtual_block_size(),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::os::unix::io::AsRawFd;
+    use std::path::PathBuf;
+
+    use vmm_sys_util::tempdir::TempDir;
+
+    use super::*;
+    use crate::disk_file::{AsyncDiskFile, DiskFd, DiskSize, PhysicalSize, Resizable};
+
+    const SECTOR: u64 = 512;
+
+    // Builds a flat VMDK in `dir`: a descriptor plus one backing data file per
+    // extent. When `allocate` is true the extent files are filled with real
+    // blocks (fixed / pre-allocated layout used in practice), otherwise they
+    // are created sparse via `set_len` (declared length but no allocated
+    // blocks). `extents` entries are (filename, access, sectors). Returns the
+    // descriptor path.
+    fn build_flat_vmdk(
+        dir: &Path,
+        create_type: &str,
+        extents: &[(&str, &str, u64)],
+        allocate: bool,
+    ) -> PathBuf {
+        let mut desc = String::from("# Disk DescriptorFile\n");
+        desc.push_str("version=1\n");
+        desc.push_str("CID=fffffffe\n");
+        desc.push_str("parentCID=ffffffff\n");
+        desc.push_str(&format!("createType={create_type}\n"));
+        desc.push_str("# Extent description\n");
+
+        for (filename, access, sectors) in extents {
+            let mut data = File::create(dir.join(filename)).unwrap();
+            if allocate {
+                data.write_all(&vec![0u8; (sectors * SECTOR) as usize])
+                    .unwrap();
+            } else {
+                data.set_len(sectors * SECTOR).unwrap();
+            }
+            data.sync_all().unwrap();
+            desc.push_str(&format!("{access} {sectors} FLAT \"{filename}\"\n"));
+        }
+
+        desc.push_str("# The Disk Data Base\n");
+        desc.push_str("ddb.adapterType = \"ide\"\n");
+
+        let desc_path = dir.join("disk.vmdk");
+        let mut df = File::create(&desc_path).unwrap();
+        df.write_all(desc.as_bytes()).unwrap();
+        df.sync_all().unwrap();
+        desc_path
+    }
+
+    // Sparse extents.
+    fn write_flat_vmdk(dir: &Path, create_type: &str, extents: &[(&str, &str, u64)]) -> PathBuf {
+        build_flat_vmdk(dir, create_type, extents, false)
+    }
+
+    // Fully pre-allocated extents.
+    fn write_flat_vmdk_allocated(
+        dir: &Path,
+        create_type: &str,
+        extents: &[(&str, &str, u64)],
+    ) -> PathBuf {
+        build_flat_vmdk(dir, create_type, extents, true)
+    }
+
+    fn open_descriptor(path: &Path) -> File {
+        File::open(path).unwrap()
+    }
+
+    // Writes a descriptor referencing `extent_lines` verbatim (no backing data
+    // files are created). Used to exercise `FlatVmdk::new`'s per-extent
+    // validation, whose zero-size/overflow checks all run before an extent file
+    // would be opened.
+    fn write_descriptor(dir: &Path, create_type: &str, extent_lines: &[&str]) -> PathBuf {
+        let mut desc = String::from("# Disk DescriptorFile\n");
+        desc.push_str("version=1\n");
+        desc.push_str("CID=fffffffe\n");
+        desc.push_str("parentCID=ffffffff\n");
+        desc.push_str(&format!("createType={create_type}\n"));
+        desc.push_str("# Extent description\n");
+        for line in extent_lines {
+            desc.push_str(line);
+            desc.push('\n');
+        }
+        desc.push_str("# The Disk Data Base\n");
+        desc.push_str("ddb.adapterType = \"ide\"\n");
+
+        let desc_path = dir.join("disk.vmdk");
+        let mut df = File::create(&desc_path).unwrap();
+        df.write_all(desc.as_bytes()).unwrap();
+        df.sync_all().unwrap();
+        desc_path
+    }
+
+    #[test]
+    fn logical_and_physical_size_single_extent() {
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-test").unwrap();
+        let path = write_flat_vmdk(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RW", 2048)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+
+        assert_eq!(disk.logical_size().unwrap(), 2048 * SECTOR);
+        // The extent is created sparse (`set_len`), so no blocks are allocated
+        // and the `st_blocks`-based physical size is 0.
+        assert_eq!(disk.physical_size().unwrap(), 0);
+    }
+
+    #[test]
+    fn logical_size_sums_multiple_extents() {
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-test").unwrap();
+        let path = write_flat_vmdk(
+            dir.as_path(),
+            "twoGbMaxExtentFlat",
+            &[("s001.vmdk", "RW", 2048), ("s002.vmdk", "RW", 1024)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+
+        assert_eq!(disk.logical_size().unwrap(), (2048 + 1024) * SECTOR);
+        // Sparse extents: no blocks are allocated, so physical size is 0.
+        assert_eq!(disk.physical_size().unwrap(), 0);
+    }
+
+    #[test]
+    fn physical_size_matches_fully_allocated_extents() {
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-test").unwrap();
+        let path = write_flat_vmdk_allocated(
+            dir.as_path(),
+            "twoGbMaxExtentFlat",
+            &[("s001.vmdk", "RW", 2048), ("s002.vmdk", "RW", 1024)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+
+        // Fully pre-allocated extents: host allocation (st_blocks) equals the
+        // declared logical size.
+        assert_eq!(disk.logical_size().unwrap(), (2048 + 1024) * SECTOR);
+        assert_eq!(disk.physical_size().unwrap(), (2048 + 1024) * SECTOR);
+    }
+
+    #[test]
+    fn fd_exposes_descriptor_file() {
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-test").unwrap();
+        let path = write_flat_vmdk(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RW", 64)],
+        );
+        let file = open_descriptor(&path);
+        let expected = file.as_raw_fd();
+
+        let disk = VmdkDisk::new(file, &path, false).unwrap();
+
+        assert_eq!(disk.fd().as_raw_fd(), expected);
+    }
+
+    #[test]
+    fn resize_is_unsupported() {
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-test").unwrap();
+        let path = write_flat_vmdk(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RW", 64)],
+        );
+        let mut disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+
+        let err = disk.resize(4096).unwrap_err();
+        assert_eq!(err.kind(), BlockErrorKind::UnsupportedFeature);
+    }
+
+    #[test]
+    fn try_clone_preserves_size() {
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-test").unwrap();
+        let path = write_flat_vmdk(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RW", 2048)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+
+        let cloned = disk.try_clone().unwrap();
+        assert_eq!(cloned.logical_size().unwrap(), disk.logical_size().unwrap());
+    }
+
+    #[test]
+    fn create_async_io_builds_worker() {
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-test").unwrap();
+        let path = write_flat_vmdk(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RW", 2048)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+
+        // Ring depth is ignored by the synchronous VMDK worker.
+        disk.create_async_io(0).unwrap();
+    }
+
+    #[test]
+    fn create_async_io_supports_multi_extent() {
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-test").unwrap();
+        let path = write_flat_vmdk(
+            dir.as_path(),
+            "twoGbMaxExtentFlat",
+            &[("s001.vmdk", "RW", 2048), ("s002.vmdk", "RW", 2048)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+
+        disk.create_async_io(32).unwrap();
+    }
+
+    #[test]
+    fn new_rejects_zero_sector_extent() {
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-zero-test").unwrap();
+        let path = write_descriptor(
+            dir.as_path(),
+            "monolithicFlat",
+            &["RW 0 FLAT \"disk-flat.vmdk\""],
+        );
+
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn new_rejects_extent_size_overflow() {
+        // size_in_sectors * 512 must fit in a u64.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-ovf-size-test").unwrap();
+        let line = format!("RW {} FLAT \"disk-flat.vmdk\"", u64::MAX);
+        let path = write_descriptor(dir.as_path(), "monolithicFlat", &[line.as_str()]);
+
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn new_rejects_extent_file_offset_overflow() {
+        // The offset * 512 must fit in a u64.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-ovf-offset-test").unwrap();
+        let line = format!("RW 1 FLAT \"disk-flat.vmdk\" {}", u64::MAX);
+        let path = write_descriptor(dir.as_path(), "monolithicFlat", &[line.as_str()]);
+
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn new_rejects_extent_file_range_overflow() {
+        // Each of offset*512 and size*512 fits in a u64, but their sum (the last
+        // byte the extent addresses in its backing file) overflows.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-ovf-range-test").unwrap();
+        // offset_in_sectors = floor(u64::MAX / 512) => offset bytes = u64::MAX -
+        // 511, size 1 sector (512 bytes) pushes the end one byte past u64::MAX.
+        let offset = u64::MAX / 512;
+        let line = format!("RW 1 FLAT \"disk-flat.vmdk\" {offset}");
+        let path = write_descriptor(dir.as_path(), "monolithicFlat", &[line.as_str()]);
+
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn new_rejects_total_virtual_size_overflow() {
+        // Two extents whose individual lengths fit in a u64 but whose running
+        // sum (the total virtual disk size) overflows. size = 2^55 - 1 =>
+        // length = 2^64 - 512, two of them overflow the total.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-ovf-total-test").unwrap();
+        let size = (1u64 << 55) - 1;
+        let l1 = format!("NOACCESS {size} FLAT \"s001.vmdk\"");
+        let l2 = format!("NOACCESS {size} FLAT \"s002.vmdk\"");
+        let path = write_descriptor(
+            dir.as_path(),
+            "twoGbMaxExtentFlat",
+            &[l1.as_str(), l2.as_str()],
+        );
+
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -484,6 +484,7 @@ pub fn preallocate_disk<P: AsRef<Path>>(file: &File, path: P) {
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum ImageType {
+    FlatVmdk,
     FixedVhd,
     Qcow2,
     Raw,
@@ -495,6 +496,7 @@ pub enum ImageType {
 impl fmt::Display for ImageType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            ImageType::FlatVmdk => write!(f, "vmdk"),
             ImageType::FixedVhd => write!(f, "vhd"),
             ImageType::Qcow2 => write!(f, "qcow2"),
             ImageType::Raw => write!(f, "raw"),
@@ -513,6 +515,7 @@ impl FromStr for ImageType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
+            "vmdk" => Ok(ImageType::FlatVmdk),
             "vhd" => Ok(ImageType::FixedVhd),
             "qcow2" => Ok(ImageType::Qcow2),
             "raw" => Ok(ImageType::Raw),
@@ -538,10 +541,23 @@ pub fn open_disk_image(path: &Path, options: &OpenOptions) -> BlockResult<File> 
 /// Determine image type through file parsing.
 pub fn detect_image_type(f: &mut File) -> BlockResult<ImageType> {
     let aligned = AlignedFile::new(f.try_clone()?, true);
+    // A VMDK descriptor file is small few hundred bytes of text. Read
+    // best-effort so a short file yields a zero-padded partial block instead
+    // of an UnexpectedEof, and let the per-format probes below decide.
     let mut block = vec![0u8; aligned.alignment()];
-    aligned
-        .read_exact_at(&mut block, 0)
-        .map_err(|e| BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::DetectImageType))?;
+    let mut filled = 0;
+    while filled < block.len() {
+        match aligned.read_at(&mut block[filled..], filled as u64) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => {
+                return Err(
+                    BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::DetectImageType)
+                );
+            }
+        }
+    }
 
     // Check 4 first bytes to get the header value and determine the image type
     let image_type = if u32::from_be_bytes(block[0..4].try_into().unwrap()) == QCOW_MAGIC {
@@ -552,6 +568,11 @@ pub fn detect_image_type(f: &mut File) -> BlockResult<ImageType> {
         ImageType::FixedVhd
     } else if u64::from_le_bytes(block[0..8].try_into().unwrap()) == VHDX_SIGN {
         ImageType::Vhdx
+    } else if formats::vmdk::has_descriptor_header(&block)
+        && formats::vmdk::is_flat_vmdk(f)
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::DetectImageType))?
+    {
+        ImageType::FlatVmdk
     } else {
         ImageType::Raw
     };
@@ -681,6 +702,18 @@ mod unit_tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
+
+    #[test]
+    fn detect_short_file_is_not_eof_error() {
+        let tmp = TempFile::new().unwrap();
+        let mut f = tmp.into_file();
+        f.write_all(b"not-a-disk-magic-just-some-short-text\n")
+            .unwrap();
+        f.sync_all().unwrap();
+
+        let image_type = detect_image_type(&mut f).unwrap();
+        assert_eq!(image_type, ImageType::Raw);
+    }
 
     #[test]
     fn test_probe_regular_file_returns_valid_alignment() {

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -2170,6 +2170,303 @@ pub fn _test_virtio_block_dynamic_vhdx_expand(guest: &Guest) {
     disk_check_consistency(vhdx_path, None);
 }
 
+pub(crate) fn _test_virtio_block_vmdk(guest: &Guest, subformat: &str) {
+    let raw_os_disk = guest.disk_config.disk(DiskType::OperatingSystem).unwrap();
+    let vmdk_path = guest.tmp_dir.as_path().join("osdisk.vmdk");
+    let vmdk_path_str = vmdk_path.to_str().unwrap();
+
+    // Convert the prepared RAW OS disk into a flat VMDK. qemu-img writes the
+    // extent file(s) next to the descriptor automatically.
+    let convert = Command::new("qemu-img")
+        .arg("convert")
+        .args(["-f", "raw"])
+        .args(["-O", "vmdk"])
+        .args(["-o", &format!("subformat={subformat}")])
+        .arg(&raw_os_disk)
+        .arg(vmdk_path_str)
+        .output()
+        .expect("Expect generating flat VMDK image from RAW image");
+    assert!(
+        convert.status.success(),
+        "qemu-img convert to VMDK (subformat={subformat}) failed: {}",
+        String::from_utf8_lossy(&convert.stderr)
+    );
+
+    let mut cloud_child = GuestCommand::new(guest)
+        .default_cpus()
+        .default_memory()
+        .default_kernel_cmdline()
+        .args([
+            "--disk",
+            // Force the flat VMDK backend explicitly instead of relying on
+            // image-format auto-detection.
+            format!("path={vmdk_path_str},image_type=vmdk").as_str(),
+            format!(
+                "path={}",
+                guest.disk_config.disk(DiskType::CloudInit).unwrap()
+            )
+            .as_str(),
+        ])
+        .default_net()
+        .capture_output()
+        .spawn()
+        .unwrap();
+
+    let r = panic::catch_unwind(|| {
+        guest.wait_vm_boot().unwrap();
+
+        assert_eq!(guest.get_cpu_count().unwrap_or_default(), 1);
+        assert!(guest.get_total_memory().unwrap_or_default() > 480_000);
+
+        // Exercise the flat VMDK write + read paths through the guest root
+        // filesystem: write a marker file, flush, and read it back.
+        guest
+            .ssh_command(
+                "echo cloud-hypervisor-vmdk | sudo tee /root/vmdk_marker > /dev/null && sync",
+            )
+            .unwrap();
+        assert_eq!(
+            guest
+                .ssh_command("sudo cat /root/vmdk_marker")
+                .unwrap()
+                .trim(),
+            "cloud-hypervisor-vmdk"
+        );
+    });
+
+    kill_child(&mut cloud_child);
+    let output = cloud_child.wait_with_output().unwrap();
+
+    handle_child_output(r, &output);
+
+    disk_check_consistency(vmdk_path_str, None);
+}
+
+pub(crate) fn _test_virtio_block_vmdk_enospc(guest: &Guest, subformat: &str) {
+    const DISK_SIZE_MIB: u64 = 16;
+
+    let vmdk_path = guest.tmp_dir.as_path().join("data.vmdk");
+    let vmdk_path_str = vmdk_path.to_str().unwrap();
+
+    let create = Command::new("qemu-img")
+        .arg("create")
+        .args(["-f", "vmdk"])
+        .args(["-o", &format!("subformat={subformat}")])
+        .arg(vmdk_path_str)
+        .arg(format!("{DISK_SIZE_MIB}M"))
+        .output()
+        .expect("Expect creating flat VMDK data disk");
+    assert!(
+        create.status.success(),
+        "qemu-img create VMDK (subformat={subformat}) failed: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    let mut cloud_child = GuestCommand::new(guest)
+        .default_cpus()
+        .default_memory()
+        .default_kernel_cmdline()
+        .args([
+            "--disk",
+            format!(
+                "path={}",
+                guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
+            )
+            .as_str(),
+            format!(
+                "path={}",
+                guest.disk_config.disk(DiskType::CloudInit).unwrap()
+            )
+            .as_str(),
+            // Force the flat VMDK backend explicitly.
+            format!("path={vmdk_path_str},image_type=vmdk").as_str(),
+        ])
+        .default_net()
+        .capture_output()
+        .spawn()
+        .unwrap();
+
+    let r = panic::catch_unwind(|| {
+        guest.wait_vm_boot().unwrap();
+
+        // The flat VMDK data disk shows up as vdc.
+        assert_eq!(
+            guest
+                .ssh_command("lsblk | grep -c vdc")
+                .unwrap()
+                .trim()
+                .parse::<u32>()
+                .unwrap_or_default(),
+            1
+        );
+
+        // 1) In-bounds direct-IO round trip: write a random pattern near the
+        //    start of the device and read it back to confirm the VMDK I/O
+        //    path is correct.
+        guest
+            .ssh_command(
+                "sudo dd if=/dev/urandom of=/tmp/pattern bs=1M count=4 && \
+                 sudo dd if=/tmp/pattern of=/dev/vdc bs=1M count=4 seek=0 \
+                     oflag=direct conv=fsync && \
+                 sudo dd if=/dev/vdc of=/tmp/readback bs=1M count=4 skip=0 \
+                     iflag=direct && \
+                 cmp /tmp/pattern /tmp/readback",
+            )
+            .expect("in-bounds flat VMDK direct IO round trip failed");
+
+        // 2) Writing past the fixed virtual capacity must fail with ENOSPC:
+        //    a flat VMDK is pre-allocated and cannot grow. dd exits non-zero
+        //    once the device is full, so `|| true` keeps ssh_command happy
+        //    while we assert on the reported error.
+        let enospc = guest
+            .ssh_command(&format!(
+                "sudo dd if=/dev/zero of=/dev/vdc bs=1M count={} oflag=direct 2>&1 || true",
+                DISK_SIZE_MIB + 8
+            ))
+            .unwrap();
+        assert!(
+            enospc.contains("No space left on device"),
+            "expected ENOSPC writing past end of pre-allocated flat VMDK, got: {enospc}"
+        );
+    });
+
+    kill_child(&mut cloud_child);
+    let output = cloud_child.wait_with_output().unwrap();
+
+    handle_child_output(r, &output);
+
+    disk_check_consistency(vmdk_path_str, None);
+}
+
+pub(crate) fn _test_virtio_block_vmdk_extent_spanning(guest: &Guest, direct: bool) {
+    // 3 GiB virtual size => a 2 GiB first extent + a 1 GiB second extent.
+    // `direct=on` opens the extents with `O_DIRECT`, which tmpfs rejects with
+    // EINVAL. guest.tmp_dir is backed by tmpfs, so for the direct
+    // case place the VMDK on ~/workloads instead (same rationale as
+    // test_virtio_block_direct_and_firmware).
+    let workloads_tmp_dir;
+    let base_dir = if direct {
+        let mut workloads_path = dirs::home_dir().unwrap();
+        workloads_path.push("workloads");
+        workloads_tmp_dir = TempDir::new_in(workloads_path.as_path()).unwrap();
+        workloads_tmp_dir.as_path()
+    } else {
+        guest.tmp_dir.as_path()
+    };
+    let vmdk_path = base_dir.join("spanning.vmdk");
+    let vmdk_path_str = vmdk_path.to_str().unwrap();
+
+    let create = Command::new("qemu-img")
+        .arg("create")
+        .args(["-f", "vmdk"])
+        .args(["-o", "subformat=twoGbMaxExtentFlat"])
+        .arg(vmdk_path_str)
+        .arg("3G")
+        .output()
+        .expect("Expect creating twoGbMaxExtentFlat VMDK data disk");
+    assert!(
+        create.status.success(),
+        "qemu-img create twoGbMaxExtentFlat VMDK failed: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    let descriptor = fs::read_to_string(&vmdk_path).expect("read VMDK descriptor");
+    let extent_lines: Vec<&str> = descriptor
+        .lines()
+        .filter(|l| l.starts_with("RW ") && l.contains("FLAT"))
+        .collect();
+    assert!(
+        extent_lines.len() >= 2,
+        "twoGbMaxExtentFlat should produce >= 2 extents, descriptor was:\n{descriptor}"
+    );
+    let first_extent_sectors: u64 = extent_lines[0]
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .expect("parse first extent sector count from descriptor");
+    let boundary_bytes = first_extent_sectors * 512;
+
+    // Straddle the boundary with a 2 MiB, 4 KiB-aligned direct-IO window
+    // (~1 MiB in each extent). Round the start down to the O_DIRECT alignment
+    // without assuming the extent size itself is 4 KiB aligned.
+    const BS: u64 = 4096;
+    const HALF: u64 = 1024 * 1024;
+    let raw_start = boundary_bytes - HALF;
+    let start = raw_start - (raw_start % BS);
+    let seek = start / BS;
+    let count = (2 * HALF) / BS;
+    assert!(
+        start < boundary_bytes && boundary_bytes < start + count * BS,
+        "write window [{start}, {}) does not straddle extent boundary {boundary_bytes}",
+        start + count * BS
+    );
+
+    // Force the flat VMDK backend explicitly, and honor the requested cache
+    // mode. `direct=on` opens the extents with `O_DIRECT` on the host.
+    let data_disk = if direct {
+        format!("path={vmdk_path_str},image_type=vmdk,direct=on")
+    } else {
+        format!("path={vmdk_path_str},image_type=vmdk")
+    };
+
+    let mut cloud_child = GuestCommand::new(guest)
+        .default_cpus()
+        .default_memory()
+        .default_kernel_cmdline()
+        .args([
+            "--disk",
+            format!(
+                "path={}",
+                guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
+            )
+            .as_str(),
+            format!(
+                "path={}",
+                guest.disk_config.disk(DiskType::CloudInit).unwrap()
+            )
+            .as_str(),
+            data_disk.as_str(),
+        ])
+        .default_net()
+        .capture_output()
+        .spawn()
+        .unwrap();
+
+    let r = panic::catch_unwind(|| {
+        guest.wait_vm_boot().unwrap();
+
+        // The twoGbMaxExtentFlat data disk shows up as vdc.
+        assert_eq!(
+            guest
+                .ssh_command("lsblk | grep -c vdc")
+                .unwrap()
+                .trim()
+                .parse::<u32>()
+                .unwrap_or_default(),
+            1
+        );
+
+        // Write a random pattern that spans the 2 GiB extent boundary.
+        guest
+            .ssh_command(&format!(
+                "sudo dd if=/dev/urandom of=/tmp/pattern bs={BS} count={count} && \
+                 sudo dd if=/tmp/pattern of=/dev/vdc bs={BS} count={count} seek={seek} \
+                     oflag=direct conv=fsync && \
+                 sudo dd if=/dev/vdc of=/tmp/readback bs={BS} count={count} skip={seek} \
+                     iflag=direct && \
+                 cmp /tmp/pattern /tmp/readback",
+            ))
+            .expect("extent-spanning direct IO round trip across the 2 GiB boundary failed");
+    });
+
+    kill_child(&mut cloud_child);
+    let output = cloud_child.wait_with_output().unwrap();
+
+    handle_child_output(r, &output);
+
+    disk_check_consistency(vmdk_path_str, None);
+}
+
 fn vhdx_image_size(disk_name: &str) -> u64 {
     fs::File::open(disk_name)
         .unwrap()

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -1597,7 +1597,7 @@ mod common_parallel {
             ImageType::Qcow2 => ("qcow2", &[]),
             ImageType::FixedVhd => ("vpc", &["-o", "subformat=fixed"]),
             ImageType::Vhdx => ("vhdx", &[]),
-            ImageType::FlatVmdk => panic!("unsupported image_type {image_type}"),
+            ImageType::FlatVmdk => ("vmdk", &["-o", "subformat=monolithicFlat"]),
             ImageType::Unknown => panic!("unsupported image_type {image_type}"),
         };
         let image_type_str = image_type.to_string();
@@ -1732,6 +1732,11 @@ mod common_parallel {
     #[test]
     fn test_virtio_block_direct_io_data_disk_4k_vhdx() {
         _test_virtio_block_direct_io_data_disk_4k(ImageType::Vhdx);
+    }
+
+    #[test]
+    fn test_virtio_block_direct_io_data_disk_4k_vmdk() {
+        _test_virtio_block_direct_io_data_disk_4k(ImageType::FlatVmdk);
     }
 
     #[test]
@@ -2042,6 +2047,42 @@ mod common_parallel {
     fn test_virtio_block_dynamic_vhdx_expand() {
         let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
         _test_virtio_block_dynamic_vhdx_expand(&guest);
+    }
+
+    #[test]
+    fn test_virtio_block_vmdk_monolithic_flat() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_virtio_block_vmdk(&guest, "monolithicFlat");
+    }
+
+    #[test]
+    fn test_virtio_block_vmdk_two_gb_max_extent_flat() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_virtio_block_vmdk(&guest, "twoGbMaxExtentFlat");
+    }
+
+    #[test]
+    fn test_virtio_block_vmdk_monolithic_flat_enospc() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_virtio_block_vmdk_enospc(&guest, "monolithicFlat");
+    }
+
+    #[test]
+    fn test_virtio_block_vmdk_two_gb_max_extent_flat_enospc() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_virtio_block_vmdk_enospc(&guest, "twoGbMaxExtentFlat");
+    }
+
+    #[test]
+    fn test_virtio_block_vmdk_two_gb_max_extent_flat_spanning() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_virtio_block_vmdk_extent_spanning(&guest, false);
+    }
+
+    #[test]
+    fn test_virtio_block_vmdk_two_gb_max_extent_flat_spanning_direct() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_virtio_block_vmdk_extent_spanning(&guest, true);
     }
 
     #[test]

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -1597,6 +1597,7 @@ mod common_parallel {
             ImageType::Qcow2 => ("qcow2", &[]),
             ImageType::FixedVhd => ("vpc", &["-o", "subformat=fixed"]),
             ImageType::Vhdx => ("vhdx", &[]),
+            ImageType::FlatVmdk => panic!("unsupported image_type {image_type}"),
             ImageType::Unknown => panic!("unsupported image_type {image_type}"),
         };
         let image_type_str = image_type.to_string();

--- a/docs/landlock.md
+++ b/docs/landlock.md
@@ -62,6 +62,31 @@ Landlock can also be enabled during `vm.create` request by passing a config like
 }
 ```
 
+### Multi-file disk formats (VMDK)
+
+For most block backends (raw, qcow2, VHD) including existing VMDK, landlock
+grants access to the `--disk path=` path value.
+
+For a Flat VMDK, its `path=` points at a small text descriptor whose
+data lives in one or more separate extent files. Granting only the descriptor
+currently leaves those extents unreachable under landlock.
+
+The process launching Cloud-Hypervisor must grant these extent paths explicitly
+via `--landlock-rules` (or the `landlock_rules` API field). The descriptor file's
+extent section mentions the extent file path which can be either:
+
+- relative (the `qemu-img` default) in which case the full path includes the descriptor
+file's parent directory
+- absolute, which can live inside the descriptor file's parent directory or in another
+directory
+
+For example, a containerd/Kata deployment where the read-only image
+layer resides under `/var/lib/containerd` should add that path:
+
+```
+--landlock-rules path="/var/lib/containerd",access="rw"
+```
+
 
 ## Usage Examples
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -714,6 +714,7 @@ fn vmm_thread_rules(
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_open, vec![]),
         (libc::SYS_openat, vec![]),
+        (libc::SYS_openat2, vec![]),
         (libc::SYS_pipe2, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_poll, vec![]),


### PR DESCRIPTION
Implement backend for VMDK virtual block format to support FLAT (fixed/pre-allocated sized) disks.
This PR does not implement the complete specification.

In summary, the implementation

1. supports 2 createType: monolithicFlat & twoGbMaxExtentFlat
2. implements synchronous I/O, does not support async_io/io_uring
3. adds unit tests and integration testing

The implementation references online specification from https://web.archive.org/web/20240527050638if_/https://www.vmware.com/app/vmdk/?src=vmdk

Fixes #7167 