### PR TITLE
vmm: Fix aarch64 vmm::vm::unit_tests::test_create_fdt_with_devices()

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -4030,7 +4030,7 @@ mod unit_tests {
             &mem,
             "console=tty0",
             &[0],
-            Some((0, 0, 0, 0)),
+            None,
             &dev_info,
             &gic,
             &None,


### PR DESCRIPTION
test_create_fdt_with_devices() fails with a divide by zero.  The caller passes Some((0, 0, 0, 0)) for CPU topology as (threads_per_core, cores_per_die, dies_per_package, packages).  The valid default is (1, 1, 1, 1), not all zero.

This affects the unit test only.  A real VM never hits it because VmConfig::validate() rejects zero with an error.

Fixes: 7fb980f17 ("arch, vmm: Pass cpu topology configuation to FDT")
Assisted-by: Claude:Opus-4.8 (1M context)