### PR TITLE
virtio-devices: Preserve queue indices across resume

### DIFF
--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -516,11 +516,36 @@ impl Pausable for VirtioCommon {
 
 #[cfg(test)]
 mod unit_tests {
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use virtio_queue::QueueT;
     use vmm_sys_util::eventfd::EFD_NONBLOCK;
 
     use super::*;
+
+    #[derive(Default)]
+    struct RecordingInterrupt {
+        queue_indices: Mutex<Vec<u16>>,
+    }
+
+    impl VirtioInterrupt for RecordingInterrupt {
+        fn trigger(&self, int_type: VirtioInterruptType) -> io::Result<()> {
+            if let VirtioInterruptType::Queue(queue_index) = int_type {
+                self.queue_indices.lock().unwrap().push(queue_index);
+            }
+            Ok(())
+        }
+
+        fn set_notifier(
+            &self,
+            _: u32,
+            _: Option<EventFd>,
+            _: &dyn hypervisor::Vm,
+        ) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     struct NoopInterrupt;
     impl VirtioInterrupt for NoopInterrupt {
@@ -614,6 +639,31 @@ mod unit_tests {
         // Dropping `common` alone must join the worker via WorkerThreads' Drop.
         drop(common);
         assert_eq!(started.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn resume_preserves_sparse_queue_indices() {
+        let interrupt = Arc::new(RecordingInterrupt::default());
+        let queues = vec![
+            (
+                1,
+                Queue::new(256).unwrap(),
+                EventFd::new(EFD_NONBLOCK).unwrap(),
+            ),
+            (
+                3,
+                Queue::new(256).unwrap(),
+                EventFd::new(EFD_NONBLOCK).unwrap(),
+            ),
+        ];
+        let mut common = VirtioCommon::default();
+
+        common.activate(&queues, interrupt.clone()).unwrap();
+        common.resume().unwrap();
+
+        assert_eq!(queues[0].2.read().unwrap(), 1);
+        assert_eq!(queues[1].2.read().unwrap(), 1);
+        assert_eq!(*interrupt.queue_indices.lock().unwrap(), vec![1, 3]);
     }
 
     #[test]

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -281,7 +281,7 @@ pub struct VirtioCommon {
     pub paused_sync: Option<Arc<Barrier>>,
     pub workers: Option<WorkerThreads>,
     pub queue_sizes: Vec<u16>,
-    pub queue_evts: Vec<EventFd>,
+    pub queue_evts: Vec<(u16, EventFd)>,
     pub device_type: u32,
     pub min_queues: u16,
     pub access_platform: Option<Arc<dyn AccessPlatform>>,
@@ -321,11 +321,14 @@ impl VirtioCommon {
 
         self.queue_evts = queues
             .iter()
-            .map(|(_, _, queue_evt)| {
-                queue_evt.try_clone().map_err(|e| {
-                    error!("failed cloning queue EventFd: {e}");
-                    ActivateError::BadActivate
-                })
+            .map(|(queue_index, _, queue_evt)| {
+                queue_evt
+                    .try_clone()
+                    .map(|queue_evt| (*queue_index, queue_evt))
+                    .map_err(|e| {
+                        error!("Failed cloning queue EventFd: {e}");
+                        ActivateError::BadActivate
+                    })
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -493,7 +496,7 @@ impl Pausable for VirtioCommon {
 
         // Signal each activated queue eventfd so workers process restored queues
         // that may already contain pending requests.
-        for queue_evt in &self.queue_evts {
+        for (_, queue_evt) in &self.queue_evts {
             queue_evt.write(1).map_err(|e| {
                 MigratableError::Resume(anyhow!(
                     "Could not notify restored virtio worker on resume: {e}"
@@ -502,8 +505,8 @@ impl Pausable for VirtioCommon {
         }
 
         // Also trigger interrupts into the guest to wake up the driver to avoid a "livelock"
-        for i in 0..self.queue_evts.len() {
-            self.trigger_interrupt(crate::VirtioInterruptType::Queue(i as u16))
+        for (queue_index, _) in &self.queue_evts {
+            self.trigger_interrupt(crate::VirtioInterruptType::Queue(*queue_index))
                 .ok();
         }
 


### PR DESCRIPTION
# virtio-devices: Preserve queue indices across resume

## Background

`VirtioCommon::activate()` stores eventfds only for queues selected by the
transport. The PCI transport filters out queues that are not ready, so the
resulting list can contain sparse queue indices.

Before this change, `VirtioCommon::resume()` used each eventfd's position in
that filtered list as the queue index when injecting an interrupt into the
guest. For example, activated queues 1 and 3 were reported as queues 0 and 1.
With per-queue MSI-X vectors, this can route the interrupt to the wrong vector
and leave a completed request stalled after restore.

The eventfd re-kick itself is not affected because each cloned eventfd still
refers to the correct queue.

## Changes

- Store each activated queue index together with its eventfd.
- Use the original queue index when injecting resume interrupts.
- Reject queue indices that cannot be represented by
  `VirtioInterruptType::Queue` instead of truncating them.
- Add a regression test with sparse queue indices 1 and 3. The test verifies
  both eventfd re-kicks and the queue indices delivered to the interrupt
  handler.

The production fix and regression test are kept in separate commits.

## Testing

```text
cargo +1.94.1 test -p virtio-devices --lib --features kvm
cargo +1.89 clippy -p virtio-devices --lib --tests --features kvm -- -D warnings
cargo +nightly fmt --all -- --check
```

All 103 `virtio-devices` unit tests pass.