### PR TITLE
vmm: Generate common cpuid as part of CpuManager::new()

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -908,11 +908,28 @@ impl CpuManager {
         #[cfg(not(feature = "tdx"))]
         let dynamic = true;
 
+        #[cfg(target_arch = "x86_64")]
+        let cpuid = {
+            let phys_bits = physical_bits(hypervisor.as_ref(), config.max_phys_bits);
+            arch::generate_common_cpuid(
+                hypervisor.as_ref(),
+                &arch::CpuidConfig {
+                    phys_bits,
+                    kvm_hyperv: config.kvm_hyperv,
+                    #[cfg(feature = "tdx")]
+                    tdx: tdx_enabled,
+                    amx: config.features.amx,
+                    profile: config.profile,
+                },
+            )
+            .map_err(Error::CommonCpuId)?
+        };
+
         Ok(Arc::new(Mutex::new(CpuManager {
             config: config.clone(),
             interrupt_controller: None,
             #[cfg(target_arch = "x86_64")]
-            cpuid: Vec::new(),
+            cpuid,
             vm,
             vcpus_kill_signalled: Arc::new(AtomicBool::new(false)),
             vcpus_pause_signalled: Arc::new(AtomicBool::new(false)),
@@ -938,31 +955,6 @@ impl CpuManager {
             #[cfg(feature = "igvm")]
             igvm_enabled,
         })))
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    pub fn populate_cpuid(
-        &mut self,
-        hypervisor: &dyn hypervisor::Hypervisor,
-        #[cfg(feature = "tdx")] tdx: bool,
-    ) -> Result<()> {
-        self.cpuid = {
-            let phys_bits = physical_bits(hypervisor, self.config.max_phys_bits);
-            arch::generate_common_cpuid(
-                hypervisor,
-                &arch::CpuidConfig {
-                    phys_bits,
-                    kvm_hyperv: self.config.kvm_hyperv,
-                    #[cfg(feature = "tdx")]
-                    tdx,
-                    amx: self.config.features.amx,
-                    profile: self.config.profile,
-                },
-            )
-            .map_err(Error::CommonCpuId)?
-        };
-
-        Ok(())
     }
 
     fn create_vcpu(

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -818,18 +818,6 @@ impl Vm {
             igvm_enabled,
         )
         .map_err(Error::CpuManager)?;
-
-        #[cfg(target_arch = "x86_64")]
-        cpu_manager
-            .lock()
-            .unwrap()
-            .populate_cpuid(
-                hypervisor.as_ref(),
-                #[cfg(feature = "tdx")]
-                tdx_enabled,
-            )
-            .map_err(Error::CpuManager)?;
-
         Ok(cpu_manager)
     }
 


### PR DESCRIPTION
This removes a need to expose a method from the CpuManager back out to
the Vm which is called immediately after creating the CpuManager.

Signed-off-by: Rob Bradford <rbradford@meta.com>
