### PR TITLE
Enable live-migration and snapshot tests for mshv builds

### DIFF
--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -194,8 +194,10 @@ pub(crate) fn cloud_hypervisor_release_path() -> String {
     workload_path.push("workloads");
 
     let mut ch_release_path = workload_path;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", not(feature = "mshv")))]
     ch_release_path.push("cloud-hypervisor-static");
+    #[cfg(all(target_arch = "x86_64", feature = "mshv"))]
+    ch_release_path.push("cloud-hypervisor-static-mshv");
     #[cfg(target_arch = "aarch64")]
     ch_release_path.push("cloud-hypervisor-static-aarch64");
 

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -5,9 +5,7 @@ use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-#[cfg(not(feature = "mshv"))]
-use std::process::Stdio;
-use std::process::{Child, Command, Output};
+use std::process::{Child, Command, Output, Stdio};
 use std::string::String;
 use std::sync::mpsc;
 use std::sync::mpsc::Receiver;
@@ -17,7 +15,6 @@ use std::{cmp, fs, io, panic, thread};
 use block::formats::qcow::ImageType as QcowImageType;
 use test_infra::*;
 use vmm_sys_util::tempdir::TempDir;
-#[cfg(not(feature = "mshv"))]
 use wait_timeout::ChildExt;
 
 const QCOW2_INCOMPATIBLE_FEATURES_OFFSET: u64 = 72;
@@ -1124,7 +1121,6 @@ pub(crate) fn bdf_from_hotplug_response(
     (segment_id, bus_id, device_id, function_id)
 }
 
-#[cfg(not(feature = "mshv"))]
 pub(crate) fn start_live_migration(
     migration_socket: &str,
     src_api_socket: &str,
@@ -1242,7 +1238,6 @@ pub(crate) fn start_live_migration(
     send_success && receive_success
 }
 
-#[cfg(not(feature = "mshv"))]
 pub(crate) fn print_and_panic(
     src_vm: Child,
     dest_vm: Child,

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6813,6 +6813,9 @@ mod common_parallel {
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
+            #[cfg(target_arch = "x86_64")]
+            guest.add_test_disk(&src_api_socket);
+
             // Start the live-migration
             let migration_socket = String::from(
                 guest
@@ -6864,6 +6867,9 @@ mod common_parallel {
             assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
 
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
+
+            #[cfg(target_arch = "x86_64")]
+            guest.remove_test_disk(&dest_api_socket);
         });
 
         // Clean-up the destination VM and make sure it terminated correctly
@@ -7170,24 +7176,6 @@ mod common_parallel {
             .output()
             .expect("Expect creating disk image to succeed");
         let pmem_path = String::from("/dev/pmem0");
-        let mut hotplug_blk_file_path = dirs::home_dir().unwrap();
-        hotplug_blk_file_path.push("workloads");
-        hotplug_blk_file_path.push("blk.img");
-        let hotplug_disk_id = "test0";
-        let hotplug_disk_params = format!(
-            "path={},id={hotplug_disk_id},readonly=true",
-            hotplug_blk_file_path.to_str().unwrap()
-        );
-        // The hotplugged disk is expected to appear as /dev/vdc and blk.img is
-        // the 16 MiB workload image used by the disk hotplug tests.
-        let hotplug_disk_count_is = |expected| {
-            guest
-                .ssh_command("lsblk | grep -c 'vdc.*16M' || true")
-                .is_ok_and(|s| s.trim().parse::<u32>().is_ok_and(|count| count == expected))
-        };
-        let hotplug_disk_exists = || hotplug_disk_count_is(1);
-        let hotplug_disk_absent = || hotplug_disk_count_is(0);
-
         // Start the source VM
         let src_vm_path = clh_command("cloud-hypervisor");
         let src_api_socket = temp_api_path(&guest.tmp_dir);
@@ -7234,20 +7222,8 @@ mod common_parallel {
             assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
-            // Test hot(re)plugging works before a migration.
-            //
-            // This currently excludes ARM, because on ARM we boot without OVMF,
-            // using direct kernel boot, where ACPI support is missing.
             #[cfg(target_arch = "x86_64")]
-            {
-                assert!(hotplug_disk_absent());
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-disk",
-                    Some(hotplug_disk_params.as_str()),
-                ));
-                assert!(wait_until(Duration::from_secs(10), hotplug_disk_exists));
-            }
+            guest.add_test_disk(&src_api_socket);
             // Start TCP live migration
             assert!(
                 start_live_migration_tcp(
@@ -7289,28 +7265,8 @@ mod common_parallel {
             assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
-            // Test hot(re)plugging works after a migration.
-            //
-            // This currently excludes ARM, because on ARM we boot without OVMF,
-            // using direct kernel boot, where ACPI support is missing.
             #[cfg(target_arch = "x86_64")]
-            {
-                assert!(hotplug_disk_exists());
-
-                assert!(remote_command(
-                    &dest_api_socket,
-                    "remove-device",
-                    Some(hotplug_disk_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), hotplug_disk_absent));
-
-                assert!(remote_command(
-                    &dest_api_socket,
-                    "add-disk",
-                    Some(hotplug_disk_params.as_str()),
-                ));
-                assert!(wait_until(Duration::from_secs(10), hotplug_disk_exists));
-            }
+            guest.remove_test_disk(&dest_api_socket);
         });
 
         // Clean up the destination VM and ensure it terminates properly
@@ -7323,13 +7279,6 @@ mod common_parallel {
             assert!(String::from_utf8_lossy(&dest_output.stdout).contains(&console_text));
         });
         handle_child_output(r, &dest_output);
-
-        #[cfg(not(target_arch = "x86_64"))]
-        {
-            let _ = hotplug_disk_params;
-            let _ = hotplug_disk_exists;
-            let _ = hotplug_disk_absent;
-        }
     }
 
     // Postcopy live migration. Verifies the destination boots a guest
@@ -7382,6 +7331,9 @@ mod common_parallel {
             assert!(guest.get_total_memory().unwrap_or_default() > 400_000);
             guest.check_devices_common(None, Some(&console_text), None);
 
+            #[cfg(target_arch = "x86_64")]
+            guest.add_test_disk(&src_api_socket);
+
             assert!(
                 start_live_migration_tcp_with_flags(
                     &src_api_socket,
@@ -7421,6 +7373,9 @@ mod common_parallel {
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
             assert!(guest.get_total_memory().unwrap_or_default() > 400_000);
             guest.check_devices_common(None, Some(&console_text), None);
+
+            #[cfg(target_arch = "x86_64")]
+            guest.remove_test_disk(&dest_api_socket);
         });
 
         let _ = dest_child.kill();
@@ -7708,7 +7663,6 @@ mod common_parallel {
             prepare_virtiofsd(&guest.tmp_dir, shared_dir.to_str().unwrap());
 
         let src_api_socket = temp_api_path(&guest.tmp_dir);
-
         // Start the source VM
         let mut src_child = GuestCommand::new(&guest)
             .args(["--api-socket", &src_api_socket])
@@ -7786,6 +7740,9 @@ mod common_parallel {
                 "pre_migration_data"
             );
 
+            #[cfg(target_arch = "x86_64")]
+            guest.add_test_disk(&src_api_socket);
+
             let migration_socket = String::from(
                 guest
                     .tmp_dir
@@ -7856,6 +7813,9 @@ mod common_parallel {
             // Verify the new file exists on the host
             let post_content = fs::read_to_string(shared_dir.join("post_migration_file")).unwrap();
             assert_eq!(post_content.trim(), "post_migration_data");
+
+            #[cfg(target_arch = "x86_64")]
+            guest.remove_test_disk(&dest_api_socket);
         });
 
         // Clean up
@@ -8110,6 +8070,9 @@ mod ivshmem {
             // Allow some normal time to elapse to check we don't get spurious reboots
             thread::sleep(Duration::new(40, 0));
 
+            #[cfg(target_arch = "x86_64")]
+            guest.add_test_disk(&src_api_socket);
+
             // Start the live-migration
             let migration_socket = String::from(
                 guest
@@ -8164,6 +8127,9 @@ mod ivshmem {
 
             // Check ivshmem device
             _test_ivshmem(&guest, &ivshmem_file_path, file_size);
+
+            #[cfg(target_arch = "x86_64")]
+            guest.remove_test_disk(&dest_api_socket);
         });
 
         // Clean-up the destination VM and make sure it terminated correctly
@@ -8725,6 +8691,9 @@ mod snapshot_restore_common {
             // Check the guest virtio-devices, e.g. block, rng, vsock, console, and net
             guest.check_devices_common(Some(&socket), Some(&console_text), None);
 
+            #[cfg(target_arch = "x86_64")]
+            guest.add_test_disk(&api_socket_source);
+
             snapshot_restore_common::snapshot_and_check_events(
                 &api_socket_source,
                 &snapshot_dir,
@@ -8890,6 +8859,9 @@ mod snapshot_restore_common {
             }
 
             guest.check_devices_common(Some(&socket), Some(&console_text), None);
+
+            #[cfg(target_arch = "x86_64")]
+            guest.remove_test_disk(&api_socket_restored);
 
             if check_clock {
                 // Across the off-host interval the restored guest's wall clock
@@ -10240,6 +10212,9 @@ mod common_sequential {
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
+            #[cfg(target_arch = "x86_64")]
+            guest.add_test_disk(&src_api_socket);
+
             // Start the live-migration
             let migration_socket = String::from(
                 guest
@@ -10306,6 +10281,9 @@ mod common_sequential {
             let total_memory = guest.get_total_memory().unwrap_or_default();
             assert!(total_memory > 4_800_000);
             assert!(total_memory < 5_760_000);
+
+            #[cfg(target_arch = "x86_64")]
+            guest.remove_test_disk(&dest_api_socket);
         });
 
         // Clean-up the destination VM and make sure it terminated correctly
@@ -10445,6 +10423,9 @@ mod common_sequential {
                 }
             }
 
+            #[cfg(target_arch = "x86_64")]
+            guest.add_test_disk(&src_api_socket);
+
             // Start the live-migration
             let migration_socket = String::from(
                 guest
@@ -10540,6 +10521,9 @@ mod common_sequential {
                     );
                 }
             }
+
+            #[cfg(target_arch = "x86_64")]
+            guest.remove_test_disk(&dest_api_socket);
         });
 
         // Clean-up the destination VM and make sure it terminated correctly

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10,7 +10,6 @@
 #![allow(dead_code)]
 use std::fs::{File, OpenOptions, copy};
 use std::io::{BufRead, BufReader, Read, Seek, Write};
-#[cfg(not(feature = "mshv"))]
 use std::net::TcpListener;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -40,14 +39,11 @@ macro_rules! basic_regular_guest {
 mod common_parallel {
     use std::cell::Cell;
     use std::io::{self, SeekFrom};
-    #[cfg(not(feature = "mshv"))]
     use std::num::NonZeroU32;
     use std::process::Command;
-    #[cfg(not(feature = "mshv"))]
     use std::sync::mpsc;
 
     use test_infra::GuestFactory;
-    #[cfg(not(feature = "mshv"))]
     use vmm::api::TimeoutStrategy;
 
     use crate::*;
@@ -6737,7 +6733,6 @@ mod common_parallel {
     // 4. The destination VM is functional (including various virtio-devices are working properly) after
     //    live migration;
     // Note: This test does not use vsock as we can't create two identical vsock on the same host.
-    #[cfg(not(feature = "mshv"))]
     fn _test_live_migration(upgrade_test: bool, local: bool, paused: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -6894,7 +6889,6 @@ mod common_parallel {
     // 5. The destination VM is functional after live migration;
     // 6. Ensure Landlock is enabled on destination VM by hotplugging a disk. As the path for
     //    this disk is not known to the destination VM this step will fail.
-    #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_with_landlock() {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -7024,7 +7018,6 @@ mod common_parallel {
     }
 
     // Function to get an available port
-    #[cfg(not(feature = "mshv"))]
     fn get_available_port() -> u16 {
         TcpListener::bind("127.0.0.1:0")
             .expect("Failed to bind to address")
@@ -7033,7 +7026,6 @@ mod common_parallel {
             .port()
     }
 
-    #[cfg(not(feature = "mshv"))]
     fn start_live_migration_tcp(
         src_api_socket: &str,
         dest_api_socket: &str,
@@ -7049,7 +7041,6 @@ mod common_parallel {
         )
     }
 
-    #[cfg(not(feature = "mshv"))]
     fn start_live_migration_tcp_with_flags(
         src_api_socket: &str,
         dest_api_socket: &str,
@@ -7154,7 +7145,6 @@ mod common_parallel {
         send_success && receive_success
     }
 
-    #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_tcp(connections: NonZeroU32) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -7284,7 +7274,6 @@ mod common_parallel {
     // Postcopy live migration. Verifies the destination boots a guest
     // that touches all of its memory, which forces every page to be
     // demand-faulted across the network.
-    #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_tcp_postcopy() {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -7383,7 +7372,6 @@ mod common_parallel {
         handle_child_output(r, &dest_output);
     }
 
-    #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_tcp_timeout(timeout_strategy: TimeoutStrategy) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -7575,37 +7563,31 @@ mod common_parallel {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_basic() {
         _test_live_migration(false, false, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_local() {
         _test_live_migration(false, true, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_basic_paused() {
         _test_live_migration(false, false, true);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_local_paused() {
         _test_live_migration(false, true, true);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_tcp() {
         _test_live_migration_tcp(NonZeroU32::new(1).unwrap());
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_tcp_parallel_connections() {
         _test_live_migration_tcp(NonZeroU32::new(8).unwrap());
     }
@@ -7617,14 +7599,12 @@ mod common_parallel {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     #[ignore = "See #8651"]
     fn test_live_migration_tcp_timeout_cancel() {
         _test_live_migration_tcp_timeout(TimeoutStrategy::Cancel);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_tcp_timeout_ignore() {
         _test_live_migration_tcp_timeout(TimeoutStrategy::Ignore);
     }
@@ -7632,25 +7612,21 @@ mod common_parallel {
     // TODO: Add test of live upgrade paused vm after cloud-hypervisor-static
     // version is updated.
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_basic() {
         _test_live_migration(true, false, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_local() {
         _test_live_migration(true, true, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     #[cfg(target_arch = "x86_64")]
     fn test_live_migration_with_landlock() {
         _test_live_migration_with_landlock();
     }
 
-    #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_virtio_fs(local: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -7832,13 +7808,11 @@ mod common_parallel {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_virtio_fs() {
         _test_live_migration_virtio_fs(false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_virtio_fs_local() {
         _test_live_migration_virtio_fs(true);
     }
@@ -7962,7 +7936,6 @@ mod dbus_api {
 }
 
 mod ivshmem {
-    #[cfg(not(feature = "mshv"))]
     use std::fs::remove_dir_all;
     use std::process::Command;
 
@@ -7970,7 +7943,6 @@ mod ivshmem {
 
     use crate::*;
 
-    #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_ivshmem(local: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -8200,7 +8172,6 @@ mod ivshmem {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_ivshmem() {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -8353,19 +8324,16 @@ mod ivshmem {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_ivshmem() {
         _test_live_migration_ivshmem(false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_ivshmem_local() {
         _test_live_migration_ivshmem(true);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_hotplug_virtiomem() {
         snapshot_restore_common::_test_snapshot_restore(
             snapshot_restore_common::SnapshotRestoreTest {
@@ -8376,7 +8344,6 @@ mod ivshmem {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))] // See issue #7437
     fn test_snapshot_restore_basic() {
         snapshot_restore_common::_test_snapshot_restore(
             snapshot_restore_common::SnapshotRestoreTest::default(),
@@ -8384,7 +8351,6 @@ mod ivshmem {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_with_resume() {
         snapshot_restore_common::_test_snapshot_restore(
             snapshot_restore_common::SnapshotRestoreTest {
@@ -8479,20 +8445,17 @@ mod ivshmem {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))] // See issue #7437
     #[cfg(target_arch = "x86_64")]
     fn test_snapshot_restore_pvpanic() {
         snapshot_restore_common::_test_snapshot_restore_devices(true);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_offload() {
         snapshot_restore_common::_test_snapshot_restore_offload(false, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_offload_virtio_mem() {
         snapshot_restore_common::_test_snapshot_restore_offload(true, false);
     }
@@ -8515,7 +8478,6 @@ mod ivshmem {
     }
 }
 
-#[cfg(not(feature = "mshv"))]
 mod snapshot_restore_common {
     use std::fs::remove_dir_all;
     use std::process::Command;
@@ -8900,6 +8862,7 @@ mod snapshot_restore_common {
         handle_child_output(r, &output);
     }
 
+    #[cfg(not(feature = "mshv"))]
     pub(crate) fn _test_snapshot_restore_uffd(
         memory_config: &str,
         memory_zone_config: &[&str],
@@ -9676,9 +9639,7 @@ mod snapshot_restore_common {
 }
 
 mod common_sequential {
-    #[cfg(not(feature = "mshv"))]
     use std::fs::remove_dir_all;
-    #[cfg(not(feature = "mshv"))]
     use std::net::{IpAddr, Ipv4Addr};
 
     use crate::*;
@@ -9716,7 +9677,6 @@ mod common_sequential {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))] // See issue #7437
     #[ignore = "See #6970"]
     fn test_snapshot_restore_with_fd() {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
@@ -9950,7 +9910,6 @@ mod common_sequential {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_virtio_fs() {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -10111,7 +10070,6 @@ mod common_sequential {
         let _ = fs::remove_file(shared_dir.join("post_restore_file"));
     }
 
-    #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_balloon(upgrade_test: bool, local: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -10298,7 +10256,6 @@ mod common_sequential {
         handle_child_output(r, &dest_output);
     }
 
-    #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_numa(upgrade_test: bool, local: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -10647,49 +10604,41 @@ mod common_sequential {
     // NUMA and balloon live migration tests run sequentially
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_balloon() {
         _test_live_migration_balloon(false, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_balloon_local() {
         _test_live_migration_balloon(false, true);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_balloon() {
         _test_live_migration_balloon(true, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_balloon_local() {
         _test_live_migration_balloon(true, true);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_numa() {
         _test_live_migration_numa(false, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_numa_local() {
         _test_live_migration_numa(false, true);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_numa() {
         _test_live_migration_numa(true, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_numa_local() {
         _test_live_migration_numa(true, true);
     }
@@ -10727,7 +10676,6 @@ mod common_sequential {
         _test_live_migration_ovs_dpdk(true, true);
     }
 
-    #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_watchdog(upgrade_test: bool, local: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -10921,7 +10869,6 @@ mod common_sequential {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_live_migration_watchdog() {
         _test_live_migration_watchdog(false, false);
     }

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7599,7 +7599,9 @@ mod common_parallel {
 
                     thread::sleep(Duration::from_secs(3));
                     assert!(
-                        src_child.try_wait().unwrap().is_some(),
+                        wait_until(Duration::from_secs(30), || {
+                            matches!(src_child.try_wait(), Ok(Some(_)))
+                        }),
                         "Source VM should have terminated after a forced migration"
                     );
 

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6813,29 +6813,6 @@ mod common_parallel {
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
-            // x86_64: Following what's done in the `test_snapshot_restore`, we need
-            // to make sure that removing and adding back the virtio-net device does
-            // not break the live-migration support for virtio-pci.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), || {
-                    guest.wait_for_ssh(Duration::from_secs(1)).is_err()
-                }));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
-            }
-
             // Start the live-migration
             let migration_socket = String::from(
                 guest
@@ -7263,22 +7240,6 @@ mod common_parallel {
             // using direct kernel boot, where ACPI support is missing.
             #[cfg(target_arch = "x86_64")]
             {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), || {
-                    guest.wait_for_ssh(Duration::from_secs(1)).is_err()
-                }));
-                // Re-add the virtio-net device
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
-
                 assert!(hotplug_disk_absent());
                 assert!(remote_command(
                     &src_api_socket,
@@ -8141,26 +8102,6 @@ mod ivshmem {
             assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
-            // x86_64: Following what's done in the `test_snapshot_restore`, we need
-            // to make sure that removing and adding back the virtio-net device does
-            // not break the live-migration support for virtio-pci.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                thread::sleep(Duration::new(10, 0));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                thread::sleep(Duration::new(10, 0));
-            }
 
             // Check ivshmem device in src guest.
             _test_ivshmem(&guest, &ivshmem_file_path, file_size);
@@ -8781,39 +8722,6 @@ mod snapshot_restore_common {
             }
             // Check the guest virtio-devices, e.g. block, rng, vsock, console, and net
             guest.check_devices_common(Some(&socket), Some(&console_text), None);
-
-            // x86_64: We check that removing and adding back the virtio-net device
-            // does not break the snapshot/restore support for virtio-pci.
-            // This is an important thing to test as the hotplug will
-            // trigger a PCI BAR reprogramming, which is a good way of
-            // checking if the stored resources are correctly restored.
-            // Unplug the virtio-net device
-            // AArch64: Device hotplug is currently not supported, skipping here.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &api_socket_source,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                let latest_events = [&MetaEvent {
-                    event: "device-removed".to_string(),
-                    device_id: Some(net_id.to_string()),
-                }];
-                assert!(wait_for_latest_events_exact(
-                    Duration::from_secs(30),
-                    &latest_events,
-                    &event_path
-                ));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &api_socket_source,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                thread::sleep(Duration::new(10, 0));
-            }
 
             snapshot_restore_common::snapshot_and_check_events(
                 &api_socket_source,
@@ -10330,29 +10238,6 @@ mod common_sequential {
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
-            // x86_64: Following what's done in the `test_snapshot_restore`, we need
-            // to make sure that removing and adding back the virtio-net device does
-            // not break the live-migration support for virtio-pci.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), || {
-                    guest.wait_for_ssh(Duration::from_secs(1)).is_err()
-                }));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
-            }
-
             // Start the live-migration
             let migration_socket = String::from(
                 guest
@@ -10556,29 +10441,6 @@ mod common_sequential {
 
                     guest.check_numa_common(Some(&[1_920_000, 1_920_000, 1_920_000]), None, None);
                 }
-            }
-
-            // x86_64: Following what's done in the `test_snapshot_restore`, we need
-            // to make sure that removing and adding back the virtio-net device does
-            // not break the live-migration support for virtio-pci.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), || {
-                    guest.wait_for_ssh(Duration::from_secs(1)).is_err()
-                }));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
             }
 
             // Start the live-migration
@@ -10953,28 +10815,6 @@ mod common_sequential {
             assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
-            // x86_64: Following what's done in the `test_snapshot_restore`, we need
-            // to make sure that removing and adding back the virtio-net device does
-            // not break the live-migration support for virtio-pci.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), || {
-                    guest.wait_for_ssh(Duration::from_secs(1)).is_err()
-                }));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
-            }
 
             // Enable watchdog and ensure its functional
             let expected_reboot_count = 1;

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -26,10 +26,22 @@ JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
 JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
 JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
 
-for required in "$FW" "$WORKLOADS_DIR/CLOUDHV.fd" "$JAMMY_OS_IMAGE" \
-    "$WORKLOADS_DIR/vmlinux-x86_64" "$WORKLOADS_DIR/bzImage-x86_64" \
-    "$WORKLOADS_DIR/alpine-minirootfs-x86_64.tar.gz" \
-    "$WORKLOADS_DIR/cloud-hypervisor-static"; do
+required_files=(
+    "$FW"
+    "$WORKLOADS_DIR/CLOUDHV.fd"
+    "$JAMMY_OS_IMAGE"
+    "$WORKLOADS_DIR/vmlinux-x86_64"
+    "$WORKLOADS_DIR/bzImage-x86_64"
+    "$WORKLOADS_DIR/alpine-minirootfs-x86_64.tar.gz"
+)
+# MSHV support in that baseline stabilised on v50.2
+if [ "$hypervisor" = "mshv" ]; then
+    required_files+=("$WORKLOADS_DIR/cloud-hypervisor-static-mshv")
+else
+    required_files+=("$WORKLOADS_DIR/cloud-hypervisor-static")
+fi
+
+for required in "${required_files[@]}"; do
     if [ ! -f "$required" ]; then
         echo "Missing: $required — run: python3 scripts/fetch_workloads.py --test integration"
         exit 1

--- a/scripts/test_assets.yaml
+++ b/scripts/test_assets.yaml
@@ -90,3 +90,11 @@ assets:
     executable: true
     arch: [aarch64]
     test: [integration]
+
+  # MSHV only supports live upgrade from v50.2.
+  - filename: cloud-hypervisor-static-mshv
+    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v50.2/cloud-hypervisor-static
+    sha1: b148aad169257e3c2eaab19bfb703379f0ac57a6
+    executable: true
+    arch: [x86_64]
+    test: [integration]

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1855,6 +1855,49 @@ impl Guest {
             "guest MemTotal {total} kB is not greater than expected {memory} kB"
         );
     }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn add_test_disk(&self, api_socket: &str) {
+        let test_disk_path = String::from(
+            self.tmp_dir
+                .as_path()
+                .join("hotplug_probe.img")
+                .to_str()
+                .unwrap(),
+        );
+        assert!(
+            exec_host_command_status(&format!(
+                "dd if=/dev/zero of={test_disk_path} bs=1M count=16 status=none"
+            ))
+            .success()
+        );
+        assert!(remote_command(
+            api_socket,
+            "add-disk",
+            Some(&format!("path={test_disk_path},id=test0,image_type=raw")),
+        ));
+        assert!(wait_until(Duration::from_secs(10), || {
+            self.ssh_command("lsblk | grep -c vdc || true")
+                .is_ok_and(|s| s.trim().parse::<u32>().is_ok_and(|c| c == 1))
+        }));
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn remove_test_disk(&self, api_socket: &str) {
+        assert_eq!(
+            self.ssh_command("lsblk | grep -c vdc")
+                .unwrap()
+                .trim()
+                .parse::<u32>()
+                .unwrap_or_default(),
+            1
+        );
+        assert!(remote_command(api_socket, "remove-device", Some("test0")));
+        assert!(wait_until(Duration::from_secs(10), || {
+            self.ssh_command("lsblk | grep -c vdc || true")
+                .is_ok_and(|s| s.trim().parse::<u32>().is_ok_and(|c| c == 0))
+        }));
+    }
 }
 
 // A factory for creating guests with different configurations. The factory is initialized


### PR DESCRIPTION
Re-enable live-migration and live-upgrade tests for MSHV. Enabled those tests that are supported and passed.