### PR TITLE
block: Vectored positioned I/O for AlignedFile and the raw engines

### DIFF
--- a/block/src/aligned_file.rs
+++ b/block/src/aligned_file.rs
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs::{File, Metadata};
-use std::io;
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::fs::FileExt;
 use std::os::unix::io::{AsRawFd, RawFd};
+use std::{io, slice};
 
 use vmm_sys_util::file_traits::FileSync;
 use vmm_sys_util::seek_hole::SeekHole;
@@ -22,6 +22,17 @@ fn is_aligned(alignment: usize, buf_ptr: usize, len: usize, offset: u64) -> bool
         || (buf_ptr.is_multiple_of(alignment)
             && len.is_multiple_of(alignment)
             && offset.is_multiple_of(alignment as u64))
+}
+
+/// True when `offset` and every iovec base/length satisfy `alignment`
+/// (`alignment == 0` means no O_DIRECT, so everything is "aligned").
+fn iovecs_are_aligned(alignment: usize, iovecs: &[libc::iovec], offset: u64) -> bool {
+    alignment == 0
+        || (offset.is_multiple_of(alignment as u64)
+            && iovecs.iter().all(|iov| {
+                (iov.iov_base as usize).is_multiple_of(alignment)
+                    && iov.iov_len.is_multiple_of(alignment)
+            }))
 }
 
 /// A `File` that transparently satisfies O_DIRECT alignment requirements.
@@ -127,6 +138,92 @@ impl AlignedFile {
         gather(abuf.as_mut_slice())?;
         abuf.write_to(&self.file)?;
         Ok(len)
+    }
+
+    /// Read into the buffers described by `iovecs`, starting at `offset`.
+    ///
+    /// # Safety
+    /// Every iovec must describe valid, writable memory of `iov_len` bytes.
+    pub(crate) unsafe fn read_vectored_at(
+        &self,
+        iovecs: &[libc::iovec],
+        offset: u64,
+    ) -> io::Result<usize> {
+        if iovecs.is_empty() {
+            return Ok(0);
+        }
+        if iovecs_are_aligned(self.alignment, iovecs, offset) {
+            // SAFETY: upheld by this fn contract.
+            let ret = unsafe {
+                libc::preadv(
+                    self.file.as_raw_fd(),
+                    iovecs.as_ptr(),
+                    iovecs.len() as libc::c_int,
+                    offset as libc::off_t,
+                )
+            };
+            if ret < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            return Ok(ret as usize);
+        }
+        let total_len = iovecs.iter().map(|iov| iov.iov_len).sum();
+        self.read_unaligned(offset, total_len, |mut data| {
+            for iov in iovecs {
+                if data.is_empty() {
+                    break;
+                }
+                let n = data.len().min(iov.iov_len);
+                // SAFETY: upheld by this fn contract.
+                let dst = unsafe { slice::from_raw_parts_mut(iov.iov_base as *mut u8, n) };
+                dst.copy_from_slice(&data[..n]);
+                data = &data[n..];
+            }
+            Ok(())
+        })
+    }
+
+    /// Write the buffers described by `iovecs`, starting at `offset`.
+    ///
+    /// # Safety
+    /// Every iovec must describe valid, readable memory of `iov_len` bytes.
+    pub(crate) unsafe fn write_vectored_at(
+        &self,
+        iovecs: &[libc::iovec],
+        offset: u64,
+    ) -> io::Result<usize> {
+        if iovecs.is_empty() {
+            return Ok(0);
+        }
+        if iovecs_are_aligned(self.alignment, iovecs, offset) {
+            // SAFETY: upheld by this fn contract.
+            let ret = unsafe {
+                libc::pwritev(
+                    self.file.as_raw_fd(),
+                    iovecs.as_ptr(),
+                    iovecs.len() as libc::c_int,
+                    offset as libc::off_t,
+                )
+            };
+            if ret < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            return Ok(ret as usize);
+        }
+        let total_len = iovecs.iter().map(|iov| iov.iov_len).sum();
+        self.write_unaligned(offset, total_len, |mut dst| {
+            for iov in iovecs {
+                if dst.is_empty() {
+                    break;
+                }
+                let n = dst.len().min(iov.iov_len);
+                // SAFETY: upheld by this fn contract.
+                let src = unsafe { slice::from_raw_parts(iov.iov_base as *const u8, n) };
+                dst[..n].copy_from_slice(src);
+                dst = &mut dst[n..];
+            }
+            Ok(())
+        })
     }
 }
 

--- a/block/src/aligned_file.rs
+++ b/block/src/aligned_file.rs
@@ -496,4 +496,78 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
+
+    /// Build an iovec over `buf`, which must outlive the iovec.
+    fn iovec_of(buf: &mut [u8]) -> libc::iovec {
+        libc::iovec {
+            iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+            iov_len: buf.len(),
+        }
+    }
+
+    #[test]
+    fn vectored_empty_is_noop() {
+        let tf = pattern_file(100);
+        let af = forced(tf.as_file().try_clone().unwrap(), 512);
+        // SAFETY: empty iovec slices point to no memory.
+        assert_eq!(unsafe { af.read_vectored_at(&[], 0) }.unwrap(), 0);
+        // SAFETY: empty iovec slices point to no memory.
+        assert_eq!(unsafe { af.write_vectored_at(&[], 0) }.unwrap(), 0);
+    }
+
+    #[test]
+    fn vectored_fast_path_roundtrip() {
+        let tf = pattern_file(4096);
+        // alignment 0 sends any iovecs through the single preadv/pwritev path.
+        let af = forced(tf.as_file().try_clone().unwrap(), 0);
+
+        let mut w0: Vec<u8> = (0..30).map(|i| ((i + 7) % 239) as u8).collect();
+        let mut w1: Vec<u8> = (0..70).map(|i| ((i + 37) % 239) as u8).collect();
+        let wiovecs = [iovec_of(&mut w0), iovec_of(&mut w1)];
+        // SAFETY: the iovecs describe the live w0/w1 buffers.
+        assert_eq!(unsafe { af.write_vectored_at(&wiovecs, 10) }.unwrap(), 100);
+        let data = [w0.as_slice(), &w1].concat();
+
+        let mut plain = vec![0u8; 100];
+        tf.as_file().read_exact_at(&mut plain, 10).unwrap();
+        assert_eq!(plain, data);
+
+        let mut r0 = vec![0u8; 30];
+        let mut r1 = vec![0u8; 70];
+        let riovecs = [iovec_of(&mut r0), iovec_of(&mut r1)];
+        // SAFETY: the iovecs describe the live r0/r1 buffers.
+        assert_eq!(unsafe { af.read_vectored_at(&riovecs, 10) }.unwrap(), 100);
+        assert_eq!([r0.as_slice(), &r1].concat(), data);
+    }
+
+    #[test]
+    fn vectored_unaligned_scatter_gather_roundtrip() {
+        let tf = pattern_file(8192);
+        let af = forced(tf.as_file().try_clone().unwrap(), 512);
+
+        // Gather three iovecs into an unaligned read-modify-write.
+        let mut w0: Vec<u8> = (0..50).map(|i| ((i + 1) % 239) as u8).collect();
+        let mut w1: Vec<u8> = (0..100).map(|i| ((i + 51) % 239) as u8).collect();
+        let mut w2: Vec<u8> = (0..50).map(|i| ((i + 151) % 239) as u8).collect();
+        let wiovecs = [iovec_of(&mut w0), iovec_of(&mut w1), iovec_of(&mut w2)];
+        // SAFETY: the iovecs describe the live w0/w1/w2 buffers.
+        assert_eq!(unsafe { af.write_vectored_at(&wiovecs, 100) }.unwrap(), 200);
+        let data = [w0.as_slice(), &w1, &w2].concat();
+
+        // Independently confirm the region and the untouched neighbors.
+        let mut expected: Vec<u8> = (0..8192).map(|i| (i % 251) as u8).collect();
+        expected[100..300].copy_from_slice(&data);
+        let mut whole = vec![0u8; 8192];
+        tf.as_file().read_exact_at(&mut whole, 0).unwrap();
+        assert_eq!(whole, expected);
+
+        // Scatter the same region back across three iovecs.
+        let mut r0 = vec![0u8; 50];
+        let mut r1 = vec![0u8; 100];
+        let mut r2 = vec![0u8; 50];
+        let riovecs = [iovec_of(&mut r0), iovec_of(&mut r1), iovec_of(&mut r2)];
+        // SAFETY: the iovecs describe the live r0/r1/r2 buffers.
+        assert_eq!(unsafe { af.read_vectored_at(&riovecs, 100) }.unwrap(), 200);
+        assert_eq!([r0.as_slice(), &r1, &r2].concat(), data);
+    }
 }

--- a/block/src/formats/raw/engine_aio.rs
+++ b/block/src/formats/raw/engine_aio.rs
@@ -51,7 +51,7 @@ impl AsyncIo for RawAio {
         self.alignment
     }
 
-    fn submit_data_operation(&mut self, mut op: AsyncIoOperation) -> AsyncIoResult<()> {
+    fn submit_data_operation(&mut self, op: AsyncIoOperation) -> AsyncIoResult<()> {
         let is_read = op.is_read();
 
         if operation_is_aligned(&op, self.alignment) {
@@ -65,7 +65,7 @@ impl AsyncIo for RawAio {
             });
         }
 
-        let result = run_unaligned_operation(&self.raw_file, &mut op)?;
+        let result = run_unaligned_operation(&self.raw_file, &op)?;
         self.data_io
             .inject_completion(AsyncIoCompletion::from_operation(op, result));
 

--- a/block/src/formats/raw/engine_sync.rs
+++ b/block/src/formats/raw/engine_sync.rs
@@ -10,7 +10,6 @@ use std::os::unix::io::AsRawFd;
 
 use vmm_sys_util::eventfd::EventFd;
 
-use super::{operation_is_aligned, run_unaligned_operation};
 use crate::async_io::{AsyncIo, AsyncIoCompletion, AsyncIoError, AsyncIoOperation, AsyncIoResult};
 use crate::sparse::{punch_hole, write_zeroes};
 use crate::{AlignedFile, is_block_device};
@@ -46,52 +45,22 @@ impl AsyncIo for RawSync {
         self.alignment
     }
 
-    fn submit_data_operation(&mut self, mut op: AsyncIoOperation) -> AsyncIoResult<()> {
+    fn submit_data_operation(&mut self, op: AsyncIoOperation) -> AsyncIoResult<()> {
         let is_read = op.is_read();
+        let iovecs = op.iovecs();
+        let offset = op.offset() as u64;
 
-        let result = if operation_is_aligned(&op, self.alignment) {
-            let fd = self.raw_file.as_raw_fd();
-            let offset = op.offset();
-            let iovecs = op.iovecs();
-
-            let result = if is_read {
-                // SAFETY: the memory pointed to by `iovecs` is backed by the op,
-                // and valid for the kernel to write to by construction of
-                // AsyncIoOperation.
-                unsafe {
-                    libc::preadv(
-                        fd as libc::c_int,
-                        iovecs.as_ptr(),
-                        iovecs.len() as libc::c_int,
-                        offset,
-                    )
-                }
-            } else {
-                // SAFETY: the memory pointed to by `iovecs` is backed by the op,
-                // and valid for the kernel to read from by construction of
-                // AsyncIoOperation.
-                unsafe {
-                    libc::pwritev(
-                        fd as libc::c_int,
-                        iovecs.as_ptr(),
-                        iovecs.len() as libc::c_int,
-                        offset,
-                    )
-                }
-            };
-            if result < 0 {
-                let error = io::Error::last_os_error();
-                return Err(if is_read {
-                    AsyncIoError::ReadVectored(error)
-                } else {
-                    AsyncIoError::WriteVectored(error)
-                });
-            }
-            result as i32
+        let result = if is_read {
+            // SAFETY: op.iovecs() describes valid memory for iov_len bytes by
+            // construction of AsyncIoOperation.
+            unsafe { self.raw_file.read_vectored_at(iovecs, offset) }
+                .map_err(AsyncIoError::ReadVectored)?
         } else {
-            run_unaligned_operation(&self.raw_file, &mut op)?
-        };
-
+            // SAFETY: op.iovecs() describes valid memory for iov_len bytes by
+            // construction of AsyncIoOperation.
+            unsafe { self.raw_file.write_vectored_at(iovecs, offset) }
+                .map_err(AsyncIoError::WriteVectored)?
+        } as i32;
         self.completion_list
             .push_back(AsyncIoCompletion::from_operation(op, result));
         self.eventfd.write(1).unwrap();

--- a/block/src/formats/raw/engine_uring.rs
+++ b/block/src/formats/raw/engine_uring.rs
@@ -48,7 +48,7 @@ impl AsyncIo for RawAsync {
         self.alignment
     }
 
-    fn submit_data_operation(&mut self, mut op: AsyncIoOperation) -> AsyncIoResult<()> {
+    fn submit_data_operation(&mut self, op: AsyncIoOperation) -> AsyncIoResult<()> {
         let is_read = op.is_read();
 
         if operation_is_aligned(&op, self.alignment) {
@@ -62,7 +62,7 @@ impl AsyncIo for RawAsync {
             });
         }
 
-        let result = run_unaligned_operation(&self.raw_file, &mut op)?;
+        let result = run_unaligned_operation(&self.raw_file, &op)?;
         self.data_io
             .inject_completion(AsyncIoCompletion::from_operation(op, result));
 
@@ -94,11 +94,11 @@ impl AsyncIo for RawAsync {
     fn submit_batch_requests(&mut self, batch_request: Vec<AsyncIoOperation>) -> AsyncIoResult<()> {
         if self.alignment != 0 {
             let mut aligned_batch = Vec::with_capacity(batch_request.len());
-            for mut op in batch_request {
+            for op in batch_request {
                 if operation_is_aligned(&op, self.alignment) {
                     aligned_batch.push(op);
                 } else {
-                    let result = run_unaligned_operation(&self.raw_file, &mut op)?;
+                    let result = run_unaligned_operation(&self.raw_file, &op)?;
                     self.data_io
                         .inject_completion(AsyncIoCompletion::from_operation(op, result));
                 }

--- a/block/src/formats/raw/mod.rs
+++ b/block/src/formats/raw/mod.rs
@@ -181,22 +181,24 @@ fn operation_is_aligned(op: &AsyncIoOperation, alignment: u64) -> bool {
 /// Runs an unaligned O_DIRECT operation synchronously through `aligned_file`.
 fn run_unaligned_operation(
     aligned_file: &AlignedFile,
-    op: &mut AsyncIoOperation,
+    op: &AsyncIoOperation,
 ) -> AsyncIoResult<i32> {
     let offset = op.offset() as u64;
-    let total_len = op.total_len();
+    let iovecs = op.iovecs();
 
-    if op.is_read() {
-        let n = aligned_file
-            .read_unaligned(offset, total_len, |data| op.write_bytes_at(0, data))
-            .map_err(AsyncIoError::ReadVectored)?;
-        Ok(n as i32)
+    let n = if op.is_read() {
+        // SAFETY: op.iovecs() describes valid memory for iov_len bytes by
+        // construction of AsyncIoOperation.
+        unsafe { aligned_file.read_vectored_at(iovecs, offset) }
+            .map_err(AsyncIoError::ReadVectored)?
     } else {
-        let n = aligned_file
-            .write_unaligned(offset, total_len, |data| op.read_bytes_at(0, data))
-            .map_err(AsyncIoError::WriteVectored)?;
-        Ok(n as i32)
-    }
+        // SAFETY: op.iovecs() describes valid memory for iov_len bytes by
+        // construction of AsyncIoOperation.
+        unsafe { aligned_file.write_vectored_at(iovecs, offset) }
+            .map_err(AsyncIoError::WriteVectored)?
+    };
+
+    Ok(n as i32)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This adds a vectored positioned I/O API to `AlignedFile` and adopts it across all three raw block engines. The O_DIRECT bounce and its scatter and gather now live in one place instead of being spread across the engines.

The raw sync engine issued its own `preadv` and `pwritev` FFI, and the AIO and uring engines fell back to a shared helper for the misaligned O_DIRECT case. Moving all onto `AlignedFile` keeps the `unsafe` next to the alignment invariants it depends on. The sync engine now uses one call for both the aligned fast path and the misaligned bounce, and the AIO and uring engines route their misaligned O_DIRECT case through that same vectored bounce.

The aligned fast paths in the AIO and uring engines still hand their iovecs to the kernel through Linux AIO and io_uring and are unchanged. The result of every operation is preserved.