### PR TITLE
virtio-devices: Use u16 for virtio queue index consistently

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -81,7 +81,7 @@ pub enum Error {
     #[error("Madvise fail.")]
     MadviseFail(#[source] io::Error),
     #[error("Invalid queue index: {0}")]
-    InvalidQueueIndex(usize),
+    InvalidQueueIndex(u16),
     #[error("Failed to signal")]
     FailedSignal(#[source] io::Error),
     #[error("Failed adding used index")]
@@ -270,10 +270,10 @@ impl BalloonEpollHandler {
         Ok(())
     }
 
-    fn process_queue(&mut self, queue_index: usize) -> result::Result<(), Error> {
+    fn process_queue(&mut self, queue_index: u16) -> result::Result<(), Error> {
         let mut used_descs = false;
         while let Some(mut desc_chain) =
-            self.queues[queue_index].pop_descriptor_chain(self.mem.memory())
+            self.queues[queue_index as usize].pop_descriptor_chain(self.mem.memory())
         {
             let data_chunk_size = size_of::<u32>();
 
@@ -348,14 +348,14 @@ impl BalloonEpollHandler {
                 }
             }
 
-            self.queues[queue_index]
+            self.queues[queue_index as usize]
                 .add_used(desc_chain.memory(), desc_chain.head_index(), 0)
                 .map_err(Error::QueueAddUsed)?;
             used_descs = true;
         }
 
         if used_descs {
-            self.signal(VirtioInterruptType::Queue(queue_index as u16))
+            self.signal(VirtioInterruptType::Queue(queue_index))
         } else {
             Ok(())
         }

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -68,7 +68,7 @@ pub struct VirtioSharedMemoryList {
 pub struct ActivationContext {
     pub mem: GuestMemoryAtomic<GuestMemoryMmap>,
     pub interrupt_cb: Arc<dyn VirtioInterrupt>,
-    pub queues: Vec<(usize, Queue, EventFd)>,
+    pub queues: Vec<(u16, Queue, EventFd)>,
     pub device_status: Arc<AtomicU8>,
 }
 
@@ -307,7 +307,7 @@ impl VirtioCommon {
 
     pub fn activate(
         &mut self,
-        queues: &[(usize, Queue, EventFd)],
+        queues: &[(u16, Queue, EventFd)],
         interrupt_cb: Arc<dyn VirtioInterrupt>,
     ) -> ActivateResult {
         if queues.len() < self.min_queues.into() {

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -316,7 +316,7 @@ pub struct VirtioPciDeviceActivator {
     memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     device: Arc<Mutex<dyn VirtioDevice>>,
     device_activated: Arc<AtomicBool>,
-    queues: Option<Vec<(usize, Queue, EventFd)>>,
+    queues: Option<Vec<(u16, Queue, EventFd)>>,
     barrier: Option<Arc<Barrier>>,
     id: String,
     status: Arc<AtomicU8>,
@@ -834,7 +834,7 @@ impl VirtioPciDevice {
             }
 
             queues.push((
-                queue_index,
+                queue_index as u16,
                 vm_virtio::clone_queue(queue),
                 self.queue_evts[queue_index].try_clone().unwrap(),
             ));

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -112,7 +112,7 @@ pub struct Vdpa {
     id: String,
     vhost: Option<VhostKernVdpa<GuestMemoryAtomic<GuestMemoryMmap>>>,
     iova_range: VhostVdpaIovaRange,
-    enabled_queues: BTreeMap<usize, bool>,
+    enabled_queues: BTreeMap<u16, bool>,
     backend_features: u64,
     migrating: bool,
 }
@@ -209,7 +209,7 @@ impl Vdpa {
                 self.vhost
                     .as_ref()
                     .unwrap()
-                    .set_vring_enable(*queue_index, enable)
+                    .set_vring_enable(*queue_index as usize, enable)
                     .map_err(Error::SetVringEnable)?;
                 *enabled = enable;
             }
@@ -222,7 +222,7 @@ impl Vdpa {
         &mut self,
         _mem: &GuestMemoryMmap,
         virtio_interrupt: &dyn VirtioInterrupt,
-        queues: &[(usize, Queue, EventFd)],
+        queues: &[(u16, Queue, EventFd)],
     ) -> Result<()> {
         assert!(self.vhost.is_some());
         self.vhost
@@ -242,7 +242,7 @@ impl Vdpa {
             self.vhost
                 .as_ref()
                 .unwrap()
-                .set_vring_num(*queue_index, queue_size)
+                .set_vring_num(*queue_index as usize, queue_size)
                 .map_err(Error::SetVringNum)?;
 
             let config_data = VringConfigData {
@@ -276,28 +276,28 @@ impl Vdpa {
             self.vhost
                 .as_ref()
                 .unwrap()
-                .set_vring_addr(*queue_index, &config_data)
+                .set_vring_addr(*queue_index as usize, &config_data)
                 .map_err(Error::SetVringAddr)?;
             self.vhost
                 .as_ref()
                 .unwrap()
-                .set_vring_base(*queue_index, 0)
+                .set_vring_base(*queue_index as usize, 0)
                 .map_err(Error::SetVringBase)?;
 
             if let Some(eventfd) =
-                virtio_interrupt.notifier(VirtioInterruptType::Queue(*queue_index as u16))
+                virtio_interrupt.notifier(VirtioInterruptType::Queue(*queue_index))
             {
                 self.vhost
                     .as_ref()
                     .unwrap()
-                    .set_vring_call(*queue_index, &eventfd)
+                    .set_vring_call(*queue_index as usize, &eventfd)
                     .map_err(Error::SetVringCall)?;
             }
 
             self.vhost
                 .as_ref()
                 .unwrap()
-                .set_vring_kick(*queue_index, queue_evt)
+                .set_vring_kick(*queue_index as usize, queue_evt)
                 .map_err(Error::SetVringKick)?;
 
             self.enabled_queues.insert(*queue_index, false);

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -277,7 +277,7 @@ pub struct VhostUserEpollHandler<S: VhostUserFrontendReqHandler> {
     pub mem: GuestMemoryAtomic<GuestMemoryMmap>,
     pub kill_evt: EventFd,
     pub pause_evt: EventFd,
-    pub queues: Vec<(usize, Queue, EventFd)>,
+    pub queues: Vec<(u16, Queue, EventFd)>,
     pub virtio_interrupt: Arc<dyn VirtioInterrupt>,
     pub acked_features: u64,
     pub acked_protocol_features: u64,
@@ -484,7 +484,7 @@ impl VhostUserCommon {
     pub fn activate<T: VhostUserFrontendReqHandler>(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
-        queues: &[(usize, Queue, EventFd)],
+        queues: &[(u16, Queue, EventFd)],
         interrupt_cb: Arc<dyn VirtioInterrupt>,
         acked_features: u64,
         backend_req_handler: Option<FrontendReqHandler<T>>,

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -65,7 +65,7 @@ pub struct VhostUserHandle {
     shm_log: Option<Arc<MmapRegion>>,
     acked_features: u64,
     vrings_info: Option<Vec<VringInfo>>,
-    queue_indexes: Vec<usize>,
+    queue_indexes: Vec<u16>,
 }
 
 impl VhostUserHandle {
@@ -167,7 +167,7 @@ impl VhostUserHandle {
     pub fn setup_vhost_user<S: VhostUserFrontendReqHandler>(
         &mut self,
         mem: &GuestMemoryMmap,
-        queues: &[(usize, Queue, EventFd)],
+        queues: &[(u16, Queue, EventFd)],
         virtio_interrupt: &dyn VirtioInterrupt,
         acked_features: u64,
         backend_req_handler: &Option<FrontendReqHandler<S>>,
@@ -195,7 +195,7 @@ impl VhostUserHandle {
         // at early stage.
         for (queue_index, queue, _) in queues.iter() {
             self.vu
-                .set_vring_num(*queue_index, queue.size())
+                .set_vring_num(*queue_index as usize, queue.size())
                 .map_err(Error::VhostUserSetVringNum)?;
         }
 
@@ -260,7 +260,7 @@ impl VhostUserHandle {
             });
 
             self.vu
-                .set_vring_addr(*queue_index, &config_data)
+                .set_vring_addr(*queue_index as usize, &config_data)
                 .map_err(Error::VhostUserSetVringAddr)?;
             let base = if let Some(bases) = vring_bases {
                 bases[i] as u16
@@ -271,19 +271,19 @@ impl VhostUserHandle {
                     .0
             };
             self.vu
-                .set_vring_base(*queue_index, base)
+                .set_vring_base(*queue_index as usize, base)
                 .map_err(Error::VhostUserSetVringBase)?;
 
             if let Some(eventfd) =
-                virtio_interrupt.notifier(VirtioInterruptType::Queue(*queue_index as u16))
+                virtio_interrupt.notifier(VirtioInterruptType::Queue(*queue_index))
             {
                 self.vu
-                    .set_vring_call(*queue_index, &eventfd)
+                    .set_vring_call(*queue_index as usize, &eventfd)
                     .map_err(Error::VhostUserSetVringCall)?;
             }
 
             self.vu
-                .set_vring_kick(*queue_index, queue_evt)
+                .set_vring_kick(*queue_index as usize, queue_evt)
                 .map_err(Error::VhostUserSetVringKick)?;
 
             self.queue_indexes.push(*queue_index);
@@ -303,10 +303,10 @@ impl VhostUserHandle {
         Ok(())
     }
 
-    fn enable_vhost_user_vrings(&mut self, queue_indexes: Vec<usize>, enable: bool) -> Result<()> {
+    fn enable_vhost_user_vrings(&mut self, queue_indexes: Vec<u16>, enable: bool) -> Result<()> {
         for queue_index in queue_indexes {
             self.vu
-                .set_vring_enable(queue_index, enable)
+                .set_vring_enable(queue_index as usize, enable)
                 .map_err(Error::VhostUserSetVringEnable)?;
         }
 
@@ -316,12 +316,12 @@ impl VhostUserHandle {
     pub fn reset_vhost_user(&mut self) -> Result<()> {
         for queue_index in self.queue_indexes.drain(..) {
             self.vu
-                .set_vring_enable(queue_index, false)
+                .set_vring_enable(queue_index as usize, false)
                 .map_err(Error::VhostUserSetVringEnable)?;
 
             let _ = self
                 .vu
-                .get_vring_base(queue_index)
+                .get_vring_base(queue_index as usize)
                 .map_err(Error::VhostUserGetVringBase)?;
         }
 
@@ -360,7 +360,7 @@ impl VhostUserHandle {
     pub fn reinitialize_vhost_user<S: VhostUserFrontendReqHandler>(
         &mut self,
         mem: &GuestMemoryMmap,
-        queues: &[(usize, Queue, EventFd)],
+        queues: &[(u16, Queue, EventFd)],
         virtio_interrupt: &dyn VirtioInterrupt,
         acked_features: u64,
         acked_protocol_features: u64,
@@ -581,7 +581,7 @@ impl VhostUserHandle {
         for queue_index in &self.queue_indexes {
             let base = self
                 .vu
-                .get_vring_base(*queue_index)
+                .get_vring_base(*queue_index as usize)
                 .map_err(Error::VhostUserGetVringBase)?;
             vring_bases.push(base as u64);
         }


### PR DESCRIPTION
- **virtio-devices: Use u16 for the queue index**
- **virtio-devices: balloon: Fix use of usize for virtio queue index**
