### PR TITLE
virtio-devices, vmm, ch-remote: Add balloon statistics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,6 +2695,7 @@ dependencies = [
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,6 +2738,7 @@ dependencies = [
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
+ "zerocopy",
 ]
 
 [[package]]

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -102,6 +102,7 @@ trait DBusApi1 {
     fn vm_add_vdpa(&self, vdpa_config: &str) -> zbus::Result<Optional<String>>;
     fn vm_add_vsock(&self, vsock_config: &str) -> zbus::Result<Optional<String>>;
     fn vm_boot(&self) -> zbus::Result<()>;
+    fn vm_balloon_stats(&self) -> zbus::Result<String>;
     fn vm_coredump(&self, vm_coredump_data: &str) -> zbus::Result<()>;
     fn vm_counters(&self) -> zbus::Result<Optional<String>>;
     fn vm_create(&self, vm_config: &str) -> zbus::Result<()>;
@@ -194,6 +195,12 @@ impl<'a> DBusApi1ProxyBlocking<'a> {
 
     fn api_vm_boot(&self) -> ApiResult {
         self.vm_boot().map_err(Error::DBusApiClient)
+    }
+
+    fn api_vm_balloon_stats(&self) -> ApiResult {
+        self.vm_balloon_stats()
+            .map(|stats| println!("{stats}"))
+            .map_err(Error::DBusApiClient)
     }
 
     fn api_vm_coredump(&self, vm_coredump_data: &str) -> ApiResult {
@@ -308,6 +315,9 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
         }
         Some("info") => {
             simple_api_command(socket, "GET", "info", None).map_err(Error::HttpApiClient)
+        }
+        Some("balloon-stats") => {
+            simple_api_command(socket, "GET", "balloon-stats", None).map_err(Error::HttpApiClient)
         }
         Some("counters") => {
             simple_api_command(socket, "GET", "counters", None).map_err(Error::HttpApiClient)
@@ -572,6 +582,7 @@ fn dbus_api_do_command(matches: &ArgMatches, proxy: &DBusApi1ProxyBlocking<'_>) 
         Some("reboot") => proxy.api_vm_reboot(),
         Some("pause") => proxy.api_vm_pause(),
         Some("info") => proxy.api_vm_info(),
+        Some("balloon-stats") => proxy.api_vm_balloon_stats(),
         Some("counters") => proxy.api_vm_counters(),
         Some("ping") => proxy.api_vmm_ping(),
         Some("shutdown") => proxy.api_vm_shutdown(),
@@ -1072,6 +1083,7 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
         Command::new("add-vsock")
             .about("Add vsock device")
             .arg(Arg::new("vsock_config").index(1).help(VsockConfig::SYNTAX)),
+        Command::new("balloon-stats").about("Statistics from the virtio-balloon device"),
         Command::new("boot").about("Boot a created VM"),
         Command::new("coredump")
             .about("Create a coredump from VM")

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -101,6 +101,7 @@ trait DBusApi1 {
     fn vm_add_user_device(&self, vm_add_user_device: &str) -> zbus::Result<Optional<String>>;
     fn vm_add_vdpa(&self, vdpa_config: &str) -> zbus::Result<Optional<String>>;
     fn vm_add_vsock(&self, vsock_config: &str) -> zbus::Result<Optional<String>>;
+    fn vm_balloon_stats(&self) -> zbus::Result<String>;
     fn vm_boot(&self) -> zbus::Result<()>;
     fn vm_coredump(&self, vm_coredump_data: &str) -> zbus::Result<()>;
     fn vm_counters(&self) -> zbus::Result<Optional<String>>;
@@ -190,6 +191,12 @@ impl<'a> DBusApi1ProxyBlocking<'a> {
 
     fn api_vm_add_vsock(&self, vsock_config: &str) -> ApiResult {
         self.print_response(self.vm_add_vsock(vsock_config))
+    }
+
+    fn api_vm_balloon_stats(&self) -> ApiResult {
+        self.vm_balloon_stats()
+            .map(|stats| println!("{stats}"))
+            .map_err(Error::DBusApiClient)
     }
 
     fn api_vm_boot(&self) -> ApiResult {
@@ -308,6 +315,9 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
         }
         Some("info") => {
             simple_api_command(socket, "GET", "info", None).map_err(Error::HttpApiClient)
+        }
+        Some("balloon-stats") => {
+            simple_api_command(socket, "GET", "balloon-stats", None).map_err(Error::HttpApiClient)
         }
         Some("counters") => {
             simple_api_command(socket, "GET", "counters", None).map_err(Error::HttpApiClient)
@@ -572,6 +582,7 @@ fn dbus_api_do_command(matches: &ArgMatches, proxy: &DBusApi1ProxyBlocking<'_>) 
         Some("reboot") => proxy.api_vm_reboot(),
         Some("pause") => proxy.api_vm_pause(),
         Some("info") => proxy.api_vm_info(),
+        Some("balloon-stats") => proxy.api_vm_balloon_stats(),
         Some("counters") => proxy.api_vm_counters(),
         Some("ping") => proxy.api_vmm_ping(),
         Some("shutdown") => proxy.api_vm_shutdown(),
@@ -1072,6 +1083,7 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
         Command::new("add-vsock")
             .about("Add vsock device")
             .arg(Arg::new("vsock_config").index(1).help(VsockConfig::SYNTAX)),
+        Command::new("balloon-stats").about("Statistics from the virtio-balloon device"),
         Command::new("boot").about("Boot a created VM"),
         Command::new("coredump")
             .about("Create a coredump from VM")

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -44,7 +44,7 @@ mod common_parallel {
     use std::sync::mpsc;
 
     use test_infra::GuestFactory;
-    use vmm::api::TimeoutStrategy;
+    use vmm::api::{BalloonStatsResponse, TimeoutStrategy};
 
     use crate::*;
 
@@ -5305,6 +5305,68 @@ mod common_parallel {
             println!("After deflating, balloon memory size is {deflated_balloon} bytes");
             // Verify the balloon size deflated
             assert!(deflated_balloon < 2147483648);
+        });
+
+        kill_child(&mut child);
+        let output = child.wait_with_output().unwrap();
+
+        handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_virtio_balloon_stats() {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+
+        let api_socket = temp_api_path(&guest.tmp_dir);
+
+        let mut child = GuestCommand::new(&guest)
+            .args(["--api-socket", &api_socket])
+            .default_cpus()
+            .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .args(["--balloon", "size=0,free_page_reporting=on"])
+            .default_disks()
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+
+            let balloon_stats = || -> Option<BalloonStatsResponse> {
+                let (success, output, _) =
+                    remote_command_w_output(&api_socket, "balloon-stats", None);
+                if !success {
+                    return None;
+                }
+
+                serde_json::from_slice(&output).ok()
+            };
+
+            let initial_last_update = Cell::new(0);
+            assert!(wait_until(Duration::from_secs(20), || {
+                let Some(response) = balloon_stats() else {
+                    return false;
+                };
+                if response.balloon_actual != 0
+                    || response.last_update == 0
+                    || response.stats.total_memory.unwrap_or_default() == 0
+                {
+                    return false;
+                }
+
+                initial_last_update.set(response.last_update);
+                true
+            }));
+
+            // The API returns the cached sample and requests a refresh for the
+            // next call.
+            assert!(wait_until(Duration::from_secs(20), || {
+                balloon_stats()
+                    .is_some_and(|response| response.last_update > initial_last_update.get())
+            }));
         });
 
         kill_child(&mut child);

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,7 @@
         - [Create a Virtual Machine](#create-a-virtual-machine)
         - [Boot a Virtual Machine](#boot-a-virtual-machine)
         - [Dump Virtual Machine Information](#dump-virtual-machine-information)
+        - [Get Balloon Statistics](#get-balloon-statistics)
         - [Reboot a Virtual Machine](#reboot-a-virtual-machine)
         - [Shut a Virtual Machine Down](#shut-a-virtual-machine-down)
     - [D-Bus API](#d-bus-api)
@@ -89,6 +90,7 @@ The Cloud Hypervisor API exposes the following actions through its endpoints:
 | Resize a disk attached to the VM        | `/vm.resize-disk`            | `/schemas/VmResizeDisk`           | N/A                      | The VM is created                                      |
 | Add/remove memory from a zone           | `/vm.resize-zone`            | `/schemas/VmResizeZone`           | N/A                      | The VM is booted                                       |
 | Dump the VM information                 | `/vm.info`                   | N/A                               | `/schemas/VmInfo`        | The VM is created                                      |
+| Get virtio-balloon statistics           | `/vm.balloon-stats`          | N/A                               | `/schemas/BalloonStatsResponse` | The VM is running and balloon statistics were negotiated |
 | Add VFIO PCI device to the VM           | `/vm.add-device`             | `/schemas/VmAddDevice`            | `/schemas/PciDeviceInfo` | The VM is booted                                       |
 | Add disk device to the VM               | `/vm.add-disk`               | `/schemas/DiskConfig`             | `/schemas/PciDeviceInfo` | The VM is booted                                       |
 | Add fs device to the VM                 | `/vm.add-fs`                 | `/schemas/FsConfig`               | `/schemas/PciDeviceInfo` | The VM is booted                                       |
@@ -167,6 +169,20 @@ curl --unix-socket /tmp/cloud-hypervisor.sock -i \
      -X GET 'http://localhost/api/v1/vm.info' \
      -H 'Accept: application/json'
 ```
+
+##### Get Balloon Statistics
+
+When the running VM has negotiated the virtio-balloon statistics feature, a
+fresh guest sample can be requested with:
+
+```shell
+curl --unix-socket /tmp/cloud-hypervisor.sock -i \
+     -X GET 'http://localhost/api/v1/vm.balloon-stats' \
+     -H 'Accept: application/json'
+```
+
+The same request is available through `ch-remote balloon-stats`. Unsupported
+guest statistics are omitted from the response.
 
 ##### Reboot a Virtual Machine
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,7 @@
         - [Create a Virtual Machine](#create-a-virtual-machine)
         - [Boot a Virtual Machine](#boot-a-virtual-machine)
         - [Dump Virtual Machine Information](#dump-virtual-machine-information)
+        - [Get Balloon Statistics](#get-balloon-statistics)
         - [Reboot a Virtual Machine](#reboot-a-virtual-machine)
         - [Shut a Virtual Machine Down](#shut-a-virtual-machine-down)
     - [D-Bus API](#d-bus-api)
@@ -71,38 +72,39 @@ The Cloud Hypervisor API exposes the following actions through its endpoints:
 
 ##### Virtual Machine (VM) Actions
 
-| Action                             | Endpoint                | Request Body                    | Response Body            | Prerequisites                                          |
-| --------------------------------------- | ---------------------------- | --------------------------------- | ------------------------ | ------------------------------------------------------ |
-| Create the VM                           | `/vm.create`                 | `/schemas/VmConfig`               | N/A                      | The VM is not created yet                              |
-| Delete the VM                           | `/vm.delete`                 | N/A                               | N/A                      | N/A                                                    |
-| Boot the VM                             | `/vm.boot`                   | N/A                               | N/A                      | The VM is created but not booted                       |
-| Shut the VM down                        | `/vm.shutdown`               | N/A                               | N/A                      | The VM is booted                                       |
-| Reboot the VM                           | `/vm.reboot`                 | N/A                               | N/A                      | The VM is booted                                       |
-| Trigger power button of the VM          | `/vm.power-button`           | N/A                               | N/A                      | The VM is booted                                       |
-| Pause the VM                            | `/vm.pause`                  | N/A                               | N/A                      | The VM is booted                                       |
-| Resume the VM                           | `/vm.resume`                 | N/A                               | N/A                      | The VM is paused                                       |
-| Take a snapshot of the VM               | `/vm.snapshot`               | `/schemas/VmSnapshotConfig`       | N/A                      | The VM is paused                                       |
-| Perform a coredump of the VM*           | `/vm.coredump`               | `/schemas/VmCoredumpData`         | N/A                      | The VM is paused                                       |
-| Restore the VM from a snapshot          | `/vm.restore`                | `/schemas/RestoreConfig`          | N/A                      | The VM is created but not booted                       |
-| Add/remove CPUs to/from the VM          | `/vm.resize`                 | `/schemas/VmResize`               | N/A                      | The VM is booted                                       |
-| Add/remove memory from the VM           | `/vm.resize`                 | `/schemas/VmResize`               | N/A                      | The VM is booted                                       |
-| Resize a disk attached to the VM        | `/vm.resize-disk`            | `/schemas/VmResizeDisk`           | N/A                      | The VM is created                                      |
-| Add/remove memory from a zone           | `/vm.resize-zone`            | `/schemas/VmResizeZone`           | N/A                      | The VM is booted                                       |
-| Dump the VM information                 | `/vm.info`                   | N/A                               | `/schemas/VmInfo`        | The VM is created                                      |
-| Add VFIO PCI device to the VM           | `/vm.add-device`             | `/schemas/VmAddDevice`            | `/schemas/PciDeviceInfo` | The VM is booted                                       |
-| Add disk device to the VM               | `/vm.add-disk`               | `/schemas/DiskConfig`             | `/schemas/PciDeviceInfo` | The VM is booted                                       |
-| Add fs device to the VM                 | `/vm.add-fs`                 | `/schemas/FsConfig`               | `/schemas/PciDeviceInfo` | The VM is booted                                       |
-| Add generic vhost-user device to the VM | `/vm.add-generic-vhost-user` | `/schemas/GenericVhostUserConfig` | `/schemas/PciDeviceInfo` | The VM is booted                                       |
-| Add pmem device to the VM               | `/vm.add-pmem`               | `/schemas/PmemConfig`             | `/schemas/PciDeviceInfo` | The VM is booted                                       |
-| Add network device to the VM            | `/vm.add-net`                | `/schemas/NetConfig`              | `/schemas/PciDeviceInfo` | The VM is booted                                       |
-| Add userspace PCI device to the VM      | `/vm.add-user-device`        | `/schemas/VmAddUserDevice`        | `/schemas/PciDeviceInfo` | The VM is booted                                       |
-| Add vdpa device to the VM               | `/vm.add-vdpa`               | `/schemas/VdpaConfig`             | `/schemas/PciDeviceInfo` | The VM is booted                                       |
-| Add vsock device to the VM              | `/vm.add-vsock`              | `/schemas/VsockConfig`            | `/schemas/PciDeviceInfo` | The VM is booted                                       |
-| Remove device from the VM               | `/vm.remove-device`          | `/schemas/VmRemoveDevice`         | N/A                      | The VM is booted                                       |
-| Dump the VM counters                    | `/vm.counters`               | N/A                               | `/schemas/VmCounters`    | The VM is booted                                       |
-| Inject an NMI                           | `/vm.nmi`                    | N/A                               | N/A                      | The VM is booted                                       |
-| Prepare to receive a migration          | `/vm.receive-migration`      | `/schemas/ReceiveMigrationData`   | N/A                      | N/A                                                    |
-| Start to send migration to target       | `/vm.send-migration`         | `/schemas/SendMigrationData`      | N/A                      | The VM is booted and (shared mem or hugepages enabled) |
+| Action                                  | Endpoint                     | Request Body                      | Response Body                   | Prerequisites                                            |
+| --------------------------------------- | ---------------------------- | --------------------------------- | ------------------------------- | -------------------------------------------------------- |
+| Create the VM                           | `/vm.create`                 | `/schemas/VmConfig`               | N/A                             | The VM is not created yet                                |
+| Delete the VM                           | `/vm.delete`                 | N/A                               | N/A                             | N/A                                                      |
+| Boot the VM                             | `/vm.boot`                   | N/A                               | N/A                             | The VM is created but not booted                         |
+| Shut the VM down                        | `/vm.shutdown`               | N/A                               | N/A                             | The VM is booted                                         |
+| Reboot the VM                           | `/vm.reboot`                 | N/A                               | N/A                             | The VM is booted                                         |
+| Trigger power button of the VM          | `/vm.power-button`           | N/A                               | N/A                             | The VM is booted                                         |
+| Pause the VM                            | `/vm.pause`                  | N/A                               | N/A                             | The VM is booted                                         |
+| Resume the VM                           | `/vm.resume`                 | N/A                               | N/A                             | The VM is paused                                         |
+| Take a snapshot of the VM               | `/vm.snapshot`               | `/schemas/VmSnapshotConfig`       | N/A                             | The VM is paused                                         |
+| Perform a coredump of the VM*           | `/vm.coredump`               | `/schemas/VmCoredumpData`         | N/A                             | The VM is paused                                         |
+| Restore the VM from a snapshot          | `/vm.restore`                | `/schemas/RestoreConfig`          | N/A                             | The VM is created but not booted                         |
+| Add/remove CPUs to/from the VM          | `/vm.resize`                 | `/schemas/VmResize`               | N/A                             | The VM is booted                                         |
+| Add/remove memory from the VM           | `/vm.resize`                 | `/schemas/VmResize`               | N/A                             | The VM is booted                                         |
+| Resize a disk attached to the VM        | `/vm.resize-disk`            | `/schemas/VmResizeDisk`           | N/A                             | The VM is created                                        |
+| Add/remove memory from a zone           | `/vm.resize-zone`            | `/schemas/VmResizeZone`           | N/A                             | The VM is booted                                         |
+| Dump the VM information                 | `/vm.info`                   | N/A                               | `/schemas/VmInfo`               | The VM is created                                        |
+| Get virtio-balloon statistics           | `/vm.balloon-stats`          | N/A                               | `/schemas/BalloonStatsResponse` | The VM is running and balloon statistics were negotiated |
+| Add VFIO PCI device to the VM           | `/vm.add-device`             | `/schemas/VmAddDevice`            | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
+| Add disk device to the VM               | `/vm.add-disk`               | `/schemas/DiskConfig`             | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
+| Add fs device to the VM                 | `/vm.add-fs`                 | `/schemas/FsConfig`               | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
+| Add generic vhost-user device to the VM | `/vm.add-generic-vhost-user` | `/schemas/GenericVhostUserConfig` | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
+| Add pmem device to the VM               | `/vm.add-pmem`               | `/schemas/PmemConfig`             | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
+| Add network device to the VM            | `/vm.add-net`                | `/schemas/NetConfig`              | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
+| Add userspace PCI device to the VM      | `/vm.add-user-device`        | `/schemas/VmAddUserDevice`        | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
+| Add vdpa device to the VM               | `/vm.add-vdpa`               | `/schemas/VdpaConfig`             | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
+| Add vsock device to the VM              | `/vm.add-vsock`              | `/schemas/VsockConfig`            | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
+| Remove device from the VM               | `/vm.remove-device`          | `/schemas/VmRemoveDevice`         | N/A                             | The VM is booted                                         |
+| Dump the VM counters                    | `/vm.counters`               | N/A                               | `/schemas/VmCounters`           | The VM is booted                                         |
+| Inject an NMI                           | `/vm.nmi`                    | N/A                               | N/A                             | The VM is booted                                         |
+| Prepare to receive a migration          | `/vm.receive-migration`      | `/schemas/ReceiveMigrationData`   | N/A                             | N/A                                                      |
+| Start to send migration to target       | `/vm.send-migration`         | `/schemas/SendMigrationData`      | N/A                             | The VM is booted and (shared mem or hugepages enabled)   |
 
 * The `vmcoredump` action is available exclusively for the `x86_64`
 architecture and can be executed only when the `guest_debug` feature is
@@ -167,6 +169,23 @@ curl --unix-socket /tmp/cloud-hypervisor.sock -i \
      -X GET 'http://localhost/api/v1/vm.info' \
      -H 'Accept: application/json'
 ```
+
+##### Get Balloon Statistics
+
+When the running VM has negotiated the virtio-balloon statistics feature, the
+most recently reported guest sample can be retrieved with:
+
+```shell
+curl --unix-socket /tmp/cloud-hypervisor.sock -i \
+     -X GET 'http://localhost/api/v1/vm.balloon-stats' \
+     -H 'Accept: application/json'
+```
+
+The same request is available through `ch-remote balloon-stats`. Reading the
+statistics also requests an asynchronous refresh for the next call. The
+`last_update` field is a host-generated UNIX timestamp in milliseconds, or zero
+if the guest has not supplied its first sample yet. Unsupported guest
+statistics are omitted from the response.
 
 ##### Reboot a Virtual Machine
 

--- a/docs/balloon.md
+++ b/docs/balloon.md
@@ -74,3 +74,25 @@ _Example_
 ```
 --balloon size=0,free_page_reporting=on
 ```
+
+## Statistics
+
+Cloud Hypervisor offers the virtio statistics queue whenever a balloon device
+is configured. The guest must negotiate `VIRTIO_BALLOON_F_STATS_VQ` before
+statistics can be queried.
+
+Use `ch-remote` to request a fresh sample from the guest:
+
+```
+ch-remote --api-socket=/path/to/api.sock balloon-stats
+```
+
+The request returns the current balloon size in bytes and the statistics
+provided by the guest. Memory quantities are expressed in bytes. Unsupported
+statistics are omitted from the response. In addition to the statistics from
+the virtio 1.4 specification, Cloud Hypervisor recognizes the Linux OOM,
+allocation stall, scan, and reclaim statistics.
+
+Statistics are collected on demand. If the VM is not running or the guest does
+not respond within one second, the request fails rather than returning a stale
+sample.

--- a/docs/balloon.md
+++ b/docs/balloon.md
@@ -74,3 +74,28 @@ _Example_
 ```
 --balloon size=0,free_page_reporting=on
 ```
+
+## Statistics
+
+Cloud Hypervisor offers the virtio statistics queue whenever a balloon device
+is configured. The guest must negotiate `VIRTIO_BALLOON_F_STATS_VQ` before
+statistics can be queried.
+
+Use `ch-remote` to retrieve the most recently reported sample:
+
+```
+ch-remote --api-socket=/path/to/api.sock balloon-stats
+```
+
+The request returns the current balloon size in bytes, a host-generated
+`last_update` UNIX timestamp in milliseconds, and the statistics provided by
+the guest. Memory quantities are expressed in bytes. Unsupported statistics are
+omitted from the response. In addition to the statistics from the virtio 1.4
+specification, Cloud Hypervisor recognizes the Linux OOM, allocation stall,
+scan, and reclaim statistics.
+
+Cloud Hypervisor caches the latest sample and returns it immediately. Each
+request also asks the guest to refresh the cache asynchronously for the next
+request. If the guest stops responding, `last_update` indicates the age of the
+cached sample. Before the first sample arrives, `last_update` is zero and
+`stats` is empty.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1544,6 +1544,7 @@ dependencies = [
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
+ "zerocopy",
 ]
 
 [[package]]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
+ "zerocopy",
 ]
 
 [[package]]

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -14,8 +14,8 @@ use micro_http::Request;
 use vm_migration::MigratableError;
 use vmm::api::http::*;
 use vmm::api::{
-    ApiRequest, RequestHandler, VmInfoResponse, VmReceiveMigrationData, VmSendMigrationData,
-    VmmPingResponse,
+    ApiRequest, BalloonStatsResponse, RequestHandler, VmInfoResponse, VmReceiveMigrationData,
+    VmSendMigrationData, VmmPingResponse,
 };
 use vmm::config::RestoreConfig;
 use vmm::vm::{Error as VmError, VmState};
@@ -214,6 +214,13 @@ impl RequestHandler for StubApiRequestHandler {
             state: VmState::Running,
             memory_actual_size: 0,
             device_tree: None,
+        })
+    }
+
+    fn vm_balloon_stats(&mut self) -> Result<BalloonStatsResponse, VmError> {
+        Ok(BalloonStatsResponse {
+            balloon_actual: 0,
+            stats: Default::default(),
         })
     }
 

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -14,8 +14,8 @@ use micro_http::Request;
 use vm_migration::MigratableError;
 use vmm::api::http::*;
 use vmm::api::{
-    ApiRequest, RequestHandler, VmInfoResponse, VmReceiveMigrationData, VmSendMigrationData,
-    VmmPingResponse,
+    ApiRequest, BalloonStatsResponse, RequestHandler, VmInfoResponse, VmReceiveMigrationData,
+    VmSendMigrationData, VmmPingResponse,
 };
 use vmm::config::RestoreConfig;
 use vmm::vm::{Error as VmError, VmState};
@@ -214,6 +214,14 @@ impl RequestHandler for StubApiRequestHandler {
             state: VmState::Running,
             memory_actual_size: 0,
             device_tree: None,
+        })
+    }
+
+    fn vm_balloon_stats(&self) -> Result<BalloonStatsResponse, VmError> {
+        Ok(BalloonStatsResponse {
+            balloon_actual: 0,
+            last_update: 0,
+            stats: Default::default(),
         })
     }
 

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -50,6 +50,7 @@ vm-memory = { workspace = true, features = [
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { workspace = true }
+zerocopy = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -15,8 +15,10 @@
 // limitations under the License.
 
 use std::io::{self, Write};
+use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::AtomicBool;
+use std::sync::mpsc::{self, Receiver, Sender, SyncSender};
 use std::sync::{Arc, Barrier};
 use std::{cmp, result};
 
@@ -36,7 +38,9 @@ use vm_memory::{
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vm_virtio::AccessPlatform;
 use vm_virtio::checked_descriptor::DescriptorChainExt;
-use vmm_sys_util::eventfd::EventFd;
+use vmm_sys_util::eventfd::{EFD_NONBLOCK, EventFd};
+use zerocopy::little_endian::{U16 as Le16, U64 as Le64};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::device::ActivationContext;
 use crate::seccomp_filters::Thread;
@@ -48,6 +52,7 @@ use crate::{
 
 const QUEUE_SIZE: u16 = 128;
 const REPORTING_QUEUE_SIZE: u16 = 32;
+const STATS_QUEUE_SIZE: u16 = 16;
 const MIN_NUM_QUEUES: usize = 2;
 
 // Inflate virtio queue event.
@@ -56,6 +61,10 @@ const INFLATE_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
 const DEFLATE_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
 // Reporting virtio queue event.
 const REPORTING_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 3;
+// Statistics virtio queue event.
+const STATS_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 4;
+// Statistics request event.
+const STATS_REQUEST_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 5;
 
 // Size of a PFN in the balloon interface.
 const VIRTIO_BALLOON_PFN_SHIFT: u64 = 12;
@@ -66,11 +75,112 @@ const VIRTIO_BALLOON_PFN_SHIFT: u64 = 12;
 // descriptor.
 const VIRTIO_BALLOON_MAX_PFN_BYTES: u32 = 256 * 4;
 
+// Enable statistics virtqueue.
+const VIRTIO_BALLOON_F_STATS_VQ: u64 = 1;
 // Deflate balloon on OOM
 const VIRTIO_BALLOON_F_DEFLATE_ON_OOM: u64 = 2;
 // Enable an additional virtqueue to let the guest notify the host about free
 // pages.
 const VIRTIO_BALLOON_F_REPORTING: u64 = 5;
+
+const VIRTIO_BALLOON_S_SWAP_IN: u16 = 0;
+const VIRTIO_BALLOON_S_SWAP_OUT: u16 = 1;
+const VIRTIO_BALLOON_S_MAJFLT: u16 = 2;
+const VIRTIO_BALLOON_S_MINFLT: u16 = 3;
+const VIRTIO_BALLOON_S_MEMFREE: u16 = 4;
+const VIRTIO_BALLOON_S_MEMTOT: u16 = 5;
+const VIRTIO_BALLOON_S_AVAIL: u16 = 6;
+const VIRTIO_BALLOON_S_CACHES: u16 = 7;
+const VIRTIO_BALLOON_S_HTLB_PGALLOC: u16 = 8;
+const VIRTIO_BALLOON_S_HTLB_PGFAIL: u16 = 9;
+// Linux extensions that are not part of virtio 1.4.
+const VIRTIO_BALLOON_S_OOM_KILL: u16 = 10;
+const VIRTIO_BALLOON_S_ALLOC_STALL: u16 = 11;
+const VIRTIO_BALLOON_S_ASYNC_SCAN: u16 = 12;
+const VIRTIO_BALLOON_S_DIRECT_SCAN: u16 = 13;
+const VIRTIO_BALLOON_S_ASYNC_RECLAIM: u16 = 14;
+const VIRTIO_BALLOON_S_DIRECT_RECLAIM: u16 = 15;
+
+// Bound allocations from untrusted descriptor chains. This accommodates far
+// more than the 16 statistics currently defined by Linux.
+const VIRTIO_BALLOON_MAX_STATS_BYTES: usize = 4096;
+
+#[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C, packed)]
+struct BalloonStat {
+    tag: Le16,
+    val: Le64,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BalloonStats {
+    pub swap_in: Option<u64>,
+    pub swap_out: Option<u64>,
+    pub major_faults: Option<u64>,
+    pub minor_faults: Option<u64>,
+    pub free_memory: Option<u64>,
+    pub total_memory: Option<u64>,
+    pub available_memory: Option<u64>,
+    pub disk_caches: Option<u64>,
+    pub hugetlb_allocations: Option<u64>,
+    pub hugetlb_failures: Option<u64>,
+    pub oom_kills: Option<u64>,
+    pub alloc_stalls: Option<u64>,
+    pub async_scans: Option<u64>,
+    pub direct_scans: Option<u64>,
+    pub async_reclaims: Option<u64>,
+    pub direct_reclaims: Option<u64>,
+}
+
+#[derive(Error, Debug)]
+pub enum BalloonStatsError {
+    #[error("Invalid balloon statistics descriptor at {0:#x}")]
+    InvalidDescriptor(u64),
+    #[error("Balloon statistics buffer is too large: {0} bytes")]
+    BufferTooLarge(usize),
+    #[error("Invalid balloon statistics buffer length: {0} bytes")]
+    InvalidBufferLength(usize),
+    #[error("Failed to read balloon statistics")]
+    GuestMemory(#[source] GuestMemoryError),
+}
+
+type BalloonStatsResult = result::Result<BalloonStats, BalloonStatsError>;
+
+struct StatsRequest {
+    response_sender: SyncSender<BalloonStatsResult>,
+}
+
+fn parse_balloon_stats(data: &[u8]) -> BalloonStatsResult {
+    let entries = <[BalloonStat]>::ref_from_bytes(data)
+        .map_err(|_| BalloonStatsError::InvalidBufferLength(data.len()))?;
+
+    let mut stats = BalloonStats::default();
+    for entry in entries {
+        let field = match entry.tag.get() {
+            VIRTIO_BALLOON_S_SWAP_IN => &mut stats.swap_in,
+            VIRTIO_BALLOON_S_SWAP_OUT => &mut stats.swap_out,
+            VIRTIO_BALLOON_S_MAJFLT => &mut stats.major_faults,
+            VIRTIO_BALLOON_S_MINFLT => &mut stats.minor_faults,
+            VIRTIO_BALLOON_S_MEMFREE => &mut stats.free_memory,
+            VIRTIO_BALLOON_S_MEMTOT => &mut stats.total_memory,
+            VIRTIO_BALLOON_S_AVAIL => &mut stats.available_memory,
+            VIRTIO_BALLOON_S_CACHES => &mut stats.disk_caches,
+            VIRTIO_BALLOON_S_HTLB_PGALLOC => &mut stats.hugetlb_allocations,
+            VIRTIO_BALLOON_S_HTLB_PGFAIL => &mut stats.hugetlb_failures,
+            VIRTIO_BALLOON_S_OOM_KILL => &mut stats.oom_kills,
+            VIRTIO_BALLOON_S_ALLOC_STALL => &mut stats.alloc_stalls,
+            VIRTIO_BALLOON_S_ASYNC_SCAN => &mut stats.async_scans,
+            VIRTIO_BALLOON_S_DIRECT_SCAN => &mut stats.direct_scans,
+            VIRTIO_BALLOON_S_ASYNC_RECLAIM => &mut stats.async_reclaims,
+            VIRTIO_BALLOON_S_DIRECT_RECLAIM => &mut stats.direct_reclaims,
+            _ => continue,
+        };
+        *field = Some(entry.val.get());
+    }
+
+    Ok(stats)
+}
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -86,6 +196,12 @@ pub enum Error {
     FailedSignal(#[source] io::Error),
     #[error("Failed adding used index")]
     QueueAddUsed(#[source] virtio_queue::Error),
+    #[error("Balloon statistics feature was not negotiated")]
+    StatsNotNegotiated,
+    #[error("Balloon statistics worker is unavailable")]
+    StatsWorkerUnavailable,
+    #[error("Failed to signal balloon statistics request")]
+    StatsRequestSignal(#[source] io::Error),
 }
 
 // Got from include/uapi/linux/virtio_balloon.h
@@ -154,7 +270,15 @@ struct BalloonEpollHandler {
     interrupt_cb: Arc<dyn VirtioInterrupt>,
     inflate_queue_evt: EventFd,
     deflate_queue_evt: EventFd,
+    stats_queue_evt: Option<EventFd>,
+    stats_request_evt: Option<EventFd>,
+    stats_request_receiver: Option<Receiver<StatsRequest>>,
+    stats_response_sender: Option<SyncSender<BalloonStatsResult>>,
+    stats_refresh_in_flight: bool,
+    stats_desc_index: Option<u16>,
+    stats_queue_index: Option<usize>,
     reporting_queue_evt: Option<EventFd>,
+    reporting_queue_index: Option<usize>,
     kill_evt: EventFd,
     pause_evt: EventFd,
     pbp: Option<PartiallyBalloonedPage>,
@@ -361,6 +485,97 @@ impl BalloonEpollHandler {
         }
     }
 
+    fn parse_stats_descriptor<M>(
+        &self,
+        desc_chain: &mut virtio_queue::DescriptorChain<M>,
+    ) -> BalloonStatsResult
+    where
+        M: Deref<Target = GuestMemoryMmap>,
+    {
+        let results: SmallVec<[_; 4]> = desc_chain
+            .checked_iter(self.access_platform.as_deref())
+            .collect();
+        let mut data = Vec::new();
+
+        for result in results {
+            let desc =
+                result.map_err(|addr| BalloonStatsError::InvalidDescriptor(addr.raw_value()))?;
+            if desc.is_write_only() {
+                return Err(BalloonStatsError::InvalidDescriptor(
+                    desc.addr().raw_value(),
+                ));
+            }
+
+            let new_len = data
+                .len()
+                .checked_add(desc.len() as usize)
+                .ok_or(BalloonStatsError::BufferTooLarge(usize::MAX))?;
+            if new_len > VIRTIO_BALLOON_MAX_STATS_BYTES {
+                return Err(BalloonStatsError::BufferTooLarge(new_len));
+            }
+            let old_len = data.len();
+            data.resize(new_len, 0);
+            desc_chain
+                .memory()
+                .read_slice(&mut data[old_len..], desc.addr())
+                .map_err(BalloonStatsError::GuestMemory)?;
+        }
+
+        parse_balloon_stats(&data)
+    }
+
+    fn start_stats_refresh(&mut self) -> result::Result<(), Error> {
+        if self.stats_response_sender.is_none() || self.stats_refresh_in_flight {
+            return Ok(());
+        }
+
+        let Some(stats_qi) = self.stats_queue_index else {
+            return Ok(());
+        };
+        let Some(desc_index) = self.stats_desc_index.take() else {
+            return Ok(());
+        };
+
+        self.queues[stats_qi]
+            .add_used(self.mem.memory().deref(), desc_index, 0)
+            .map_err(Error::QueueAddUsed)?;
+        self.stats_refresh_in_flight = true;
+        self.signal(VirtioInterruptType::Queue(stats_qi as u16))
+    }
+
+    fn process_stats_requests(&mut self) -> result::Result<(), Error> {
+        let Some(receiver) = self.stats_request_receiver.as_ref() else {
+            return Ok(());
+        };
+
+        while let Ok(request) = receiver.try_recv() {
+            self.stats_response_sender = Some(request.response_sender);
+        }
+        self.start_stats_refresh()
+    }
+
+    fn process_stats_queue(&mut self, queue_index: usize) -> result::Result<(), Error> {
+        if self.stats_desc_index.is_some() {
+            return Ok(());
+        }
+
+        let Some(mut desc_chain) = self.queues[queue_index].pop_descriptor_chain(self.mem.memory())
+        else {
+            return Ok(());
+        };
+
+        let desc_index = desc_chain.head_index();
+        if self.stats_refresh_in_flight {
+            let response = self.parse_stats_descriptor(&mut desc_chain);
+            self.stats_refresh_in_flight = false;
+            if let Some(response_sender) = self.stats_response_sender.take() {
+                let _ = response_sender.send(response);
+            }
+        }
+        self.stats_desc_index = Some(desc_index);
+        self.start_stats_refresh()
+    }
+
     fn process_reporting_queue(&mut self, queue_index: usize) -> result::Result<(), Error> {
         let mut used_descs = false;
         while let Some(mut desc_chain) =
@@ -406,8 +621,21 @@ impl BalloonEpollHandler {
         let mut helper = EpollHelper::new(&self.kill_evt, &self.pause_evt)?;
         helper.add_event(self.inflate_queue_evt.as_raw_fd(), INFLATE_QUEUE_EVENT)?;
         helper.add_event(self.deflate_queue_evt.as_raw_fd(), DEFLATE_QUEUE_EVENT)?;
+        if let Some(stats_queue_evt) = self.stats_queue_evt.as_ref() {
+            helper.add_event(stats_queue_evt.as_raw_fd(), STATS_QUEUE_EVENT)?;
+        }
+        if let Some(stats_request_evt) = self.stats_request_evt.as_ref() {
+            helper.add_event(stats_request_evt.as_raw_fd(), STATS_REQUEST_EVENT)?;
+        }
         if let Some(reporting_queue_evt) = self.reporting_queue_evt.as_ref() {
             helper.add_event(reporting_queue_evt.as_raw_fd(), REPORTING_QUEUE_EVENT)?;
+        }
+
+        // A descriptor retained by the source is available again after restore,
+        // but its original queue kick is not. Recover it before waiting on epoll.
+        if let Some(queue_index) = self.stats_queue_index {
+            self.process_stats_queue(queue_index)
+                .map_err(|e| EpollHelperError::HandleEvent(anyhow!(e)))?;
         }
         helper.run(paused, paused_sync, self)?;
 
@@ -447,6 +675,44 @@ impl EpollHelperHandler for BalloonEpollHandler {
                     ))
                 })?;
             }
+            STATS_QUEUE_EVENT => {
+                if let Some(stats_queue_evt) = self.stats_queue_evt.as_ref() {
+                    stats_queue_evt.read().map_err(|e| {
+                        EpollHelperError::HandleEvent(anyhow!(
+                            "Failed to get stats queue event: {e:?}"
+                        ))
+                    })?;
+                    if let Some(qi) = self.stats_queue_index {
+                        self.process_stats_queue(qi).map_err(|e| {
+                            EpollHelperError::HandleEvent(anyhow!(
+                                "Failed to process stats queue: {e:?}"
+                            ))
+                        })?;
+                    }
+                } else {
+                    return Err(EpollHelperError::HandleEvent(anyhow!(
+                        "Invalid stats queue event as no eventfd registered"
+                    )));
+                }
+            }
+            STATS_REQUEST_EVENT => {
+                if let Some(stats_request_evt) = self.stats_request_evt.as_ref() {
+                    stats_request_evt.read().map_err(|e| {
+                        EpollHelperError::HandleEvent(anyhow!(
+                            "Failed to get stats request event: {e:?}"
+                        ))
+                    })?;
+                    self.process_stats_requests().map_err(|e| {
+                        EpollHelperError::HandleEvent(anyhow!(
+                            "Failed to request balloon statistics: {e:?}"
+                        ))
+                    })?;
+                } else {
+                    return Err(EpollHelperError::HandleEvent(anyhow!(
+                        "Invalid stats request event as no eventfd registered"
+                    )));
+                }
+            }
             REPORTING_QUEUE_EVENT => {
                 if let Some(reporting_queue_evt) = self.reporting_queue_evt.as_ref() {
                     reporting_queue_evt.read().map_err(|e| {
@@ -454,9 +720,10 @@ impl EpollHelperHandler for BalloonEpollHandler {
                             "Failed to get reporting queue event: {e:?}"
                         ))
                     })?;
-                    self.process_reporting_queue(2).map_err(|e| {
+                    let qi = self.reporting_queue_index.unwrap();
+                    self.process_reporting_queue(qi).map_err(|e| {
                         EpollHelperError::HandleEvent(anyhow!(
-                            "Failed to signal used inflate queue: {e:?}"
+                            "Failed to signal used reporting queue: {e:?}"
                         ))
                     })?;
                 } else {
@@ -490,6 +757,8 @@ pub struct Balloon {
     config: VirtioBalloonConfig,
     seccomp_action: SeccompAction,
     exit_evt: EventFd,
+    stats_request_evt: EventFd,
+    stats_request_sender: Option<Sender<StatsRequest>>,
 }
 
 impl Balloon {
@@ -516,7 +785,7 @@ impl Balloon {
                 true,
             )
         } else {
-            let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
+            let mut avail_features = 1u64 << VIRTIO_F_VERSION_1 | 1u64 << VIRTIO_BALLOON_F_STATS_VQ;
             if deflate_on_oom {
                 avail_features |= 1u64 << VIRTIO_BALLOON_F_DEFLATE_ON_OOM;
             }
@@ -535,9 +804,17 @@ impl Balloon {
             (avail_features, 0, config, false)
         };
 
-        if free_page_reporting {
+        // Stats queue must come before reporting queue to match virtio spec
+        // queue index ordering (the guest transport compresses out disabled
+        // queues).
+        if avail_features & (1u64 << VIRTIO_BALLOON_F_STATS_VQ) != 0 {
+            queue_sizes.push(STATS_QUEUE_SIZE);
+        }
+        if avail_features & (1u64 << VIRTIO_BALLOON_F_REPORTING) != 0 {
             queue_sizes.push(REPORTING_QUEUE_SIZE);
         }
+
+        let stats_request_evt = EventFd::new(EFD_NONBLOCK)?;
 
         Ok(Balloon {
             common: VirtioCommon {
@@ -554,6 +831,8 @@ impl Balloon {
             config,
             seccomp_action,
             exit_evt,
+            stats_request_evt,
+            stats_request_sender: None,
         })
     }
 
@@ -568,6 +847,27 @@ impl Balloon {
     // Get the actual size of the virtio-balloon.
     pub fn get_actual(&self) -> u64 {
         (self.config.actual as u64) << VIRTIO_BALLOON_PFN_SHIFT
+    }
+
+    // Request fresh statistics from the virtio-balloon.
+    pub fn begin_stats_request(
+        &self,
+    ) -> Result<Receiver<result::Result<BalloonStats, BalloonStatsError>>, Error> {
+        if !self.common.feature_acked(VIRTIO_BALLOON_F_STATS_VQ) {
+            return Err(Error::StatsNotNegotiated);
+        }
+        let request_sender = self
+            .stats_request_sender
+            .as_ref()
+            .ok_or(Error::StatsWorkerUnavailable)?;
+        let (response_sender, response_receiver) = mpsc::sync_channel(1);
+        request_sender
+            .send(StatsRequest { response_sender })
+            .map_err(|_| Error::StatsWorkerUnavailable)?;
+        self.stats_request_evt
+            .write(1)
+            .map_err(Error::StatsRequestSignal)?;
+        Ok(response_receiver)
     }
 
     fn state(&self) -> BalloonState {
@@ -654,13 +954,40 @@ impl VirtioDevice for Balloon {
         let (_, queue, queue_evt) = queues.remove(0);
         virtqueues.push(queue);
         let deflate_queue_evt = queue_evt;
-        let reporting_queue_evt =
-            if self.common.feature_acked(VIRTIO_BALLOON_F_REPORTING) && !queues.is_empty() {
+
+        let (stats_queue_evt, stats_queue_index, stats_request_evt, stats_request_receiver) =
+            if self.common.feature_acked(VIRTIO_BALLOON_F_STATS_VQ) && !queues.is_empty() {
+                let qi = virtqueues.len();
                 let (_, queue, queue_evt) = queues.remove(0);
                 virtqueues.push(queue);
-                Some(queue_evt)
+
+                while self.stats_request_evt.read().is_ok() {}
+                let (request_sender, request_receiver) = mpsc::channel();
+                self.stats_request_sender = Some(request_sender);
+                let request_evt = self
+                    .stats_request_evt
+                    .try_clone()
+                    .map_err(crate::ActivateError::CloneEventFd)?;
+
+                (
+                    Some(queue_evt),
+                    Some(qi),
+                    Some(request_evt),
+                    Some(request_receiver),
+                )
             } else {
-                None
+                self.stats_request_sender = None;
+                (None, None, None, None)
+            };
+
+        let (reporting_queue_evt, reporting_queue_index) =
+            if self.common.feature_acked(VIRTIO_BALLOON_F_REPORTING) && !queues.is_empty() {
+                let qi = virtqueues.len();
+                let (_, queue, queue_evt) = queues.remove(0);
+                virtqueues.push(queue);
+                (Some(queue_evt), Some(qi))
+            } else {
+                (None, None)
             };
 
         let mut handler = BalloonEpollHandler {
@@ -669,7 +996,15 @@ impl VirtioDevice for Balloon {
             interrupt_cb: interrupt_cb.clone(),
             inflate_queue_evt,
             deflate_queue_evt,
+            stats_queue_evt,
+            stats_request_evt,
+            stats_request_receiver,
+            stats_response_sender: None,
+            stats_refresh_in_flight: false,
+            stats_desc_index: None,
+            stats_queue_index,
             reporting_queue_evt,
+            reporting_queue_index,
             kill_evt,
             pause_evt,
             pbp: None,
@@ -679,7 +1014,7 @@ impl VirtioDevice for Balloon {
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
 
-        self.common.spawn_worker(
+        if let Err(e) = self.common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioBalloon,
@@ -687,7 +1022,10 @@ impl VirtioDevice for Balloon {
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
-        )?;
+        ) {
+            self.stats_request_sender = None;
+            return Err(e);
+        }
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())
@@ -702,6 +1040,7 @@ impl VirtioDevice for Balloon {
     }
 
     fn reset(&mut self) {
+        self.stats_request_sender = None;
         self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
     }
@@ -728,3 +1067,173 @@ impl Snapshottable for Balloon {
 }
 impl Transportable for Balloon {}
 impl Migratable for Balloon {}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::sync_channel;
+
+    use vm_memory::bitmap::AtomicBitmap;
+    use vm_virtio::queue::testing::VirtQueue;
+
+    use super::*;
+
+    type TestMemory = vm_memory::GuestMemoryMmap<AtomicBitmap>;
+
+    struct NoopInterrupt;
+
+    impl VirtioInterrupt for NoopInterrupt {
+        fn trigger(&self, _int_type: VirtioInterruptType) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn set_notifier(
+            &self,
+            _int_type: u32,
+            _notifier: Option<EventFd>,
+            _vm: &dyn hypervisor::Vm,
+        ) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn stat(tag: u16, value: u64) -> Vec<u8> {
+        BalloonStat {
+            tag: Le16::new(tag),
+            val: Le64::new(value),
+        }
+        .as_bytes()
+        .to_vec()
+    }
+
+    #[test]
+    fn parse_standard_and_linux_stats() {
+        let mut data = Vec::new();
+        for (tag, value) in (0u16..=15).zip(100u64..) {
+            data.extend(stat(tag, value));
+        }
+
+        let stats = parse_balloon_stats(&data).unwrap();
+        assert_eq!(stats.swap_in, Some(100));
+        assert_eq!(stats.swap_out, Some(101));
+        assert_eq!(stats.major_faults, Some(102));
+        assert_eq!(stats.minor_faults, Some(103));
+        assert_eq!(stats.free_memory, Some(104));
+        assert_eq!(stats.total_memory, Some(105));
+        assert_eq!(stats.available_memory, Some(106));
+        assert_eq!(stats.disk_caches, Some(107));
+        assert_eq!(stats.hugetlb_allocations, Some(108));
+        assert_eq!(stats.hugetlb_failures, Some(109));
+        assert_eq!(stats.oom_kills, Some(110));
+        assert_eq!(stats.alloc_stalls, Some(111));
+        assert_eq!(stats.async_scans, Some(112));
+        assert_eq!(stats.direct_scans, Some(113));
+        assert_eq!(stats.async_reclaims, Some(114));
+        assert_eq!(stats.direct_reclaims, Some(115));
+    }
+
+    #[test]
+    fn parse_stats_accepts_arbitrary_order_and_unknown_tags() {
+        let data = [
+            stat(VIRTIO_BALLOON_S_MEMTOT, 4096),
+            stat(u16::MAX, 123),
+            stat(VIRTIO_BALLOON_S_SWAP_IN, 10),
+        ]
+        .concat();
+
+        let stats = parse_balloon_stats(&data).unwrap();
+        assert_eq!(stats.total_memory, Some(4096));
+        assert_eq!(stats.swap_in, Some(10));
+        assert_eq!(stats.swap_out, None);
+    }
+
+    #[test]
+    fn parse_stats_rejects_partial_entry() {
+        let mut data = stat(VIRTIO_BALLOON_S_MEMFREE, 1024);
+        data.push(0);
+
+        assert!(matches!(
+            parse_balloon_stats(&data),
+            Err(BalloonStatsError::InvalidBufferLength(11))
+        ));
+    }
+
+    #[test]
+    fn stats_request_requires_negotiated_feature() {
+        let balloon = Balloon::new(
+            "balloon0".to_string(),
+            0,
+            false,
+            false,
+            false,
+            SeccompAction::Allow,
+            EventFd::new(EFD_NONBLOCK).unwrap(),
+            None,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            balloon.begin_stats_request(),
+            Err(Error::StatsNotNegotiated)
+        ));
+    }
+
+    #[test]
+    fn stats_request_returns_fresh_descriptor() {
+        const QUEUE_ADDRESS: GuestAddress = GuestAddress(0x1_0000);
+        const STATS_ADDRESS: GuestAddress = GuestAddress(0x1_000);
+
+        let memory = TestMemory::from_ranges(&[(GuestAddress(0), 0x2_0000)]).unwrap();
+        let guest_queue = VirtQueue::new(QUEUE_ADDRESS, &memory, 16);
+        let initial = stat(VIRTIO_BALLOON_S_MEMFREE, 100);
+        memory.write_slice(&initial, STATS_ADDRESS).unwrap();
+        guest_queue.dtable[0].set(STATS_ADDRESS.raw_value(), initial.len() as u32, 0, 0);
+        guest_queue.avail.ring[0].set(0);
+        guest_queue.avail.idx.set(1);
+
+        let (request_sender, request_receiver) = mpsc::channel();
+        let mut handler = BalloonEpollHandler {
+            mem: GuestMemoryAtomic::new(memory.clone()),
+            queues: vec![guest_queue.create_queue()],
+            interrupt_cb: Arc::new(NoopInterrupt),
+            inflate_queue_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            deflate_queue_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            stats_queue_evt: Some(EventFd::new(EFD_NONBLOCK).unwrap()),
+            stats_request_evt: Some(EventFd::new(EFD_NONBLOCK).unwrap()),
+            stats_request_receiver: Some(request_receiver),
+            stats_response_sender: None,
+            stats_refresh_in_flight: false,
+            stats_desc_index: None,
+            stats_queue_index: Some(0),
+            reporting_queue_evt: None,
+            reporting_queue_index: None,
+            kill_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            pause_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            pbp: None,
+            access_platform: None,
+        };
+
+        handler.process_stats_queue(0).unwrap();
+        assert_eq!(handler.stats_desc_index, Some(0));
+
+        let (response_sender, response_receiver) = sync_channel(1);
+        request_sender
+            .send(StatsRequest { response_sender })
+            .unwrap();
+        handler.process_stats_requests().unwrap();
+        assert!(handler.stats_refresh_in_flight);
+        assert_eq!(handler.stats_desc_index, None);
+
+        let refreshed = stat(VIRTIO_BALLOON_S_MEMFREE, 200);
+        memory.write_slice(&refreshed, STATS_ADDRESS).unwrap();
+        guest_queue.avail.ring[1].set(0);
+        guest_queue.avail.idx.set(2);
+        handler.process_stats_queue(0).unwrap();
+
+        assert_eq!(
+            response_receiver.recv().unwrap().unwrap().free_memory,
+            Some(200)
+        );
+        assert!(!handler.stats_refresh_in_flight);
+        assert_eq!(handler.stats_desc_index, Some(0));
+    }
+}

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -15,10 +15,13 @@
 // limitations under the License.
 
 use std::io::{self, Write};
+use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Barrier};
-use std::{cmp, result};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Barrier, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{cmp, mem, result};
 
 use anyhow::anyhow;
 use event_monitor::event;
@@ -36,7 +39,9 @@ use vm_memory::{
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vm_virtio::AccessPlatform;
 use vm_virtio::checked_descriptor::DescriptorChainExt;
-use vmm_sys_util::eventfd::EventFd;
+use vmm_sys_util::eventfd::{EFD_NONBLOCK, EventFd};
+use zerocopy::little_endian::{U16 as Le16, U64 as Le64};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::device::ActivationContext;
 use crate::seccomp_filters::Thread;
@@ -48,6 +53,7 @@ use crate::{
 
 const QUEUE_SIZE: u16 = 128;
 const REPORTING_QUEUE_SIZE: u16 = 32;
+const STATS_QUEUE_SIZE: u16 = 32;
 const MIN_NUM_QUEUES: usize = 2;
 
 // Inflate virtio queue event.
@@ -56,6 +62,10 @@ const INFLATE_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
 const DEFLATE_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
 // Reporting virtio queue event.
 const REPORTING_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 3;
+// Statistics virtio queue event.
+const STATS_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 4;
+// Statistics request event.
+const STATS_REQUEST_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 5;
 
 // Size of a PFN in the balloon interface.
 const VIRTIO_BALLOON_PFN_SHIFT: u64 = 12;
@@ -66,11 +76,115 @@ const VIRTIO_BALLOON_PFN_SHIFT: u64 = 12;
 // descriptor.
 const VIRTIO_BALLOON_MAX_PFN_BYTES: u32 = 256 * 4;
 
+// Enable statistics virtqueue.
+const VIRTIO_BALLOON_F_STATS_VQ: u64 = 1;
 // Deflate balloon on OOM
 const VIRTIO_BALLOON_F_DEFLATE_ON_OOM: u64 = 2;
 // Enable an additional virtqueue to let the guest notify the host about free
 // pages.
 const VIRTIO_BALLOON_F_REPORTING: u64 = 5;
+
+const VIRTIO_BALLOON_S_SWAP_IN: u16 = 0;
+const VIRTIO_BALLOON_S_SWAP_OUT: u16 = 1;
+const VIRTIO_BALLOON_S_MAJFLT: u16 = 2;
+const VIRTIO_BALLOON_S_MINFLT: u16 = 3;
+const VIRTIO_BALLOON_S_MEMFREE: u16 = 4;
+const VIRTIO_BALLOON_S_MEMTOT: u16 = 5;
+const VIRTIO_BALLOON_S_AVAIL: u16 = 6;
+const VIRTIO_BALLOON_S_CACHES: u16 = 7;
+const VIRTIO_BALLOON_S_HTLB_PGALLOC: u16 = 8;
+const VIRTIO_BALLOON_S_HTLB_PGFAIL: u16 = 9;
+// Linux extensions that are not part of virtio 1.4.
+const VIRTIO_BALLOON_S_OOM_KILL: u16 = 10;
+const VIRTIO_BALLOON_S_ALLOC_STALL: u16 = 11;
+const VIRTIO_BALLOON_S_ASYNC_SCAN: u16 = 12;
+const VIRTIO_BALLOON_S_DIRECT_SCAN: u16 = 13;
+const VIRTIO_BALLOON_S_ASYNC_RECLAIM: u16 = 14;
+const VIRTIO_BALLOON_S_DIRECT_RECLAIM: u16 = 15;
+
+// Bound allocations from untrusted descriptor chains. This accommodates far
+// more than the 16 statistics currently defined by Linux.
+const VIRTIO_BALLOON_MAX_STATS_BYTES: usize = 4096;
+
+#[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C, packed)]
+struct BalloonStat {
+    tag: Le16,
+    val: Le64,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BalloonStats {
+    pub swap_in: Option<u64>,
+    pub swap_out: Option<u64>,
+    pub major_faults: Option<u64>,
+    pub minor_faults: Option<u64>,
+    pub free_memory: Option<u64>,
+    pub total_memory: Option<u64>,
+    pub available_memory: Option<u64>,
+    pub disk_caches: Option<u64>,
+    pub hugetlb_allocations: Option<u64>,
+    pub hugetlb_failures: Option<u64>,
+    pub oom_kills: Option<u64>,
+    pub alloc_stalls: Option<u64>,
+    pub async_scans: Option<u64>,
+    pub direct_scans: Option<u64>,
+    pub async_reclaims: Option<u64>,
+    pub direct_reclaims: Option<u64>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct BalloonStatsSnapshot {
+    pub stats: BalloonStats,
+    pub last_update: u64,
+}
+
+#[derive(Error, Debug)]
+pub enum BalloonStatsError {
+    #[error("Invalid balloon statistics descriptor at {0:#x}")]
+    InvalidDescriptor(u64),
+    #[error("Balloon statistics buffer is too large: {0} bytes")]
+    BufferTooLarge(usize),
+    #[error("Invalid balloon statistics buffer length: {0} bytes")]
+    InvalidBufferLength(usize),
+    #[error("Failed to read balloon statistics")]
+    GuestMemory(#[source] GuestMemoryError),
+}
+
+type BalloonStatsResult = result::Result<BalloonStats, BalloonStatsError>;
+type BalloonStatsCache = Arc<Mutex<Option<BalloonStatsSnapshot>>>;
+
+fn parse_balloon_stats(data: &[u8]) -> BalloonStatsResult {
+    let entries = <[BalloonStat]>::ref_from_bytes(data)
+        .map_err(|_| BalloonStatsError::InvalidBufferLength(data.len()))?;
+
+    let mut stats = BalloonStats::default();
+    for entry in entries {
+        let field = match entry.tag.get() {
+            VIRTIO_BALLOON_S_SWAP_IN => &mut stats.swap_in,
+            VIRTIO_BALLOON_S_SWAP_OUT => &mut stats.swap_out,
+            VIRTIO_BALLOON_S_MAJFLT => &mut stats.major_faults,
+            VIRTIO_BALLOON_S_MINFLT => &mut stats.minor_faults,
+            VIRTIO_BALLOON_S_MEMFREE => &mut stats.free_memory,
+            VIRTIO_BALLOON_S_MEMTOT => &mut stats.total_memory,
+            VIRTIO_BALLOON_S_AVAIL => &mut stats.available_memory,
+            VIRTIO_BALLOON_S_CACHES => &mut stats.disk_caches,
+            VIRTIO_BALLOON_S_HTLB_PGALLOC => &mut stats.hugetlb_allocations,
+            VIRTIO_BALLOON_S_HTLB_PGFAIL => &mut stats.hugetlb_failures,
+            VIRTIO_BALLOON_S_OOM_KILL => &mut stats.oom_kills,
+            VIRTIO_BALLOON_S_ALLOC_STALL => &mut stats.alloc_stalls,
+            VIRTIO_BALLOON_S_ASYNC_SCAN => &mut stats.async_scans,
+            VIRTIO_BALLOON_S_DIRECT_SCAN => &mut stats.direct_scans,
+            VIRTIO_BALLOON_S_ASYNC_RECLAIM => &mut stats.async_reclaims,
+            VIRTIO_BALLOON_S_DIRECT_RECLAIM => &mut stats.direct_reclaims,
+            _ => continue,
+        };
+        *field = Some(entry.val.get());
+    }
+
+    Ok(stats)
+}
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -86,6 +200,12 @@ pub enum Error {
     FailedSignal(#[source] io::Error),
     #[error("Failed adding used index")]
     QueueAddUsed(#[source] virtio_queue::Error),
+    #[error("Balloon statistics feature was not negotiated")]
+    StatsNotNegotiated,
+    #[error("Balloon statistics worker is unavailable")]
+    StatsWorkerUnavailable,
+    #[error("Failed to signal balloon statistics request")]
+    StatsRequestSignal(#[source] io::Error),
 }
 
 // Got from include/uapi/linux/virtio_balloon.h
@@ -148,13 +268,30 @@ const CONFIG_ACTUAL_SIZE: usize = 4;
 // SAFETY: it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioBalloonConfig {}
 
+enum BalloonStatsState {
+    WaitingForInitialDescriptor,
+    Idle { descriptor_index: u16 },
+    Pending,
+}
+
+struct BalloonStatsHandler {
+    queue_evt: EventFd,
+    queue_index: usize,
+    request_evt: EventFd,
+    request_receiver: Receiver<()>,
+    stats_cache: BalloonStatsCache,
+    state: BalloonStatsState,
+}
+
 struct BalloonEpollHandler {
     mem: GuestMemoryAtomic<GuestMemoryMmap>,
     queues: Vec<Queue>,
     interrupt_cb: Arc<dyn VirtioInterrupt>,
     inflate_queue_evt: EventFd,
     deflate_queue_evt: EventFd,
+    stats_handler: Option<BalloonStatsHandler>,
     reporting_queue_evt: Option<EventFd>,
+    reporting_queue_index: Option<usize>,
     kill_evt: EventFd,
     pause_evt: EventFd,
     pbp: Option<PartiallyBalloonedPage>,
@@ -361,6 +498,103 @@ impl BalloonEpollHandler {
         }
     }
 
+    fn parse_stats_descriptor<M>(
+        desc_chain: &mut virtio_queue::DescriptorChain<M>,
+        access_platform: Option<&dyn AccessPlatform>,
+    ) -> BalloonStatsResult
+    where
+        M: Deref<Target = GuestMemoryMmap>,
+    {
+        let results: SmallVec<[_; 4]> = desc_chain.checked_iter(access_platform).collect();
+        let mut data = Vec::new();
+
+        for result in results {
+            let desc =
+                result.map_err(|addr| BalloonStatsError::InvalidDescriptor(addr.raw_value()))?;
+            if desc.is_write_only() {
+                return Err(BalloonStatsError::InvalidDescriptor(
+                    desc.addr().raw_value(),
+                ));
+            }
+
+            let old_len = data.len();
+            let new_len = data
+                .len()
+                .checked_add(desc.len() as usize)
+                .ok_or(BalloonStatsError::BufferTooLarge(usize::MAX))?;
+            if new_len > VIRTIO_BALLOON_MAX_STATS_BYTES {
+                return Err(BalloonStatsError::BufferTooLarge(new_len));
+            }
+            data.resize(new_len, 0);
+            desc_chain
+                .memory()
+                .read_slice(&mut data[old_len..], desc.addr())
+                .map_err(BalloonStatsError::GuestMemory)?;
+        }
+
+        parse_balloon_stats(&data)
+    }
+
+    fn process_stats_queue(&mut self) -> result::Result<(), Error> {
+        let queue_index = {
+            let stats_handler = self.stats_handler.as_ref().unwrap();
+            if matches!(stats_handler.state, BalloonStatsState::Idle { .. }) {
+                return Ok(());
+            }
+            stats_handler.queue_index
+        };
+        let Some(mut desc_chain) = self.queues[queue_index].pop_descriptor_chain(self.mem.memory())
+        else {
+            return Ok(());
+        };
+        let descriptor_index = desc_chain.head_index();
+        let stats = Self::parse_stats_descriptor(&mut desc_chain, self.access_platform.as_deref());
+
+        let stats_handler = self.stats_handler.as_mut().unwrap();
+        match stats {
+            Ok(stats) => {
+                let last_update = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_or(0, |duration| {
+                        u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+                    });
+                *stats_handler.stats_cache.lock().unwrap() =
+                    Some(BalloonStatsSnapshot { stats, last_update });
+            }
+            Err(error) => warn!("Ignoring invalid balloon statistics: {error}"),
+        }
+
+        match mem::replace(
+            &mut stats_handler.state,
+            BalloonStatsState::Idle { descriptor_index },
+        ) {
+            BalloonStatsState::WaitingForInitialDescriptor | BalloonStatsState::Pending => {}
+            BalloonStatsState::Idle { .. } => unreachable!(),
+        }
+        Ok(())
+    }
+
+    fn process_stats_request(&mut self) -> result::Result<(), Error> {
+        let (queue_index, descriptor_index) = {
+            let stats_handler = self.stats_handler.as_mut().unwrap();
+            match &mut stats_handler.state {
+                BalloonStatsState::WaitingForInitialDescriptor => return Ok(()),
+                BalloonStatsState::Idle { descriptor_index } => {
+                    (stats_handler.queue_index, *descriptor_index)
+                }
+                BalloonStatsState::Pending => return Ok(()),
+            }
+        };
+
+        self.queues[queue_index]
+            .add_used(self.mem.memory().deref(), descriptor_index, 0)
+            .map_err(Error::QueueAddUsed)?;
+        self.stats_handler.as_mut().unwrap().state = BalloonStatsState::Pending;
+        self.signal(VirtioInterruptType::Queue(queue_index as u16))?;
+
+        Ok(())
+    }
+
     fn process_reporting_queue(&mut self, queue_index: usize) -> result::Result<(), Error> {
         let mut used_descs = false;
         while let Some(mut desc_chain) =
@@ -406,8 +640,19 @@ impl BalloonEpollHandler {
         let mut helper = EpollHelper::new(&self.kill_evt, &self.pause_evt)?;
         helper.add_event(self.inflate_queue_evt.as_raw_fd(), INFLATE_QUEUE_EVENT)?;
         helper.add_event(self.deflate_queue_evt.as_raw_fd(), DEFLATE_QUEUE_EVENT)?;
+        if let Some(stats_handler) = &self.stats_handler {
+            helper.add_event(stats_handler.queue_evt.as_raw_fd(), STATS_QUEUE_EVENT)?;
+            helper.add_event(stats_handler.request_evt.as_raw_fd(), STATS_REQUEST_EVENT)?;
+        }
         if let Some(reporting_queue_evt) = self.reporting_queue_evt.as_ref() {
             helper.add_event(reporting_queue_evt.as_raw_fd(), REPORTING_QUEUE_EVENT)?;
+        }
+
+        // A descriptor retained by the source is available again after restore,
+        // but its original queue kick is not. Recover it before waiting on epoll.
+        if self.stats_handler.is_some() {
+            self.process_stats_queue()
+                .map_err(|e| EpollHelperError::HandleEvent(anyhow!(e)))?;
         }
         helper.run(paused, paused_sync, self)?;
 
@@ -447,6 +692,45 @@ impl EpollHelperHandler for BalloonEpollHandler {
                     ))
                 })?;
             }
+            STATS_QUEUE_EVENT => {
+                let stats_handler = self.stats_handler.as_ref().ok_or_else(|| {
+                    EpollHelperError::HandleEvent(anyhow!(
+                        "Invalid stats queue event as no eventfd registered"
+                    ))
+                })?;
+                stats_handler.queue_evt.read().map_err(|e| {
+                    EpollHelperError::HandleEvent(anyhow!("Failed to get stats queue event: {e:?}"))
+                })?;
+                self.process_stats_queue().map_err(|e| {
+                    EpollHelperError::HandleEvent(anyhow!("Failed to process stats queue: {e:?}"))
+                })?;
+            }
+            STATS_REQUEST_EVENT => {
+                let stats_handler = self.stats_handler.as_ref().ok_or_else(|| {
+                    EpollHelperError::HandleEvent(anyhow!(
+                        "Invalid stats request event as no eventfd registered"
+                    ))
+                })?;
+                stats_handler.request_evt.read().map_err(|e| {
+                    EpollHelperError::HandleEvent(anyhow!(
+                        "Failed to get stats request event: {e:?}"
+                    ))
+                })?;
+
+                while self
+                    .stats_handler
+                    .as_mut()
+                    .unwrap()
+                    .request_receiver
+                    .try_recv()
+                    .is_ok()
+                {}
+                self.process_stats_request().map_err(|e| {
+                    EpollHelperError::HandleEvent(anyhow!(
+                        "Failed to request balloon statistics: {e:?}"
+                    ))
+                })?;
+            }
             REPORTING_QUEUE_EVENT => {
                 if let Some(reporting_queue_evt) = self.reporting_queue_evt.as_ref() {
                     reporting_queue_evt.read().map_err(|e| {
@@ -454,9 +738,10 @@ impl EpollHelperHandler for BalloonEpollHandler {
                             "Failed to get reporting queue event: {e:?}"
                         ))
                     })?;
-                    self.process_reporting_queue(2).map_err(|e| {
+                    let qi = self.reporting_queue_index.unwrap();
+                    self.process_reporting_queue(qi).map_err(|e| {
                         EpollHelperError::HandleEvent(anyhow!(
-                            "Failed to signal used inflate queue: {e:?}"
+                            "Failed to signal used reporting queue: {e:?}"
                         ))
                     })?;
                 } else {
@@ -490,6 +775,9 @@ pub struct Balloon {
     config: VirtioBalloonConfig,
     seccomp_action: SeccompAction,
     exit_evt: EventFd,
+    stats_request_evt: EventFd,
+    stats_request_sender: Option<Sender<()>>,
+    stats_cache: BalloonStatsCache,
 }
 
 impl Balloon {
@@ -516,7 +804,7 @@ impl Balloon {
                 true,
             )
         } else {
-            let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
+            let mut avail_features = 1u64 << VIRTIO_F_VERSION_1 | 1u64 << VIRTIO_BALLOON_F_STATS_VQ;
             if deflate_on_oom {
                 avail_features |= 1u64 << VIRTIO_BALLOON_F_DEFLATE_ON_OOM;
             }
@@ -535,9 +823,17 @@ impl Balloon {
             (avail_features, 0, config, false)
         };
 
-        if free_page_reporting {
+        // Stats queue must come before reporting queue to match virtio spec
+        // queue index ordering (the guest transport compresses out disabled
+        // queues).
+        if avail_features & (1u64 << VIRTIO_BALLOON_F_STATS_VQ) != 0 {
+            queue_sizes.push(STATS_QUEUE_SIZE);
+        }
+        if avail_features & (1u64 << VIRTIO_BALLOON_F_REPORTING) != 0 {
             queue_sizes.push(REPORTING_QUEUE_SIZE);
         }
+
+        let stats_request_evt = EventFd::new(EFD_NONBLOCK)?;
 
         Ok(Balloon {
             common: VirtioCommon {
@@ -554,6 +850,9 @@ impl Balloon {
             config,
             seccomp_action,
             exit_evt,
+            stats_request_evt,
+            stats_request_sender: None,
+            stats_cache: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -568,6 +867,36 @@ impl Balloon {
     // Get the actual size of the virtio-balloon.
     pub fn get_actual(&self) -> u64 {
         (self.config.actual as u64) << VIRTIO_BALLOON_PFN_SHIFT
+    }
+
+    fn request_stats_refresh(&self) -> Result<(), Error> {
+        let request_sender = self
+            .stats_request_sender
+            .as_ref()
+            .ok_or(Error::StatsWorkerUnavailable)?;
+        request_sender
+            .send(())
+            .map_err(|_| Error::StatsWorkerUnavailable)?;
+        self.stats_request_evt
+            .write(1)
+            .map_err(Error::StatsRequestSignal)
+    }
+
+    // Return the latest statistics and request an asynchronous refresh.
+    pub fn stats(&self) -> Result<BalloonStatsSnapshot, Error> {
+        if !self.common.feature_acked(VIRTIO_BALLOON_F_STATS_VQ) {
+            return Err(Error::StatsNotNegotiated);
+        }
+        let stats = self.stats_cache.lock().unwrap().clone();
+
+        if let Err(error) = self.request_stats_refresh() {
+            if stats.is_none() {
+                return Err(error);
+            }
+            warn!("Failed to refresh balloon statistics: {error}");
+        }
+
+        Ok(stats.unwrap_or_default())
     }
 
     fn state(&self) -> BalloonState {
@@ -645,6 +974,7 @@ impl VirtioDevice for Balloon {
             device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
+        *self.stats_cache.lock().unwrap() = None;
         let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
 
         let mut virtqueues = Vec::new();
@@ -654,13 +984,42 @@ impl VirtioDevice for Balloon {
         let (_, queue, queue_evt) = queues.remove(0);
         virtqueues.push(queue);
         let deflate_queue_evt = queue_evt;
-        let reporting_queue_evt =
-            if self.common.feature_acked(VIRTIO_BALLOON_F_REPORTING) && !queues.is_empty() {
+
+        let stats_handler =
+            if self.common.feature_acked(VIRTIO_BALLOON_F_STATS_VQ) && !queues.is_empty() {
+                let qi = virtqueues.len();
                 let (_, queue, queue_evt) = queues.remove(0);
                 virtqueues.push(queue);
-                Some(queue_evt)
+
+                let _ = self.stats_request_evt.read();
+                let (request_sender, request_receiver) = mpsc::channel();
+                self.stats_request_sender = Some(request_sender);
+                let request_evt = self
+                    .stats_request_evt
+                    .try_clone()
+                    .map_err(crate::ActivateError::CloneEventFd)?;
+
+                Some(BalloonStatsHandler {
+                    queue_evt,
+                    queue_index: qi,
+                    request_evt,
+                    request_receiver,
+                    stats_cache: Arc::clone(&self.stats_cache),
+                    state: BalloonStatsState::WaitingForInitialDescriptor,
+                })
             } else {
+                self.stats_request_sender = None;
                 None
+            };
+
+        let (reporting_queue_evt, reporting_queue_index) =
+            if self.common.feature_acked(VIRTIO_BALLOON_F_REPORTING) && !queues.is_empty() {
+                let qi = virtqueues.len();
+                let (_, queue, queue_evt) = queues.remove(0);
+                virtqueues.push(queue);
+                (Some(queue_evt), Some(qi))
+            } else {
+                (None, None)
             };
 
         let mut handler = BalloonEpollHandler {
@@ -669,7 +1028,9 @@ impl VirtioDevice for Balloon {
             interrupt_cb: interrupt_cb.clone(),
             inflate_queue_evt,
             deflate_queue_evt,
+            stats_handler,
             reporting_queue_evt,
+            reporting_queue_index,
             kill_evt,
             pause_evt,
             pbp: None,
@@ -679,7 +1040,7 @@ impl VirtioDevice for Balloon {
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
 
-        self.common.spawn_worker(
+        if let Err(e) = self.common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioBalloon,
@@ -687,7 +1048,10 @@ impl VirtioDevice for Balloon {
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
-        )?;
+        ) {
+            self.stats_request_sender = None;
+            return Err(e);
+        }
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())
@@ -702,7 +1066,9 @@ impl VirtioDevice for Balloon {
     }
 
     fn reset(&mut self) {
+        self.stats_request_sender = None;
         self.common.reset();
+        *self.stats_cache.lock().unwrap() = None;
         event!("virtio-device", "reset", "id", &self.id);
     }
 }
@@ -728,3 +1094,454 @@ impl Snapshottable for Balloon {
 }
 impl Transportable for Balloon {}
 impl Migratable for Balloon {}
+
+#[cfg(test)]
+mod tests {
+    use vm_memory::bitmap::AtomicBitmap;
+    use vm_virtio::queue::testing::VirtQueue;
+
+    use super::*;
+
+    type TestMemory = vm_memory::GuestMemoryMmap<AtomicBitmap>;
+
+    struct NoopInterrupt;
+
+    impl VirtioInterrupt for NoopInterrupt {
+        fn trigger(&self, _int_type: VirtioInterruptType) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn set_notifier(
+            &self,
+            _int_type: u32,
+            _notifier: Option<EventFd>,
+            _vm: &dyn hypervisor::Vm,
+        ) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn create_stats_handler(
+        memory: &TestMemory,
+        queue: Queue,
+        state: BalloonStatsState,
+    ) -> BalloonEpollHandler {
+        let (_, request_receiver) = mpsc::channel();
+
+        BalloonEpollHandler {
+            mem: GuestMemoryAtomic::new(memory.clone()),
+            queues: vec![queue],
+            interrupt_cb: Arc::new(NoopInterrupt),
+            inflate_queue_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            deflate_queue_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            stats_handler: Some(BalloonStatsHandler {
+                queue_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+                queue_index: 0,
+                request_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+                request_receiver,
+                stats_cache: Arc::new(Mutex::new(None)),
+                state,
+            }),
+            reporting_queue_evt: None,
+            reporting_queue_index: None,
+            kill_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            pause_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            pbp: None,
+            access_platform: None,
+        }
+    }
+
+    fn stat(tag: u16, value: u64) -> Vec<u8> {
+        BalloonStat {
+            tag: Le16::new(tag),
+            val: Le64::new(value),
+        }
+        .as_bytes()
+        .to_vec()
+    }
+
+    #[test]
+    fn parse_standard_and_linux_stats() {
+        let mut data = Vec::new();
+        for (tag, value) in (0u16..=15).zip(100u64..) {
+            data.extend(stat(tag, value));
+        }
+
+        let stats = parse_balloon_stats(&data).unwrap();
+        assert_eq!(stats.swap_in, Some(100));
+        assert_eq!(stats.swap_out, Some(101));
+        assert_eq!(stats.major_faults, Some(102));
+        assert_eq!(stats.minor_faults, Some(103));
+        assert_eq!(stats.free_memory, Some(104));
+        assert_eq!(stats.total_memory, Some(105));
+        assert_eq!(stats.available_memory, Some(106));
+        assert_eq!(stats.disk_caches, Some(107));
+        assert_eq!(stats.hugetlb_allocations, Some(108));
+        assert_eq!(stats.hugetlb_failures, Some(109));
+        assert_eq!(stats.oom_kills, Some(110));
+        assert_eq!(stats.alloc_stalls, Some(111));
+        assert_eq!(stats.async_scans, Some(112));
+        assert_eq!(stats.direct_scans, Some(113));
+        assert_eq!(stats.async_reclaims, Some(114));
+        assert_eq!(stats.direct_reclaims, Some(115));
+    }
+
+    #[test]
+    fn parse_stats_accepts_arbitrary_order_and_unknown_tags() {
+        let data = [
+            stat(VIRTIO_BALLOON_S_MEMTOT, 4096),
+            stat(u16::MAX, 123),
+            stat(VIRTIO_BALLOON_S_SWAP_IN, 10),
+        ]
+        .concat();
+
+        let stats = parse_balloon_stats(&data).unwrap();
+        assert_eq!(stats.total_memory, Some(4096));
+        assert_eq!(stats.swap_in, Some(10));
+        assert_eq!(stats.swap_out, None);
+    }
+
+    #[test]
+    fn parse_stats_rejects_partial_entry() {
+        let mut data = stat(VIRTIO_BALLOON_S_MEMFREE, 1024);
+        data.push(0);
+
+        assert!(matches!(
+            parse_balloon_stats(&data),
+            Err(BalloonStatsError::InvalidBufferLength(11))
+        ));
+    }
+
+    #[test]
+    fn stats_require_negotiated_feature() {
+        let balloon = Balloon::new(
+            "balloon0".to_string(),
+            0,
+            false,
+            false,
+            false,
+            SeccompAction::Allow,
+            EventFd::new(EFD_NONBLOCK).unwrap(),
+            None,
+        )
+        .unwrap();
+
+        assert!(matches!(balloon.stats(), Err(Error::StatsNotNegotiated)));
+    }
+
+    #[test]
+    fn stats_request_refresh_before_initial_sample() {
+        let mut balloon = Balloon::new(
+            "balloon0".to_string(),
+            0,
+            false,
+            false,
+            false,
+            SeccompAction::Allow,
+            EventFd::new(EFD_NONBLOCK).unwrap(),
+            None,
+        )
+        .unwrap();
+        balloon.common.acked_features = 1u64 << VIRTIO_BALLOON_F_STATS_VQ;
+        let (request_sender, request_receiver) = mpsc::channel();
+        balloon.stats_request_sender = Some(request_sender);
+
+        assert_eq!(balloon.stats().unwrap(), BalloonStatsSnapshot::default());
+        assert_eq!(request_receiver.try_recv(), Ok(()));
+    }
+
+    #[test]
+    fn stats_return_cached_sample_while_requesting_refresh() {
+        let mut balloon = Balloon::new(
+            "balloon0".to_string(),
+            0,
+            false,
+            false,
+            false,
+            SeccompAction::Allow,
+            EventFd::new(EFD_NONBLOCK).unwrap(),
+            None,
+        )
+        .unwrap();
+        balloon.common.acked_features = 1u64 << VIRTIO_BALLOON_F_STATS_VQ;
+        let (request_sender, request_receiver) = mpsc::channel();
+        balloon.stats_request_sender = Some(request_sender);
+        let cached = BalloonStatsSnapshot {
+            stats: BalloonStats {
+                free_memory: Some(100),
+                ..Default::default()
+            },
+            last_update: 1,
+        };
+        *balloon.stats_cache.lock().unwrap() = Some(cached.clone());
+
+        assert_eq!(balloon.stats().unwrap(), cached);
+        assert_eq!(request_receiver.try_recv(), Ok(()));
+
+        assert_eq!(balloon.stats().unwrap(), cached);
+        assert_eq!(request_receiver.try_recv(), Ok(()));
+    }
+
+    #[test]
+    fn stats_return_cached_sample_if_refresh_worker_is_unavailable() {
+        let mut balloon = Balloon::new(
+            "balloon0".to_string(),
+            0,
+            false,
+            false,
+            false,
+            SeccompAction::Allow,
+            EventFd::new(EFD_NONBLOCK).unwrap(),
+            None,
+        )
+        .unwrap();
+        balloon.common.acked_features = 1u64 << VIRTIO_BALLOON_F_STATS_VQ;
+        let (request_sender, request_receiver) = mpsc::channel();
+        drop(request_receiver);
+        balloon.stats_request_sender = Some(request_sender);
+        let cached = BalloonStatsSnapshot {
+            stats: BalloonStats {
+                free_memory: Some(100),
+                ..Default::default()
+            },
+            last_update: 1,
+        };
+        *balloon.stats_cache.lock().unwrap() = Some(cached.clone());
+
+        assert_eq!(balloon.stats().unwrap(), cached);
+    }
+
+    #[test]
+    fn stats_queue_caches_initial_and_refreshed_descriptors() {
+        const QUEUE_ADDRESS: GuestAddress = GuestAddress(0x1_0000);
+        const STATS_ADDRESS: GuestAddress = GuestAddress(0x1_000);
+
+        let memory = TestMemory::from_ranges(&[(GuestAddress(0), 0x2_0000)]).unwrap();
+        let guest_queue = VirtQueue::new(QUEUE_ADDRESS, &memory, 16);
+        let initial = stat(VIRTIO_BALLOON_S_MEMFREE, 100);
+        memory.write_slice(&initial, STATS_ADDRESS).unwrap();
+        guest_queue.dtable[0].set(STATS_ADDRESS.raw_value(), initial.len() as u32, 0, 0);
+        guest_queue.avail.ring[0].set(0);
+        guest_queue.avail.idx.set(1);
+
+        let mut handler = create_stats_handler(
+            &memory,
+            guest_queue.create_queue(),
+            BalloonStatsState::WaitingForInitialDescriptor,
+        );
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        handler.process_stats_queue().unwrap();
+        let after = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        let initial_snapshot = handler
+            .stats_handler
+            .as_ref()
+            .unwrap()
+            .stats_cache
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap();
+        assert_eq!(initial_snapshot.stats.free_memory, Some(100));
+        assert!((before..=after).contains(&u128::from(initial_snapshot.last_update)));
+        assert!(matches!(
+            &handler.stats_handler.as_ref().unwrap().state,
+            BalloonStatsState::Idle {
+                descriptor_index: 0
+            }
+        ));
+
+        handler.process_stats_request().unwrap();
+        assert!(matches!(
+            &handler.stats_handler.as_ref().unwrap().state,
+            BalloonStatsState::Pending
+        ));
+
+        let refreshed = stat(VIRTIO_BALLOON_S_MEMFREE, 200);
+        memory.write_slice(&refreshed, STATS_ADDRESS).unwrap();
+        guest_queue.avail.ring[1].set(0);
+        guest_queue.avail.idx.set(2);
+        handler.process_stats_queue().unwrap();
+
+        let refreshed_snapshot = handler
+            .stats_handler
+            .as_ref()
+            .unwrap()
+            .stats_cache
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap();
+        assert_eq!(refreshed_snapshot.stats.free_memory, Some(200));
+        assert!(refreshed_snapshot.last_update >= initial_snapshot.last_update);
+        assert!(matches!(
+            &handler.stats_handler.as_ref().unwrap().state,
+            BalloonStatsState::Idle {
+                descriptor_index: 0
+            }
+        ));
+    }
+
+    #[test]
+    fn stats_queue_does_not_consume_descriptor_while_idle() {
+        const QUEUE_ADDRESS: GuestAddress = GuestAddress(0x1_0000);
+        const STATS_ADDRESS: GuestAddress = GuestAddress(0x1_000);
+
+        let memory = TestMemory::from_ranges(&[(GuestAddress(0), 0x2_0000)]).unwrap();
+        let guest_queue = VirtQueue::new(QUEUE_ADDRESS, &memory, 16);
+        guest_queue.dtable[0].set(STATS_ADDRESS.raw_value(), 10, 0, 0);
+        guest_queue.avail.ring[0].set(0);
+        guest_queue.avail.idx.set(1);
+        let mut handler = create_stats_handler(
+            &memory,
+            guest_queue.create_queue(),
+            BalloonStatsState::Idle {
+                descriptor_index: 1,
+            },
+        );
+
+        handler.process_stats_queue().unwrap();
+
+        assert_eq!(handler.queues[0].next_avail(), 0);
+        assert!(matches!(
+            &handler.stats_handler.as_ref().unwrap().state,
+            BalloonStatsState::Idle {
+                descriptor_index: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn stats_request_is_ignored_while_refresh_is_pending() {
+        const QUEUE_ADDRESS: GuestAddress = GuestAddress(0x1_0000);
+
+        let memory = TestMemory::from_ranges(&[(GuestAddress(0), 0x2_0000)]).unwrap();
+        let guest_queue = VirtQueue::new(QUEUE_ADDRESS, &memory, 16);
+        let mut handler = create_stats_handler(
+            &memory,
+            guest_queue.create_queue(),
+            BalloonStatsState::Pending,
+        );
+
+        handler.process_stats_request().unwrap();
+
+        assert!(matches!(
+            &handler.stats_handler.as_ref().unwrap().state,
+            BalloonStatsState::Pending
+        ));
+    }
+
+    #[test]
+    fn stats_request_before_initial_descriptor_is_ignored() {
+        const QUEUE_ADDRESS: GuestAddress = GuestAddress(0x1_0000);
+        const STATS_ADDRESS: GuestAddress = GuestAddress(0x1_000);
+
+        let memory = TestMemory::from_ranges(&[(GuestAddress(0), 0x2_0000)]).unwrap();
+        let guest_queue = VirtQueue::new(QUEUE_ADDRESS, &memory, 16);
+        let mut handler = create_stats_handler(
+            &memory,
+            guest_queue.create_queue(),
+            BalloonStatsState::WaitingForInitialDescriptor,
+        );
+
+        handler.process_stats_request().unwrap();
+        assert!(matches!(
+            &handler.stats_handler.as_ref().unwrap().state,
+            BalloonStatsState::WaitingForInitialDescriptor
+        ));
+
+        let initial = stat(VIRTIO_BALLOON_S_MEMFREE, 100);
+        memory.write_slice(&initial, STATS_ADDRESS).unwrap();
+        guest_queue.dtable[0].set(STATS_ADDRESS.raw_value(), initial.len() as u32, 0, 0);
+        guest_queue.avail.ring[0].set(0);
+        guest_queue.avail.idx.set(1);
+        handler.process_stats_queue().unwrap();
+        assert!(matches!(
+            &handler.stats_handler.as_ref().unwrap().state,
+            BalloonStatsState::Idle {
+                descriptor_index: 0
+            }
+        ));
+        assert_eq!(
+            handler
+                .stats_handler
+                .as_ref()
+                .unwrap()
+                .stats_cache
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .stats
+                .free_memory,
+            Some(100)
+        );
+    }
+
+    #[test]
+    fn stats_request_propagates_queue_error() {
+        const QUEUE_ADDRESS: GuestAddress = GuestAddress(0x1_0000);
+
+        let memory = TestMemory::from_ranges(&[(GuestAddress(0), 0x2_0000)]).unwrap();
+        let guest_queue = VirtQueue::new(QUEUE_ADDRESS, &memory, 16);
+        let mut handler = create_stats_handler(
+            &memory,
+            guest_queue.create_queue(),
+            BalloonStatsState::Idle {
+                descriptor_index: 16,
+            },
+        );
+        assert!(matches!(
+            handler.process_stats_request(),
+            Err(Error::QueueAddUsed(_))
+        ));
+    }
+
+    #[test]
+    fn invalid_stats_do_not_replace_cached_sample() {
+        const QUEUE_ADDRESS: GuestAddress = GuestAddress(0x1_0000);
+        const INVALID_STATS_ADDRESS: GuestAddress = GuestAddress(0x3_0000);
+
+        let memory = TestMemory::from_ranges(&[(GuestAddress(0), 0x2_0000)]).unwrap();
+        let guest_queue = VirtQueue::new(QUEUE_ADDRESS, &memory, 16);
+        guest_queue.dtable[0].set(INVALID_STATS_ADDRESS.raw_value(), 10, 0, 0);
+        guest_queue.avail.ring[0].set(0);
+        guest_queue.avail.idx.set(1);
+        let mut handler = create_stats_handler(
+            &memory,
+            guest_queue.create_queue(),
+            BalloonStatsState::Pending,
+        );
+        let cached = BalloonStatsSnapshot {
+            stats: BalloonStats {
+                free_memory: Some(100),
+                ..Default::default()
+            },
+            last_update: 1,
+        };
+        *handler
+            .stats_handler
+            .as_ref()
+            .unwrap()
+            .stats_cache
+            .lock()
+            .unwrap() = Some(cached.clone());
+
+        handler.process_stats_queue().unwrap();
+        assert_eq!(
+            *handler
+                .stats_handler
+                .as_ref()
+                .unwrap()
+                .stats_cache
+                .lock()
+                .unwrap(),
+            Some(cached)
+        );
+    }
+}

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -41,7 +41,7 @@ use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::{GuestAddress, GuestMemory};
 use vm_virtio::VirtioDeviceType;
 
-pub use self::balloon::Balloon;
+pub use self::balloon::{Balloon, BalloonStats};
 pub use self::block::{Block, BlockState};
 pub use self::console::{Console, ConsoleResizer, Endpoint};
 pub use self::device::{

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -41,7 +41,7 @@ use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::{GuestAddress, GuestMemoryBackend};
 use vm_virtio::VirtioDeviceType;
 
-pub use self::balloon::Balloon;
+pub use self::balloon::{Balloon, BalloonStats, BalloonStatsSnapshot};
 pub use self::block::{Block, BlockState};
 pub use self::console::{Console, ConsoleResizer, Endpoint};
 pub use self::device::{

--- a/vmm/src/api/dbus/mod.rs
+++ b/vmm/src/api/dbus/mod.rs
@@ -22,9 +22,10 @@ use super::{ApiAction, ApiRequest};
 use crate::api::VmCoredump;
 use crate::api::{
     AddDisk, Body, VmAddDevice, VmAddFs, VmAddGenericVhostUser, VmAddNet, VmAddPmem,
-    VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmCounters, VmCreate, VmDelete, VmInfo,
-    VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeZone,
-    VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot, VmmPing, VmmShutdown,
+    VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBalloonStats, VmBoot, VmCounters, VmCreate, VmDelete,
+    VmInfo, VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize,
+    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot, VmmPing,
+    VmmShutdown,
 };
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::{Error as VmmError, NetConfig, Result as VmmResult, VmConfig};
@@ -207,6 +208,16 @@ impl DBusApi {
 
     async fn vm_counters(&self) -> Result<Optional<String>> {
         self.vm_action(&VmCounters, ()).await
+    }
+
+    async fn vm_balloon_stats(&self) -> Result<String> {
+        let api_sender = self.clone_api_sender().await;
+        let api_notifier = self.clone_api_notifier()?;
+
+        let result = blocking::unblock(move || VmBalloonStats.send(api_notifier, api_sender, ()))
+            .await
+            .map_err(api_error)?;
+        serde_json::to_string(&result).map_err(api_error)
     }
 
     async fn vm_create(&self, vm_config: String) -> Result<()> {

--- a/vmm/src/api/dbus/mod.rs
+++ b/vmm/src/api/dbus/mod.rs
@@ -22,9 +22,10 @@ use super::{ApiAction, ApiRequest};
 use crate::api::VmCoredump;
 use crate::api::{
     AddDisk, Body, VmAddDevice, VmAddFs, VmAddGenericVhostUser, VmAddNet, VmAddPmem,
-    VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmCounters, VmCreate, VmDelete, VmInfo,
-    VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeZone,
-    VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot, VmmPing, VmmShutdown,
+    VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBalloonStats, VmBoot, VmCounters, VmCreate, VmDelete,
+    VmInfo, VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize,
+    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot, VmmPing,
+    VmmShutdown,
 };
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::{Error as VmmError, NetConfig, Result as VmmResult, VmConfig};
@@ -180,6 +181,16 @@ impl DBusApi {
     async fn vm_add_vsock(&self, vsock_config: String) -> Result<Optional<String>> {
         let vsock_config = serde_json::from_str(&vsock_config).map_err(api_error)?;
         self.vm_action(&VmAddVsock, vsock_config).await
+    }
+
+    async fn vm_balloon_stats(&self) -> Result<String> {
+        let api_sender = self.clone_api_sender().await;
+        let api_notifier = self.clone_api_notifier()?;
+
+        let result = blocking::unblock(move || VmBalloonStats.send(api_notifier, api_sender, ()))
+            .await
+            .map_err(api_error)?;
+        serde_json::to_string(&result).map_err(api_error)
     }
 
     async fn vm_boot(&self) -> Result<()> {

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -50,10 +50,10 @@ use crate::api::http::http_endpoint::fds_helper::{attach_fds_to_cfg, attach_fds_
 use crate::api::http::{EndpointHandler, HttpError, error_response};
 use crate::api::{
     AddDisk, ApiAction, ApiError, ApiRequest, DeviceConfig, NetConfig, VmAddDevice, VmAddFs,
-    VmAddGenericVhostUser, VmAddNet, VmAddPmem, VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot,
-    VmConfig, VmCounters, VmDelete, VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration,
-    VmReceiveMigrationData, VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore,
-    VmResume, VmSendMigration, VmShutdown, VmSnapshot,
+    VmAddGenericVhostUser, VmAddNet, VmAddPmem, VmAddUserDevice, VmAddVdpa, VmAddVsock,
+    VmBalloonStats as VmBalloonStatsAction, VmBoot, VmConfig, VmCounters, VmDelete, VmNmi, VmPause,
+    VmPowerButton, VmReboot, VmReceiveMigration, VmReceiveMigrationData, VmRemoveDevice, VmResize,
+    VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::config::RestoreConfig;
 use crate::cpu::Error as CpuError;
@@ -725,6 +725,33 @@ impl EndpointHandler for VmInfo {
                     let info_serialized = serde_json::to_string(&info).unwrap();
 
                     response.set_body(Body::new(info_serialized));
+                    response
+                }
+                Err(e) => error_response(e),
+            },
+            _ => error_response(HttpError::BadRequest),
+        }
+    }
+}
+
+// /api/v1/vm.balloon-stats handler
+pub struct VmBalloonStats {}
+
+impl EndpointHandler for VmBalloonStats {
+    fn handle_request(
+        &self,
+        req: &Request,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+    ) -> Response {
+        match req.method() {
+            Method::Get => match VmBalloonStatsAction
+                .send(api_notifier, api_sender, ())
+                .map_err(HttpError::ApiError)
+            {
+                Ok(stats) => {
+                    let mut response = Response::new(Version::Http11, StatusCode::OK);
+                    response.set_body(Body::new(serde_json::to_string(&stats).unwrap()));
                     response
                 }
                 Err(e) => error_response(e),

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -734,6 +734,33 @@ impl EndpointHandler for VmInfo {
     }
 }
 
+// /api/v1/vm.balloon-stats handler
+pub struct VmBalloonStats {}
+
+impl EndpointHandler for VmBalloonStats {
+    fn handle_request(
+        &self,
+        req: &Request,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+    ) -> Response {
+        match req.method() {
+            Method::Get => match api::VmBalloonStats
+                .send(api_notifier, api_sender, ())
+                .map_err(HttpError::ApiError)
+            {
+                Ok(stats) => {
+                    let mut response = Response::new(Version::Http11, StatusCode::OK);
+                    response.set_body(Body::new(serde_json::to_string(&stats).unwrap()));
+                    response
+                }
+                Err(e) => error_response(e),
+            },
+            _ => error_response(HttpError::BadRequest),
+        }
+    }
+}
+
 // /api/v1/vmm.info handler
 pub struct VmmPing {}
 

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -24,7 +24,9 @@ use serde_json::Error as SerdeError;
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
-use self::http_endpoint::{VmActionHandler, VmCreate, VmInfo, VmmPing, VmmShutdown};
+use self::http_endpoint::{
+    VmActionHandler, VmBalloonStats, VmCreate, VmInfo, VmmPing, VmmShutdown,
+};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::api::VmCoredump;
 use crate::api::{
@@ -233,6 +235,8 @@ pub static HTTP_ROUTES: LazyLock<HttpRoutes> = LazyLock::new(|| {
         endpoint!("/vm.boot"),
         Box::new(VmActionHandler::new(&VmBoot)),
     );
+    r.routes
+        .insert(endpoint!("/vm.balloon-stats"), Box::new(VmBalloonStats {}));
     r.routes.insert(
         endpoint!("/vm.counters"),
         Box::new(VmActionHandler::new(&VmCounters)),

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -24,7 +24,9 @@ use serde_json::Error as SerdeError;
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
-use self::http_endpoint::{VmActionHandler, VmCreate, VmInfo, VmmPing, VmmShutdown};
+use self::http_endpoint::{
+    VmActionHandler, VmBalloonStats, VmCreate, VmInfo, VmmPing, VmmShutdown,
+};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::api::VmCoredump;
 use crate::api::{
@@ -248,6 +250,8 @@ pub static HTTP_ROUTES: LazyLock<HttpRoutes> = LazyLock::new(|| {
         endpoint!("/vm.boot"),
         Box::new(VmActionHandler::new(&VmBoot)),
     );
+    r.routes
+        .insert(endpoint!("/vm.balloon-stats"), Box::new(VmBalloonStats {}));
     r.routes.insert(
         endpoint!("/vm.counters"),
         Box::new(VmActionHandler::new(&VmCounters)),

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -100,6 +100,10 @@ pub enum ApiError {
     #[error("The VM info is not available")]
     VmInfo(#[source] VmError),
 
+    /// The virtio-balloon statistics are not available.
+    #[error("The virtio-balloon statistics are not available")]
+    VmBalloonStats(#[source] VmError),
+
     /// The VM could not be paused.
     #[error("The VM could not be paused")]
     VmPause(#[source] VmError),
@@ -226,6 +230,12 @@ pub struct VmInfoResponse {
     pub state: VmState,
     pub memory_actual_size: u64,
     pub device_tree: Option<DeviceTree>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct BalloonStatsResponse {
+    pub balloon_actual: u64,
+    pub stats: virtio_devices::BalloonStats,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -769,6 +779,9 @@ pub enum ApiResponsePayload {
     /// Virtual machine information
     VmInfo(VmInfoResponse),
 
+    /// Virtio-balloon statistics
+    VmBalloonStats(Box<BalloonStatsResponse>),
+
     /// Vmm ping response
     VmmPing(VmmPingResponse),
 
@@ -800,6 +813,8 @@ pub trait RequestHandler {
     fn vm_reboot(&mut self) -> Result<(), VmError>;
 
     fn vm_info(&self) -> Result<VmInfoResponse, VmError>;
+
+    fn vm_balloon_stats(&mut self) -> Result<BalloonStatsResponse, VmError>;
 
     fn vmm_ping(&self) -> VmmPingResponse;
 
@@ -1359,6 +1374,43 @@ impl ApiAction for VmCounters {
         data: Self::RequestBody,
     ) -> ApiResult<Self::ResponseBody> {
         get_response_body(self, api_evt, api_sender, data)
+    }
+}
+
+pub struct VmBalloonStats;
+
+impl ApiAction for VmBalloonStats {
+    type RequestBody = ();
+    type ResponseBody = BalloonStatsResponse;
+
+    fn request(&self, _: Self::RequestBody, response_sender: Sender<ApiResponse>) -> ApiRequest {
+        Box::new(move |vmm| {
+            info!("API request event: VmBalloonStats");
+
+            let response = vmm
+                .vm_balloon_stats()
+                .map_err(ApiError::VmBalloonStats)
+                .map(Box::new)
+                .map(ApiResponsePayload::VmBalloonStats);
+
+            response_sender
+                .send(response)
+                .map_err(VmmError::ApiResponseSend)?;
+
+            Ok(false)
+        })
+    }
+
+    fn send(
+        &self,
+        api_evt: EventFd,
+        api_sender: Sender<ApiRequest>,
+        data: Self::RequestBody,
+    ) -> ApiResult<Self::ResponseBody> {
+        match get_response(self, api_evt, api_sender, data)? {
+            ApiResponsePayload::VmBalloonStats(stats) => Ok(*stats),
+            _ => Err(ApiError::ResponsePayloadType),
+        }
     }
 }
 
@@ -2076,6 +2128,22 @@ mod unit_tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[test]
+    fn test_balloon_stats_response_omits_unsupported_stats() {
+        let response = BalloonStatsResponse {
+            balloon_actual: 4096,
+            stats: virtio_devices::BalloonStats {
+                free_memory: Some(1024),
+                ..Default::default()
+            },
+        };
+
+        let value = serde_json::to_value(response).unwrap();
+        assert_eq!(value["balloon_actual"], 4096);
+        assert_eq!(value["stats"]["free_memory"], 1024);
+        assert!(value["stats"].get("swap_in").is_none());
     }
 
     #[test]

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -102,6 +102,10 @@ pub enum ApiError {
     #[error("The VM info is not available")]
     VmInfo(#[source] VmError),
 
+    /// The virtio-balloon statistics are not available.
+    #[error("The virtio-balloon statistics are not available")]
+    VmBalloonStats(#[source] VmError),
+
     /// The VM could not be paused.
     #[error("The VM could not be paused")]
     VmPause(#[source] VmError),
@@ -228,6 +232,13 @@ pub struct VmInfoResponse {
     pub state: VmState,
     pub memory_actual_size: u64,
     pub device_tree: Option<DeviceTree>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct BalloonStatsResponse {
+    pub balloon_actual: u64,
+    pub last_update: u64,
+    pub stats: virtio_devices::BalloonStats,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -837,6 +848,9 @@ pub enum ApiResponsePayload {
     /// Virtual machine information
     VmInfo(VmInfoResponse),
 
+    /// Virtio-balloon statistics
+    VmBalloonStats(Box<BalloonStatsResponse>),
+
     /// Vmm ping response
     VmmPing(VmmPingResponse),
 
@@ -868,6 +882,8 @@ pub trait RequestHandler {
     fn vm_reboot(&mut self) -> Result<(), VmError>;
 
     fn vm_info(&self) -> Result<VmInfoResponse, VmError>;
+
+    fn vm_balloon_stats(&self) -> Result<BalloonStatsResponse, VmError>;
 
     fn vmm_ping(&self) -> VmmPingResponse;
 
@@ -1427,6 +1443,43 @@ impl ApiAction for VmCounters {
         data: Self::RequestBody,
     ) -> ApiResult<Self::ResponseBody> {
         get_response_body(self, api_evt, api_sender, data)
+    }
+}
+
+pub struct VmBalloonStats;
+
+impl ApiAction for VmBalloonStats {
+    type RequestBody = ();
+    type ResponseBody = BalloonStatsResponse;
+
+    fn request(&self, _: Self::RequestBody, response_sender: Sender<ApiResponse>) -> ApiRequest {
+        Box::new(move |vmm| {
+            info!("API request event: VmBalloonStats");
+
+            let response = vmm
+                .vm_balloon_stats()
+                .map_err(ApiError::VmBalloonStats)
+                .map(Box::new)
+                .map(ApiResponsePayload::VmBalloonStats);
+
+            response_sender
+                .send(response)
+                .map_err(VmmError::ApiResponseSend)?;
+
+            Ok(false)
+        })
+    }
+
+    fn send(
+        &self,
+        api_evt: EventFd,
+        api_sender: Sender<ApiRequest>,
+        data: Self::RequestBody,
+    ) -> ApiResult<Self::ResponseBody> {
+        match get_response(self, api_evt, api_sender, data)? {
+            ApiResponsePayload::VmBalloonStats(stats) => Ok(*stats),
+            _ => Err(ApiError::ResponsePayloadType),
+        }
     }
 }
 
@@ -2144,6 +2197,24 @@ mod unit_tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[test]
+    fn test_balloon_stats_response_omits_unsupported_stats() {
+        let response = BalloonStatsResponse {
+            balloon_actual: 4096,
+            last_update: 1234,
+            stats: virtio_devices::BalloonStats {
+                free_memory: Some(1024),
+                ..Default::default()
+            },
+        };
+
+        let value = serde_json::to_value(response).unwrap();
+        assert_eq!(value["balloon_actual"], 4096);
+        assert_eq!(value["last_update"], 1234);
+        assert_eq!(value["stats"]["free_memory"], 1024);
+        assert!(value["stats"].get("swap_in").is_none());
     }
 
     #[test]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -52,6 +52,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/VmCounters"
 
+  /vm.balloon-stats:
+    get:
+      summary: Get fresh statistics from the virtio-balloon device
+      responses:
+        200:
+          description: Virtio-balloon statistics reported by the guest
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BalloonStatsResponse"
+        500:
+          description: The statistics could not be retrieved, e.g. the statistics feature was not negotiated with the guest driver.
+
   /vm.create:
     put:
       summary: Create the cloud-hypervisor Virtual Machine (VM) instance. The instance is not booted, only created.
@@ -568,6 +581,87 @@ components:
         additionalProperties:
           type: integer
           format: int64
+
+    BalloonStatsResponse:
+      required:
+        - balloon_actual
+        - stats
+      type: object
+      properties:
+        balloon_actual:
+          type: integer
+          format: int64
+          description: Current balloon size in bytes
+        stats:
+          $ref: "#/components/schemas/BalloonStats"
+
+    BalloonStats:
+      type: object
+      properties:
+        swap_in:
+          type: integer
+          format: int64
+          description: Memory swapped into the guest in bytes
+        swap_out:
+          type: integer
+          format: int64
+          description: Memory swapped out by the guest in bytes
+        major_faults:
+          type: integer
+          format: int64
+          description: Number of major page faults
+        minor_faults:
+          type: integer
+          format: int64
+          description: Number of minor page faults
+        free_memory:
+          type: integer
+          format: int64
+          description: Unused guest memory in bytes
+        total_memory:
+          type: integer
+          format: int64
+          description: Total guest memory in bytes
+        available_memory:
+          type: integer
+          format: int64
+          description: Guest memory available without swapping in bytes
+        disk_caches:
+          type: integer
+          format: int64
+          description: Reclaimable guest disk caches in bytes
+        hugetlb_allocations:
+          type: integer
+          format: int64
+          description: Number of successful hugetlb allocations
+        hugetlb_failures:
+          type: integer
+          format: int64
+          description: Number of failed hugetlb allocations
+        oom_kills:
+          type: integer
+          format: int64
+          description: Number of guest OOM kills reported by Linux
+        alloc_stalls:
+          type: integer
+          format: int64
+          description: Number of guest memory allocation stalls reported by Linux
+        async_scans:
+          type: integer
+          format: int64
+          description: Memory scanned asynchronously by Linux in bytes
+        direct_scans:
+          type: integer
+          format: int64
+          description: Memory scanned directly by Linux in bytes
+        async_reclaims:
+          type: integer
+          format: int64
+          description: Memory reclaimed asynchronously by Linux in bytes
+        direct_reclaims:
+          type: integer
+          format: int64
+          description: Memory reclaimed directly by Linux in bytes
 
     PciDeviceInfo:
       required:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -54,6 +54,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/VmCounters"
 
+  /vm.balloon-stats:
+    get:
+      summary: Get cached statistics from the virtio-balloon device
+      responses:
+        200:
+          description: Most recently reported virtio-balloon statistics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BalloonStatsResponse"
+        500:
+          description: The statistics could not be retrieved, e.g. the statistics feature was not negotiated with the guest driver.
+
   /vm.create:
     put:
       summary: Create the cloud-hypervisor Virtual Machine (VM) instance. The instance is not booted, only created.
@@ -628,6 +641,92 @@ components:
         additionalProperties:
           type: integer
           format: int64
+
+    BalloonStatsResponse:
+      required:
+        - balloon_actual
+        - last_update
+        - stats
+      type: object
+      properties:
+        balloon_actual:
+          type: integer
+          format: int64
+          description: Current balloon size in bytes
+        last_update:
+          type: integer
+          format: int64
+          description: Host UNIX timestamp in milliseconds when statistics were last updated, or zero before the first sample
+        stats:
+          $ref: "#/components/schemas/BalloonStats"
+
+    BalloonStats:
+      type: object
+      properties:
+        swap_in:
+          type: integer
+          format: int64
+          description: Memory swapped into the guest in bytes
+        swap_out:
+          type: integer
+          format: int64
+          description: Memory swapped out by the guest in bytes
+        major_faults:
+          type: integer
+          format: int64
+          description: Number of major page faults
+        minor_faults:
+          type: integer
+          format: int64
+          description: Number of minor page faults
+        free_memory:
+          type: integer
+          format: int64
+          description: Unused guest memory in bytes
+        total_memory:
+          type: integer
+          format: int64
+          description: Total guest memory in bytes
+        available_memory:
+          type: integer
+          format: int64
+          description: Guest memory available without swapping in bytes
+        disk_caches:
+          type: integer
+          format: int64
+          description: Reclaimable guest disk caches in bytes
+        hugetlb_allocations:
+          type: integer
+          format: int64
+          description: Number of successful hugetlb allocations
+        hugetlb_failures:
+          type: integer
+          format: int64
+          description: Number of failed hugetlb allocations
+        oom_kills:
+          type: integer
+          format: int64
+          description: Number of guest OOM kills reported by Linux
+        alloc_stalls:
+          type: integer
+          format: int64
+          description: Number of guest memory allocation stalls reported by Linux
+        async_scans:
+          type: integer
+          format: int64
+          description: Memory scanned asynchronously by Linux in bytes
+        direct_scans:
+          type: integer
+          format: int64
+          description: Memory scanned directly by Linux in bytes
+        async_reclaims:
+          type: integer
+          format: int64
+          description: Memory reclaimed asynchronously by Linux in bytes
+        direct_reclaims:
+          type: integer
+          format: int64
+          description: Memory reclaimed directly by Linux in bytes
 
     PciDeviceInfo:
       required:

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -24,7 +24,9 @@ use std::os::unix::io::{AsRawFd, FromRawFd};
 #[cfg(not(target_arch = "riscv64"))]
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 #[cfg(not(target_arch = "riscv64"))]
 use std::time::Instant;
 use std::{iter, path, result, sync};
@@ -573,6 +575,22 @@ pub enum DeviceManagerError {
     /// Failed to resize virtio-balloon
     #[error("Failed to resize virtio-balloon")]
     VirtioBalloonResize(#[source] balloon::Error),
+
+    /// Failed to request virtio-balloon statistics.
+    #[error("Failed to request virtio-balloon statistics")]
+    VirtioBalloonStats(#[source] balloon::Error),
+
+    /// Guest returned invalid virtio-balloon statistics.
+    #[error("Guest returned invalid virtio-balloon statistics")]
+    InvalidVirtioBalloonStats(#[source] balloon::BalloonStatsError),
+
+    /// Timed out waiting for virtio-balloon statistics.
+    #[error("Timed out waiting for virtio-balloon statistics")]
+    VirtioBalloonStatsTimeout,
+
+    /// Virtio-balloon statistics worker disconnected.
+    #[error("Virtio-balloon statistics worker disconnected")]
+    VirtioBalloonStatsDisconnected,
 
     /// Missing virtio-balloon, can't proceed as expected.
     #[error("Missing virtio-balloon, can't proceed as expected")]
@@ -5487,6 +5505,33 @@ impl DeviceManager {
         }
 
         0
+    }
+
+    pub fn balloon_stats(&self) -> DeviceManagerResult<(u64, virtio_devices::BalloonStats)> {
+        // Keep a non-responsive guest from blocking the VMM API loop indefinitely.
+        const STATS_TIMEOUT: Duration = Duration::from_secs(1);
+
+        let balloon = self
+            .balloon
+            .as_ref()
+            .ok_or(DeviceManagerError::MissingVirtioBalloon)?;
+        let response_receiver = balloon
+            .lock()
+            .unwrap()
+            .begin_stats_request()
+            .map_err(DeviceManagerError::VirtioBalloonStats)?;
+        let stats = match response_receiver.recv_timeout(STATS_TIMEOUT) {
+            Ok(result) => result.map_err(DeviceManagerError::InvalidVirtioBalloonStats)?,
+            Err(RecvTimeoutError::Timeout) => {
+                return Err(DeviceManagerError::VirtioBalloonStatsTimeout);
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(DeviceManagerError::VirtioBalloonStatsDisconnected);
+            }
+        };
+        let actual = balloon.lock().unwrap().get_actual();
+
+        Ok((actual, stats))
     }
 
     pub fn resize_disk(&mut self, device_id: &str, new_size: u64) -> DeviceManagerResult<()> {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -575,6 +575,10 @@ pub enum DeviceManagerError {
     #[error("Failed to resize virtio-balloon")]
     VirtioBalloonResize(#[source] balloon::Error),
 
+    /// Failed to request virtio-balloon statistics.
+    #[error("Failed to request virtio-balloon statistics")]
+    VirtioBalloonStats(#[source] balloon::Error),
+
     /// Missing virtio-balloon, can't proceed as expected.
     #[error("Missing virtio-balloon, can't proceed as expected")]
     MissingVirtioBalloon,
@@ -5508,6 +5512,18 @@ impl DeviceManager {
         }
 
         0
+    }
+
+    pub fn balloon_stats(&self) -> DeviceManagerResult<virtio_devices::BalloonStatsSnapshot> {
+        let balloon = self
+            .balloon
+            .as_ref()
+            .ok_or(DeviceManagerError::MissingVirtioBalloon)?;
+        balloon
+            .lock()
+            .unwrap()
+            .stats()
+            .map_err(DeviceManagerError::VirtioBalloonStats)
     }
 
     pub fn resize_disk(&mut self, device_id: &str, new_size: u64) -> DeviceManagerResult<()> {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -48,8 +48,8 @@ use vmm_sys_util::signal::unblock_signal;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
 use crate::api::{
-    ApiRequest, ApiResponse, MigrationMode, RequestHandler, TimeoutStrategy, VmInfoResponse,
-    VmReceiveMigrationData, VmSendMigrationData, VmmPingResponse,
+    ApiRequest, ApiResponse, BalloonStatsResponse, MigrationMode, RequestHandler, TimeoutStrategy,
+    VmInfoResponse, VmReceiveMigrationData, VmSendMigrationData, VmmPingResponse,
 };
 use crate::config::{MemoryRestoreMode, RestoreConfig, add_to_config};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -2611,6 +2611,20 @@ impl RequestHandler for Vmm {
             memory_actual_size,
             device_tree,
         })
+    }
+
+    fn vm_balloon_stats(&mut self) -> result::Result<BalloonStatsResponse, VmError> {
+        match &mut self.vm {
+            VmOwnership::Owned(vm) if vm.get_state() == VmState::Running => {
+                let (balloon_actual, stats) = vm.balloon_stats()?;
+                Ok(BalloonStatsResponse {
+                    balloon_actual,
+                    stats,
+                })
+            }
+            VmOwnership::Owned(_) | VmOwnership::None => Err(VmError::VmNotRunning),
+            VmOwnership::Migration { .. } => Err(VmError::VmMigrating),
+        }
     }
 
     fn vmm_ping(&self) -> VmmPingResponse {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -48,8 +48,8 @@ use vmm_sys_util::signal::unblock_signal;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
 use crate::api::{
-    ApiRequest, ApiResponse, MigrationMode, RequestHandler, TimeoutStrategy, VmInfoResponse,
-    VmReceiveMigrationData, VmSendMigrationData, VmmPingResponse,
+    ApiRequest, ApiResponse, BalloonStatsResponse, MigrationMode, RequestHandler, TimeoutStrategy,
+    VmInfoResponse, VmReceiveMigrationData, VmSendMigrationData, VmmPingResponse,
 };
 use crate::config::{MemoryRestoreMode, RestoreConfig, VmMemoryZoneUpdateData, add_to_config};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -2704,6 +2704,21 @@ impl RequestHandler for Vmm {
             memory_actual_size,
             device_tree,
         })
+    }
+
+    fn vm_balloon_stats(&self) -> result::Result<BalloonStatsResponse, VmError> {
+        match &self.vm {
+            VmOwnership::Owned(vm) if vm.get_state() == VmState::Running => {
+                let snapshot = vm.balloon_stats()?;
+                Ok(BalloonStatsResponse {
+                    balloon_actual: vm.balloon_size(),
+                    last_update: snapshot.last_update,
+                    stats: snapshot.stats,
+                })
+            }
+            VmOwnership::Owned(_) | VmOwnership::None => Err(VmError::VmNotRunning),
+            VmOwnership::Migration { .. } => Err(VmError::VmMigrating),
+        }
     }
 
     fn vmm_ping(&self) -> VmmPingResponse {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2993,6 +2993,14 @@ impl Vm {
         self.device_manager.lock().unwrap().balloon_size()
     }
 
+    pub fn balloon_stats(&self) -> Result<(u64, virtio_devices::BalloonStats)> {
+        self.device_manager
+            .lock()
+            .unwrap()
+            .balloon_stats()
+            .map_err(Error::DeviceManager)
+    }
+
     /// Get the actual size of the virtio_mem regions
     pub fn virtio_mem_plugged_size(&self) -> u64 {
         self.memory_manager

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2989,6 +2989,14 @@ impl Vm {
         self.device_manager.lock().unwrap().balloon_size()
     }
 
+    pub fn balloon_stats(&self) -> Result<virtio_devices::BalloonStatsSnapshot> {
+        self.device_manager
+            .lock()
+            .unwrap()
+            .balloon_stats()
+            .map_err(Error::DeviceManager)
+    }
+
     /// Get the actual size of the virtio_mem regions
     pub fn virtio_mem_plugged_size(&self) -> u64 {
         self.memory_manager


### PR DESCRIPTION
Allow retrieving guest memory statistics from the virtio-balloon device via the HTTP API, D-Bus, or ch-remote CLI when the guest has negotiated the statistics feature. 
Each request triggers a fresh sample from the guest driver with a one-second timeout to prevent an unresponsive guest from blocking the VMM API loop. 
The response includes standard virtio 1.4 statistics as well as Linux-specific extensions such as oom_kills, direct_reclaim, and alloc_stall when reported by the guest.

Example:
```
$ ch-remote --api-socket ch.sock balloon-stats | jq
{
  "balloon_actual": 0,
  "stats": {
    "swap_in": 0,
    "swap_out": 0,
    "major_faults": 369,
    "minor_faults": 504067,
    "free_memory": 1961717760,
    "total_memory": 2074480640,
    "available_memory": 1902641152,
    "disk_caches": 34332672,
    "hugetlb_allocations": 0,
    "hugetlb_failures": 0,
    "oom_kills": 1,
    "alloc_stalls": 318,
    "async_scans": 286834688,
    "direct_scans": 153067520,
    "async_reclaims": 83509248,
    "direct_reclaims": 20037632
  }
}
```

