### PR TITLE
arch: Fix duplicate l3-cache FDT node names for multi-package guests

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -285,8 +285,8 @@ fn create_cpu_nodes(
     if cache_exist && l3_cache_size != 0 && !l2_cache_shared && l3_cache_shared {
         let mut i: u32 = 0;
         while i < packages.into() {
-            let l3_cache_name = "l3-cache0";
-            let l3_cache_node = fdt.begin_node(l3_cache_name)?;
+            let l3_cache_name = format!("l3-cache{i}");
+            let l3_cache_node = fdt.begin_node(&l3_cache_name)?;
             // ARM L3 cache is generally shared within the package (socket), so the
             // L3 cache node pointed to by the CPU in the package has the same L3
             // cache PHANDLE. The L3 cache phandle must start from the largest L2


### PR DESCRIPTION
create_cpu_nodes() emits one shared-L3 cache node per package when the host reports a shared L3, but names every node with the constant "l3-cache0". For a guest topology with packages >= 2 the generated device tree carries the same name siblings.  It results in the following error.

> $ dtc -I dtb -O dts ./guest.dtb
> <stdout>: ERROR (duplicate_node_names): /cpus/l3-cache0: Duplicate node name
> ERROR: Input tree has errors, aborting (use -f to force output)

I used the following topology, "--cpus boot=8,topology=1:4:1:2", threads=1, cores=4, dies=1, packages=2: 8 cpus across 2 sockets. packages >= 2 is what makes the bug appear.

From guest dump /sys/firmware/fdt, and decompile it by dtc command. Without this patch:
                l3-cache0 {
			...
                };

                l3-cache0 {
			...
                };

With this patch:
                l3-cache0 {
			...
                };

                l3-cache1 {
			...
                };

Fixes: 5857d4851 ("aarch64/fdt: fix cache  sharing issue for cache passthrough on aarch64")
Assisted-by: Claude:Opus-4.8 (1M context)