### PR TITLE
Add missing 404 responses to spec

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -40,6 +40,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VmInfo"
+        404:
+          description: The VM information is not available because the VM is not created.
 
   /vm.counters:
     get:
@@ -176,6 +178,8 @@ paths:
       responses:
         204:
           description: The disk was successfully resized.
+        404:
+          description: The disk could not be resized because the VM is not created.
         500:
           description: The disk could not be resized.
 
@@ -192,6 +196,8 @@ paths:
       responses:
         204:
           description: The memory zone was successfully resized.
+        404:
+          description: The memory zone could not be resized because the VM is not created.
         500:
           description: The memory zone could not be resized.
 
@@ -252,6 +258,8 @@ paths:
                 $ref: "#/components/schemas/PciDeviceInfo"
         204:
           description: The new disk was successfully (cold) added to the VM instance.
+        404:
+          description: The new disk could not be added because the VM is not created.
         500:
           description: The new disk could not be added to the VM instance.
 
@@ -274,6 +282,8 @@ paths:
                 $ref: "#/components/schemas/PciDeviceInfo"
         204:
           description: The new device was successfully (cold) added to the VM instance.
+        404:
+          description: The new device could not be added because the VM is not created.
         500:
           description: The new device could not be added to the VM instance.
 
@@ -296,6 +306,8 @@ paths:
                 $ref: "#/components/schemas/PciDeviceInfo"
         204:
           description: The new device was successfully (cold) added to the VM instance.
+        404:
+          description: The new device could not be added because the VM is not created.
         500:
           description: The new device could not be added to the VM instance.
 
@@ -318,6 +330,8 @@ paths:
                 $ref: "#/components/schemas/PciDeviceInfo"
         204:
           description: The new device was successfully (cold) added to the VM instance.
+        404:
+          description: The new device could not be added because the VM is not created.
         500:
           description: The new device could not be added to the VM instance.
 
@@ -340,6 +354,8 @@ paths:
                 $ref: "#/components/schemas/PciDeviceInfo"
         204:
           description: The new device was successfully (cold) added to the VM instance.
+        404:
+          description: The new device could not be added because the VM is not created.
         500:
           description: The new device could not be added to the VM instance.
 
@@ -362,6 +378,8 @@ paths:
                 $ref: "#/components/schemas/PciDeviceInfo"
         204:
           description: The new device was successfully (cold) added to the VM instance.
+        404:
+          description: The new device could not be added because the VM is not created.
         500:
           description: The new device could not be added to the VM instance.
 
@@ -384,6 +402,8 @@ paths:
                 $ref: "#/components/schemas/PciDeviceInfo"
         204:
           description: The new vDPA device was successfully (cold) added to the VM instance.
+        404:
+          description: The new vDPA device could not be added because the VM is not created.
         500:
           description: The new vDPA device could not be added to the VM instance.
 


### PR DESCRIPTION
## Summary

PR #8320 changed several API endpoints to return `404 Not Found` when the
VM has not been created yet, but the OpenAPI specification was never updated
to document these responses. This PR syncs the spec with the implemented
behaviour.

## Endpoints updated

Added the missing `404` response for:

- `/vm.info`
- `/vm.resize-disk`
- `/vm.resize-zone`
- `/vm.add-disk`
- `/vm.add-fs`
- `/vm.add-generic-vhost-user`
- `/vm.add-pmem`
- `/vm.add-net`
- `/vm.add-vsock`
- `/vm.add-vdpa`

Each `404` documents that the operation cannot be performed because the VM
is not created, matching the HTTP status codes already returned by the code.

## Related

Follow-up to #8320.

---

_LLM assistance: this spec change was drafted with Claude (Opus 4.8) and
reviewed and understood by the author (`Assisted-by: Claude:Opus-4.8` in the
commit)._