### PR TITLE
ci: Bump virtio-villain to v0.5.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -854,7 +854,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VILLAIN_REPO: https://github.com/weltling/virtio-villain.git
-      VILLAIN_REF: v0.5.2
+      VILLAIN_REF: v0.5.5
     steps:
       - name: Code checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Further stability improvements in the villain harness keep printed verdicts when a batch times out, stop batch timeouts from wedging benign tests, and capture VMM stderr separately so it cannot corrupt verdict markers, reducing spurious WEDGED results.