### PR TITLE
vmm: external userfaultfd handoff for out-of-process memory management

### DIFF
--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -319,6 +319,16 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
             simple_api_command(socket, "PUT", "shutdown", None).map_err(Error::HttpApiClient)
         }
         Some("nmi") => simple_api_command(socket, "PUT", "nmi", None).map_err(Error::HttpApiClient),
+        Some("uffd-attach") => {
+            let sub = matches.subcommand_matches("uffd-attach").unwrap();
+            let body = serde_json::json!({
+                "handoff_socket": sub.get_one::<String>("socket").unwrap(),
+                "mode": sub.get_one::<String>("mode").unwrap(),
+            })
+            .to_string();
+            simple_api_command(socket, "PUT", "uffd-attach", Some(&body))
+                .map_err(Error::HttpApiClient)
+        }
         Some("resize") => {
             let resize = resize_config(
                 matches
@@ -1150,6 +1160,22 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
                     .index(1)
                     .required(true)
                     .help("<destination_url>"),
+            ),
+        Command::new("uffd-attach")
+            .about("Attach an external userfaultfd manager to a running VM")
+            .arg(
+                Arg::new("mode")
+                    .long("mode")
+                    .help("'|'-separated UFFD mode tokens, e.g. WP|WP_ASYNC")
+                    .required(true)
+                    .num_args(1),
+            )
+            .arg(
+                Arg::new("socket")
+                    .long("socket")
+                    .help("Path to the userfaultfd manager's Unix socket")
+                    .required(true)
+                    .num_args(1),
             ),
     ]
     .to_vec()

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -1051,6 +1051,7 @@ mod unit_tests {
                 reserve: false,
                 zones: None,
                 thp: true,
+                uffd_handoff: None,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -3,15 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::ffi::{CStr, CString};
 use std::fs::{self, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{self, Error, Read, Seek, SeekFrom, Write};
+use std::mem::{self, MaybeUninit};
 use std::net::{IpAddr, Ipv4Addr};
 use std::os::unix::io::AsRawFd;
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::string::String;
 use std::sync::mpsc;
-use std::time::Duration;
-use std::{panic, thread};
+use std::time::{Duration, Instant};
+use std::{panic, ptr, thread};
 
 use block::ImageType;
 use net_util::MacAddr;
@@ -3568,5 +3570,1013 @@ pub(crate) fn _test_vdpa_block(guest: &Guest) {
     kill_child(&mut child);
     let output = child.wait_with_output().unwrap();
 
+    handle_child_output(r, &output);
+}
+
+/// Receive one framed handoff/notify message from the VMM. Returns
+/// (fds, body_bytes) where `body_bytes` is the JSON payload with the
+/// 4-byte length header stripped, and `fds` is the SCM_RIGHTS array.
+///
+/// Wire format: each message is `<u32 LE body length><JSON body>`,
+/// sent as two iovecs in one sendmsg so the ancillary fds attach to
+/// the right message. For the initial `handoff` message the fds are
+/// `[uffd, region0_memfd, region1_memfd, ...]`; for an `add_region`
+/// message it's just the new region's backing fd (or empty).
+fn recv_fds_with_body(stream: &UnixStream) -> (Vec<i32>, Vec<u8>) {
+    use std::os::unix::io::AsRawFd;
+
+    // 64KB body buffer; cmsg sized to hold up to 16 fds (plenty for
+    // any VM the integration tests construct).
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+    const MAX_FDS: usize = 16;
+    let cmsg_space = unsafe { libc::CMSG_SPACE((mem::size_of::<i32>() * MAX_FDS) as u32) };
+    let mut cmsg_buf = vec![0u8; cmsg_space as usize];
+    let mut msg: libc::msghdr = unsafe { mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_controllen = cmsg_space as _;
+
+    let n = unsafe { libc::recvmsg(stream.as_raw_fd(), &mut msg, 0) };
+    assert!(n > 0, "recvmsg failed: {}", Error::last_os_error());
+    let n = n as usize;
+    assert!(n >= 4, "framed message too short: {n} bytes");
+    let body_len = u32::from_le_bytes(buf[..4].try_into().unwrap()) as usize;
+    assert_eq!(
+        n,
+        4 + body_len,
+        "framed message size mismatch: recvmsg returned {n}, header says {body_len}"
+    );
+    // Drop the header; callers want only the JSON body.
+    buf.drain(..4);
+    buf.truncate(body_len);
+
+    // MSG_CTRUNC means the kernel silently dropped some of the
+    // ancillary data because our cmsg buffer was too small. For
+    // SCM_RIGHTS that's catastrophic: the dropped fds are leaked
+    // (never installed in this process) and the surviving fd array
+    // we'd decode is partial garbage. Better to fail loudly here
+    // than silently operate on the wrong fd.
+    assert_eq!(
+        msg.msg_flags & libc::MSG_CTRUNC,
+        0,
+        "ancillary data truncated — VMM sent more than {MAX_FDS} fds"
+    );
+
+    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+    assert!(!cmsg.is_null(), "no cmsg received");
+    // Defensive: the helper only knows how to decode SCM_RIGHTS. If
+    // the VMM ever attaches credentials or other cmsg types the byte
+    // payload would be misinterpreted as fd integers, and the
+    // teardown `libc::close()` on a "received fd" would close an
+    // unrelated open file in this process.
+    assert_eq!(
+        unsafe { (*cmsg).cmsg_level },
+        libc::SOL_SOCKET,
+        "unexpected cmsg_level"
+    );
+    assert_eq!(
+        unsafe { (*cmsg).cmsg_type },
+        libc::SCM_RIGHTS,
+        "unexpected cmsg_type"
+    );
+    let cmsg_hdr_len = unsafe { libc::CMSG_LEN(0) } as usize;
+    let payload_len = unsafe { (*cmsg).cmsg_len as usize - cmsg_hdr_len };
+    let n_fds = payload_len / mem::size_of::<i32>();
+    assert!(n_fds > 0, "no fds in cmsg");
+    let mut fds = vec![-1i32; n_fds];
+    unsafe {
+        ptr::copy_nonoverlapping(
+            libc::CMSG_DATA(cmsg),
+            fds.as_mut_ptr() as *mut u8,
+            payload_len,
+        );
+    }
+    for fd in &fds {
+        assert!(*fd >= 0, "received invalid fd");
+    }
+    (fds, buf)
+}
+
+const UFFD_EVENT_PAGEFAULT: u8 = 0x12;
+const UFFDIO_API: u64 = 0xc018_aa3f;
+const UFFDIO_ZEROPAGE: u64 = 0xc020_aa04;
+const UFFD_API_VERSION: u64 = 0xAA;
+const PAGEMAP_SCAN: u64 = 0xc060_6610;
+// Documented PAGEMAP_SCAN categories and flags (uapi/linux/fs.h).
+const PAGE_IS_WRITTEN: u64 = 1 << 1;
+const PAGE_IS_PRESENT: u64 = 1 << 3;
+const PAGE_IS_HUGE: u64 = 1 << 6;
+const PM_SCAN_WP_MATCHING: u64 = 1 << 0;
+
+#[repr(C)]
+struct UffdioApi {
+    api: u64,
+    features: u64,
+    ioctls: u64,
+}
+
+#[repr(C)]
+struct UffdMsg {
+    event: u8,
+    _reserved1: u8,
+    _reserved2: u16,
+    _reserved3: u32,
+    pf_flags: u64,
+    pf_address: u64,
+    _pad: [u8; 8],
+}
+
+#[repr(C)]
+struct UffdioZeropage {
+    range_start: u64,
+    range_len: u64,
+    mode: u64,
+    zeropage: i64,
+}
+
+/// Create a blocking eventfd usable as a thread-stop signal. Writing
+/// any non-zero u64 to it makes a `poll(POLLIN)` on the fd return
+/// immediately; the test code uses this to unblock a fault handler
+/// thread *before* closing the uffd it was polling, so the handler
+/// never operates on a stale fd value (close-while-polling race).
+fn make_stop_fd() -> i32 {
+    let fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC) };
+    assert!(fd >= 0, "eventfd: {}", Error::last_os_error());
+    fd
+}
+
+/// Signal the handler to exit via `stop_fd`. Caller must `join()` the
+/// handler before closing any fds the handler was polling.
+fn signal_stop(stop_fd: i32) {
+    let one: u64 = 1;
+    let n = unsafe {
+        libc::write(
+            stop_fd,
+            &one as *const u64 as *const libc::c_void,
+            mem::size_of::<u64>(),
+        )
+    };
+    assert_eq!(n, mem::size_of::<u64>() as isize);
+}
+
+/// Minimal fault handler: resolves MISSING faults with UFFDIO_ZEROPAGE.
+/// Exits when `stop_fd` becomes readable (caller writes to it during
+/// teardown) or when the uffd's `POLLHUP` fires. Returns the number
+/// of faults handled.
+fn run_fault_handler(uffd_fd: i32, stop_fd: i32) -> u64 {
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) as u64 };
+    let mut faults: u64 = 0;
+
+    loop {
+        let mut pfds = [
+            libc::pollfd {
+                fd: uffd_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: stop_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+        let ret = unsafe { libc::poll(pfds.as_mut_ptr(), pfds.len() as libc::nfds_t, -1) };
+        if ret < 0 {
+            break;
+        }
+        if pfds[1].revents & libc::POLLIN != 0 {
+            break;
+        }
+        if pfds[0].revents & libc::POLLHUP != 0 {
+            break;
+        }
+        if pfds[0].revents & libc::POLLIN == 0 {
+            continue;
+        }
+
+        let mut msg = MaybeUninit::<UffdMsg>::uninit();
+        let n = unsafe {
+            libc::read(
+                uffd_fd,
+                msg.as_mut_ptr() as *mut libc::c_void,
+                mem::size_of::<UffdMsg>(),
+            )
+        };
+        if n != mem::size_of::<UffdMsg>() as isize {
+            break;
+        }
+        let msg = unsafe { msg.assume_init() };
+        if msg.event != UFFD_EVENT_PAGEFAULT {
+            continue;
+        }
+
+        let addr = msg.pf_address & !(page_size - 1);
+
+        // MISSING fault: allocate a zero page. The VMM's pending write
+        // (kernel data, ACPI tables, etc.) completes on the new page.
+        let mut zp = UffdioZeropage {
+            range_start: addr,
+            range_len: page_size,
+            mode: 0,
+            zeropage: 0,
+        };
+        unsafe {
+            libc::ioctl(uffd_fd, UFFDIO_ZEROPAGE as libc::Ioctl, &mut zp);
+        }
+        faults += 1;
+    }
+    faults
+}
+
+/// Wait for the VM to reach "Running" state by polling vm.info.
+fn wait_vm_running(api_socket: &str, timeout_secs: u64) {
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        let (ok, output, _) = remote_command_w_output(api_socket, "info", None);
+        if ok {
+            let info: serde_json::Value = serde_json::from_slice(&output).unwrap_or_default();
+            if info["state"].as_str() == Some("Running") {
+                return;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "VM did not reach Running state within {timeout_secs}s"
+        );
+        thread::sleep(Duration::from_millis(500));
+    }
+}
+
+/// Test the boot-time uffd-handoff flow:
+/// 1. Start cloud-hypervisor with only the API socket
+/// 2. Bind the handoff socket and create the VM with
+///    `uffd_handoff` set in the memory config
+/// 3. Trigger boot in a background thread; CH dials the handoff socket
+///    during MemoryManager construction
+/// 4. Accept the connection, recv the uffd + regions JSON, start a
+///    fault handler thread, send the ACK byte
+/// 5. Boot completes; verify VM running and fault handler saw faults
+pub(crate) fn _test_uffd_handoff(guest: &Guest) {
+    use std::io::Write;
+
+    let api_socket = temp_api_path(&guest.tmp_dir);
+    let kernel_path = direct_kernel_boot_path();
+    let handoff_sock_path = guest
+        .tmp_dir
+        .as_path()
+        .join("uffd-handoff.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let mut child = GuestCommand::new(guest)
+        .args(["--api-socket", &api_socket])
+        .capture_output()
+        .spawn()
+        .unwrap();
+
+    thread::sleep(Duration::new(1, 0));
+
+    let r = panic::catch_unwind(|| {
+        assert!(remote_command(&api_socket, "ping", None));
+
+        // 1. Bind the handoff socket BEFORE asking CH to boot.
+        let listener = UnixListener::bind(&handoff_sock_path).unwrap();
+
+        // 2. Create the VM with uffd_handoff set.
+        let config = serde_json::json!({
+            "payload": {
+                "kernel": kernel_path.to_str().unwrap(),
+                "cmdline": DIRECT_KERNEL_BOOT_CMDLINE,
+            },
+            "cpus": { "boot_vcpus": 1, "max_vcpus": 1 },
+            "memory": {
+                "size": 536_870_912u64,
+                "shared": true,
+                "uffd_handoff": {
+                    "socket": handoff_sock_path,
+                    "mode": "MISSING",
+                },
+            },
+            "disks": [
+                { "path": guest.disk_config.disk(DiskType::OperatingSystem).unwrap() },
+            ],
+            "serial": { "mode": "Null" },
+            "console": { "mode": "Tty" },
+        });
+        let config_path = guest.tmp_dir.as_path().join("vm-config.json");
+        fs::write(&config_path, config.to_string()).unwrap();
+        assert!(remote_command(
+            &api_socket,
+            "create",
+            Some(config_path.to_str().unwrap()),
+        ));
+
+        // 3. Boot runs in a background thread because it blocks on the
+        //    handoff socket — the manager (this thread) needs to accept
+        //    the connection and ACK before boot can proceed.
+        let api_sock_clone = api_socket.clone();
+        let boot_thread = thread::spawn(move || remote_command(&api_sock_clone, "boot", None));
+
+        // 4. Accept handoff: recv (fds, JSON body), spawn fault handler,
+        //    send ACK so CH can finish creating the VM. fds[0] is the
+        //    uffd; remaining fds are per-region backing memfds (we
+        //    don't use them here).
+        let (mut stream, _) = listener.accept().unwrap();
+        let (fds, body) = recv_fds_with_body(&stream);
+        let uffd_fd = fds[0];
+        for &extra in &fds[1..] {
+            unsafe { libc::close(extra) };
+        }
+        drop(listener);
+
+        let parsed: serde_json::Value = serde_json::from_slice(&body).expect("valid handoff JSON");
+        // Handshake is self-describing: it carries the protocol version
+        // and the register mode the fd was configured with, so a manager
+        // need not agree the mode out of band.
+        assert_eq!(parsed["type"].as_str(), Some("handoff"), "handoff type");
+        assert_eq!(parsed["version"].as_u64(), Some(0), "handoff version");
+        assert_eq!(
+            parsed["mode"].as_str(),
+            Some("MISSING"),
+            "handoff advertises the configured mode"
+        );
+        let regions = parsed["regions"].as_array().expect("regions array");
+        assert!(!regions.is_empty(), "handoff carried no regions");
+
+        let stop_fd = make_stop_fd();
+        let fault_handler = thread::spawn(move || run_fault_handler(uffd_fd, stop_fd));
+
+        stream.write_all(b"A").expect("send ACK");
+        drop(stream);
+
+        // 5. Boot must succeed and VM must reach Running.
+        assert!(boot_thread.join().unwrap(), "vm.boot failed");
+        wait_vm_running(&api_socket, 30);
+        thread::sleep(Duration::from_secs(5));
+
+        let (ok, output, _) = remote_command_w_output(&api_socket, "info", None);
+        assert!(ok, "vm.info failed");
+        let info: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(info["state"].as_str(), Some("Running"), "VM not running");
+
+        // Order matters: signal first, join the handler, *then* close
+        // the fds it was polling. Closing the uffd before the handler
+        // returns is racy — the fd integer could be reused for an
+        // unrelated open() between close and the next poll/read.
+        signal_stop(stop_fd);
+        let total_faults = fault_handler.join().unwrap();
+        unsafe { libc::close(uffd_fd) };
+        unsafe { libc::close(stop_fd) };
+        assert!(
+            total_faults > 0,
+            "fault handler saw no faults (expected faults during boot)"
+        );
+    });
+
+    kill_child(&mut child);
+    let output = child.wait_with_output().unwrap();
+
+    handle_child_output(r, &output);
+}
+
+#[repr(C)]
+struct PmScanArg {
+    size: u64,
+    flags: u64,
+    start: u64,
+    end: u64,
+    walk_end: u64,
+    vec: u64,
+    vec_len: u64,
+    max_pages: u64,
+    category_inverted: u64,
+    category_mask: u64,
+    category_anyof_mask: u64,
+    return_mask: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct PageRegion {
+    start: u64,
+    end: u64,
+    categories: u64,
+}
+
+/// One PAGEMAP_SCAN pass over `[start, end)` on `/proc/<pid>/pagemap`,
+/// following `walk_end` continuations so the whole range is covered.
+/// Returns the number of pages the kernel reported as matching the
+/// filter. The mask / flag arguments map 1:1 onto `struct pm_scan_arg`
+/// (see uapi/linux/fs.h):
+///
+/// - `category_mask` page matches only if it has *all* these categories
+/// - `category_inverted` categories whose match sense is flipped: a bit
+///   listed here matches when its value is *0*. Lets a single scan
+///   express e.g. "present AND not written".
+/// - `category_anyof_mask` page matches if it has *any* of these
+/// - `flags` e.g. `PM_SCAN_WP_MATCHING` to (re-)write-protect every
+///   matched page in the same pass
+/// - `return_mask` categories reported back in `page_region.categories`
+///
+/// Page count is the sum of returned region lengths — i.e. the number
+/// of pages that matched the filter (not merely those with a given
+/// return bit).
+#[allow(clippy::too_many_arguments)]
+fn pagemap_scan_count(
+    pid: u32,
+    start: u64,
+    end: u64,
+    flags: u64,
+    category_mask: u64,
+    category_inverted: u64,
+    category_anyof_mask: u64,
+    return_mask: u64,
+) -> io::Result<u64> {
+    use std::os::fd::AsRawFd;
+
+    let f = OpenOptions::new()
+        .read(true)
+        .write(flags & PM_SCAN_WP_MATCHING != 0)
+        .open(format!("/proc/{pid}/pagemap"))?;
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) as u64 };
+    let mut vec_buf = vec![PageRegion::default(); 1024];
+    let mut matched: u64 = 0;
+    let mut cur = start;
+
+    while cur < end {
+        let mut arg = PmScanArg {
+            size: mem::size_of::<PmScanArg>() as u64,
+            flags,
+            start: cur,
+            end,
+            walk_end: 0,
+            vec: vec_buf.as_mut_ptr() as u64,
+            vec_len: vec_buf.len() as u64,
+            max_pages: 0,
+            category_inverted,
+            category_mask,
+            category_anyof_mask,
+            return_mask,
+        };
+        let ret = unsafe { libc::ioctl(f.as_raw_fd(), PAGEMAP_SCAN as libc::Ioctl, &mut arg) };
+        if ret < 0 {
+            return Err(Error::last_os_error());
+        }
+        for region in vec_buf.iter().take(ret as usize) {
+            matched += (region.end - region.start) / page_size;
+        }
+        if arg.walk_end <= cur || arg.walk_end >= end {
+            break;
+        }
+        cur = arg.walk_end;
+    }
+    Ok(matched)
+}
+
+/// Count resident pages (`PAGE_IS_PRESENT`) in `[start, end)`.
+fn pagemap_present_pages(pid: u32, start: u64, end: u64) -> io::Result<u64> {
+    pagemap_scan_count(pid, start, end, 0, PAGE_IS_PRESENT, 0, 0, PAGE_IS_PRESENT)
+}
+
+/// Arm write tracking: write-protect every resident page in the range
+/// via the documented WP-async engine (`PM_SCAN_WP_MATCHING`). After
+/// this, a guest write to any of these pages is resolved silently by
+/// the kernel and surfaces as `PAGE_IS_WRITTEN` on the next scan.
+/// Returns the number of pages armed.
+fn pagemap_arm_wp(pid: u32, start: u64, end: u64) -> io::Result<u64> {
+    pagemap_scan_count(
+        pid,
+        start,
+        end,
+        PM_SCAN_WP_MATCHING,
+        PAGE_IS_PRESENT,
+        0,
+        0,
+        PAGE_IS_PRESENT,
+    )
+}
+
+/// Hot set: pages written since the last arm (`PAGE_IS_WRITTEN`). When
+/// `rearm` is set, matched pages are re-write-protected in the same
+/// pass so the next interval starts clean — the documented WSS
+/// sampling loop.
+fn pagemap_hot_pages(pid: u32, start: u64, end: u64, rearm: bool) -> io::Result<u64> {
+    let flags = if rearm { PM_SCAN_WP_MATCHING } else { 0 };
+    pagemap_scan_count(
+        pid,
+        start,
+        end,
+        flags,
+        PAGE_IS_WRITTEN,
+        0,
+        0,
+        PAGE_IS_WRITTEN,
+    )
+}
+
+/// Reclaimable set: the complement of the hot set among *resident*
+/// pages — present but *not active* since the last arm, where "active"
+/// is the hot category `PAGE_IS_WRITTEN` (the WP write-set). This is
+/// the page set a
+/// memory manager would reclaim: track the hot set positively, then
+/// reclaim everything else. Unlike a positive "cold" classifier, this
+/// has no blind spot for pre-populated-but-unused pages (e.g. a
+/// pre-faulted tmpfs file) — they are present-and-not-hot, so they fall
+/// into the reclaimable set correctly. Matched directly in one pass via
+/// `category_inverted` (`PAGE_IS_PRESENT` set and `active` clear), so it
+/// never races a `present - hot` subtraction across two scans.
+fn pagemap_reclaimable_pages(pid: u32, start: u64, end: u64, active: u64) -> io::Result<u64> {
+    pagemap_scan_count(
+        pid,
+        start,
+        end,
+        0,
+        PAGE_IS_PRESENT | active, // both bits constrained
+        active,                   // ...but `active` matches when 0
+        0,
+        PAGE_IS_PRESENT | active,
+    )
+}
+
+/// Hole set: non-resident pages, matched directly via inverted
+/// `PAGE_IS_PRESENT` (the bit must be 0).
+fn pagemap_hole_pages(pid: u32, start: u64, end: u64) -> io::Result<u64> {
+    pagemap_scan_count(pid, start, end, 0, PAGE_IS_PRESENT, PAGE_IS_PRESENT, 0, 0)
+}
+
+/// Count pages that are part of a PMD-mapped transparent huge page
+/// (`PAGE_IS_HUGE`) in `[start, end)`. Used to confirm THP-backed
+/// guest RAM actually survives the uffd-WP handoff as huge pages.
+fn pagemap_huge_pages(pid: u32, start: u64, end: u64) -> io::Result<u64> {
+    pagemap_scan_count(pid, start, end, 0, PAGE_IS_HUGE, 0, 0, PAGE_IS_HUGE)
+}
+
+/// Validate the documented WP-async write-set-tracking interface end to
+/// end: attach with `mode=WP|WP_ASYNC`, then use `PAGEMAP_SCAN` on
+/// `/proc/<vmm>/pagemap` to classify guest region 0 pages into
+/// hot / cold / hole and assert all three are observable.
+///
+///   - hole = not `PAGE_IS_PRESENT`   (region tail the guest never populated)
+///   - cold = `PAGE_IS_PRESENT`, not written since the last arm
+///   - hot  = `PAGE_IS_WRITTEN`       (guest wrote it since the last arm)
+///
+/// Parameterised over the guest-RAM backing:
+///   - `shared`: `false` = MAP_PRIVATE memfd (writes land on anon COW
+///     pages); `true` = MAP_SHARED memfd / shmem — the representative
+///     uffd-handoff deployment, and the backing that needs
+///     `UFFD_FEATURE_WP_HUGETLBFS_SHMEM` for WP tracking (CH derives
+///     that feature from the shared backing in `do_uffd_handoff`).
+///   - `thp`: when `true`, guest RAM is MADV_HUGEPAGE'd; the test then
+///     asserts the handed-off region still contains PMD-mapped huge
+///     pages (`PAGE_IS_HUGE`) — i.e. THP survives uffd-WP registration
+///     and the pagemap machinery reports it. When `false`, asserts no
+///     huge pages (MADV_NOHUGEPAGE control).
+///
+/// This is exactly the interface an external memory manager uses to
+/// drive tiering / eviction, built on the standard uffd-WP primitives:
+/// `UFFDIO_REGISTER_MODE_WP`, `UFFD_FEATURE_WP_ASYNC`,
+/// `UFFD_FEATURE_WP_HUGETLBFS_SHMEM`, `PAGE_IS_WRITTEN`,
+/// `PAGE_IS_HUGE` and `PM_SCAN_WP_MATCHING`.
+/// Probe the running kernel for `UFFD_FEATURE_WP_ASYNC` (Linux 6.7+). The
+/// write-set / resume tests rely on WP-async plus `PAGEMAP_SCAN`, so they
+/// skip (rather than fail) on older kernels that lack it.
+fn kernel_has_uffd_wp_async() -> bool {
+    const UFFD_FEATURE_WP_ASYNC: u64 = 1 << 15;
+    let fd =
+        unsafe { libc::syscall(libc::SYS_userfaultfd, libc::O_CLOEXEC | libc::O_NONBLOCK) } as i32;
+    if fd < 0 {
+        return false;
+    }
+    let mut api = UffdioApi {
+        api: UFFD_API_VERSION,
+        features: 0,
+        ioctls: 0,
+    };
+    let ret = unsafe { libc::ioctl(fd, UFFDIO_API as libc::Ioctl, &mut api) };
+    unsafe { libc::close(fd) };
+    ret == 0 && api.features & UFFD_FEATURE_WP_ASYNC != 0
+}
+
+/// Return the active token (the one in `[brackets]`) of a THP sysfs knob,
+/// e.g. `"always"` from `"always [madvise] never"`.
+fn thp_sysfs_active(path: &str) -> Option<String> {
+    let s = fs::read_to_string(path).ok()?;
+    s.split_whitespace()
+        .find(|t| t.starts_with('[') && t.ends_with(']'))
+        .map(|t| t.trim_matches(['[', ']']).to_string())
+}
+
+/// Whether the host THP policy backs a freshly-faulted 512M guest region
+/// with PMD huge pages *without* CH opting in via `MADV_HUGEPAGE`.
+///
+/// The `thp=off` write-set variants need 4K mappings to exercise 4K-page
+/// write-set tracking, but CH's `thp=off` only declines `MADV_HUGEPAGE` —
+/// it never sets `MADV_NOHUGEPAGE` — so on a host that forces huge folios
+/// the 4K precondition can't hold and the test must skip, not fail.
+///
+/// - anon (`shared=off`): only `enabled=always` forms THP unadvised.
+/// - shmem (`shared=on`): `always`/`within_size`/`force` back a large
+///   mapping with huge folios; `advise`/`deny`/`never` stay 4K.
+fn host_thp_forces_huge(shared: bool) -> bool {
+    if shared {
+        matches!(
+            thp_sysfs_active("/sys/kernel/mm/transparent_hugepage/shmem_enabled").as_deref(),
+            Some("always") | Some("within_size") | Some("force")
+        )
+    } else {
+        thp_sysfs_active("/sys/kernel/mm/transparent_hugepage/enabled").as_deref() == Some("always")
+    }
+}
+
+fn run_uffd_writeset(guest: &Guest, shared: bool, thp: bool) {
+    use std::io::Write;
+
+    if !kernel_has_uffd_wp_async() {
+        eprintln!(
+            "skipping uffd write-set test: kernel lacks UFFD_FEATURE_WP_ASYNC \
+             (needs Linux 6.7+)"
+        );
+        return;
+    }
+
+    let tag = format!(
+        "writeset {}/{}",
+        if shared { "shmem" } else { "anon" },
+        if thp { "thp" } else { "4k" }
+    );
+
+    // The thp=off variants require guest RAM to be 4K-mapped. On a host
+    // whose THP policy forces huge folios (e.g. enabled=always, or
+    // shmem_enabled=within_size/always/force) that can't be guaranteed,
+    // so skip rather than fail (see host_thp_forces_huge).
+    if !thp && host_thp_forces_huge(shared) {
+        let knob = if shared { "shmem_enabled" } else { "enabled" };
+        eprintln!(
+            "[{tag}] skipping: host THP policy forces huge folios \
+             (transparent_hugepage/{knob}); thp=off cannot guarantee 4K \
+             mappings on this host"
+        );
+        return;
+    }
+    let api_socket = temp_api_path(&guest.tmp_dir);
+    let handoff_sock_path = guest
+        .tmp_dir
+        .as_path()
+        .join("uffd-writeset.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let mem = format!(
+        "size=512M,shared={},thp={}",
+        if shared { "on" } else { "off" },
+        if thp { "on" } else { "off" }
+    );
+    let mut cmd = GuestCommand::new(guest);
+    cmd.default_cpus()
+        .args(["--memory", &mem])
+        .default_kernel_cmdline()
+        .default_disks()
+        .default_net()
+        .args(["--api-socket", &api_socket])
+        .args(["--serial", "tty", "--console", "off"])
+        .capture_output();
+    if thp {
+        // Some hosts disable THP process-wide (PR_SET_THP_DISABLE);
+        // clear it in the VMM child so guest RAM can actually be backed
+        // by PMD-mapped huge pages.
+        cmd.enable_thp_in_child();
+    }
+    let mut child = cmd.spawn().unwrap();
+    let vmm_pid = child.id();
+
+    let r = panic::catch_unwind(|| {
+        eprintln!("[{tag}] waiting for VM boot");
+        guest.wait_vm_boot().unwrap();
+        eprintln!("[{tag}] VM booted");
+
+        // Attach with the documented WP-async mode.
+        let listener = UnixListener::bind(&handoff_sock_path).unwrap();
+        let api_sock_clone = api_socket.clone();
+        let handoff_sock_clone = handoff_sock_path.clone();
+        let attach_thread = thread::spawn(move || {
+            let body = serde_json::json!({
+                "handoff_socket": handoff_sock_clone,
+                "mode": "WP|WP_ASYNC",
+            })
+            .to_string();
+            let mut sock = UnixStream::connect(&api_sock_clone).unwrap();
+            api_client::simple_api_command(&mut sock, "PUT", "uffd-attach", Some(&body))
+        });
+
+        let (mut stream, _) = listener.accept().unwrap();
+        let (fds, body) = recv_fds_with_body(&stream);
+        let uffd_fd = fds[0];
+        for &extra in &fds[1..] {
+            unsafe { libc::close(extra) };
+        }
+        drop(listener);
+        let parsed: serde_json::Value = serde_json::from_slice(&body).expect("valid handoff JSON");
+        let regions = parsed["regions"].as_array().expect("regions array");
+        assert!(!regions.is_empty(), "handoff carried no regions");
+        let host_va = regions[0]["host_virt_addr"].as_u64().unwrap();
+        let size = regions[0]["size"].as_u64().unwrap();
+
+        // WP-async resolves writes in-kernel, so no fault messages are
+        // delivered — no handler thread needed. We still must ACK so CH
+        // returns from the attach call.
+        stream.write_all(b"A").unwrap();
+        drop(stream);
+        attach_thread
+            .join()
+            .unwrap()
+            .expect("uffd-attach API call failed");
+        eprintln!("[{tag}] attach API succeeded");
+
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) as u64 };
+        let total_pages = size / page_size;
+        let start = host_va;
+        let end = host_va + size;
+
+        // PMD validation: check the THP state of the handed-off region
+        // *before* arming (PM_SCAN_WP_MATCHING may split huge pages).
+        // This proves PMD-mapped guest RAM survives uffd-WP
+        // registration and that PAGEMAP_SCAN reports it.
+        let huge = pagemap_huge_pages(vmm_pid, start, end).expect("HUGE scan");
+        eprintln!("[{tag}] huge_pages={huge}");
+        if thp {
+            assert!(
+                huge > 0,
+                "thp=on but PAGEMAP_SCAN found no PMD-mapped (PAGE_IS_HUGE) \
+                 pages — THP did not survive the uffd-WP handoff"
+            );
+        } else {
+            assert_eq!(huge, 0, "thp=off but PAGEMAP_SCAN found {huge} PMD pages");
+        }
+
+        // Hole detection: a freshly-booted 512M guest never populates
+        // the whole region, so a chunk stays non-resident.
+        let present = pagemap_present_pages(vmm_pid, start, end).expect("PRESENT scan");
+        eprintln!("[{tag}] total_pages={total_pages} present={present}");
+        assert!(present > 0, "no resident pages");
+        assert!(
+            present < total_pages,
+            "expected hole pages but the whole region is resident \
+             (present={present}, total={total_pages})"
+        );
+
+        // Arm write tracking: WP every resident page, clearing its
+        // written state.
+        let armed = pagemap_arm_wp(vmm_pid, start, end).expect("arm WP");
+        eprintln!("[{tag}] armed={armed}");
+        assert!(armed > 0, "armed no pages");
+
+        // Drive a bounded amount of guest writes so some armed pages
+        // flip to written (hot) while others stay untouched (and thus
+        // fall into the reclaimable set).
+        guest
+            .ssh_command("dd if=/dev/zero of=/tmp/wss bs=1M count=32 conv=fsync 2>/dev/null; sync")
+            .unwrap();
+
+        // Poll the hot set — guest activity plus our dd dirty armed
+        // resident pages.
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let mut hot = 0;
+        while Instant::now() < deadline {
+            hot = pagemap_hot_pages(vmm_pid, start, end, false).expect("WRITTEN scan");
+            if hot > 0 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+
+        // Hot-tracking model: positively track the hot (written) set,
+        // then the reclaim policy is "reclaim everything not hot". The
+        // reclaimable-resident set is present-and-not-written, matched
+        // directly via category_inverted (no present-minus-hot race);
+        // `hole` is non-resident (already reclaimed / never populated).
+        let reclaimable = pagemap_reclaimable_pages(vmm_pid, start, end, PAGE_IS_WRITTEN)
+            .expect("reclaimable scan");
+        let hole = pagemap_hole_pages(vmm_pid, start, end).expect("hole scan");
+        eprintln!("[{tag}] hot={hot} reclaimable={reclaimable} hole={hole} total={total_pages}");
+
+        assert!(hot > 0, "expected written (hot) pages within 15s, got 0");
+        assert!(
+            reclaimable > 0,
+            "expected resident-but-unwritten (reclaimable) pages, got 0"
+        );
+        assert!(hole > 0, "expected non-resident (hole) pages, got 0");
+
+        unsafe { libc::close(uffd_fd) };
+        eprintln!("[{tag}] hot/reclaimable/hole all observed, shutting down VM");
+
+        guest.ssh_command("sudo poweroff").unwrap();
+        thread::sleep(Duration::new(20, 0));
+    });
+
+    kill_child(&mut child);
+    let output = child.wait_with_output().unwrap();
+    handle_child_output(r, &output);
+}
+
+pub(crate) fn _test_uffd_writeset_anon(guest: &Guest) {
+    run_uffd_writeset(guest, false, false);
+}
+
+pub(crate) fn _test_uffd_writeset_shmem(guest: &Guest) {
+    run_uffd_writeset(guest, true, false);
+}
+
+pub(crate) fn _test_uffd_writeset_anon_thp(guest: &Guest) {
+    run_uffd_writeset(guest, false, true);
+}
+
+pub(crate) fn _test_uffd_writeset_shmem_thp(guest: &Guest) {
+    run_uffd_writeset(guest, true, true);
+}
+
+/// Manager-restart resilience. CH retains its own dup of the uffd for
+/// the VM's lifetime, so a manager crash leaves the registrations alive
+/// and any guest fault simply blocks (CH never resolves faults itself —
+/// no zero-fill, no data loss). `do_uffd_handoff` is idempotent: a
+/// second attach re-sends the *same* uffd fd + current region set
+/// (resume) instead of creating a new uffd or re-registering.
+///
+/// This attaches a manager, simulates its death (closes the manager's
+/// uffd dup and the socket), re-attaches over a *fresh* socket, and
+/// proves the resumed handoff carries a live uffd by running a WP-async
+/// write-set cycle against the still-registered region — which only
+/// works because CH kept the registration alive across the restart.
+pub(crate) fn _test_uffd_resume(guest: &Guest) {
+    use std::io::Write;
+
+    if !kernel_has_uffd_wp_async() {
+        eprintln!(
+            "skipping uffd resume test: kernel lacks UFFD_FEATURE_WP_ASYNC \
+             (needs Linux 6.7+)"
+        );
+        return;
+    }
+
+    let tag = "uffd/resume";
+    let api_socket = temp_api_path(&guest.tmp_dir);
+    let sock_a = guest
+        .tmp_dir
+        .as_path()
+        .join("uffd-resume-a.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let sock_b = guest
+        .tmp_dir
+        .as_path()
+        .join("uffd-resume-b.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // anon 4k keeps WP-async deterministic (no huge-folio granularity).
+    let mem = "size=512M,shared=off,thp=off";
+    let mut cmd = GuestCommand::new(guest);
+    cmd.default_cpus()
+        .args(["--memory", mem])
+        .default_kernel_cmdline()
+        .default_disks()
+        .default_net()
+        .args(["--api-socket", &api_socket])
+        .args(["--serial", "tty", "--console", "off"])
+        .capture_output();
+    let mut child = cmd.spawn().unwrap();
+    let vmm_pid = child.id();
+
+    let r = panic::catch_unwind(|| {
+        eprintln!("[{tag}] waiting for VM boot");
+        guest.wait_vm_boot().unwrap();
+        eprintln!("[{tag}] VM booted");
+
+        // Trigger a uffd-attach API call against `handoff` in a
+        // background thread (the call blocks on the handshake).
+        let attach = |handoff: &str| {
+            let api = api_socket.clone();
+            let handoff = handoff.to_string();
+            thread::spawn(move || {
+                let body = serde_json::json!({
+                    "handoff_socket": handoff,
+                    "mode": "WP|WP_ASYNC",
+                })
+                .to_string();
+                let mut sock = UnixStream::connect(&api).unwrap();
+                api_client::simple_api_command(&mut sock, "PUT", "uffd-attach", Some(&body))
+            })
+        };
+
+        // ---- Manager 1: initial attach ----
+        let listener_a = UnixListener::bind(&sock_a).unwrap();
+        let attach_a = attach(&sock_a);
+        let (mut stream_a, _) = listener_a.accept().unwrap();
+        let (fds_a, body_a) = recv_fds_with_body(&stream_a);
+        let uffd_a = fds_a[0];
+        for &extra in &fds_a[1..] {
+            unsafe { libc::close(extra) };
+        }
+        drop(listener_a);
+        let parsed_a: serde_json::Value =
+            serde_json::from_slice(&body_a).expect("valid handoff JSON");
+        let regions_a = parsed_a["regions"]
+            .as_array()
+            .expect("regions array")
+            .clone();
+        assert!(!regions_a.is_empty(), "initial handoff carried no regions");
+        let host_va = regions_a[0]["host_virt_addr"].as_u64().unwrap();
+        let size = regions_a[0]["size"].as_u64().unwrap();
+        stream_a.write_all(b"A").unwrap();
+        attach_a
+            .join()
+            .unwrap()
+            .expect("initial uffd-attach failed");
+        eprintln!("[{tag}] manager 1 attached ({} regions)", regions_a.len());
+
+        // ---- Simulate manager 1 death ----
+        // Drop the manager's uffd dup and its socket. CH still holds its
+        // own dup, so the uffd and its registrations stay alive.
+        unsafe { libc::close(uffd_a) };
+        drop(stream_a);
+        eprintln!("[{tag}] manager 1 gone; CH retains the uffd");
+
+        // ---- Manager 2: resume over a fresh socket ----
+        let listener_b = UnixListener::bind(&sock_b).unwrap();
+        let attach_b = attach(&sock_b);
+        let (mut stream_b, _) = listener_b.accept().unwrap();
+        let (fds_b, body_b) = recv_fds_with_body(&stream_b);
+        let uffd_b = fds_b[0];
+        for &extra in &fds_b[1..] {
+            unsafe { libc::close(extra) };
+        }
+        drop(listener_b);
+        let parsed_b: serde_json::Value =
+            serde_json::from_slice(&body_b).expect("valid resume JSON");
+        let regions_b = parsed_b["regions"].as_array().expect("regions array");
+        assert!(!regions_b.is_empty(), "resume carried no regions");
+        assert!(uffd_b >= 0, "resume delivered no uffd fd");
+        // Resume must re-send the identical region layout.
+        assert_eq!(
+            regions_b.len(),
+            regions_a.len(),
+            "resume region count changed"
+        );
+        assert_eq!(
+            regions_b[0]["host_virt_addr"].as_u64().unwrap(),
+            host_va,
+            "resume region host_virt_addr changed"
+        );
+        assert_eq!(
+            regions_b[0]["size"].as_u64().unwrap(),
+            size,
+            "resume region size changed"
+        );
+        stream_b.write_all(b"A").unwrap();
+        attach_b.join().unwrap().expect("resume uffd-attach failed");
+        eprintln!("[{tag}] manager 2 resumed ({} regions)", regions_b.len());
+
+        // ---- Prove the resumed uffd is live ----
+        // The WP-async write-set only tracks if the VMA is still
+        // registered with uffd-WP, which survives only because CH kept
+        // its dup across the restart. Arm, drive guest writes, confirm.
+        let start = host_va;
+        let end = host_va + size;
+        let armed = pagemap_arm_wp(vmm_pid, start, end).expect("arm WP");
+        assert!(armed > 0, "armed no pages after resume");
+        guest
+            .ssh_command("dd if=/dev/zero of=/tmp/wss bs=1M count=32 conv=fsync 2>/dev/null; sync")
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let mut hot = 0;
+        while Instant::now() < deadline {
+            hot = pagemap_hot_pages(vmm_pid, start, end, false).expect("WRITTEN scan");
+            if hot > 0 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+        eprintln!("[{tag}] post-resume armed={armed} hot={hot}");
+        assert!(
+            hot > 0,
+            "no written pages after resume — registration lost?"
+        );
+
+        unsafe { libc::close(uffd_b) };
+        eprintln!("[{tag}] resume verified, shutting down VM");
+        guest.ssh_command("sudo poweroff").unwrap();
+        thread::sleep(Duration::new(20, 0));
+    });
+
+    kill_child(&mut child);
+    let output = child.wait_with_output().unwrap();
     handle_child_output(r, &output);
 }

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -68,6 +68,47 @@ mod common_parallel {
     }
 
     #[test]
+    fn test_uffd_handoff() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_uffd_handoff(&guest);
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_uffd_writeset_anon() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_uffd_writeset_anon(&guest);
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_uffd_writeset_shmem() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_uffd_writeset_shmem(&guest);
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_uffd_writeset_anon_thp() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_uffd_writeset_anon_thp(&guest);
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_uffd_writeset_shmem_thp() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_uffd_writeset_shmem_thp(&guest);
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_uffd_resume() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_uffd_resume(&guest);
+    }
+
+    #[test]
     fn test_multi_cpu() {
         let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
         _test_multi_cpu(&guest);

--- a/docs/api.md
+++ b/docs/api.md
@@ -101,6 +101,7 @@ The Cloud Hypervisor API exposes the following actions through its endpoints:
 | Remove device from the VM               | `/vm.remove-device`          | `/schemas/VmRemoveDevice`         | N/A                      | The VM is booted                                       |
 | Dump the VM counters                    | `/vm.counters`               | N/A                               | `/schemas/VmCounters`    | The VM is booted                                       |
 | Inject an NMI                           | `/vm.nmi`                    | N/A                               | N/A                      | The VM is booted                                       |
+| Attach an external userfaultfd manager  | `/vm.uffd-attach`            | `/schemas/UffdAttachData`         | N/A                      | The VM is running                                      |
 | Prepare to receive a migration          | `/vm.receive-migration`      | `/schemas/ReceiveMigrationData`   | N/A                      | N/A                                                    |
 | Start to send migration to target       | `/vm.send-migration`         | `/schemas/SendMigrationData`      | N/A                      | The VM is booted and (shared mem or hugepages enabled) |
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -23,11 +23,12 @@ struct MemoryConfig {
     reserve: bool,
     thp: bool,
     zones: Option<Vec<MemoryZoneConfig>>,
+    uffd_handoff: Option<UffdHandoffConfig>,
 }
 ```
 
 ```
---memory <memory>	Memory parameters "size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,hugepage_size=<hugepage_size>,hotplug_method=acpi|virtio-mem,hotplug_size=<hotpluggable_memory_size>,hotplugged_size=<hotplugged_memory_size>,prefault=on|off,reserve=on|off,thp=on|off" [default: size=512M,thp=on]
+--memory <memory>	Memory parameters "size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,hugepage_size=<hugepage_size>,hotplug_method=acpi|virtio-mem,hotplug_size=<hotpluggable_memory_size>,hotplugged_size=<hotplugged_memory_size>,prefault=on|off,reserve=on|off,thp=on|off,uffd_handoff_socket=<path>,uffd_handoff_mode=<modes>" [default: size=512M,thp=on]
 ```
 
 ### `size`
@@ -223,6 +224,44 @@ _Example_
 
 ```
 --memory size=1G,thp=on
+```
+
+### `uffd_handoff_socket` and `uffd_handoff_mode`
+
+Hand the guest RAM off to an external `userfaultfd` manager at boot. When both
+options are set, the VMM creates a `userfaultfd`, registers all guest RAM
+according to `uffd_handoff_mode`, connects to the Unix socket at
+`uffd_handoff_socket`, and passes the fd (with a description of the registered
+regions) to the manager over `SCM_RIGHTS` before the VM boots. The manager then
+owns fault handling and/or access tracking for guest memory (for example demand
+paging, working-set tracking, or eviction).
+
+Both options must be set together. `uffd_handoff_mode` is a `|`-separated set of
+tokens: register-mode tokens `MISSING` and `WP` drive `UFFDIO_REGISTER`, and
+feature tokens `WP_UNPOPULATED` and `WP_ASYNC` drive `UFFDIO_API`. At least one
+register-mode token is required, and the tokens are validated when the
+configuration is parsed. The same handoff can also be performed at runtime on a
+running VM via the `vm.uffd-attach` HTTP API.
+
+The handoff message includes the VMM's pid so the manager can reach
+`/proc/<vmm_pid>/pagemap` (working-set scanning) and
+`/proc/<vmm_pid>/map_files` (backing-store access). This requires the manager to
+run in the **same PID namespace** as the VMM (and see a `/proc` mounted for it),
+plus `CAP_SYS_PTRACE`-equivalent access. Cross-PID-namespace handoff is not
+supported — the orchestrator that launches the VMM and the manager is
+responsible for placing them in the same PID namespace. The userfaultfd itself
+is passed as a file descriptor and works regardless; only the `/proc/<vmm_pid>`
+side-channel needs the shared namespace.
+
+When Landlock is enabled, the boot-time `uffd_handoff_socket` is authorized
+automatically. A runtime `vm.uffd-attach` uses a socket path not known at boot,
+so it is not covered by the boot-time ruleset — authorize that path explicitly
+via `--landlock-rules` (or perform the handoff at boot instead).
+
+_Example_
+
+```
+--memory size=1G,shared=on,uffd_handoff_socket=/tmp/uffd.sock,uffd_handoff_mode=MISSING
 ```
 
 ## Advanced Parameters

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -153,6 +153,7 @@ impl RequestHandler for StubApiRequestHandler {
                     reserve: false,
                     zones: None,
                     thp: true,
+                    uffd_handoff: None,
                 },
                 payload: Some(PayloadConfig {
                     kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -14,8 +14,8 @@ use micro_http::Request;
 use vm_migration::MigratableError;
 use vmm::api::http::*;
 use vmm::api::{
-    ApiRequest, RequestHandler, VmInfoResponse, VmReceiveMigrationData, VmSendMigrationData,
-    VmmPingResponse,
+    ApiRequest, RequestHandler, UffdAttachData, VmInfoResponse, VmReceiveMigrationData,
+    VmSendMigrationData, VmmPingResponse,
 };
 use vmm::config::RestoreConfig;
 use vmm::vm::{Error as VmError, VmState};
@@ -85,6 +85,10 @@ struct StubApiRequestHandler;
 
 impl RequestHandler for StubApiRequestHandler {
     fn vm_create(&mut self, _: Box<VmConfig>) -> Result<(), VmError> {
+        Ok(())
+    }
+
+    fn vm_uffd_attach(&mut self, _: UffdAttachData) -> Result<(), VmError> {
         Ok(())
     }
 

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1915,6 +1915,25 @@ impl<'a> GuestCommand<'a> {
         self
     }
 
+    /// Clear an inherited `PR_SET_THP_DISABLE` in the spawned child so
+    /// transparent huge pages can form even when the launching
+    /// environment disabled THP process-wide (e.g. some dev hosts set
+    /// this by default). Needed by tests that assert on THP / PMD
+    /// mappings; harmless otherwise.
+    pub fn enable_thp_in_child(&mut self) -> &mut Self {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: prctl(PR_SET_THP_DISABLE, 0) is async-signal-safe and
+        // the closure does nothing else, so it is safe to run between
+        // fork and exec.
+        unsafe {
+            self.command.pre_exec(|| {
+                libc::prctl(libc::PR_SET_THP_DISABLE, 0, 0, 0, 0);
+                Ok(())
+            });
+        }
+        self
+    }
+
     pub fn spawn(&mut self) -> io::Result<Child> {
         use VerbosityLevel::*;
         match &self.verbosity {

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -51,7 +51,7 @@ use crate::api::{
     VmAddGenericVhostUser, VmAddNet, VmAddPmem, VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot,
     VmConfig, VmCounters, VmDelete, VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration,
     VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration,
-    VmShutdown, VmSnapshot,
+    VmShutdown, VmSnapshot, VmUffdAttach,
 };
 use crate::config::RestoreConfig;
 use crate::cpu::Error as CpuError;
@@ -464,6 +464,7 @@ vm_action_put_handler_body!(VmResizeZone);
 vm_action_put_handler_body!(VmSnapshot);
 vm_action_put_handler_body!(VmReceiveMigration);
 vm_action_put_handler_body!(VmSendMigration);
+vm_action_put_handler_body!(VmUffdAttach);
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 vm_action_put_handler_body!(VmCoredump);

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -55,6 +55,7 @@ use crate::api::{
 };
 use crate::config::RestoreConfig;
 use crate::cpu::Error as CpuError;
+use crate::memory_manager::Error as MemoryManagerError;
 use crate::vm::Error as VmError;
 
 /// Helper module for attaching externally opened FDs to config objects.
@@ -464,7 +465,41 @@ vm_action_put_handler_body!(VmResizeZone);
 vm_action_put_handler_body!(VmSnapshot);
 vm_action_put_handler_body!(VmReceiveMigration);
 vm_action_put_handler_body!(VmSendMigration);
-vm_action_put_handler_body!(VmUffdAttach);
+
+// Custom handler (rather than vm_action_put_handler_body!) so a re-attach
+// with a different UFFD mode maps to 400 Bad Request instead of the
+// generic 500: it's a client error the caller can fix (don't change the
+// mode), not a server fault. micro_http has no 409 Conflict variant, so
+// 400 is the closest representable status. Every other handoff failure
+// still falls through to HttpError::ApiError (500).
+impl PutHandler for VmUffdAttach {
+    fn handle_request(
+        &'static self,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+        body: &Option<Body>,
+        _files: Vec<File>,
+    ) -> result::Result<Option<Body>, HttpError> {
+        if let Some(body) = body {
+            self.send(
+                api_notifier,
+                api_sender,
+                serde_json::from_slice(body.raw())?,
+            )
+            .map_err(|e| match e {
+                ApiError::VmUffdAttach(VmError::MemoryManager(
+                    MemoryManagerError::UffdHandoffModeMismatch { .. }
+                    | MemoryManagerError::UffdManagerStillAttached,
+                )) => HttpError::BadRequest,
+                _ => HttpError::ApiError(e),
+            })
+        } else {
+            Err(HttpError::BadRequest)
+        }
+    }
+}
+
+impl GetHandler for VmUffdAttach {}
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 vm_action_put_handler_body!(VmCoredump);

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -31,7 +31,7 @@ use crate::api::{
     AddDisk, ApiError, ApiRequest, VmAddDevice, VmAddFs, VmAddGenericVhostUser, VmAddNet,
     VmAddPmem, VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmCounters, VmDelete, VmNmi,
     VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk,
-    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
+    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot, VmUffdAttach,
 };
 use crate::landlock::Landlock;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
@@ -307,6 +307,10 @@ pub static HTTP_ROUTES: LazyLock<HttpRoutes> = LazyLock::new(|| {
         .insert(endpoint!("/vmm.shutdown"), Box::new(VmmShutdown {}));
     r.routes
         .insert(endpoint!("/vm.nmi"), Box::new(VmActionHandler::new(&VmNmi)));
+    r.routes.insert(
+        endpoint!("/vm.uffd-attach"),
+        Box::new(VmActionHandler::new(&VmUffdAttach)),
+    );
 
     r
 });

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -58,6 +58,7 @@ use crate::device_tree::DeviceTree;
 use crate::migration::transport::{
     MAX_MIGRATION_CONNECTIONS, TcpAddressParseError, tcp_address_to_server_name,
 };
+use crate::userfaultfd::UffdHandoffSpec;
 use crate::vm::{Error as VmError, VmState};
 use crate::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, NetConfig, PmemConfig,
@@ -215,6 +216,10 @@ pub enum ApiError {
     /// Error triggering NMI
     #[error("Error triggering NMI")]
     VmNmi(#[source] VmError),
+
+    /// Error attaching external uffd manager
+    #[error("Error attaching external uffd manager")]
+    VmUffdAttach(#[source] VmError),
 }
 pub type ApiResult<T> = Result<T, ApiError>;
 
@@ -391,6 +396,19 @@ impl VmReceiveMigrationData {
 
         Ok(())
     }
+}
+
+/// Request body for the `vm.uffd-attach` endpoint.
+///
+/// `mode` is a `|`-separated set of UFFD-mode tokens, e.g.
+/// `"WP|WP_ASYNC"`. Register-mode tokens (`MISSING`, `WP`) drive
+/// `UFFDIO_REGISTER`; feature tokens (`WP_UNPOPULATED`, `WP_ASYNC`)
+/// drive `UFFDIO_API`'s features. Required — the manager has to
+/// pick what to track.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UffdAttachData {
+    pub handoff_socket: String,
+    pub mode: UffdHandoffSpec,
 }
 
 #[derive(Copy, Clone, Default, Deserialize, Serialize, Debug, PartialEq, Eq)]
@@ -760,6 +778,8 @@ pub trait RequestHandler {
     ) -> Result<(), MigratableError>;
 
     fn vm_nmi(&mut self) -> Result<(), VmError>;
+
+    fn vm_uffd_attach(&mut self, data: UffdAttachData) -> Result<(), VmError>;
 }
 
 /// It would be nice if we could pass around an object like this:
@@ -1910,6 +1930,39 @@ impl ApiAction for VmNmi {
             let response = vmm
                 .vm_nmi()
                 .map_err(ApiError::VmNmi)
+                .map(|_| ApiResponsePayload::Empty);
+
+            response_sender
+                .send(response)
+                .map_err(VmmError::ApiResponseSend)?;
+
+            Ok(false)
+        })
+    }
+
+    fn send(
+        &self,
+        api_evt: EventFd,
+        api_sender: Sender<ApiRequest>,
+        data: Self::RequestBody,
+    ) -> ApiResult<Self::ResponseBody> {
+        get_response_body(self, api_evt, api_sender, data)
+    }
+}
+
+pub struct VmUffdAttach;
+
+impl ApiAction for VmUffdAttach {
+    type RequestBody = UffdAttachData;
+    type ResponseBody = Option<Body>;
+
+    fn request(&self, data: Self::RequestBody, response_sender: Sender<ApiResponse>) -> ApiRequest {
+        Box::new(move |vmm| {
+            info!("API request event: VmUffdAttach");
+
+            let response = vmm
+                .vm_uffd_attach(data)
+                .map_err(ApiError::VmUffdAttach)
                 .map(|_| ApiResponsePayload::Empty);
 
             response_sender

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -452,6 +452,26 @@ paths:
         204:
           description: The NMI successfully injected.
 
+  /vm.uffd-attach:
+    put:
+      summary: Attach an external userfaultfd manager to a running VM.
+      requestBody:
+        description: The userfaultfd handoff configuration
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UffdAttachData"
+        required: true
+      responses:
+        204:
+          description: The userfaultfd manager was successfully attached.
+        400:
+          description: The request was invalid, or a manager is already attached with a different mode.
+        404:
+          description: The VM instance could not be found.
+        500:
+          description: The userfaultfd manager could not be attached.
+
   /vm.restore:
     put:
       summary: Restore a VM from a snapshot.
@@ -908,6 +928,40 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/MemoryZoneConfig"
+        uffd_handoff:
+          $ref: "#/components/schemas/UffdHandoffConfig"
+
+    UffdHandoffConfig:
+      required:
+        - socket
+        - mode
+      type: object
+      properties:
+        socket:
+          type: string
+          description: Path to a Unix socket where the external userfaultfd manager listens.
+        mode:
+          type: string
+          description: >-
+            "|"-separated userfaultfd mode tokens, e.g. "MISSING|WP|WP_ASYNC".
+            Register-mode tokens (MISSING, WP) drive UFFDIO_REGISTER; feature
+            tokens (WP_UNPOPULATED, WP_ASYNC) drive UFFDIO_API. Validated when
+            the configuration is parsed.
+
+    UffdAttachData:
+      required:
+        - handoff_socket
+        - mode
+      type: object
+      properties:
+        handoff_socket:
+          type: string
+          description: Path to a Unix socket where the external userfaultfd manager listens.
+        mode:
+          type: string
+          description: >-
+            "|"-separated userfaultfd mode tokens, e.g. "WP|WP_ASYNC". Same
+            grammar as MemoryConfig.uffd_handoff.mode.
 
     TokenBucket:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -28,6 +28,7 @@ use virtio_devices::vhost_user::VIRTIO_FS_TAG_LEN;
 use virtio_devices::{RateLimiterConfig, TokenBucketConfig, net, vhost_user};
 
 use crate::landlock::LandlockAccess;
+use crate::userfaultfd::UffdHandoffSpec;
 use crate::vm_config::*;
 
 const MAX_NUM_PCI_SEGMENTS: u16 = 96;
@@ -1094,7 +1095,9 @@ impl MemoryConfig {
             .add("hugepage_size")
             .add("prefault")
             .add("reserve")
-            .add("thp");
+            .add("thp")
+            .add("uffd_handoff_socket")
+            .add("uffd_handoff_mode");
         parser.parse(memory).map_err(Error::ParseMemory)?;
 
         let size = parser
@@ -1148,6 +1151,22 @@ impl MemoryConfig {
             .map_err(Error::ParseMemory)?
             .unwrap_or(Toggle(true))
             .0;
+        let uffd_handoff = match (
+            parser.get("uffd_handoff_socket"),
+            parser
+                .convert::<UffdHandoffSpec>("uffd_handoff_mode")
+                .map_err(Error::ParseMemory)?,
+        ) {
+            (Some(socket), Some(mode)) => Some(UffdHandoffConfig { socket, mode }),
+            (None, None) => None,
+            (Some(_), None) | (None, Some(_)) => {
+                return Err(Error::ParseMemory(OptionParserError::InvalidValue(
+                    "uffd_handoff_socket and uffd_handoff_mode must both be set or \
+                     both omitted"
+                        .to_string(),
+                )));
+            }
+        };
 
         let zones: Option<Vec<MemoryZoneConfig>> = if let Some(memory_zones) = &memory_zones {
             let mut zones = Vec::new();
@@ -1250,6 +1269,7 @@ impl MemoryConfig {
             reserve,
             zones,
             thp,
+            uffd_handoff,
         })
     }
 
@@ -3870,6 +3890,9 @@ mod unit_tests {
     use net_util::MacAddr;
 
     use super::*;
+    use crate::userfaultfd::{
+        UFFD_FEATURE_WP_ASYNC, UFFDIO_REGISTER_MODE_MISSING, UFFDIO_REGISTER_MODE_WP,
+    };
 
     #[test]
     fn test_cpu_parsing() -> Result<()> {
@@ -4141,6 +4164,33 @@ mod unit_tests {
                 ..Default::default()
             }
         );
+        // uffd_handoff defaults to None
+        let bare = MemoryConfig::parse("size=1G", None)?;
+        assert!(bare.uffd_handoff.is_none());
+        // socket + mode together populate the sub-struct
+        assert_eq!(
+            MemoryConfig::parse(
+                "size=0,uffd_handoff_socket=/tmp/m.sock,\
+                 uffd_handoff_mode=MISSING|WP|WP_ASYNC",
+                None
+            )?,
+            MemoryConfig {
+                size: 0,
+                uffd_handoff: Some(UffdHandoffConfig {
+                    socket: "/tmp/m.sock".to_string(),
+                    mode: UffdHandoffSpec {
+                        register: UFFDIO_REGISTER_MODE_MISSING | UFFDIO_REGISTER_MODE_WP,
+                        features: UFFD_FEATURE_WP_ASYNC,
+                    },
+                }),
+                ..Default::default()
+            }
+        );
+        // Bad token surfaces at parse-time (not later at handoff).
+        MemoryConfig::parse("size=0,uffd_handoff_mode=BOGUS", None).unwrap_err();
+        // Socket without mode (or vice versa) is rejected.
+        MemoryConfig::parse("size=0,uffd_handoff_socket=/tmp/m.sock", None).unwrap_err();
+        MemoryConfig::parse("size=0,uffd_handoff_mode=WP", None).unwrap_err();
         Ok(())
     }
 
@@ -5391,6 +5441,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 reserve: false,
                 zones: None,
                 thp: true,
+                uffd_handoff: None,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),
@@ -6419,6 +6470,26 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             invalid_config.validate(),
             Err(ValidationError::InvalidDeviceExcludeMmapBar(6))
         );
+
+        // --- uffd handoff validation tests ---
+
+        let handoff = || {
+            Some(UffdHandoffConfig {
+                socket: "/tmp/m.sock".to_string(),
+                mode: UffdHandoffSpec::parse("MISSING|WP").unwrap(),
+            })
+        };
+
+        // uffd handoff works with or without shared memory
+        let mut valid_uffd_config = valid_config.clone();
+        valid_uffd_config.memory.uffd_handoff = handoff();
+        valid_uffd_config.memory.shared = false;
+        valid_uffd_config.validate().unwrap();
+
+        let mut valid_uffd_shared = valid_config.clone();
+        valid_uffd_shared.memory.uffd_handoff = handoff();
+        valid_uffd_shared.memory.shared = true;
+        valid_uffd_shared.validate().unwrap();
 
         let mut still_valid_config = valid_config.clone();
         // SAFETY: Safe as the file was just opened

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -48,8 +48,8 @@ use vmm_sys_util::signal::unblock_signal;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
 use crate::api::{
-    ApiRequest, ApiResponse, MigrationMode, RequestHandler, TimeoutStrategy, VmInfoResponse,
-    VmReceiveMigrationData, VmSendMigrationData, VmmPingResponse,
+    ApiRequest, ApiResponse, MigrationMode, RequestHandler, TimeoutStrategy, UffdAttachData,
+    VmInfoResponse, VmReceiveMigrationData, VmSendMigrationData, VmmPingResponse,
 };
 use crate::config::{MemoryRestoreMode, RestoreConfig, add_to_config};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -2979,6 +2979,28 @@ impl RequestHandler for Vmm {
             VmOwnership::Migration { .. } => Err(VmError::VmMigrating),
             VmOwnership::None => Err(VmError::VmNotRunning),
         }
+    }
+
+    fn vm_uffd_attach(&mut self, data: UffdAttachData) -> result::Result<(), VmError> {
+        let vm = match self.vm {
+            VmOwnership::Owned(ref vm) => vm,
+            VmOwnership::Migration { .. } => return Err(VmError::VmMigrating),
+            VmOwnership::None => return Err(VmError::VmNotCreated),
+        };
+        // Reject attach from Created/Shutdown/BreakPoint/Paused. The
+        // kernel-level UFFDIO_REGISTER would mostly survive these, but
+        // Shutdown can race the teardown of the very VMAs we'd be
+        // registering, and Created has no guest activity to track.
+        // Restrict to Running for clarity; loosen if a real caller
+        // needs Paused later.
+        if vm.get_state() != VmState::Running {
+            return Err(VmError::VmNotRunning);
+        }
+        vm.memory_manager()
+            .lock()
+            .unwrap()
+            .do_uffd_handoff(&data.handoff_socket, data.mode)
+            .map_err(VmError::MemoryManager)
     }
 
     fn vm_receive_migration(

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3324,6 +3324,7 @@ mod unit_tests {
                 reserve: false,
                 zones: None,
                 thp: true,
+                uffd_handoff: None,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -229,7 +229,9 @@ pub struct UffdRegionInfo {
 /// Newest uffd-handoff protocol version sent by this implementation.
 ///
 /// Carried in the `Handoff` handshake so the manager can tell what
-/// wire contract it is talking to. Mirrors the migration protocol's
+/// wire contract it is talking to; follow-up messages on an
+/// established session (e.g. `AddRegion`) inherit the handshake's
+/// version and don't repeat it. Mirrors the migration protocol's
 /// `CURRENT_PROTOCOL_VERSION` idiom (see `vm-migration::protocol`): a
 /// missing/zeroed version is legacy `v0`, and the field only ever
 /// grows additively unless the shape changes incompatibly.
@@ -258,17 +260,19 @@ const UFFD_HANDOFF_TIMEOUT: Duration = Duration::from_secs(2);
 ///   `UffdHandoffSpec` token string, e.g. `"MISSING|WP|WP_ASYNC"`) so
 ///   the message is self-describing: the manager learns from the
 ///   handoff itself what the fd is registered for, rather than relying
-///   on out-of-band agreement. `regions` is sorted by `guest_phys_addr`
-///   ascending so the on-the-wire layout is reproducible across runs.
-///   The VMM's pid is included so the manager can construct
-///   `/proc/<vmm_pid>/map_files/...` paths if it needs direct
-///   backing-store access.
+///   on out-of-band agreement. This also lets a future mode transition
+///   (re-key: a fresh fd with a different `mode` over the same socket)
+///   reuse the exact same message with no new variant. `regions` is
+///   sorted by `guest_phys_addr` ascending so the on-the-wire layout is
+///   reproducible across runs. The VMM's pid is included so the
+///   manager can construct `/proc/<vmm_pid>/map_files/...` paths if
+///   it needs direct backing-store access.
 /// - `AddRegion` is sent on memory hot-add (ACPI hotplug) after the
 ///   initial handoff and carries no SCM_RIGHTS ancillary data — the
-///   uffd was already handed off, and any backing-store fd the manager
-///   needs is obtained via the same /proc/<pid>/map_files mechanism.
-///   The session `mode`/`version` are those of the preceding `Handoff`,
-///   so they are not repeated here.
+///   uffd was already handed off, and any backing-store fd the
+///   manager needs is obtained via the same /proc/<pid>/map_files
+///   mechanism. The session `mode`/`version` are those of the
+///   preceding `Handoff`, so they are not repeated here.
 #[derive(Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum UffdHandoffMessage<'a> {
@@ -348,21 +352,25 @@ pub struct MemoryManager {
 
     /// Connection back to the uffd manager, kept alive after the
     /// initial handoff so the VMM can push add-region notifications on
-    /// memory hot-add. `None` if no manager is attached or the
-    /// connection has been dropped after an I/O failure.
+    /// memory hot-add. `None` if no manager is currently attached or
+    /// the connection has been dropped after an I/O failure.
     uffd_handoff_sock: Option<UnixStream>,
 
-    /// CH's own copy of the userfaultfd handed off to the manager,
-    /// held for the VM's lifetime. The kernel refcounts the fd, so
-    /// keeping our dup keeps the registrations alive even if the
-    /// manager exits — faulting threads then block until a manager
-    /// returns rather than losing data (CH never resolves faults).
+    /// CH's own copy of the userfaultfd handed off to the manager.
+    /// Held so that hot-added VMAs can be registered against the same
+    /// uffd context (mirroring the boot-time handoff, where the VMM
+    /// does all the `UFFDIO_REGISTER` calls before handing the fd
+    /// over). Kernel refcounts the fd, so the manager's dup'd copy is
+    /// unaffected by us holding ours.
     uffd_handoff_fd: Option<OwnedFd>,
 
-    /// Register-mode bits the active uffd was configured with — used
-    /// when issuing `UFFDIO_REGISTER` against newly hot-added VMAs so
-    /// they match the rest of the registered set.
-    uffd_register_mode: Option<u64>,
+    /// The `UffdHandoffSpec` the active uffd was configured with. The
+    /// register bits drive `UFFDIO_REGISTER` against newly hot-added
+    /// VMAs so they match the rest of the registered set, and the whole
+    /// spec is compared against a re-attach request to distinguish a
+    /// resume (same spec) from a mode change (different spec — a re-key,
+    /// which is not yet supported).
+    uffd_spec: Option<userfaultfd::UffdHandoffSpec>,
 }
 
 #[derive(Error, Debug)]
@@ -558,9 +566,28 @@ pub enum Error {
     #[error("uffd handoff JSON encode error")]
     UffdHandoffEncode(#[source] serde_json::Error),
 
-    /// uffd already handed off to this VM
-    #[error("uffd already handed off to this VM")]
-    UffdAlreadyAttached,
+    /// A uffd is already attached with a different mode. Re-attaching
+    /// with the same mode is a resume; changing the mode would be a
+    /// re-key (tear down the old uffd, create a new one), which is not
+    /// implemented yet.
+    #[error(
+        "uffd already attached with mode '{active}'; changing mode to \
+         '{requested}' (re-key) is not supported"
+    )]
+    UffdHandoffModeMismatch {
+        active: userfaultfd::UffdHandoffSpec,
+        requested: userfaultfd::UffdHandoffSpec,
+    },
+
+    /// A uffd manager is already attached and still appears alive on its
+    /// handoff socket. Resuming would put a second reader on the uffd
+    /// queue and corrupt fault handling, so refuse. The orchestrator
+    /// must ensure the previous manager is gone before re-attaching.
+    #[error(
+        "uffd manager already attached and still alive; refusing to resume \
+         (ensure the previous manager has exited first)"
+    )]
+    UffdManagerStillAttached,
 }
 
 impl From<UffdError> for Error {
@@ -1334,8 +1361,40 @@ impl MemoryManager {
     ) -> Result<(), Error> {
         use std::os::fd::AsFd;
 
+        // A uffd is already attached. Re-attaching with the *same* spec
+        // is a resume/reconnect — re-send the existing uffd fd and the
+        // current region set rather than creating a fresh uffd (the
+        // manager side is identical to a first attach, so it need not
+        // know whether it is resuming; see `resume_uffd_handoff`).
+        //
+        // Re-attaching with a *different* spec would be a mode change
+        // (re-key): tear down the old uffd, create a new one, transition
+        // the registrations. That is not implemented yet, so reject it
+        // explicitly rather than silently ignoring the new spec and
+        // re-sending the old fd. Erroring here reserves the "different
+        // mode" semantics for a future re-key without defining a
+        // behaviour callers could come to depend on.
         if self.uffd_attached {
-            return Err(Error::UffdAlreadyAttached);
+            let active = self
+                .uffd_spec
+                .expect("uffd_attached implies uffd_spec is set");
+            if active != mode {
+                return Err(Error::UffdHandoffModeMismatch {
+                    active,
+                    requested: mode,
+                });
+            }
+            // Best-effort guard against putting a second reader on the
+            // uffd queue: only resume if the previous manager appears
+            // gone (its handoff socket is closed). This catches an
+            // accidental double-attach against a healthy manager; it is
+            // not full enforcement (the single-live-manager invariant
+            // remains the orchestrator's — CH cannot revoke a dup once
+            // sent).
+            if !self.manager_appears_gone() {
+                return Err(Error::UffdManagerStillAttached);
+            }
+            return self.resume_uffd_handoff(socket_path);
         }
 
         let register_mode = mode.register;
@@ -1372,14 +1431,17 @@ impl MemoryManager {
 
         let sock = Self::send_uffd_handoff(socket_path, mode, &regions, uffd.as_fd())?;
 
-        // Keep the uffd fd, the register mode, and the manager socket
-        // so a later ACPI hot-add can register the new VMA against this
-        // uffd and notify the manager (see `notify_uffd_add_region`).
-        // Holding CH's dup of the uffd for the VM's lifetime also keeps
-        // the registrations alive if the manager dies: faulting vCPUs
-        // block (CH never resolves faults itself) instead of losing data.
+        // Keep the socket, the uffd fd, and the spec so future ACPI
+        // hot-adds can register the new VMA against this uffd and notify
+        // the manager (see `notify_uffd_add_region`), so a restarted
+        // manager can resume by being re-sent this same fd (see
+        // `resume_uffd_handoff`), and so a re-attach with a different
+        // spec can be recognised as a mode change. CH holds this dup for
+        // the VM's lifetime: it keeps the kernel registrations alive so
+        // that if the manager dies, faulting vCPUs block (CH never
+        // resolves faults itself — no zero-fill) instead of losing data.
         self.uffd_attached = true;
-        self.uffd_register_mode = Some(register_mode);
+        self.uffd_spec = Some(mode);
         self.uffd_handoff_sock = Some(sock);
         self.uffd_handoff_fd = Some(uffd);
 
@@ -1398,7 +1460,7 @@ impl MemoryManager {
     /// Collect uffd region descriptors for all guest RAM zones, sorted
     /// by guest physical address. `self.memory_zones` is a HashMap with
     /// non-deterministic iteration order, so the sort keeps the on-wire
-    /// layout reproducible across runs.
+    /// layout reproducible across runs and across resume.
     fn collect_uffd_regions(&self) -> Vec<UffdRegionInfo> {
         let mut regions = Vec::new();
         for zone in self.memory_zones.values() {
@@ -1421,7 +1483,8 @@ impl MemoryManager {
 
     /// Connect to `socket_path`, send a framed `Handoff` message with
     /// `uffd_fd` attached via SCM_RIGHTS, and wait for the manager's
-    /// 1-byte ACK. Returns the connected handshake socket.
+    /// 1-byte ACK. Returns the connected socket (kept for later
+    /// add-region notifications and as the resume channel).
     ///
     /// Framing: every message is `<u32 LE body length><body>`, sent as
     /// two iovecs in one sendmsg so the SCM_RIGHTS ancillary fd attaches
@@ -1467,6 +1530,92 @@ impl MemoryManager {
         Ok(sock)
     }
 
+    /// Best-effort liveness probe of the currently-attached manager via
+    /// its retained handoff socket. Returns true when the manager looks
+    /// gone (safe to resume): the socket peer has closed (EOF/reset), or
+    /// no socket is retained (the connection was already dropped).
+    /// Returns false when the connection is still open — a live manager,
+    /// so resuming would race two readers on the uffd queue.
+    ///
+    /// A `MSG_PEEK | MSG_DONTWAIT` recv is non-destructive and never
+    /// blocks. On manager exit/kill the kernel closes its fds
+    /// synchronously, so a dead manager reads as EOF here and a live one
+    /// as EAGAIN — the probe never resumes against a detectably-live
+    /// manager. It is a guard rail, not enforcement of the
+    /// single-live-manager invariant (which stays the orchestrator's).
+    fn manager_appears_gone(&self) -> bool {
+        use std::os::fd::AsRawFd;
+
+        let Some(sock) = self.uffd_handoff_sock.as_ref() else {
+            return true; // connection already dropped -> assume gone
+        };
+        let mut buf = [0u8; 1];
+        // SAFETY: peeking one byte into a valid local buffer on a valid fd.
+        let n = unsafe {
+            libc::recv(
+                sock.as_raw_fd(),
+                buf.as_mut_ptr().cast(),
+                buf.len(),
+                libc::MSG_PEEK | libc::MSG_DONTWAIT,
+            )
+        };
+        match n {
+            0 => true, // EOF: peer closed -> manager gone
+            n if n < 0 => matches!(
+                io::Error::last_os_error().raw_os_error(),
+                // Peer reset/gone -> safe to resume. EAGAIN (open, no
+                // data pending) and any other error -> treat as alive
+                // and refuse, erring on the side of not racing readers.
+                Some(libc::ECONNRESET) | Some(libc::ENOTCONN) | Some(libc::EPIPE)
+            ),
+            _ => false, // unexpected pending data -> connection alive
+        }
+    }
+
+    /// Resume a uffd handoff after the external manager restarted.
+    ///
+    /// CH keeps its dup of the uffd for the VM's lifetime, so the
+    /// kernel-side registrations and WP markers survive a manager
+    /// crash, and while the manager is gone faulting vCPUs simply block
+    /// — CH never resolves faults itself (no zero-fill, no data loss).
+    /// On reconnect we re-send the *same* uffd fd plus the current
+    /// region set to the new manager, which then drains the queued fault
+    /// backlog and wakes the stalled vCPUs. No new uffd is created and
+    /// no VMA is re-registered.
+    ///
+    /// INVARIANT: at most one live manager at a time. Once the fd is
+    /// sent via SCM_RIGHTS, CH cannot revoke a manager's dup, and two
+    /// readers racing the uffd queue corrupts fault handling. The
+    /// orchestrator MUST ensure the previous manager is dead before
+    /// resuming (and must not attach a second manager while one is
+    /// live). CH does not — cannot — enforce this. `manager_appears_gone`
+    /// is a best-effort guard against the accidental case.
+    fn resume_uffd_handoff(&mut self, socket_path: &str) -> Result<(), Error> {
+        use std::os::fd::AsFd;
+
+        // `uffd_attached` is only ever set together with
+        // `uffd_handoff_fd` and `uffd_spec`, so both are present here.
+        // Resume re-sends the same spec the uffd was created with, so
+        // the resumed manager sees an identical `Handoff` to a first
+        // attach.
+        let mode = self
+            .uffd_spec
+            .expect("uffd_attached implies uffd_spec is set");
+        let uffd = self
+            .uffd_handoff_fd
+            .as_ref()
+            .expect("uffd_attached implies uffd_handoff_fd is set");
+        let regions = self.collect_uffd_regions();
+        let sock = Self::send_uffd_handoff(socket_path, mode, &regions, uffd.as_fd())?;
+        self.uffd_handoff_sock = Some(sock);
+
+        info!(
+            "uffd: resumed handoff ({} regions) to {socket_path}",
+            regions.len()
+        );
+        Ok(())
+    }
+
     /// Register a hot-added VMA against the active uffd, matching the
     /// register modes negotiated for the initial handoff. No-op when no
     /// manager is attached.
@@ -1479,16 +1628,14 @@ impl MemoryManager {
     fn register_hotadd_region_with_uffd(&self, region: &Arc<GuestRegionMmap>) -> Result<(), Error> {
         use std::os::fd::AsFd;
 
-        let (Some(uffd_fd), Some(register_mode)) =
-            (self.uffd_handoff_fd.as_ref(), self.uffd_register_mode)
-        else {
+        let (Some(uffd_fd), Some(spec)) = (self.uffd_handoff_fd.as_ref(), self.uffd_spec) else {
             return Ok(()); // no manager attached
         };
         uffd::register(
             uffd_fd.as_fd(),
             region.as_ptr() as u64,
             region.len(),
-            register_mode,
+            spec.register,
         )
         .map_err(Error::UffdHandoffRegister)?;
         Ok(())
@@ -2268,7 +2415,7 @@ impl MemoryManager {
             uffd_attached: false,
             uffd_handoff_sock: None,
             uffd_handoff_fd: None,
-            uffd_register_mode: None,
+            uffd_spec: None,
         };
 
         if let Some(handoff) = &config.uffd_handoff {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1016,12 +1016,16 @@ impl MemoryManager {
                     source: e,
                 })? as u64;
 
-            let ioctls = uffd::register(uffd_fd.as_fd(), host_addr, range.length).map_err(|e| {
-                UffdError::Register {
-                    addr: host_addr,
-                    len: range.length,
-                    source: e,
-                }
+            let ioctls = uffd::register(
+                uffd_fd.as_fd(),
+                host_addr,
+                range.length,
+                userfaultfd::UFFDIO_REGISTER_MODE_MISSING,
+            )
+            .map_err(|e| UffdError::Register {
+                addr: host_addr,
+                len: range.length,
+                source: e,
             })?;
 
             if ioctls & userfaultfd::UFFD_API_RANGE_IOCTLS_BASIC

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -263,6 +263,12 @@ const UFFD_HANDOFF_TIMEOUT: Duration = Duration::from_secs(2);
 ///   The VMM's pid is included so the manager can construct
 ///   `/proc/<vmm_pid>/map_files/...` paths if it needs direct
 ///   backing-store access.
+/// - `AddRegion` is sent on memory hot-add (ACPI hotplug) after the
+///   initial handoff and carries no SCM_RIGHTS ancillary data — the
+///   uffd was already handed off, and any backing-store fd the manager
+///   needs is obtained via the same /proc/<pid>/map_files mechanism.
+///   The session `mode`/`version` are those of the preceding `Handoff`,
+///   so they are not repeated here.
 #[derive(Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum UffdHandoffMessage<'a> {
@@ -271,6 +277,9 @@ enum UffdHandoffMessage<'a> {
         vmm_pid: u32,
         mode: String,
         regions: &'a [UffdRegionInfo],
+    },
+    AddRegion {
+        region: &'a UffdRegionInfo,
     },
 }
 
@@ -337,12 +346,23 @@ pub struct MemoryManager {
     /// second registration on the same VMA.
     uffd_attached: bool,
 
+    /// Connection back to the uffd manager, kept alive after the
+    /// initial handoff so the VMM can push add-region notifications on
+    /// memory hot-add. `None` if no manager is attached or the
+    /// connection has been dropped after an I/O failure.
+    uffd_handoff_sock: Option<UnixStream>,
+
     /// CH's own copy of the userfaultfd handed off to the manager,
     /// held for the VM's lifetime. The kernel refcounts the fd, so
     /// keeping our dup keeps the registrations alive even if the
     /// manager exits — faulting threads then block until a manager
     /// returns rather than losing data (CH never resolves faults).
     uffd_handoff_fd: Option<OwnedFd>,
+
+    /// Register-mode bits the active uffd was configured with — used
+    /// when issuing `UFFDIO_REGISTER` against newly hot-added VMAs so
+    /// they match the rest of the registered set.
+    uffd_register_mode: Option<u64>,
 }
 
 #[derive(Error, Debug)]
@@ -541,14 +561,6 @@ pub enum Error {
     /// uffd already handed off to this VM
     #[error("uffd already handed off to this VM")]
     UffdAlreadyAttached,
-
-    /// Failed to notify uffd manager of a hot-added region
-    #[error("Failed to notify uffd manager of hot-added region")]
-    UffdNotify(#[source] io::Error),
-
-    /// Failed to encode the uffd add-region notification
-    #[error("Failed to encode uffd add-region notification")]
-    UffdNotifyEncode(#[source] serde_json::Error),
 }
 
 impl From<UffdError> for Error {
@@ -1358,13 +1370,17 @@ impl MemoryManager {
                 .map_err(Error::UffdHandoffRegister)?;
         }
 
-        Self::send_uffd_handoff(socket_path, mode, &regions, uffd.as_fd())?;
+        let sock = Self::send_uffd_handoff(socket_path, mode, &regions, uffd.as_fd())?;
 
-        // Keep CH's dup of the uffd for the VM's lifetime: it keeps the
-        // kernel registrations alive, so if the manager dies faulting
-        // vCPUs block (CH never resolves faults itself — no zero-fill)
-        // instead of losing data.
+        // Keep the uffd fd, the register mode, and the manager socket
+        // so a later ACPI hot-add can register the new VMA against this
+        // uffd and notify the manager (see `notify_uffd_add_region`).
+        // Holding CH's dup of the uffd for the VM's lifetime also keeps
+        // the registrations alive if the manager dies: faulting vCPUs
+        // block (CH never resolves faults itself) instead of losing data.
         self.uffd_attached = true;
+        self.uffd_register_mode = Some(register_mode);
+        self.uffd_handoff_sock = Some(sock);
         self.uffd_handoff_fd = Some(uffd);
 
         info!(
@@ -1449,6 +1465,92 @@ impl MemoryManager {
         let mut ack = [0u8; 1];
         sock.read_exact(&mut ack).map_err(Error::UffdHandoff)?;
         Ok(sock)
+    }
+
+    /// Register a hot-added VMA against the active uffd, matching the
+    /// register modes negotiated for the initial handoff. No-op when no
+    /// manager is attached.
+    ///
+    /// Called on the hot-add path *before* the region is committed to
+    /// `memory_zones` / the allocator: a registration failure means the
+    /// region could not be covered by the manager (guest faults there
+    /// would bypass it), so it must fail the hot-add — and failing here,
+    /// pre-commit, leaves no half-added region behind.
+    fn register_hotadd_region_with_uffd(&self, region: &Arc<GuestRegionMmap>) -> Result<(), Error> {
+        use std::os::fd::AsFd;
+
+        let (Some(uffd_fd), Some(register_mode)) =
+            (self.uffd_handoff_fd.as_ref(), self.uffd_register_mode)
+        else {
+            return Ok(()); // no manager attached
+        };
+        uffd::register(
+            uffd_fd.as_fd(),
+            region.as_ptr() as u64,
+            region.len(),
+            register_mode,
+        )
+        .map_err(Error::UffdHandoffRegister)?;
+        Ok(())
+    }
+
+    /// Best-effort `add_region` notification to the uffd manager for a
+    /// newly hot-added region that is *already* uffd-registered (see
+    /// `register_hotadd_region_with_uffd`) and committed. No-op when no
+    /// manager is attached.
+    ///
+    /// Not fatal to the hot-add: on any I/O failure the manager
+    /// connection is dropped and a warning logged, but the region stays
+    /// added and registered. A reconnecting manager re-syncs the full
+    /// region set when it reconnects (see `collect_uffd_regions`), so the
+    /// missed notification is not lost.
+    ///
+    /// AddRegion carries no SCM_RIGHTS ancillary data: the manager
+    /// already holds the uffd. The 5s SO_RCVTIMEO / SO_SNDTIMEO set at
+    /// handoff time persist on the socket, so this send/recv is bounded.
+    fn notify_uffd_add_region(&mut self, region: &Arc<GuestRegionMmap>) {
+        use std::io::Read as _;
+
+        use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+
+        let Some(sock) = self.uffd_handoff_sock.as_mut() else {
+            return; // no manager attached, or connection already dropped
+        };
+        let info = UffdRegionInfo {
+            guest_phys_addr: region.start_addr().raw_value(),
+            host_virt_addr: region.as_ptr() as u64,
+            size: region.len(),
+            backing_file_offset: region.file_offset().map_or(0, |fo| fo.start()),
+        };
+        let body = match serde_json::to_vec(&UffdHandoffMessage::AddRegion { region: &info }) {
+            Ok(body) => body,
+            Err(e) => {
+                warn!("uffd: failed to encode add-region notification: {e}");
+                return;
+            }
+        };
+        let header = (body.len() as u32).to_le_bytes();
+
+        let mut send_and_ack = || -> io::Result<()> {
+            sock.send_with_fds(&[&header[..], &body[..]], &[])
+                .map_err(|e| io::Error::from_raw_os_error(e.errno()))?;
+            let mut ack = [0u8; 1];
+            sock.read_exact(&mut ack)
+        };
+        if let Err(e) = send_and_ack() {
+            warn!(
+                "uffd: failed to notify manager of hot-added region \
+                 gpa={:#x}: {e}; dropping manager connection (a reconnecting \
+                 manager re-syncs the region set on resume)",
+                info.guest_phys_addr
+            );
+            self.uffd_handoff_sock = None;
+            return;
+        }
+        info!(
+            "uffd: notified manager of hot-added region gpa={:#x} size={:#x}",
+            info.guest_phys_addr, info.size
+        );
     }
 
     /// Serve UFFD faults via `source`, prefaulting one page per idle
@@ -2164,7 +2266,9 @@ impl MemoryManager {
             uefi_flash: None,
             thp: config.thp,
             uffd_attached: false,
+            uffd_handoff_sock: None,
             uffd_handoff_fd: None,
+            uffd_register_mode: None,
         };
 
         if let Some(handoff) = &config.uffd_handoff {
@@ -2660,16 +2764,27 @@ impl MemoryManager {
 
         let region = self.add_ram_region(start_addr, size)?;
 
-        // Add region to the list of regions associated with the default
-        // memory zone.
-        if let Some(memory_zone) = self.memory_zones.get_mut(DEFAULT_MEMORY_ZONE) {
-            memory_zone.regions.push(Arc::clone(&region));
-        }
+        // If a uffd manager is attached, register the new VMA against the
+        // existing uffd *before* committing the region. A registration
+        // failure means the region cannot be covered by the manager
+        // (guest faults there would bypass it), so fail the hot-add here
+        // — before it lands in memory_zones or the allocator — rather
+        // than leaving a committed-but-uncovered region. Notifying the
+        // manager happens after commit, below.
+        self.register_hotadd_region_with_uffd(&region)?;
 
         // Tell the allocator
         self.ram_allocator
             .allocate(Some(start_addr), size as GuestUsize, None)
             .ok_or(Error::MemoryRangeAllocation)?;
+
+        // Add region to the list of regions associated with the default
+        // memory zone. Done after the fallible steps above so a failure
+        // doesn't leave the region committed here (and re-advertised to a
+        // resuming manager via collect_uffd_regions).
+        if let Some(memory_zone) = self.memory_zones.get_mut(DEFAULT_MEMORY_ZONE) {
+            memory_zone.regions.push(Arc::clone(&region));
+        }
 
         // Update the slot so that it can be queried via the I/O port
         let slot = &mut self.hotplug_slots[self.next_hotplug_slot];
@@ -2679,6 +2794,12 @@ impl MemoryManager {
         slot.length = region.len();
 
         self.next_hotplug_slot += 1;
+
+        // The region is now fully added and uffd-registered; tell the
+        // manager. Best-effort — a failure drops the manager connection
+        // but does not fail the hot-add (a reconnecting manager re-syncs
+        // the region set on resume).
+        self.notify_uffd_add_region(&region);
 
         Ok(region)
     }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -11,13 +11,15 @@ use std::io::{self, Seek, SeekFrom};
 use std::mem::{MaybeUninit, zeroed};
 use std::num::NonZeroUsize;
 use std::ops::{BitAnd, Not, Sub};
-use std::os::fd::{AsFd, OwnedFd};
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Barrier, Mutex};
-use std::{cmp, ffi, panic, result, thread, time};
+use std::time::Duration;
+use std::{cmp, ffi, panic, process, result, thread, time};
 
 use acpi_tables::{Aml, aml};
 use anyhow::{Context, anyhow};
@@ -184,6 +186,94 @@ impl MemoryZone {
 
 pub type MemoryZones = HashMap<String, MemoryZone>;
 
+/// Metadata about a memory region registered for the uffd handoff,
+/// sent to the external manager as part of the handoff message.
+///
+/// `host_virt_addr` is the address in the *VMM's* address space that
+/// the kernel associates with the userfaultfd. The manager passes it
+/// back to the kernel in `UFFDIO_COPY` / `UFFDIO_WRITEPROTECT` /
+/// `PAGEMAP_SCAN`; the kernel resolves it against the VMM's mm
+/// (because the uffd was created there), not the manager's.
+///
+/// `backing_file_offset` is the byte offset within the backing file
+/// where this region begins. Relevant when a manager opens the
+/// backing storage for direct manipulation (eviction, snapshot read
+/// back), which it does via
+/// `openat("/proc/<vmm_pid>/map_files/<host_va_start>-<host_va_end>", ...)`.
+/// That path is resolved by the kernel against the live VMA, which
+/// avoids the races a raw fd or string path would expose (fd may
+/// have been closed and the number reused; path may have been
+/// unlinked or replaced). It requires CAP_SYS_PTRACE-equivalent on
+/// the manager (same-UID + dumpable, or root).
+///
+/// `vmm_pid` (in the `Handoff` message) is the VMM's pid in the VMM's
+/// own PID namespace. For it to name the VMM in the manager's
+/// `/proc`, the manager must run in the **same PID namespace** as the
+/// VMM and see a `/proc` mounted for it. Cross-PID-namespace handoff
+/// is not supported: a nested VMM cannot report its ancestor-namespace
+/// pid, so the orchestrator — which knows what runs in which namespace
+/// — is responsible for co-locating the manager and the VMM in one PID
+/// namespace (or otherwise arranging that `vmm_pid` resolves). The uffd
+/// itself is passed by fd and needs none of this — only the
+/// `/proc/<vmm_pid>` side-channel (`pagemap` scanning, `map_files`
+/// access) does.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UffdRegionInfo {
+    pub guest_phys_addr: u64,
+    pub host_virt_addr: u64,
+    pub size: u64,
+    #[serde(default)]
+    pub backing_file_offset: u64,
+}
+
+/// Newest uffd-handoff protocol version sent by this implementation.
+///
+/// Carried in the `Handoff` handshake so the manager can tell what
+/// wire contract it is talking to. Mirrors the migration protocol's
+/// `CURRENT_PROTOCOL_VERSION` idiom (see `vm-migration::protocol`): a
+/// missing/zeroed version is legacy `v0`, and the field only ever
+/// grows additively unless the shape changes incompatibly.
+pub const CURRENT_UFFD_HANDOFF_VERSION: u16 = 0;
+
+/// Per-step send/recv timeout for the handoff handshake.
+///
+/// The handshake (connect + sendmsg + 1-byte ACK) runs synchronously on
+/// the VMM control thread — the runtime-attach path also holds the
+/// `MemoryManager` mutex across it — so a manager that accepts the
+/// connection but then stalls must not block the VMM indefinitely. This
+/// bounds each blocking step; worst-case unresponsiveness is a small
+/// multiple of it. (`connect(2)` to an absent socket fails fast rather
+/// than waiting this long.) Moving the handshake off the VMM thread
+/// entirely (async attach) is left as future work.
+const UFFD_HANDOFF_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Wire-format for messages on the uffd handoff socket. All messages
+/// are length-prefixed (`u32` little-endian header before the JSON
+/// body) and tagged with a `type` discriminator so a single parser
+/// handles every kind:
+///
+/// - `Handoff` is the initial handshake sent inside `do_uffd_handoff`
+///   alongside the uffd fd in SCM_RIGHTS. It carries `version` (the
+///   handshake protocol version) and `mode` (the canonical
+///   `UffdHandoffSpec` token string, e.g. `"MISSING|WP|WP_ASYNC"`) so
+///   the message is self-describing: the manager learns from the
+///   handoff itself what the fd is registered for, rather than relying
+///   on out-of-band agreement. `regions` is sorted by `guest_phys_addr`
+///   ascending so the on-the-wire layout is reproducible across runs.
+///   The VMM's pid is included so the manager can construct
+///   `/proc/<vmm_pid>/map_files/...` paths if it needs direct
+///   backing-store access.
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum UffdHandoffMessage<'a> {
+    Handoff {
+        version: u16,
+        vmm_pid: u32,
+        mode: String,
+        regions: &'a [UffdRegionInfo],
+    },
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 struct GuestRamMapping {
     slot: u32,
@@ -241,6 +331,18 @@ pub struct MemoryManager {
     pub acpi_address: Option<GuestAddress>,
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     uefi_flash: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
+
+    /// True after a successful uffd handoff. Subsequent attach
+    /// attempts are rejected because `UFFDIO_REGISTER` won't accept a
+    /// second registration on the same VMA.
+    uffd_attached: bool,
+
+    /// CH's own copy of the userfaultfd handed off to the manager,
+    /// held for the VM's lifetime. The kernel refcounts the fd, so
+    /// keeping our dup keeps the registrations alive even if the
+    /// manager exits — faulting threads then block until a manager
+    /// returns rather than losing data (CH never resolves faults).
+    uffd_handoff_fd: Option<OwnedFd>,
 }
 
 #[derive(Error, Debug)]
@@ -419,6 +521,34 @@ pub enum Error {
     /// Failed to prefault memory
     #[error("Failed to prefault memory")]
     PrefaultMemory(#[source] io::Error),
+
+    /// Failed to create userfaultfd for handoff
+    #[error("Failed to create userfaultfd for handoff")]
+    UffdHandoffCreate(#[source] io::Error),
+
+    /// Failed to register memory region with userfaultfd for handoff
+    #[error("Failed to register memory region with userfaultfd for handoff")]
+    UffdHandoffRegister(#[source] io::Error),
+
+    /// uffd handoff socket error
+    #[error("uffd handoff socket error")]
+    UffdHandoff(#[source] io::Error),
+
+    /// uffd handoff JSON encode error
+    #[error("uffd handoff JSON encode error")]
+    UffdHandoffEncode(#[source] serde_json::Error),
+
+    /// uffd already handed off to this VM
+    #[error("uffd already handed off to this VM")]
+    UffdAlreadyAttached,
+
+    /// Failed to notify uffd manager of a hot-added region
+    #[error("Failed to notify uffd manager of hot-added region")]
+    UffdNotify(#[source] io::Error),
+
+    /// Failed to encode the uffd add-region notification
+    #[error("Failed to encode uffd add-region notification")]
+    UffdNotifyEncode(#[source] serde_json::Error),
 }
 
 impl From<UffdError> for Error {
@@ -1163,6 +1293,164 @@ impl MemoryManager {
             .is_some_and(|h| !h.prefault_complete.load(Ordering::Acquire))
     }
 
+    // --- uffd handoff support ---
+
+    /// Create a userfaultfd, register all guest memory regions
+    /// according to `mode`, and hand the fd off to an external manager
+    /// listening on `socket_path`.
+    ///
+    /// `mode` carries the parsed UFFD register modes and async
+    /// features (validated by `UffdHandoffSpec::parse` at the API/config
+    /// boundary). Mode-combination validity is left to the kernel,
+    /// which surfaces `EINVAL` from
+    /// `UFFDIO_REGISTER`.
+    ///
+    /// CH adds `UFFD_FEATURE_MISSING_{SHMEM,HUGETLBFS}` derived from
+    /// the memory backing when MISSING is requested.
+    ///
+    /// Protocol on the handoff socket: one `sendmsg`, ancillary data
+    /// carries the uffd, the body is a framed JSON `Handoff` message
+    /// (`version`, `vmm_pid`, `mode`, and the `regions` array — see
+    /// `UffdHandoffMessage`). The manager replies with one byte to
+    /// confirm it has started reading from the fd. By the time this
+    /// function returns, the manager owns the uffd and is ready to
+    /// service faults.
+    pub(crate) fn do_uffd_handoff(
+        &mut self,
+        socket_path: &str,
+        mode: userfaultfd::UffdHandoffSpec,
+    ) -> Result<(), Error> {
+        use std::os::fd::AsFd;
+
+        if self.uffd_attached {
+            return Err(Error::UffdAlreadyAttached);
+        }
+
+        let register_mode = mode.register;
+
+        // Derive baseline UFFD_API features from the requested register
+        // modes; OR in any async features the caller asked for.
+        let mut required_features = mode.features;
+        if register_mode & userfaultfd::UFFDIO_REGISTER_MODE_MISSING != 0 {
+            if self.shared {
+                required_features |= userfaultfd::UFFD_FEATURE_MISSING_SHMEM;
+            }
+            if self.hugepages {
+                required_features |= userfaultfd::UFFD_FEATURE_MISSING_HUGETLBFS;
+            }
+        }
+        // UFFDIO_REGISTER_MODE_WP against shmem or hugetlbfs VMAs
+        // needs WP_HUGETLBFS_SHMEM negotiated via UFFDIO_API. On
+        // anonymous private RAM the feature is a no-op; UFFDIO_REGISTER
+        // returns EINVAL without it on the shared/hugepage backings.
+        if register_mode & userfaultfd::UFFDIO_REGISTER_MODE_WP != 0
+            && (self.shared || self.hugepages)
+        {
+            required_features |= userfaultfd::UFFD_FEATURE_WP_HUGETLBFS_SHMEM;
+        }
+
+        let uffd = uffd::create(required_features).map_err(Error::UffdHandoffCreate)?;
+
+        let regions = self.collect_uffd_regions();
+
+        for r in &regions {
+            uffd::register(uffd.as_fd(), r.host_virt_addr, r.size, register_mode)
+                .map_err(Error::UffdHandoffRegister)?;
+        }
+
+        Self::send_uffd_handoff(socket_path, mode, &regions, uffd.as_fd())?;
+
+        // Keep CH's dup of the uffd for the VM's lifetime: it keeps the
+        // kernel registrations alive, so if the manager dies faulting
+        // vCPUs block (CH never resolves faults itself — no zero-fill)
+        // instead of losing data.
+        self.uffd_attached = true;
+        self.uffd_handoff_fd = Some(uffd);
+
+        info!(
+            "uffd: handed off uffd ({} regions) to {socket_path}",
+            regions.len()
+        );
+
+        // On any error path above, `uffd` (the OwnedFd) is dropped at
+        // scope exit — closing it auto-unregisters all VMAs in the
+        // kernel, leaving the VM in its pre-attach state. On the
+        // success path we stash it instead (see above).
+        Ok(())
+    }
+
+    /// Collect uffd region descriptors for all guest RAM zones, sorted
+    /// by guest physical address. `self.memory_zones` is a HashMap with
+    /// non-deterministic iteration order, so the sort keeps the on-wire
+    /// layout reproducible across runs.
+    fn collect_uffd_regions(&self) -> Vec<UffdRegionInfo> {
+        let mut regions = Vec::new();
+        for zone in self.memory_zones.values() {
+            for region in &zone.regions {
+                regions.push(UffdRegionInfo {
+                    guest_phys_addr: region.start_addr().raw_value(),
+                    host_virt_addr: region.as_ptr() as u64,
+                    size: region.len(),
+                    backing_file_offset: region.file_offset().map_or(0, |fo| fo.start()),
+                });
+            }
+        }
+        regions.sort_by_key(|r| r.guest_phys_addr);
+        regions
+        // TODO: virtio-pmem regions live outside `self.memory_zones`
+        // (DeviceManager creates its own MmapRegions), so they're not
+        // included in the handoff today. If a manager workflow ever
+        // needs pmem coverage, this and the hot-add hook need extending.
+    }
+
+    /// Connect to `socket_path`, send a framed `Handoff` message with
+    /// `uffd_fd` attached via SCM_RIGHTS, and wait for the manager's
+    /// 1-byte ACK. Returns the connected handshake socket.
+    ///
+    /// Framing: every message is `<u32 LE body length><body>`, sent as
+    /// two iovecs in one sendmsg so the SCM_RIGHTS ancillary fd attaches
+    /// to the right message. The ACK closes the boot-before-handoff
+    /// race: returning means the manager has the uffd and is polling.
+    ///
+    /// Bounded by `UFFD_HANDOFF_TIMEOUT` per send/recv: this runs on the
+    /// VMM control thread and the runtime-attach path holds the
+    /// MemoryManager mutex across it, so an unresponsive manager would
+    /// otherwise wedge the VMM and every operation that needs memory
+    /// state (resize, snapshot, hotplug). See that const for the
+    /// blocking/async trade-off.
+    fn send_uffd_handoff(
+        socket_path: &str,
+        mode: userfaultfd::UffdHandoffSpec,
+        regions: &[UffdRegionInfo],
+        uffd_fd: BorrowedFd<'_>,
+    ) -> Result<UnixStream, Error> {
+        use std::io::Read as _;
+        use std::os::fd::AsRawFd;
+
+        use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+
+        let body = serde_json::to_vec(&UffdHandoffMessage::Handoff {
+            version: CURRENT_UFFD_HANDOFF_VERSION,
+            vmm_pid: process::id(),
+            mode: mode.to_string(),
+            regions,
+        })
+        .map_err(Error::UffdHandoffEncode)?;
+
+        let mut sock = UnixStream::connect(socket_path).map_err(Error::UffdHandoff)?;
+        sock.set_write_timeout(Some(UFFD_HANDOFF_TIMEOUT))
+            .map_err(Error::UffdHandoff)?;
+        sock.set_read_timeout(Some(UFFD_HANDOFF_TIMEOUT))
+            .map_err(Error::UffdHandoff)?;
+        let header = (body.len() as u32).to_le_bytes();
+        sock.send_with_fds(&[&header[..], &body[..]], &[uffd_fd.as_raw_fd()])
+            .map_err(|e| Error::UffdHandoff(io::Error::from_raw_os_error(e.errno())))?;
+
+        let mut ack = [0u8; 1];
+        sock.read_exact(&mut ack).map_err(Error::UffdHandoff)?;
+        Ok(sock)
+    }
+
     /// Serve UFFD faults via `source`, prefaulting one page per idle
     /// iteration.
     #[expect(clippy::needless_pass_by_value)]
@@ -1875,7 +2163,13 @@ impl MemoryManager {
             #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
             uefi_flash: None,
             thp: config.thp,
+            uffd_attached: false,
+            uffd_handoff_fd: None,
         };
+
+        if let Some(handoff) = &config.uffd_handoff {
+            memory_manager.do_uffd_handoff(&handoff.socket, handoff.mode)?;
+        }
 
         Ok(Arc::new(Mutex::new(memory_manager)))
     }

--- a/vmm/src/uffd.rs
+++ b/vmm/src/uffd.rs
@@ -132,12 +132,19 @@ pub(crate) fn create(required_features: u64) -> Result<OwnedFd, Error> {
     Ok(fd)
 }
 
-/// Register a memory range for missing-page fault handling.
-pub(crate) fn register(fd: BorrowedFd<'_>, addr: u64, len: u64) -> Result<u64, Error> {
+/// Register a memory range for fault handling with the given mode flags.
+///
+/// Common modes:
+/// - `UFFDIO_REGISTER_MODE_MISSING`: missing-page faults (snapshot restore)
+/// - `UFFDIO_REGISTER_MODE_MISSING | UFFDIO_REGISTER_MODE_WP`: missing
+///   faults and write-protect tracking. WP-related ioctls
+///   (`UFFDIO_WRITEPROTECT`) are issued by the external manager on
+///   the handed-off fd.
+pub(crate) fn register(fd: BorrowedFd<'_>, addr: u64, len: u64, mode: u64) -> Result<u64, Error> {
     let mut reg = UffdioRegister {
         range_start: addr,
         range_len: len,
-        mode: userfaultfd::UFFDIO_REGISTER_MODE_MISSING,
+        mode,
         ioctls: 0,
     };
     // SAFETY: `reg` is a valid, correctly-sized struct for this ioctl.

--- a/vmm/src/userfaultfd.rs
+++ b/vmm/src/userfaultfd.rs
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt;
+use std::str::FromStr;
+
 // See include/uapi/linux/userfaultfd.h in the kernel code.
 pub const UFFDIO_API: u64 = 0xc018_aa3f; // _IOWR(0xAA, 0x3F, struct uffdio_api)
 pub const UFFDIO_REGISTER: u64 = 0xc020_aa00; // _IOWR(0xAA, 0x00, struct uffdio_register)
@@ -44,3 +47,215 @@ pub const UFFD_FEATURE_WP_ASYNC: u64 = 1 << 15;
 const _UFFDIO_COPY: u64 = 0x03;
 const _UFFDIO_WAKE: u64 = 0x02;
 pub const UFFD_API_RANGE_IOCTLS_BASIC: u64 = (1 << _UFFDIO_WAKE) | (1 << _UFFDIO_COPY);
+
+/// Parsed `MISSING|WP|WP_UNPOPULATED|WP_ASYNC`-style configuration
+/// spec for a single uffd handoff.
+///
+/// Two kernel surfaces are deliberately conflated into one user-facing
+/// token string:
+/// - register modes (MISSING, WP) → `UFFDIO_REGISTER` `mode` field
+/// - features (WP_UNPOPULATED, WP_ASYNC) → `UFFDIO_API`
+///   `features` field
+///
+/// They live in different ioctls and the async features are also
+/// toggleable later via `UFFDIO_SET_MODE`, but for the handoff use
+/// case they describe one decision (“how do I want this uffd
+/// configured?”), the token namespaces are disjoint, and the only
+/// features we accept here are the ones tightly coupled to the
+/// WP register mode — so a single spec is the ergonomic choice.
+///
+/// Stored as the parsed bits but serialised on the wire (CLI / JSON
+/// config / HTTP body) as the original token-string form, so config
+/// validation surfaces parse errors at deserialise time rather than
+/// at handoff time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(into = "String", try_from = "String")]
+pub struct UffdHandoffSpec {
+    pub register: u64,
+    pub features: u64,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum UffdHandoffSpecParseError {
+    #[error(
+        "unknown UFFD mode token '{0}' (expected one of \
+        MISSING, WP, WP_UNPOPULATED, WP_ASYNC)"
+    )]
+    UnknownToken(String),
+    #[error("UFFD mode requires at least one register mode (MISSING, WP)")]
+    NoRegisterMode,
+    #[error("UFFD feature '{feature}' requires register mode '{requires}'")]
+    FeatureRequiresRegisterMode {
+        feature: &'static str,
+        requires: &'static str,
+    },
+}
+
+impl UffdHandoffSpec {
+    /// Parse a `|`-separated set of tokens (whitespace around tokens is
+    /// trimmed). At least one register-mode token is required; async
+    /// tokens are optional.
+    pub fn parse(s: &str) -> Result<Self, UffdHandoffSpecParseError> {
+        let mut register = 0u64;
+        let mut features = 0u64;
+        for token in s.split('|').map(str::trim).filter(|t| !t.is_empty()) {
+            match token {
+                "MISSING" => register |= UFFDIO_REGISTER_MODE_MISSING,
+                "WP" => register |= UFFDIO_REGISTER_MODE_WP,
+                "WP_UNPOPULATED" => features |= UFFD_FEATURE_WP_UNPOPULATED,
+                "WP_ASYNC" => features |= UFFD_FEATURE_WP_ASYNC,
+                other => return Err(UffdHandoffSpecParseError::UnknownToken(other.into())),
+            }
+        }
+        if register == 0 {
+            return Err(UffdHandoffSpecParseError::NoRegisterMode);
+        }
+        // Feature/register cross-checks: each accepted feature is
+        // tightly coupled to a register mode (per the type docstring).
+        // Catch invalid combos here so the manager gets a 400 at
+        // deserialise time instead of a 5xx from UFFDIO_REGISTER.
+        if features & (UFFD_FEATURE_WP_UNPOPULATED | UFFD_FEATURE_WP_ASYNC) != 0
+            && register & UFFDIO_REGISTER_MODE_WP == 0
+        {
+            let feature = if features & UFFD_FEATURE_WP_ASYNC != 0 {
+                "WP_ASYNC"
+            } else {
+                "WP_UNPOPULATED"
+            };
+            return Err(UffdHandoffSpecParseError::FeatureRequiresRegisterMode {
+                feature,
+                requires: "WP",
+            });
+        }
+        Ok(UffdHandoffSpec { register, features })
+    }
+}
+
+impl FromStr for UffdHandoffSpec {
+    type Err = UffdHandoffSpecParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl fmt::Display for UffdHandoffSpec {
+    /// Canonical representation: tokens in fixed order joined by `|`.
+    /// Round-trips through `parse` (modulo input ordering / whitespace).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut tokens: Vec<&str> = Vec::with_capacity(4);
+        if self.register & UFFDIO_REGISTER_MODE_MISSING != 0 {
+            tokens.push("MISSING");
+        }
+        if self.register & UFFDIO_REGISTER_MODE_WP != 0 {
+            tokens.push("WP");
+        }
+        if self.features & UFFD_FEATURE_WP_UNPOPULATED != 0 {
+            tokens.push("WP_UNPOPULATED");
+        }
+        if self.features & UFFD_FEATURE_WP_ASYNC != 0 {
+            tokens.push("WP_ASYNC");
+        }
+        f.write_str(&tokens.join("|"))
+    }
+}
+
+impl From<UffdHandoffSpec> for String {
+    fn from(m: UffdHandoffSpec) -> String {
+        m.to_string()
+    }
+}
+
+impl TryFrom<String> for UffdHandoffSpec {
+    type Error = UffdHandoffSpecParseError;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::parse(&s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_register_mode() {
+        let m = UffdHandoffSpec::parse("WP").unwrap();
+        assert_eq!(m.register, UFFDIO_REGISTER_MODE_WP);
+        assert_eq!(m.features, 0);
+    }
+
+    #[test]
+    fn parse_combination() {
+        let m = UffdHandoffSpec::parse("MISSING|WP|WP_ASYNC").unwrap();
+        assert_eq!(
+            m.register,
+            UFFDIO_REGISTER_MODE_MISSING | UFFDIO_REGISTER_MODE_WP
+        );
+        assert_eq!(m.features, UFFD_FEATURE_WP_ASYNC);
+    }
+
+    #[test]
+    fn parse_whitespace_tolerant() {
+        let m = UffdHandoffSpec::parse(" MISSING |  WP ").unwrap();
+        assert_eq!(
+            m.register,
+            UFFDIO_REGISTER_MODE_MISSING | UFFDIO_REGISTER_MODE_WP
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unknown_token() {
+        assert_eq!(
+            UffdHandoffSpec::parse("MISSING|FOO"),
+            Err(UffdHandoffSpecParseError::UnknownToken("FOO".into()))
+        );
+    }
+
+    #[test]
+    fn parse_rejects_no_register_mode() {
+        assert_eq!(
+            UffdHandoffSpec::parse(""),
+            Err(UffdHandoffSpecParseError::NoRegisterMode)
+        );
+        assert_eq!(
+            UffdHandoffSpec::parse("WP_ASYNC"),
+            Err(UffdHandoffSpecParseError::NoRegisterMode)
+        );
+    }
+
+    #[test]
+    fn parse_rejects_feature_without_register_mode() {
+        assert_eq!(
+            UffdHandoffSpec::parse("MISSING|WP_ASYNC"),
+            Err(UffdHandoffSpecParseError::FeatureRequiresRegisterMode {
+                feature: "WP_ASYNC",
+                requires: "WP",
+            })
+        );
+        assert_eq!(
+            UffdHandoffSpec::parse("MISSING|WP_UNPOPULATED"),
+            Err(UffdHandoffSpecParseError::FeatureRequiresRegisterMode {
+                feature: "WP_UNPOPULATED",
+                requires: "WP",
+            })
+        );
+    }
+
+    #[test]
+    fn display_canonical_and_roundtrip() {
+        assert_eq!(UffdHandoffSpec::parse("WP").unwrap().to_string(), "WP");
+        assert_eq!(
+            UffdHandoffSpec::parse("MISSING|WP").unwrap().to_string(),
+            "MISSING|WP"
+        );
+        // Display order is fixed regardless of parse-input order.
+        let m = UffdHandoffSpec::parse("WP_ASYNC|WP|MISSING").unwrap();
+        assert_eq!(m.to_string(), "MISSING|WP|WP_ASYNC");
+        // Round-trip preserves bits.
+        assert_eq!(UffdHandoffSpec::parse(&m.to_string()).unwrap(), m);
+        // WP + WP_UNPOPULATED tokens.
+        let wp = UffdHandoffSpec::parse("WP|WP_UNPOPULATED").unwrap();
+        assert_eq!(wp.register, UFFDIO_REGISTER_MODE_WP);
+        assert_eq!(wp.features, UFFD_FEATURE_WP_UNPOPULATED);
+        assert_eq!(wp.to_string(), "WP|WP_UNPOPULATED");
+    }
+}

--- a/vmm/src/userfaultfd.rs
+++ b/vmm/src/userfaultfd.rs
@@ -32,10 +32,14 @@ const _: () = assert!(USERFAULTFD_IOC_NEW == ioctl_ioc(0, 0xAA, 0x00, 0));
 const _: () = assert!(USERFAULTFD_IOC_NEW <= u32::MAX as u64);
 
 pub const UFFD_API: u64 = 0xAA;
-pub const UFFDIO_REGISTER_MODE_MISSING: u64 = 1;
+pub const UFFDIO_REGISTER_MODE_MISSING: u64 = 1 << 0;
+pub const UFFDIO_REGISTER_MODE_WP: u64 = 1 << 1;
 pub const UFFD_EVENT_PAGEFAULT: u8 = 0x12;
 pub const UFFD_FEATURE_MISSING_HUGETLBFS: u64 = 1 << 4;
 pub const UFFD_FEATURE_MISSING_SHMEM: u64 = 1 << 5;
+pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u64 = 1 << 6;
+pub const UFFD_FEATURE_WP_UNPOPULATED: u64 = 1 << 13;
+pub const UFFD_FEATURE_WP_ASYNC: u64 = 1 << 15;
 
 const _UFFDIO_COPY: u64 = 0x03;
 const _UFFDIO_WAKE: u64 = 0x02;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3095,6 +3095,10 @@ impl Vm {
         unimplemented!()
     }
 
+    pub fn memory_manager(&self) -> &Arc<Mutex<MemoryManager>> {
+        &self.memory_manager
+    }
+
     pub fn memory_manager_data(&self) -> MemoryManagerSnapshotData {
         self.memory_manager.lock().unwrap().snapshot_data()
     }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -22,6 +22,7 @@ use virtio_devices::RateLimiterConfig;
 
 use crate::Landlock;
 use crate::landlock::LandlockError;
+use crate::userfaultfd::UffdHandoffSpec;
 
 pub type LandlockResult<T> = result::Result<T, LandlockError>;
 
@@ -320,6 +321,24 @@ pub struct MemoryConfig {
     pub zones: Option<Vec<MemoryZoneConfig>>,
     #[serde(default = "default_memoryconfig_thp")]
     pub thp: bool,
+    /// Boot-time userfaultfd handoff. If set, the VMM creates a
+    /// userfaultfd registered per `mode`, then dials `socket` and
+    /// hands the fd (with region metadata) over before the VM boots.
+    #[serde(default)]
+    pub uffd_handoff: Option<UffdHandoffConfig>,
+}
+
+/// Both fields are required when this struct is present — there is no
+/// sensible default for the UFFD register mode, so the user has to
+/// pick what they want.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct UffdHandoffConfig {
+    /// Path to a Unix socket where the external uffd manager listens.
+    pub socket: String,
+    /// `|`-separated UFFD mode tokens, e.g. `"MISSING|WP|WP_ASYNC"`.
+    /// Tokens: `MISSING`, `WP` (register modes); `WP_UNPOPULATED`,
+    /// `WP_ASYNC` (features). Validated at deserialise time.
+    pub mode: UffdHandoffSpec,
 }
 
 pub const DEFAULT_MEMORY_MB: u64 = 512;
@@ -339,6 +358,7 @@ impl Default for MemoryConfig {
             reserve: false,
             zones: None,
             thp: true,
+            uffd_handoff: None,
         }
     }
 }
@@ -1227,6 +1247,15 @@ impl VmConfig {
             for zone in mem_zones.iter() {
                 zone.apply_landlock(&mut landlock)?;
             }
+        }
+
+        // Boot-time uffd handoff: CH connect()s to the manager's socket
+        // during boot, so it must be reachable under Landlock. A runtime
+        // `vm.uffd-attach` uses a socket not known at boot and is thus not
+        // covered here — with Landlock enabled the operator must
+        // pre-authorize that path via `landlock_rules`.
+        if let Some(handoff) = &self.memory.uffd_handoff {
+            landlock.add_rule_with_access(Path::new(&handoff.socket), "rw")?;
         }
 
         let disks = &self.disks;


### PR DESCRIPTION
## Summary

This series lets Cloud Hypervisor hand its guest-RAM `userfaultfd` to a
separate manager process over a Unix socket, so that demand paging,
live-migration, snapshotting, and working-set tracking can be implemented
**outside** the VMM. CH creates the uffd, registers it over guest RAM in a
caller-chosen mode, and passes the fd (plus a description of the registered
regions) via `SCM_RIGHTS`. From that point the manager owns the fault stream;
CH stays out of the policy business.

It generalizes the mechanism CH already has for postcopy restore
(`SocketUffdMemorySource`) into a first-class, runtime-controllable interface,
available both at boot and at runtime.

## Motivation — mechanism, not policy

Baking migration/snapshot/tiering *policy* into the VMM doesn't scale: every
new strategy means new VMM code and a new release. The same argument that put
block and net backends behind `vhost-user` applies to guest memory. Exposing
the uffd handoff as a stable interface lets an orchestrator ship and iterate on
that policy independently — CH provides the fault plane, the manager provides
the behavior.

## User-facing interface

**Boot-time** (via `--memory`):

```
--memory size=1G,shared=on,uffd_handoff_socket=/run/uffd.sock,uffd_handoff_mode=MISSING|WP|WP_ASYNC
```

Both fields are required together; there is no default mode — the caller picks
what to register. `uffd_handoff_mode` is a `|`-separated token set:
`MISSING`, `WP` (register modes) and `WP_UNPOPULATED`, `WP_ASYNC` (features).
At least one register mode is required. Tokens are parsed and validated at
config-deserialise time, so a bad spec fails fast rather than at handoff.

**Runtime** (HTTP API + `ch-remote`) — attach a manager to an already-running VM:

```
PUT /api/v1/vm.uffd-attach   { "handoff_socket": "/run/uffd.sock", "mode": "MISSING|WP|WP_ASYNC" }
ch-remote --api-socket <sock> vm.uffd-attach --socket /run/uffd.sock --mode "MISSING|WP|WP_ASYNC"
```

Handoff is synchronous and race-free: CH dials the socket, sends the fd + a
JSON region descriptor, and waits for a one-byte ACK confirming the manager is
polling. By the time the call returns, every guest access faults into the
manager (at boot this happens inside `MemoryManager::new`, closing the
boot-before-handoff window).

## Wire protocol

Length-prefixed JSON, versioned and self-describing from day one so future mode
transitions don't need a flag day:

```
Handoff  { version, vmm_pid, mode, regions:[{ guest_phys_addr, size, host_addr, ... }] }
AddRegion{ ... }        // pushed on memory hot-add
```

`UffdHandoffSpec` round-trips through its token string on the wire, so what the
manager sees is exactly what the operator configured.

## Resume & the single-manager invariant

The manager may crash and restart. CH keeps its own dup of the uffd for the
VM's lifetime, so registrations survive and faults simply **block (no data
loss)** while the manager is gone. `vm.uffd-attach` is idempotent: re-attaching
with the *same* mode re-sends the existing fd and current region set (a resume —
the manager can't tell it apart from a first attach; it just drains the backlog
and wakes the stalled vCPUs). Re-attaching with a *different* mode is rejected
(a re-key is not implemented; 400, not 5xx). Exactly one live manager at a time
is the orchestrator's invariant — once the fd is sent, CH cannot revoke a dup.

## Commits (bisectable, each builds & is clippy/rustfmt-clean)

1. `vmm: extend userfaultfd bindings for WP register modes`
2. `vmm: add UffdHandoffSpec parser for UFFD-mode token strings`
3. `vmm: add boot-time userfaultfd handoff over Unix socket`
4. `vmm: notify the uffd manager of hot-added memory regions`
5. `vmm: add vm.uffd-attach HTTP API for runtime uffd handoff`
6. `vmm: resume uffd handoff after manager restart`
7. `ch-remote: add vm.uffd-attach subcommand`
8. `docs: document external userfaultfd handoff`
9. `tests: add uffd handoff integration tests`

## Operational notes

- **Same PID namespace.** The handoff carries `vmm_pid` so the manager can
  `PAGEMAP_SCAN`/read `/proc/<pid>/pagemap`; that pid is only meaningful if CH
  and the manager share a PID namespace. Whoever launches the two is
  responsible for that — documented in `docs/memory.md`.
- **Landlock.** When Landlock is enabled, the handoff socket path needs an
  explicit `rw` rule; CH adds one for the configured socket.

## Out of scope

`UFFDIO_REGISTER_MODE_RWP` (read-write-protect access tracking — it also catches
reads, which `WP`'s write-only signal misses) is a follow-up, submitted once the
RWP kernel support reaches a released kernel. The set exposed here — `MISSING`,
`WP`, `WP_UNPOPULATED`, `WP_ASYNC` — already covers postcopy migration and
WP-async write-set tracking on current kernels.

## Testing

New integration tests (`test_uffd_handoff`, `test_uffd_resume`,
`test_uffd_writeset_{anon,shmem,anon_thp,shmem_thp}`) exercise boot handoff,
manager-restart resume, and WP-async write-set classification via `PAGEMAP_SCAN`
over both private and shared (shmem) backings, with and without THP — all
passing. The write-set tests self-skip on kernels without `UFFD_FEATURE_WP_ASYNC`.

Based on `v53.0`.
