### PR TITLE
Allow source VM to be preserved after snapshot

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8475,6 +8475,12 @@ mod ivshmem {
     }
 
     #[test]
+    #[cfg(not(feature = "mshv"))]
+    fn test_snapshot_restore_offload_preserve_source() {
+        snapshot_restore_common::_test_snapshot_restore_offload_preserve_source();
+    }
+
+    #[test]
     fn test_virtio_pmem_persist_writes() {
         test_virtio_pmem(false, false);
     }
@@ -9462,6 +9468,208 @@ mod snapshot_restore_common {
         handle_child_output(r, &output);
 
         let _ = remove_dir_all(offload_dir.as_str());
+    }
+
+    // Offload snapshot with the source VM preserved.
+    pub(crate) fn _test_snapshot_restore_offload_preserve_source() {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+        let kernel_path = direct_kernel_boot_path();
+        let api_socket = temp_api_path(&guest.tmp_dir);
+
+        let offload_dir = String::from(
+            guest
+                .tmp_dir
+                .as_path()
+                .join("offload-store")
+                .to_str()
+                .unwrap(),
+        );
+        fs::create_dir(&offload_dir).unwrap();
+        let snapshot_socket = String::from(
+            guest
+                .tmp_dir
+                .as_path()
+                .join("snapshot-offload.sock")
+                .to_str()
+                .unwrap(),
+        );
+
+        // Second round uses its own dir and socket to avoid path contention.
+        let offload_dir2 = String::from(
+            guest
+                .tmp_dir
+                .as_path()
+                .join("offload-store2")
+                .to_str()
+                .unwrap(),
+        );
+        fs::create_dir(&offload_dir2).unwrap();
+        let snapshot_socket2 = String::from(
+            guest
+                .tmp_dir
+                .as_path()
+                .join("snapshot-offload2.sock")
+                .to_str()
+                .unwrap(),
+        );
+
+        let num_queues = 2;
+        let (mut blk_daemon_child, vubd_socket_path) =
+            prepare_vubd(&guest.tmp_dir, "blk.img", num_queues, false, false);
+
+        let blk_params = format!(
+            "vhost_user=true,socket={vubd_socket_path},num_queues={num_queues},queue_size=128",
+        );
+
+        let mut child = GuestCommand::new(&guest)
+            .args(["--api-socket", &api_socket])
+            .args(["--cpus", "boot=2"])
+            .args(["--memory", "size=512M,shared=on"])
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .args([
+                "--disk",
+                format!(
+                    "path={}",
+                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
+                )
+                .as_str(),
+                format!(
+                    "path={}",
+                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
+                )
+                .as_str(),
+                blk_params.as_str(),
+            ])
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let snap_daemon: Mutex<Option<Child>> = Mutex::new(None);
+        let r = panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+            assert_eq!(guest.get_cpu_count().unwrap_or_default(), 2);
+
+            // The vhost-user-block device shows up as /dev/vdc (after the OS and
+            // cloud-init disks).
+            assert_eq!(
+                guest
+                    .ssh_command("lsblk | grep -c vdc")
+                    .unwrap()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default(),
+                1
+            );
+
+            // Read the whole block device with direct I/O so the request always
+            // reaches the backend rather than the guest page cache.
+            let read_vhost_user_blk = || {
+                assert_eq!(
+                    guest
+                        .ssh_command(
+                            "sudo dd if=/dev/vdc of=/dev/null bs=1M count=16 iflag=direct \
+                             > /dev/null 2>&1 && echo ok"
+                        )
+                        .unwrap()
+                        .trim(),
+                    "ok"
+                );
+            };
+
+            // Baseline read before any snapshot.
+            read_vhost_user_blk();
+
+            // Snapshot the paused source, resume and prove the vhost-user-block
+            // device still serves I/O.
+            let snapshot_round = |snapshot_socket: &str, offload_dir: &str| {
+                // Daemon binds the socket and listens for the snapshot.
+                let daemon = Command::new(clh_command("offload_daemon"))
+                    .args([
+                        "snapshot",
+                        "--socket",
+                        snapshot_socket,
+                        "--output-dir",
+                        offload_dir,
+                    ])
+                    .stderr(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .spawn()
+                    .unwrap();
+                *snap_daemon.lock().unwrap() = Some(daemon);
+                assert!(wait_until(Duration::from_secs(5), || Path::new(
+                    snapshot_socket
+                )
+                .exists()));
+
+                // Pause, then snapshot while asking to preserve the source.
+                assert!(remote_command(&api_socket, "pause", None));
+                assert!(remote_command(
+                    &api_socket,
+                    "send-migration",
+                    Some(
+                        format!(
+                            "destination_url=unix:{snapshot_socket},local=on,preserve_source=on"
+                        )
+                        .as_str(),
+                    ),
+                ));
+
+                // The daemon should exit cleanly after persisting the snapshot.
+                let daemon_output = snap_daemon
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .unwrap()
+                    .wait_with_output()
+                    .unwrap();
+                assert!(
+                    daemon_output.status.success(),
+                    "offload daemon (snapshot) failed: stderr={}",
+                    String::from_utf8_lossy(&daemon_output.stderr)
+                );
+
+                // The source VMM must not have exited.
+                thread::sleep(Duration::from_secs(2));
+                assert!(
+                    remote_command(&api_socket, "ping", None),
+                    "source VMM exited after preserve_source snapshot"
+                );
+
+                // The VM must be left paused, and be resumable.
+                assert_eq!(vm_state(&api_socket), "Paused");
+                assert!(remote_command(&api_socket, "resume", None));
+                assert_eq!(vm_state(&api_socket), "Running");
+
+                // A direct read succeeds only if the vhost-user-block vrings
+                // resumed after the snapshot.
+                guest.wait_for_ssh(Duration::from_secs(30)).unwrap();
+                read_vhost_user_blk();
+            };
+
+            // Exercises the device state save and resume path.
+            snapshot_round(&snapshot_socket, &offload_dir);
+            // Second round proves vring re-initialization stays correct across
+            // repeated snapshots, otherwise the second save would capture
+            // mismatched bases and resume would fail.
+            snapshot_round(&snapshot_socket2, &offload_dir2);
+        });
+
+        if let Some(mut daemon) = snap_daemon.into_inner().unwrap() {
+            let _ = daemon.kill();
+            let _ = daemon.wait();
+        }
+        kill_child(&mut child);
+        let output = child.wait_with_output().unwrap();
+        let _ = blk_daemon_child.kill();
+        let _ = blk_daemon_child.wait();
+        let _ = fs::remove_file(&snapshot_socket);
+        let _ = fs::remove_file(&snapshot_socket2);
+        let _ = remove_dir_all(offload_dir.as_str());
+        let _ = remove_dir_all(offload_dir2.as_str());
+        handle_child_output(r, &output);
     }
 }
 

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -162,9 +162,11 @@ over the existing local live-migration protocol, playing the migration
 peer role:
 
 - On snapshot, CH acts as the migration sender and the daemon acts as the
-  receiver. The source VM shuts down on success, exactly as it would for a
-  local live migration. Memory is transferred via `SCM_RIGHTS`, CH handing
-  off the daemon one memfd per guest-memory slot.
+  receiver. By default the source VM shuts down on success, exactly as it
+  would for a local live migration. Passing `preserve_source=on` instead
+  leaves the source VM paused and owned by the VMM once the snapshot
+  completes, so it can be resumed afterwards. Memory is transferred via
+  `SCM_RIGHTS`, CH handing off the daemon one memfd per guest-memory slot.
 - On restore, CH acts as the migration receiver and the daemon acts as the
   sender. The daemon provides one memfd per slot, populated from its
   storage, and CH uses those memfds directly as guest RAM backing.
@@ -200,6 +202,30 @@ migration today.
 ./ch-remote --api-socket /tmp/cloud-hypervisor.sock \
     send-migration destination_url=unix:/tmp/offload.sock,local=on
 ```
+
+### Preserve the source VM
+
+By default an offload snapshot destroys the source VM on success. If you want
+to preserve the source VM, add `preserve_source=on` (only valid together
+with `local=on`) to the `send-migration` command:
+
+```bash
+./ch-remote --api-socket /tmp/cloud-hypervisor.sock pause
+./ch-remote --api-socket /tmp/cloud-hypervisor.sock \
+    send-migration destination_url=unix:/tmp/offload.sock,local=on,preserve_source=on
+# The source VMM keeps running, the VM is left paused. Resume it when ready:
+./ch-remote --api-socket /tmp/cloud-hypervisor.sock resume
+```
+
+With `preserve_source=on` the VM is left `paused` and owned by the VMM, with
+its devices intact and its disk locks still held.
+
+Because the source keeps running and holding its disk locks, its live disk
+content diverges from the memory captured in the snapshot, and a restore
+cannot re-acquire the locks on those same images. To restore the snapshot
+consistently, you should copy the disk images while the VM is still
+paused, and restore the daemon's snapshot against those copies. Otherwise,
+you might end up in an undefined state leading to possible bugs.
 
 ### Restore offload usage
 
@@ -258,9 +284,11 @@ The daemon implements the local live-migration wire protocol defined in
 On the snapshot path, the daemon must finish reading from every memory fd
 before it ACKs `CompletePaused`. Cloud Hypervisor blocks at the
 `CompletePaused` handshake until the daemon ACKs. Once it ACKs, the source
-VM shuts down and the daemon's fds are the only remaining record of guest
-RAM. The reference daemon dumps each slot to disk and `fsync`s before
-ACKing.
+VM shuts down (unless `preserve_source=on` was requested) and the daemon's
+fds are the only remaining record of guest RAM. The reference daemon dumps
+each slot to disk and `fsync`s before ACKing. This ordering matters even with
+`preserve_source=on` because the source is only resumed after the handshake
+returns, so the daemon always captures a consistent image.
 
 ### Reference daemon
 

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -337,6 +337,7 @@ impl VhostUserBackendMut for VhostUserBlkBackend {
         VhostUserProtocolFeatures::CONFIG
             | VhostUserProtocolFeatures::MQ
             | VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS
+            | VhostUserProtocolFeatures::DEVICE_STATE
     }
 
     fn set_event_idx(&mut self, enabled: bool) {
@@ -450,6 +451,21 @@ impl VhostUserBackendMut for VhostUserBlkBackend {
         &mut self,
         _mem: GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> VhostUserBackendResult<()> {
+        Ok(())
+    }
+
+    fn set_device_state_fd(
+        &mut self,
+        _direction: VhostTransferStateDirection,
+        _phase: VhostTransferStatePhase,
+        _file: File,
+    ) -> VhostUserBackendResult<Option<File>> {
+        // This device completes requests synchronously and keeps no inflight
+        // state.
+        Ok(None)
+    }
+
+    fn check_device_state(&self) -> VhostUserBackendResult<()> {
         Ok(())
     }
 }

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -111,6 +111,8 @@ pub enum ActivateError {
     BadActivate,
     #[error("Failed to clone EventFd")]
     CloneEventFd(#[source] io::Error),
+    #[error("Failed to create EventFd")]
+    CreateEventFd(#[source] io::Error),
     #[error("Failed to spawn thread")]
     ThreadSpawn(#[source] io::Error),
     #[error("Failed to setup vhost-user-fs daemon")]

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -265,6 +265,7 @@ pub const DEFAULT_VIRTIO_FEATURES: u64 = (1 << VIRTIO_F_RING_INDIRECT_DESC)
 
 const HUP_CONNECTION_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
 const BACKEND_REQ_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
+const RESUME_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 3;
 
 #[derive(Default)]
 pub struct Inflight {
@@ -287,6 +288,7 @@ pub struct VhostUserEpollHandler<S: VhostUserFrontendReqHandler> {
     pub inflight: Option<Inflight>,
     /// Flag set by the worker when the vhost-user backend is no longer reachable.
     pub disconnected: Arc<AtomicBool>,
+    pub resume_evt: EventFd,
 }
 
 impl<S: VhostUserFrontendReqHandler> VhostUserEpollHandler<S> {
@@ -305,6 +307,8 @@ impl<S: VhostUserFrontendReqHandler> VhostUserEpollHandler<S> {
         if let Some(backend_req_handler) = &self.backend_req_handler {
             helper.add_event(backend_req_handler.as_raw_fd(), BACKEND_REQ_EVENT)?;
         }
+
+        helper.add_event(self.resume_evt.as_raw_fd(), RESUME_EVENT)?;
 
         helper.run(paused, paused_sync, self)?;
 
@@ -415,6 +419,26 @@ impl<S: VhostUserFrontendReqHandler> EpollHelperHandler for VhostUserEpollHandle
                     Ok(())
                 }
             }
+            RESUME_EVENT => {
+                let _ = self.resume_evt.read();
+                self.vu
+                    .lock()
+                    .unwrap()
+                    .resume(
+                        &self.mem.memory(),
+                        &self.queues,
+                        self.virtio_interrupt.as_ref(),
+                        self.acked_features,
+                        &self.backend_req_handler,
+                        self.inflight.as_mut(),
+                    )
+                    .map_err(|e| {
+                        EpollHelperError::HandleEvent(anyhow!(
+                            "failed to resume vhost-user backend for socket {}: {e:?}",
+                            self.socket_path
+                        ))
+                    })
+            }
             _ => Err(EpollHelperError::HandleEvent(anyhow!(
                 "Unknown event for vhost-user thread"
             ))),
@@ -472,6 +496,7 @@ pub struct VhostUserCommon {
     pub disconnected: Arc<AtomicBool>,
     saved_dirty_log: Option<MemoryRangeTable>,
     dirty_logging: bool,
+    resume_evt: Option<EventFd>,
 }
 
 impl VhostUserCommon {
@@ -527,6 +552,13 @@ impl VhostUserCommon {
             )
             .map_err(ActivateError::VhostUserSetup)?;
 
+        let resume_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(ActivateError::CreateEventFd)?;
+        self.resume_evt = Some(
+            resume_evt
+                .try_clone()
+                .map_err(ActivateError::CloneEventFd)?,
+        );
+
         Ok(VhostUserEpollHandler {
             vu: vu.clone(),
             mem,
@@ -541,6 +573,7 @@ impl VhostUserCommon {
             backend_req_handler,
             inflight,
             disconnected: self.disconnected.clone(),
+            resume_evt,
         })
     }
 
@@ -706,31 +739,22 @@ impl VhostUserCommon {
     }
 
     fn resume_internal(&mut self) -> result::Result<(), MigratableError> {
-        // Skip the resume_vhost_user call if the backend is disconnected. Process the queue
-        // interrupts to kick any paused workers.
         if self.disconnected.load(Ordering::Relaxed) {
             return Err(MigratableError::DeviceDisconnected(
                 self.socket_path.clone(),
             ));
         }
 
-        if let Some(vu) = &self.vu
-            && let Err(e) = vu.lock().unwrap().resume_vhost_user()
-        {
-            if e.is_transport_lost() {
-                self.disconnected.store(true, Ordering::Relaxed);
-                return Err(MigratableError::DeviceDisconnected(
-                    self.socket_path.clone(),
-                ));
-            }
+        let Some(evt) = &self.resume_evt else {
+            return Ok(());
+        };
 
-            return Err(MigratableError::Resume(anyhow!(
-                "Error resuming vhost-user backend for socket {}: {e:?}",
+        evt.write(1).map_err(|e| {
+            MigratableError::Resume(anyhow!(
+                "Error signaling vhost-user resume for socket {}: {e}",
                 self.socket_path
-            )));
-        }
-
-        Ok(())
+            ))
+        })
     }
 
     pub fn resume(&mut self) -> result::Result<(), MigratableError> {

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -67,6 +67,7 @@ pub struct VhostUserHandle {
     acked_features: u64,
     vrings_info: Option<Vec<VringInfo>>,
     queue_indexes: Vec<u16>,
+    vring_bases: Option<Vec<u64>>,
 }
 
 impl VhostUserHandle {
@@ -171,6 +172,9 @@ impl VhostUserHandle {
         {
             return Err(Error::VringBasesCountMismatch(bases.len(), queues.len()));
         }
+
+        // May run more than once on the same handle (resume after snapshot)
+        self.queue_indexes.clear();
 
         self.vu
             .set_features(acked_features)
@@ -427,6 +431,7 @@ impl VhostUserHandle {
                 acked_features: 0,
                 vrings_info: None,
                 queue_indexes: Vec::new(),
+                vring_bases: None,
             };
             vhost_user
                 .vu
@@ -485,6 +490,7 @@ impl VhostUserHandle {
                         acked_features: 0,
                         vrings_info: None,
                         queue_indexes: Vec::new(),
+                        vring_bases: None,
                     })
                     .map_err(Error::VhostUserConnect);
 
@@ -580,7 +586,7 @@ impl VhostUserHandle {
         Ok(())
     }
 
-    pub fn resume_vhost_user(&mut self) -> Result<()> {
+    fn resume_vhost_user(&mut self) -> Result<()> {
         if self.ready {
             self.enable_vhost_user_vrings(self.queue_indexes.clone(), true)?;
         }
@@ -641,7 +647,37 @@ impl VhostUserHandle {
             .check_device_state()
             .map_err(Error::VhostUserCheckDeviceState)?;
 
+        // Store the bases in case we need to resume after snapshot
+        self.vring_bases = Some(vring_bases.clone());
+
         Ok((state, vring_bases))
+    }
+
+    /// Resume the vhost-user backend from the device thread.
+    /// Initialize the vrings from the bases captured earlier, or simply
+    /// enable them if they haven't been stopped.
+    pub fn resume<S: VhostUserFrontendReqHandler>(
+        &mut self,
+        mem: &GuestMemoryMmap,
+        queues: &[(u16, Queue, EventFd)],
+        virtio_interrupt: &dyn VirtioInterrupt,
+        acked_features: u64,
+        backend_req_handler: &Option<FrontendReqHandler<S>>,
+        inflight: Option<&mut Inflight>,
+    ) -> Result<()> {
+        let Some(vring_bases) = self.vring_bases.take() else {
+            return self.resume_vhost_user();
+        };
+
+        self.setup_vhost_user(
+            mem,
+            queues,
+            virtio_interrupt,
+            acked_features,
+            backend_req_handler,
+            inflight,
+            Some(&vring_bases),
+        )
     }
 
     pub fn restore_state<C>(&mut self, state: &VhostUserState<C>) -> Result<()> {

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -590,6 +590,10 @@ pub struct VmSendMigrationData {
     /// Send memory across socket without copying
     #[serde(default)]
     pub local: bool,
+    /// Keep the source VM alive in a paused state once the migration is
+    /// complete.
+    #[serde(default)]
+    pub preserve_source: bool,
     /// The maximum downtime the migration aims for.
     ///
     /// Usually, on the order of a few hundred milliseconds.
@@ -621,7 +625,7 @@ pub struct VmSendMigrationData {
 
 impl VmSendMigrationData {
     pub const SYNTAX: &'static str = "VM send migration parameters \
-        \"destination_url=<url>[,local=on|off,\
+        \"destination_url=<url>[,local=on|off,preserve_source=on|off,\
         downtime_ms=<milliseconds>,timeout_s=<seconds>,\
         timeout_strategy=cancel|ignore,connections=<amount>,\
         tls_dir=<path>,memory_mode=precopy|postcopy]\"";
@@ -649,6 +653,7 @@ impl VmSendMigrationData {
         parser
             .add("destination_url")
             .add("local")
+            .add("preserve_source")
             .add("downtime_ms")
             .add("timeout_s")
             .add("timeout_strategy")
@@ -666,6 +671,11 @@ impl VmSendMigrationData {
         })?;
         let local = parser
             .convert::<Toggle>("local")
+            .map_err(VmSendMigrationConfigError::ParseError)?
+            .unwrap_or(Toggle(false))
+            .0;
+        let preserve_source = parser
+            .convert::<Toggle>("preserve_source")
             .map_err(VmSendMigrationConfigError::ParseError)?
             .unwrap_or(Toggle(false))
             .0;
@@ -718,6 +728,7 @@ impl VmSendMigrationData {
         let data = Self {
             destination_url,
             local,
+            preserve_source,
             downtime_ms,
             timeout_s,
             timeout_strategy,
@@ -784,6 +795,12 @@ impl VmSendMigrationData {
                         .to_string(),
                 ));
             }
+        }
+
+        if self.preserve_source && !self.local {
+            return Err(VmSendMigrationConfigError::ValidationError(
+                "preserve_source option is only supported with the local option.".to_string(),
+            ));
         }
 
         if let Some(tls_dir) = &self.tls_dir {
@@ -2408,6 +2425,7 @@ mod unit_tests {
             VmSendMigrationData {
                 destination_url: "tcp:192.168.1.1:8080".to_string(),
                 local: false,
+                preserve_source: false,
                 downtime_ms: NonZeroU64::new(150).unwrap(),
                 timeout_s: VmSendMigrationData::default_timeout_s(),
                 timeout_strategy: Default::default(),
@@ -2429,6 +2447,7 @@ mod unit_tests {
             VmSendMigrationData {
                 destination_url: "tcp:192.168.1.1:8080".to_string(),
                 local: false,
+                preserve_source: false,
                 downtime_ms: NonZeroU64::new(150).unwrap(),
                 timeout_s: NonZeroU64::new(900).unwrap(),
                 timeout_strategy: TimeoutStrategy::Ignore,
@@ -2453,5 +2472,23 @@ mod unit_tests {
             "destination_url=tcp:192.168.1.1:8080,memory_mode=postcopy,connections=4",
         )
         .unwrap_err();
+
+        // preserve_source is accepted together with local (offload snapshot).
+        let data = VmSendMigrationData::parse(
+            "destination_url=unix:/tmp/sock,local=on,preserve_source=on",
+        )
+        .unwrap();
+        assert!(data.preserve_source);
+        assert!(data.local);
+
+        // preserve_source defaults to false when unspecified.
+        let data = VmSendMigrationData::parse("destination_url=unix:/tmp/sock,local=on").unwrap();
+        assert!(!data.preserve_source);
+
+        // preserve_source without local must be rejected.
+        VmSendMigrationData::parse("destination_url=tcp:192.168.1.1:8080,preserve_source=on")
+            .unwrap_err();
+        VmSendMigrationData::parse("destination_url=unix:/tmp/sock,preserve_source=on")
+            .unwrap_err();
     }
 }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1670,8 +1670,11 @@ impl Vmm {
         };
         transport::send_config(&mut socket, &vm_migration_config)?;
 
-        // Let every Migratable object know about the migration being started.
-        vm.start_migration()?;
+        // Let every Migratable object know about the migration being started
+        // unless the source VM must be preserved.
+        if !send_data_migration.preserve_source {
+            vm.start_migration()?;
+        }
 
         if send_data_migration.local
             || matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
@@ -1716,8 +1719,11 @@ impl Vmm {
 
         // We release the locks early to enable locking them on the destination host.
         // The VM is already stopped.
-        vm.release_disk_locks()
-            .map_err(|e| MigratableError::UnlockError(anyhow!("{e}")))?;
+        // Keep the locks held if the source VM must be preserved.
+        if !send_data_migration.preserve_source {
+            vm.release_disk_locks()
+                .map_err(|e| MigratableError::UnlockError(anyhow!("{e}")))?;
+        }
 
         // For postcopy, serve faults before sending State so the destination
         // can fault pages in during restore.
@@ -1809,7 +1815,12 @@ impl Vmm {
         }
 
         // Let every Migratable object know about the migration being complete
-        vm.complete_migration()
+        // unless the source VM must be preserved.
+        if send_data_migration.preserve_source {
+            Ok(())
+        } else {
+            vm.complete_migration()
+        }
     }
 
     /// Serve `Command::PageFault` requests from local guest memory on the fault
@@ -2031,6 +2042,7 @@ impl Vmm {
             vm,
             migration_result: migration_res,
             initial_vm_state,
+            preserve_source,
         } = migration_worker_handle.join();
 
         let mut try_resume_vm_after_failed_migration = |mut vm: Vm| {
@@ -2056,6 +2068,10 @@ impl Vmm {
         };
 
         match migration_res {
+            Ok(()) if preserve_source => {
+                // Give the source VM back to the VMM.
+                self.vm = VmOwnership::Owned(vm);
+            }
             Ok(()) => {
                 self.vm = VmOwnership::None;
                 let mut vm = vm;

--- a/vmm/src/migration/worker.rs
+++ b/vmm/src/migration/worker.rs
@@ -127,6 +127,7 @@ impl MigrationWorker {
             vm,
             migration_result,
             initial_vm_state: self.initial_vm_state,
+            preserve_source: self.config.preserve_source,
         }
     }
 
@@ -180,11 +181,13 @@ impl MigrationWorker {
 pub struct MigrationWorkerResult {
     /// The VM that was migrated.
     ///
-    /// If `migration_result` is `Ok`, the VM is paused and can be deleted.
-    /// If `migration_result` is `Err`, the VM can be resumed and given back to
-    /// the VMM.
+    /// If `migration_result` is `Ok`, the VM is paused and can be deleted
+    /// unless `preserve_source` is true, which means the VM is given back
+    /// to the VMM in a paused state.
+    /// If `Err`, the VM can be resumed and given back to the VMM.
     pub vm: Vm,
     /// The result of [`Vmm::send_migration`].
     pub migration_result: Result<(), MigratableError>,
     pub initial_vm_state: VmState,
+    pub preserve_source: bool,
 }


### PR DESCRIPTION
Extend the migration support so that a source VM can be kept alive.
This benefits the snapshot case where the offload daemon can now
snapshot a VM without tearing it down.

For vhost-user devices, a snapshot involved the vrings to be stopped,
but they couldn't be resumed. This PR aims at fixing this by saving
the vrings base so that it can be safely reset after the snapshot has
succeeded.

Finally, the vhost-user-block backend has been updated to support
DEVICE_STATE feature so that it can be used as part of the integration
tests for validating the keep alive feature introduced with the PR.
