### PR TITLE
block: Fix QCOW double allocation after a failed L2 relocation

### DIFF
--- a/block/src/formats/qcow/metadata.rs
+++ b/block/src/formats/qcow/metadata.rs
@@ -728,6 +728,15 @@ impl QcowState {
         set_refcounts: &mut Vec<(u64, u64)>,
     ) -> io::Result<()> {
         if !self.l2_cache.get(l1_index).unwrap().dirty() {
+            // Allocate the new cluster for the relocated L2 table before
+            // releasing the old one: if this allocation fails (ENOSPC at
+            // allocator exhaustion) the old table must stay off the free
+            // lists, or a later allocation would hand it out and overwrite a
+            // live L2 table (issue #8606). The cluster will be written when
+            // the cache is flushed.
+            let new_addr = self.get_new_cluster(None)?;
+            set_refcounts.push((new_addr, 1));
+
             // Free the previously used cluster if one exists. Modified tables are always
             // written to new clusters so the L1 table can be committed to disk after they
             // are and L1 never points at an invalid table.
@@ -737,10 +746,6 @@ impl QcowState {
                 set_refcounts.push((addr, 0));
             }
 
-            // Allocate a new cluster to store the L2 table and update the L1 table to point
-            // to the new table. The cluster will be written when the cache is flushed.
-            let new_addr = self.get_new_cluster(None)?;
-            set_refcounts.push((new_addr, 1));
             self.l1_table[l1_index] = new_addr; // marks l1_table dirty via IndexMut
         }
         // Write the L2 entry - IndexMut marks the L2 table dirty automatically.
@@ -1134,5 +1139,165 @@ impl QcowState {
         if let Err(e) = self.header.set_corrupt_bit(self.raw_file.file_mut()) {
             log::warn!("Failed to persist corrupt bit: {e}");
         }
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    // Regression for the ENOSPC unwind on the relocate-on-write path: when
+    // the allocation for the relocated table fails, the still-referenced old
+    // L2 table must not be left on the free lists (issue #8606).
+    #[test]
+    fn failed_l2_relocate_keeps_live_table_off_free_lists() {
+        let cluster_size: u64 = 1 << 16;
+        let temp = super::super::QcowTempDisk::new(64 * cluster_size, None, false, true, false)
+            .unwrap()
+            .into_tempfile();
+        let raw = crate::AlignedFile::new(temp.as_file().try_clone().unwrap(), false);
+        let (mut inner, _backing, _sparse) =
+            super::super::parser::parse_qcow(raw, 0, true).unwrap();
+
+        // Materialize an L2 table plus one data cluster, then flush so the
+        // next write to the region takes the relocate-on-write path.
+        let super::ClusterWriteMapping::Allocated {
+            offset: data_cluster,
+        } = inner.map_write(0, None).expect("initial write");
+        inner.sync_caches().expect("flush");
+        let live_l2 = inner.l1_table[0];
+        assert_ne!(live_l2, 0);
+
+        // Exhaust the allocator down to two reusable clusters: shrink the
+        // refcount horizon so the file cannot grow, and leave exactly enough
+        // for the data cluster of the next write plus the refcount-block
+        // relocation it triggers, but nothing for relocating its L2 table.
+        let file_clusters = inner
+            .raw_file
+            .file_mut()
+            .metadata()
+            .unwrap()
+            .len()
+            .div_ceil(cluster_size);
+        inner.refcounts = super::super::refcount::RefCount::new(
+            &mut inner.raw_file,
+            inner.header.refcount_table_offset,
+            1,
+            file_clusters,
+            cluster_size,
+            16,
+        )
+        .unwrap();
+        let freed = super::mem::take(&mut inner.unref_clusters);
+        assert!(
+            !freed.is_empty(),
+            "the first write must have relocated the refcount block, freeing its old cluster"
+        );
+        inner.avail_clusters.clear();
+        inner.avail_clusters.push(data_cluster);
+        inner.avail_clusters.extend(freed);
+
+        let err = inner
+            .map_write(cluster_size, None)
+            .expect_err("relocation must fail with the allocator exhausted");
+        assert_eq!(err.raw_os_error(), Some(libc::ENOSPC));
+        assert!(
+            inner.avail_clusters.is_empty(),
+            "the failure must land on the L2 relocation, with every candidate consumed"
+        );
+
+        assert_eq!(
+            inner.l1_table[0], live_l2,
+            "L1 must still reference the old table after the failed write"
+        );
+        assert!(
+            !inner.unref_clusters.contains(&live_l2) && !inner.avail_clusters.contains(&live_l2),
+            "a still-referenced L2 table must never enter the free lists"
+        );
+    }
+
+    // The same defect is reached constantly by images holding compressed
+    // clusters: writing to a compressed cluster always takes the
+    // decompress -> append_data_cluster -> update_cluster_addr path, so every
+    // such write relocates its L2 table.
+    #[test]
+    fn failed_l2_relocate_after_compressed_write_keeps_live_table() {
+        use std::os::unix::fs::FileExt;
+
+        const COMPRESSED_FLAG: u64 = 1 << 62;
+        let cluster_size: u64 = 1 << 16;
+        let temp = super::super::QcowTempDisk::new(64 * cluster_size, None, false, true, false)
+            .unwrap()
+            .into_tempfile();
+
+        // Seed an L2 table plus a data cluster, flush, then compress that data
+        // cluster in place so re-writing it takes the compressed path.
+        {
+            let raw = crate::AlignedFile::new(temp.as_file().try_clone().unwrap(), false);
+            let (mut inner, _backing, _sparse) =
+                super::super::parser::parse_qcow(raw, 0, true).unwrap();
+            inner
+                .map_write(0, Some(vec![0xab; cluster_size as usize]))
+                .expect("seed write");
+            inner.sync_caches().expect("flush");
+        }
+        super::super::common::unit_tests::compress_allocated_clusters(
+            &mut temp.as_file().try_clone().unwrap(),
+        );
+
+        // Re-open so the L2 cache reflects the on-disk compressed entry.
+        let raw = crate::AlignedFile::new(temp.as_file().try_clone().unwrap(), false);
+        let (mut inner, _backing, _sparse) =
+            super::super::parser::parse_qcow(raw, 0, true).unwrap();
+        let live_l2 = inner.l1_table[0];
+        assert_ne!(live_l2, 0);
+
+        // An already allocated plain cluster would be written in place with no
+        // relocation, so confirm the seed really is compressed.
+        let mut entry = [0u8; 8];
+        temp.as_file().read_exact_at(&mut entry, live_l2).unwrap();
+        assert_ne!(
+            u64::from_be_bytes(entry) & COMPRESSED_FLAG,
+            0,
+            "the seed cluster must be compressed to trigger the relocation"
+        );
+
+        // Cap file growth at the current horizon and leave exactly two free
+        // clusters: enough for the write's data cluster and the refcount block
+        // relocation it triggers, but nothing for relocating the L2 table.
+        let file_clusters = inner
+            .raw_file
+            .file_mut()
+            .metadata()
+            .unwrap()
+            .len()
+            .div_ceil(cluster_size);
+        inner.refcounts = super::super::refcount::RefCount::new(
+            &mut inner.raw_file,
+            inner.header.refcount_table_offset,
+            1,
+            file_clusters,
+            cluster_size,
+            16,
+        )
+        .unwrap();
+        let mut free = super::mem::take(&mut inner.avail_clusters);
+        free.retain(|&c| c != live_l2 && c != 0);
+        assert!(free.len() >= 2, "need two free clusters for the budget");
+        inner.avail_clusters.clear();
+        inner.avail_clusters.push(free[0]);
+        inner.avail_clusters.push(free[1]);
+
+        let err = inner
+            .map_write(0, None)
+            .expect_err("the L2 relocation must fail with the allocator exhausted");
+        assert_eq!(err.raw_os_error(), Some(libc::ENOSPC));
+
+        assert_eq!(
+            inner.l1_table[0], live_l2,
+            "L1 must still reference the old table after the failed write"
+        );
+        assert!(
+            !inner.unref_clusters.contains(&live_l2) && !inner.avail_clusters.contains(&live_l2),
+            "a still-referenced L2 table must never enter the free lists"
+        );
     }
 }


### PR DESCRIPTION
# block: Fix QCOW double allocation after a failed L2 relocation

## What breaks

At allocator exhaustion, `update_cluster_addr()` can leave a **live L2 table on the
free list**, so a later allocation hands that still-referenced table to a new writer,
which overwrites it. Everything mapped through that table becomes unreachable.

The image is not flagged corrupt (`corrupt: false`), so this is silent: neither the
VMM nor the guest is told, and the damage surfaces much later as unreadable data.

This is distinct from the two allocator bugs already fixed on main — the stale
punch-hole (#8624, which only ever zeroes) and the pointer-table cursor bug
(17b6fd9). It reproduces on current main with both of those fixes present.

## Root cause

`update_cluster_addr()` releases the old L2 table before securing its replacement:

```rust
let addr = self.l1_table[l1_index];
if addr != 0 {
    self.unref_clusters.push(addr);   // old table released
    set_refcounts.push((addr, 0));    // its refcount zeroing is deferred
}
let new_addr = self.get_new_cluster(None)?;   // ENOSPC here unwinds the caller
self.l1_table[l1_index] = new_addr;
```

When `get_new_cluster()` fails, `?` returns through `map_write()`, which drops the
local `set_refcounts` vector. What survives is the damage:

* the old table sits in `unref_clusters` (a field, not a local),
* its refcount was never zeroed,
* `l1_table[l1_index]` still points at it, and
* the cached table is still clean.

The next metadata flush moves `unref_clusters` into `avail_clusters`, publishing a
live L2 table to the allocator. Because the cached table stayed clean, any later
write into the same L1 slot re-enters the branch and pushes the same cluster again,
so a single cluster can be handed to two writers at once.

Images holding compressed clusters reach this constantly: writing to a compressed
cluster always takes `decompress -> append_data_cluster -> update_cluster_addr`, so
every such write relocates its L2 table.

## Fix

Allocate the replacement first, release the old table only after that succeeds:

```
allocate replacement -> release old table -> update L1
```

A failed relocation now leaves the old table referenced, off the free lists, intact.

## Tests

Two deterministic regression tests, both red before the change and green after:

* `failed_l2_relocate_keeps_live_table_off_free_lists` — plain write, allocator
  exhausted exactly at the L2 relocation step.
* `failed_l2_relocate_after_compressed_write_keeps_live_table` — the compressed
  cluster entry point that makes this reachable in practice.

Building the second test surfaced that refcount blocks also relocate on their first
post-flush modification, so the scenario budgets a cluster for that relocation too.

## Validation

* `cargo fmt --all -- --check`
* `cargo test --locked -p block` — 227 passed
* `cargo test --locked -p block --features io_uring` — 255 passed
* `cargo clippy -p block --all-targets` — clean

Runtime A/B on an isolated host, both arms from a byte-identical 32 GiB qcow2 seed
(100% compressed clusters), same workload driven to allocator exhaustion, clean
shutdown, offline `qemu-img check` plus an L2-table content classifier:

Five runs, three on unpatched main and two with this change, each from the same seed:

| run | binary | double-allocated clusters | L2 tables overwritten | qemu-img errors | leaked | cycles | files written | ENOSPC |
|---|---|---|---|---|---|---|---|---|
| 1 | main | **5** | 1 | 6,993 | 6,311 | 18 | 110 | 24,224 |
| 2 | main | **2** | 0 | 27,015 | 32,770 | 24 | 125 | 20,896 |
| 3 | main | **1** | 0 | 1 | 6,312 | 19 | 128 | 39,309 |
| 4 | patched | **0** | 0 | **0** | 1 | 24 | 204 | 26,427 |
| 5 | patched | **0** | 0 | **0** | 1 | 18 | 154 | 34,890 |

"Double-allocated" counts clusters where `qemu-img check` reports `reference > refcount`,
i.e. the allocator handed the same cluster to more than one user. It appears in **3/3**
unpatched runs and **0/2** patched runs. Every patched run did at least as much work as
the lightest unpatched run on both cycles and files written, so this is not a
did-less-work artifact.

The L2-table overwrite is the rare catastrophic tail of the same defect: it landed in
one of the three unpatched runs. When it does land, that single overwritten table
accounts for roughly 7,000 `qemu-img check` errors on its own, because its foreign
content is then parsed as L2 entries pointing past end-of-file.

The `corrupt` header flag stayed false in every run, patched or not — nothing in the
stack notices.

## Known remaining gap (not addressed here)

The same ENOSPC unwind can also drop the deferred refcount update of a cluster that
was already wired into the tables earlier in the same `map_write()` — a fresh L2
table from `cache_l2_cluster_alloc()`, for example. The reference then persists with
refcount 0. In-run this is inert, but a later reopen rebuilds the free list from
refcounts and would offer that still-referenced cluster for reuse. Making the wiring
and the refcount application atomic under the unwind is a larger change; this patch
closes the path that overwrites live clusters within a single run.

Separately, once the allocator is exhausted, DISCARD requests also fail (deallocation
needs an allocation to record the refcount change), so the image cannot recover its
own free space. Worth a look, but out of scope here.
