### PR TITLE
aarch64: Correctly snapshot GIC Redistributor and ICC states

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -17,7 +17,6 @@ use std::hash::BuildHasher;
 use std::sync::{Arc, Mutex};
 
 use hypervisor::arch::aarch64::gic::Vgic;
-use hypervisor::arch::aarch64::regs::MPIDR_EL1;
 use log::{Level, log_enabled};
 use thiserror::Error;
 use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryBackend};
@@ -50,10 +49,6 @@ pub enum Error {
     #[error("Error configuring the general purpose registers")]
     RegsConfiguration(#[source] hypervisor::HypervisorCpuError),
 
-    /// Error configuring the MPIDR register
-    #[error("Error configuring the MPIDR register")]
-    VcpuRegMpidr(#[source] hypervisor::HypervisorCpuError),
-
     /// Error initializing PMU for vcpu
     #[error("Error initializing PMU for vcpu")]
     VcpuInitPmu,
@@ -72,7 +67,7 @@ pub fn configure_vcpu(
     vcpu: &dyn hypervisor::Vcpu,
     id: u32,
     boot_setup: Option<(EntryPoint, &GuestMemoryAtomic<GuestMemoryMmap>)>,
-) -> super::Result<u64> {
+) -> super::Result<()> {
     if let Some((kernel_entry_point, _guest_memory)) = boot_setup {
         vcpu.setup_regs(
             id,
@@ -81,9 +76,7 @@ pub fn configure_vcpu(
         )
         .map_err(Error::RegsConfiguration)?;
     }
-
-    let mpidr = vcpu.get_sys_reg(MPIDR_EL1).map_err(Error::VcpuRegMpidr)?;
-    Ok(mpidr)
+    Ok(())
 }
 
 pub fn arch_memory_regions() -> Vec<(GuestAddress, usize, RegionType)> {

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -17,7 +17,6 @@ use std::hash::BuildHasher;
 use std::sync::{Arc, Mutex};
 
 use hypervisor::arch::aarch64::gic::Vgic;
-use hypervisor::arch::aarch64::regs::MPIDR_EL1;
 use log::{Level, log_enabled};
 use thiserror::Error;
 use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryBackend};
@@ -72,7 +71,7 @@ pub fn configure_vcpu(
     vcpu: &dyn hypervisor::Vcpu,
     id: u32,
     boot_setup: Option<(EntryPoint, &GuestMemoryAtomic<GuestMemoryMmap>)>,
-) -> super::Result<u64> {
+) -> super::Result<()> {
     if let Some((kernel_entry_point, _guest_memory)) = boot_setup {
         vcpu.setup_regs(
             id,
@@ -81,9 +80,7 @@ pub fn configure_vcpu(
         )
         .map_err(Error::RegsConfiguration)?;
     }
-
-    let mpidr = vcpu.get_sys_reg(MPIDR_EL1).map_err(Error::VcpuRegMpidr)?;
-    Ok(mpidr)
+    Ok(())
 }
 
 pub fn arch_memory_regions() -> Vec<(GuestAddress, usize, RegionType)> {

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -7,7 +7,6 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
 use arch::layout;
-use hypervisor::CpuState;
 use hypervisor::arch::aarch64::gic::{GicState, Vgic, VgicConfig};
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup,
@@ -63,19 +62,9 @@ impl Gic {
         Ok(gic)
     }
 
-    pub fn restore_vgic(
-        &mut self,
-        state: Option<GicState>,
-        saved_vcpu_states: &[CpuState],
-    ) -> Result<()> {
-        self.set_gicr_typers(saved_vcpu_states);
-        self.vgic
-            .clone()
-            .unwrap()
-            .lock()
-            .unwrap()
-            .set_state(&state.unwrap())
-            .map_err(Error::RestoreGic)
+    pub fn restore_vgic(&self, state: Option<GicState>) -> Result<()> {
+        let mut vgic = self.vgic.as_ref().unwrap().lock().unwrap();
+        vgic.set_state(&state.unwrap()).map_err(Error::RestoreGic)
     }
 
     fn enable(&self) -> Result<()> {
@@ -126,11 +115,6 @@ impl Gic {
 
     pub fn get_vgic(&mut self) -> Result<Arc<Mutex<dyn Vgic>>> {
         Ok(self.vgic.clone().unwrap())
-    }
-
-    pub fn set_gicr_typers(&mut self, vcpu_states: &[CpuState]) {
-        let vgic = self.vgic.as_ref().unwrap().clone();
-        vgic.lock().unwrap().set_gicr_typers(vcpu_states);
     }
 }
 

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -7,7 +7,6 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
 use arch::layout;
-use hypervisor::CpuState;
 use hypervisor::arch::aarch64::gic::{GicState, Vgic, VgicConfig};
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup,
@@ -63,19 +62,10 @@ impl Gic {
         Ok(gic)
     }
 
-    pub fn restore_vgic(
-        &mut self,
-        state: Option<GicState>,
-        saved_vcpu_states: &[CpuState],
-    ) -> Result<()> {
-        self.set_gicr_typers(saved_vcpu_states);
-        self.vgic
-            .clone()
-            .unwrap()
-            .lock()
-            .unwrap()
-            .set_state(&state.unwrap())
-            .map_err(Error::RestoreGic)
+    pub fn restore_vgic(&self, state: Option<GicState>, mpidrs: Vec<u64>) -> Result<()> {
+        let mut vgic = self.vgic.as_ref().unwrap().lock().unwrap();
+        vgic.set_mpidrs(mpidrs);
+        vgic.set_state(&state.unwrap()).map_err(Error::RestoreGic)
     }
 
     fn enable(&self) -> Result<()> {
@@ -126,11 +116,6 @@ impl Gic {
 
     pub fn get_vgic(&mut self) -> Result<Arc<Mutex<dyn Vgic>>> {
         Ok(self.vgic.clone().unwrap())
-    }
-
-    pub fn set_gicr_typers(&mut self, vcpu_states: &[CpuState]) {
-        let vgic = self.vgic.as_ref().unwrap().clone();
-        vgic.lock().unwrap().set_gicr_typers(vcpu_states);
     }
 }
 

--- a/hypervisor/src/arch/aarch64/gic.rs
+++ b/hypervisor/src/arch/aarch64/gic.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use crate::kvm::aarch64::gic::Gicv3ItsState;
 #[cfg(feature = "mshv")]
 use crate::mshv::aarch64::gic::MshvGicV2MState;
-use crate::{CpuState, HypervisorDeviceError, HypervisorVmError};
+use crate::{HypervisorDeviceError, HypervisorVmError};
 
 /// Errors thrown while setting up the VGIC.
 #[derive(Debug, Error)]
@@ -111,9 +111,6 @@ pub trait Vgic: Send + Sync {
     /// Returns the MSI reg property of the device
     fn msi_properties(&self) -> [u64; 2];
 
-    /// Get the values of GICR_TYPER for each vCPU.
-    fn set_gicr_typers(&mut self, vcpu_states: &[CpuState]);
-
     /// Downcast the trait object to its concrete type.
     fn as_any_concrete_mut(&mut self) -> &mut dyn Any;
 
@@ -125,4 +122,7 @@ pub trait Vgic: Send + Sync {
 
     /// Saves GIC internal data tables into RAM.
     fn save_data_tables(&self) -> Result<()>;
+
+    /// Set the per-vCPU MPIDRs.
+    fn set_mpidrs(&mut self, mpidrs: Vec<u64>);
 }

--- a/hypervisor/src/arch/aarch64/gic.rs
+++ b/hypervisor/src/arch/aarch64/gic.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use crate::kvm::aarch64::gic::Gicv3ItsState;
 #[cfg(feature = "mshv")]
 use crate::mshv::aarch64::gic::MshvGicV2MState;
-use crate::{CpuState, HypervisorDeviceError, HypervisorVmError};
+use crate::{HypervisorDeviceError, HypervisorVmError};
 
 /// Errors thrown while setting up the VGIC.
 #[derive(Debug, Error)]
@@ -110,9 +110,6 @@ pub trait Vgic: Send + Sync {
 
     /// Returns the MSI reg property of the device
     fn msi_properties(&self) -> [u64; 2];
-
-    /// Get the values of GICR_TYPER for each vCPU.
-    fn set_gicr_typers(&mut self, vcpu_states: &[CpuState]);
 
     /// Downcast the trait object to its concrete type.
     fn as_any_concrete_mut(&mut self) -> &mut dyn Any;

--- a/hypervisor/src/arch/aarch64/mod.rs
+++ b/hypervisor/src/arch/aarch64/mod.rs
@@ -24,6 +24,15 @@ pub fn get_cntfrq() -> u64 {
     cntfrq
 }
 
+/// Return the MPIDR based on the vCPU ID
+/// Based on reset_mpidr() in linux/arch/arm64/kvm/sys_regs.c
+pub const fn mpidr_from_vcpu_id(vcpu_id: u64) -> u64 {
+    (vcpu_id & 0x0f)                    // Aff0, bits [7:0]
+    | (((vcpu_id >> 4) & 0xff) << 8)    // Aff1, bits [15:8]
+    | (((vcpu_id >> 12) & 0xff) << 16)  // Aff2, bits [23:16]
+    | (1 << 31) // RES1
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ExtendedReg {
     pub id: u64,

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -11,13 +11,13 @@ use std::any::Any;
 use dist_regs::{get_dist_regs, read_ctlr, set_dist_regs, write_ctlr};
 use icc_regs::{get_icc_regs, set_icc_regs};
 use kvm_ioctls::DeviceFd;
-use redist_regs::{construct_gicr_typers, get_redist_regs, set_redist_regs};
+use redist_regs::{get_gicr_typers, get_redist_regs, set_redist_regs};
 use serde::{Deserialize, Serialize};
 
+use crate::Vm;
 use crate::arch::aarch64::gic::{Error, GicState, Result, Vgic, VgicConfig};
 use crate::device::HypervisorDeviceError;
 use crate::kvm::KvmVm;
-use crate::{CpuState, Vm};
 
 const GITS_CTLR: u32 = 0x0000;
 const GITS_IIDR: u32 = 0x0004;
@@ -84,9 +84,6 @@ pub struct KvmGicV3Its {
 
     /// The KVM device for the Its device
     its_device: Option<DeviceFd>,
-
-    /// Vector holding values of GICR_TYPER for each vCPU
-    gicr_typers: Vec<u64>,
 
     /// GIC distributor address
     dist_addr: u64,
@@ -271,7 +268,6 @@ impl KvmGicV3Its {
         let mut gic_device = KvmGicV3Its {
             device: vgic,
             its_device: None,
-            gicr_typers: vec![0; config.vcpu_count.try_into().unwrap()],
             dist_addr: config.dist_addr,
             dist_size: config.dist_size,
             redists_addr: config.redists_addr,
@@ -321,18 +317,13 @@ impl Vgic for KvmGicV3Its {
         [self.msi_addr, self.msi_size]
     }
 
-    fn set_gicr_typers(&mut self, vcpu_states: &[CpuState]) {
-        let gicr_typers = construct_gicr_typers(vcpu_states);
-        self.gicr_typers = gicr_typers;
-    }
-
     fn as_any_concrete_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Save the state of GICv3ITS.
     fn state(&self) -> Result<GicState> {
-        let gicr_typers = self.gicr_typers.clone();
+        let gicr_typers = get_gicr_typers(self.vcpu_count);
 
         let gicd_ctlr = read_ctlr(&self.device)?;
 
@@ -402,7 +393,7 @@ impl Vgic for KvmGicV3Its {
     fn set_state(&mut self, state: &GicState) -> Result<()> {
         let kvm_state: Gicv3ItsState = state.clone().into();
 
-        let gicr_typers = self.gicr_typers.clone();
+        let gicr_typers = get_gicr_typers(self.vcpu_count);
 
         write_ctlr(&self.device, kvm_state.gicd_ctlr)?;
 

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -475,9 +475,10 @@ impl Vgic for KvmGicV3Its {
 mod unit_tests {
     use crate::HypervisorVmConfig;
     use crate::aarch64::gic::{
-        get_dist_regs, get_icc_regs, get_redist_regs, set_dist_regs, set_icc_regs, set_redist_regs,
+        get_dist_regs, get_gicr_typers, get_icc_regs, get_redist_regs, set_dist_regs, set_icc_regs,
+        set_redist_regs,
     };
-    use crate::arch::aarch64::gic::VgicConfig;
+    use crate::arch::aarch64::gic::{Vgic, VgicConfig};
     use crate::kvm::KvmGicV3Its;
 
     fn create_test_vgic_config() -> VgicConfig {
@@ -555,5 +556,65 @@ mod unit_tests {
         let gic = vm.create_vgic(&vgic_config).expect("Cannot create gic");
 
         gic.lock().unwrap().save_data_tables().unwrap();
+    }
+
+    fn create_test_multi_vcpu_vgic_config() -> VgicConfig {
+        // Two redistributors (2 * GIC_V3_REDIST_SIZE = 2 * 0x02_0000).
+        VgicConfig {
+            vcpu_count: 2,
+            dist_addr: 0x0900_0000 - 0x01_0000,
+            dist_size: 0x01_0000,
+            redists_addr: 0x0900_0000 - 0x01_0000 - 0x04_0000,
+            redists_size: 0x04_0000,
+            msi_addr: 0x0900_0000 - 0x01_0000 - 0x04_0000 - 0x02_0000,
+            msi_size: 0x02_0000,
+            nr_irqs: 256,
+        }
+    }
+
+    #[test]
+    fn test_gic_state_save_restore_roundtrip() {
+        let hv = crate::new().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
+        let vcpu0 = vm.create_vcpu(0, None).unwrap();
+        let vcpu1 = vm.create_vcpu(1, None).unwrap();
+
+        // Initialise vCPUs
+        let mut kvi = vcpu0.create_vcpu_init();
+        vm.get_preferred_target(&mut kvi).unwrap();
+        vcpu0.vcpu_init(&kvi).unwrap();
+        let mut kvi = vcpu1.create_vcpu_init();
+        vm.get_preferred_target(&mut kvi).unwrap();
+        vcpu1.vcpu_init(&kvi).unwrap();
+
+        let gicr_typers = get_gicr_typers(2);
+        assert_eq!(gicr_typers.len(), 2);
+        let typer0 = vec![gicr_typers[0]];
+        let typer1 = vec![gicr_typers[1]];
+
+        let mut gic = KvmGicV3Its::new(&*vm, &create_test_multi_vcpu_vgic_config())
+            .expect("Cannot create gic");
+
+        // Give vCPU0 redistributor state that differs from vCPU1's.
+        let mut regs0 = get_redist_regs(&gic.device, &typer0).unwrap();
+        let last = regs0.len() - 1;
+        regs0[last] ^= 0xffff_ffff;
+        set_redist_regs(&gic.device, &typer0, &regs0).unwrap();
+
+        let expected0 = get_redist_regs(&gic.device, &typer0).unwrap();
+        let expected1 = get_redist_regs(&gic.device, &typer1).unwrap();
+        assert_ne!(expected0, expected1);
+
+        let snapshot = gic.state().unwrap();
+
+        // Swap the states to intentionally clobber the redist states
+        // Restore should set these back to values before the snapshot.
+        set_redist_regs(&gic.device, &typer0, &expected1).unwrap();
+        set_redist_regs(&gic.device, &typer1, &expected0).unwrap();
+
+        gic.set_state(&snapshot).unwrap();
+
+        assert_eq!(get_redist_regs(&gic.device, &typer0).unwrap(), expected0);
+        assert_eq!(get_redist_regs(&gic.device, &typer1).unwrap(), expected1);
     }
 }

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -491,9 +491,11 @@ impl Vgic for KvmGicV3Its {
 mod unit_tests {
     use crate::HypervisorVmConfig;
     use crate::aarch64::gic::{
-        get_dist_regs, get_icc_regs, get_redist_regs, set_dist_regs, set_icc_regs, set_redist_regs,
+        get_dist_regs, get_gicr_typers, get_icc_regs, get_redist_regs, set_dist_regs, set_icc_regs,
+        set_redist_regs,
     };
-    use crate::arch::aarch64::gic::VgicConfig;
+    use crate::arch::aarch64::gic::{Vgic, VgicConfig};
+    use crate::arch::aarch64::regs::MPIDR_EL1;
     use crate::kvm::KvmGicV3Its;
 
     fn create_test_vgic_config() -> VgicConfig {
@@ -571,5 +573,70 @@ mod unit_tests {
         let gic = vm.create_vgic(&vgic_config).expect("Cannot create gic");
 
         gic.lock().unwrap().save_data_tables().unwrap();
+    }
+
+    fn create_test_multi_vcpu_vgic_config() -> VgicConfig {
+        // Two redistributors (2 * GIC_V3_REDIST_SIZE = 2 * 0x02_0000).
+        VgicConfig {
+            vcpu_count: 2,
+            dist_addr: 0x0900_0000 - 0x01_0000,
+            dist_size: 0x01_0000,
+            redists_addr: 0x0900_0000 - 0x01_0000 - 0x04_0000,
+            redists_size: 0x04_0000,
+            msi_addr: 0x0900_0000 - 0x01_0000 - 0x04_0000 - 0x02_0000,
+            msi_size: 0x02_0000,
+            nr_irqs: 256,
+        }
+    }
+
+    #[test]
+    fn test_gic_state_save_restore_roundtrip() {
+        let hv = crate::new().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
+        let vcpu0 = vm.create_vcpu(0, None).unwrap();
+        let vcpu1 = vm.create_vcpu(1, None).unwrap();
+
+        // Initialise vCPUs
+        let mut kvi = vcpu0.create_vcpu_init();
+        vm.get_preferred_target(&mut kvi).unwrap();
+        vcpu0.vcpu_init(&kvi).unwrap();
+        let mut kvi = vcpu1.create_vcpu_init();
+        vm.get_preferred_target(&mut kvi).unwrap();
+        vcpu1.vcpu_init(&kvi).unwrap();
+
+        let mpidrs = vec![
+            vcpu0.get_sys_reg(MPIDR_EL1).unwrap(),
+            vcpu1.get_sys_reg(MPIDR_EL1).unwrap(),
+        ];
+        let gicr_typers = get_gicr_typers(&mpidrs);
+        assert_eq!(gicr_typers.len(), 2);
+        let typer0 = vec![gicr_typers[0]];
+        let typer1 = vec![gicr_typers[1]];
+
+        let mut gic = KvmGicV3Its::new(&*vm, &create_test_multi_vcpu_vgic_config())
+            .expect("Cannot create gic");
+        gic.set_mpidrs(mpidrs);
+
+        // Give vCPU0 redistributor state that differs from vCPU1's.
+        let mut regs0 = get_redist_regs(&gic.device, &typer0).unwrap();
+        let last = regs0.len() - 1;
+        regs0[last] ^= 0xffff_ffff;
+        set_redist_regs(&gic.device, &typer0, &regs0).unwrap();
+
+        let expected0 = get_redist_regs(&gic.device, &typer0).unwrap();
+        let expected1 = get_redist_regs(&gic.device, &typer1).unwrap();
+        assert_ne!(expected0, expected1);
+
+        let snapshot = gic.state().unwrap();
+
+        // Swap the states to intentionally clobber the redist states
+        // Restore should set these back to values before the snapshot.
+        set_redist_regs(&gic.device, &typer0, &expected1).unwrap();
+        set_redist_regs(&gic.device, &typer1, &expected0).unwrap();
+
+        gic.set_state(&snapshot).unwrap();
+
+        assert_eq!(get_redist_regs(&gic.device, &typer0).unwrap(), expected0);
+        assert_eq!(get_redist_regs(&gic.device, &typer1).unwrap(), expected1);
     }
 }

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -11,13 +11,13 @@ use std::any::Any;
 use dist_regs::{get_dist_regs, read_ctlr, set_dist_regs, write_ctlr};
 use icc_regs::{get_icc_regs, set_icc_regs};
 use kvm_ioctls::DeviceFd;
-use redist_regs::{construct_gicr_typers, get_redist_regs, set_redist_regs};
+use redist_regs::{get_gicr_typers, get_redist_regs, set_redist_regs};
 use serde::{Deserialize, Serialize};
 
+use crate::Vm;
 use crate::arch::aarch64::gic::{Error, GicState, Result, Vgic, VgicConfig};
 use crate::device::HypervisorDeviceError;
 use crate::kvm::KvmVm;
-use crate::{CpuState, Vm};
 
 const GITS_CTLR: u32 = 0x0000;
 const GITS_IIDR: u32 = 0x0004;
@@ -85,8 +85,8 @@ pub struct KvmGicV3Its {
     /// The KVM device for the Its device
     its_device: Option<DeviceFd>,
 
-    /// Vector holding values of GICR_TYPER for each vCPU
-    gicr_typers: Vec<u64>,
+    /// Per-vCPU MPIDRs.
+    vcpu_mpidrs: Option<Vec<u64>>,
 
     /// GIC distributor address
     dist_addr: u64,
@@ -271,7 +271,7 @@ impl KvmGicV3Its {
         let mut gic_device = KvmGicV3Its {
             device: vgic,
             its_device: None,
-            gicr_typers: vec![0; config.vcpu_count.try_into().unwrap()],
+            vcpu_mpidrs: None,
             dist_addr: config.dist_addr,
             dist_size: config.dist_size,
             redists_addr: config.redists_addr,
@@ -321,18 +321,17 @@ impl Vgic for KvmGicV3Its {
         [self.msi_addr, self.msi_size]
     }
 
-    fn set_gicr_typers(&mut self, vcpu_states: &[CpuState]) {
-        let gicr_typers = construct_gicr_typers(vcpu_states);
-        self.gicr_typers = gicr_typers;
-    }
-
     fn as_any_concrete_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Save the state of GICv3ITS.
     fn state(&self) -> Result<GicState> {
-        let gicr_typers = self.gicr_typers.clone();
+        let mpidrs = self
+            .vcpu_mpidrs
+            .as_ref()
+            .expect("vGIC MPIDRs must be set before save/restore");
+        let gicr_typers = get_gicr_typers(mpidrs);
 
         let gicd_ctlr = read_ctlr(&self.device)?;
 
@@ -402,7 +401,11 @@ impl Vgic for KvmGicV3Its {
     fn set_state(&mut self, state: &GicState) -> Result<()> {
         let kvm_state: Gicv3ItsState = state.clone().into();
 
-        let gicr_typers = self.gicr_typers.clone();
+        let mpidrs = self
+            .vcpu_mpidrs
+            .as_ref()
+            .expect("vGIC MPIDRs must be set before save/restore");
+        let gicr_typers = get_gicr_typers(mpidrs);
 
         write_ctlr(&self.device, kvm_state.gicd_ctlr)?;
 
@@ -477,6 +480,10 @@ impl Vgic for KvmGicV3Its {
         })?;
         // Flush ITS tables to guest RAM.
         gicv3_its_tables_access(self.its_device.as_ref().unwrap(), true)
+    }
+
+    fn set_mpidrs(&mut self, mpidrs: Vec<u64>) {
+        self.vcpu_mpidrs = Some(mpidrs);
     }
 }
 

--- a/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
@@ -4,15 +4,10 @@
 
 use kvm_ioctls::DeviceFd;
 
-use crate::CpuState;
 use crate::arch::aarch64::gic::{Error, Result};
+use crate::arch::aarch64::mpidr_from_vcpu_id;
 use crate::device::HypervisorDeviceError;
-use crate::kvm::VcpuKvmState;
-use crate::kvm::kvm_bindings::{
-    KVM_DEV_ARM_VGIC_GRP_REDIST_REGS, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG,
-    KVM_REG_ARM64_SYSREG_OP0_MASK, KVM_REG_ARM64_SYSREG_OP0_SHIFT, KVM_REG_ARM64_SYSREG_OP2_MASK,
-    KVM_REG_ARM64_SYSREG_OP2_SHIFT, KVM_REG_SIZE_U64, kvm_device_attr, kvm_one_reg,
-};
+use crate::kvm::kvm_bindings::{KVM_DEV_ARM_VGIC_GRP_REDIST_REGS, kvm_device_attr};
 
 // Relevant redistributor registers that we want to save/restore.
 const GICR_CTLR: u32 = 0x0000;
@@ -38,12 +33,6 @@ const GICR_ICFGR0: u32 = GICR_SGI_OFFSET + 0x0C00;
 
 const KVM_DEV_ARM_VGIC_V3_MPIDR_SHIFT: u32 = 32;
 const KVM_DEV_ARM_VGIC_V3_MPIDR_MASK: u64 = 0xffffffff << KVM_DEV_ARM_VGIC_V3_MPIDR_SHIFT as u64;
-
-const KVM_ARM64_SYSREG_MPIDR_EL1: u64 = KVM_REG_ARM64
-    | KVM_REG_SIZE_U64
-    | KVM_REG_ARM64_SYSREG as u64
-    | (((3_u64) << KVM_REG_ARM64_SYSREG_OP0_SHIFT) & KVM_REG_ARM64_SYSREG_OP0_MASK as u64)
-    | (((5_u64) << KVM_REG_ARM64_SYSREG_OP2_SHIFT) & KVM_REG_ARM64_SYSREG_OP2_MASK as u64);
 
 /// This is how we represent the registers of a distributor.
 /// It is relevant their offset from the base address of the
@@ -195,8 +184,8 @@ pub fn set_redist_regs(gic: &DeviceFd, gicr_typer: &[u64], state: &[u32]) -> Res
     )
 }
 
-pub fn construct_gicr_typers(vcpu_states: &[CpuState]) -> Vec<u64> {
-    /* Pre-construct the GICR_TYPER:
+pub fn get_gicr_typers(vcpu_count: u64) -> Vec<u64> {
+    /* Return a GICR_TYPER from the vCPU MPIDR affinities:
      * For our implementation:
      *  Top 32 bits are the affinity value of the associated CPU
      *  CommonLPIAff == 01 (redistributors with same Aff3 share LPI table)
@@ -209,19 +198,13 @@ pub fn construct_gicr_typers(vcpu_states: &[CpuState]) -> Vec<u64> {
      *  PLPIS == 0 (physical LPIs not supported)
      */
     let mut gicr_typers: Vec<u64> = Vec::new();
-    for (index, state) in vcpu_states.iter().enumerate() {
-        let state: VcpuKvmState = state.clone().into();
-        let last = (index == vcpu_states.len() - 1) as u64;
-        // state.sys_regs is a big collection of system registers, including MIPDR_EL1
-        let mpidr: Vec<kvm_one_reg> = state
-            .sys_regs
-            .into_iter()
-            .filter(|reg| reg.id == KVM_ARM64_SYSREG_MPIDR_EL1)
-            .collect();
-        //calculate affinity
-        let mut cpu_affid = mpidr[0].addr & 1095233437695;
+    for vcpu_id in 0..vcpu_count {
+        let mpidr = mpidr_from_vcpu_id(vcpu_id);
+        let last = (vcpu_id == vcpu_count - 1) as u64;
+        // Calculate affinity.
+        let mut cpu_affid = mpidr & 0xff_00ff_ffff;
         cpu_affid = ((cpu_affid & 0xFF00000000) >> 8) | (cpu_affid & 0xFFFFFF);
-        gicr_typers.push((cpu_affid << 32) | (1 << 24) | ((index as u64) << 8) | (last << 4));
+        gicr_typers.push((cpu_affid << 32) | (1 << 24) | (vcpu_id << 8) | (last << 4));
     }
 
     gicr_typers

--- a/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
@@ -4,15 +4,9 @@
 
 use kvm_ioctls::DeviceFd;
 
-use crate::CpuState;
 use crate::arch::aarch64::gic::{Error, Result};
 use crate::device::HypervisorDeviceError;
-use crate::kvm::VcpuKvmState;
-use crate::kvm::kvm_bindings::{
-    KVM_DEV_ARM_VGIC_GRP_REDIST_REGS, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG,
-    KVM_REG_ARM64_SYSREG_OP0_MASK, KVM_REG_ARM64_SYSREG_OP0_SHIFT, KVM_REG_ARM64_SYSREG_OP2_MASK,
-    KVM_REG_ARM64_SYSREG_OP2_SHIFT, KVM_REG_SIZE_U64, kvm_device_attr, kvm_one_reg,
-};
+use crate::kvm::kvm_bindings::{KVM_DEV_ARM_VGIC_GRP_REDIST_REGS, kvm_device_attr};
 
 // Relevant redistributor registers that we want to save/restore.
 const GICR_CTLR: u32 = 0x0000;
@@ -38,12 +32,6 @@ const GICR_ICFGR0: u32 = GICR_SGI_OFFSET + 0x0C00;
 
 const KVM_DEV_ARM_VGIC_V3_MPIDR_SHIFT: u32 = 32;
 const KVM_DEV_ARM_VGIC_V3_MPIDR_MASK: u64 = 0xffffffff << KVM_DEV_ARM_VGIC_V3_MPIDR_SHIFT as u64;
-
-const KVM_ARM64_SYSREG_MPIDR_EL1: u64 = KVM_REG_ARM64
-    | KVM_REG_SIZE_U64
-    | KVM_REG_ARM64_SYSREG as u64
-    | (((3_u64) << KVM_REG_ARM64_SYSREG_OP0_SHIFT) & KVM_REG_ARM64_SYSREG_OP0_MASK as u64)
-    | (((5_u64) << KVM_REG_ARM64_SYSREG_OP2_SHIFT) & KVM_REG_ARM64_SYSREG_OP2_MASK as u64);
 
 /// This is how we represent the registers of a distributor.
 /// It is relevant their offset from the base address of the
@@ -195,8 +183,8 @@ pub fn set_redist_regs(gic: &DeviceFd, gicr_typer: &[u64], state: &[u32]) -> Res
     )
 }
 
-pub fn construct_gicr_typers(vcpu_states: &[CpuState]) -> Vec<u64> {
-    /* Pre-construct the GICR_TYPER:
+pub fn get_gicr_typers(vcpu_mpidrs: &[u64]) -> Vec<u64> {
+    /* Return a GICR_TYPER from the vCPU MPIDR affinities:
      * For our implementation:
      *  Top 32 bits are the affinity value of the associated CPU
      *  CommonLPIAff == 01 (redistributors with same Aff3 share LPI table)
@@ -209,17 +197,10 @@ pub fn construct_gicr_typers(vcpu_states: &[CpuState]) -> Vec<u64> {
      *  PLPIS == 0 (physical LPIs not supported)
      */
     let mut gicr_typers: Vec<u64> = Vec::new();
-    for (index, state) in vcpu_states.iter().enumerate() {
-        let state: VcpuKvmState = state.clone().into();
-        let last = (index == vcpu_states.len() - 1) as u64;
-        // state.sys_regs is a big collection of system registers, including MIPDR_EL1
-        let mpidr: Vec<kvm_one_reg> = state
-            .sys_regs
-            .into_iter()
-            .filter(|reg| reg.id == KVM_ARM64_SYSREG_MPIDR_EL1)
-            .collect();
-        //calculate affinity
-        let mut cpu_affid = mpidr[0].addr & 1095233437695;
+    for (index, &mpidr) in vcpu_mpidrs.iter().enumerate() {
+        let last = (index == vcpu_mpidrs.len() - 1) as u64;
+        // Calculate affinity.
+        let mut cpu_affid = mpidr & 0xff_00ff_ffff;
         cpu_affid = ((cpu_affid & 0xFF00000000) >> 8) | (cpu_affid & 0xFFFFFF);
         gicr_typers.push((cpu_affid << 32) | (1 << 24) | ((index as u64) << 8) | (last << 4));
     }

--- a/hypervisor/src/mshv/aarch64/gic/mod.rs
+++ b/hypervisor/src/mshv/aarch64/gic/mod.rs
@@ -6,8 +6,8 @@ use std::any::Any;
 
 use serde::{Deserialize, Serialize};
 
+use crate::Vm;
 use crate::arch::aarch64::gic::{GicState, Result, Vgic, VgicConfig};
-use crate::{CpuState, Vm};
 
 pub struct MshvGicV2M {
     /// GIC distributor address
@@ -102,10 +102,6 @@ impl Vgic for MshvGicV2M {
             self.redists_addr,
             self.redists_size,
         ]
-    }
-
-    fn set_gicr_typers(&mut self, _vcpu_states: &[CpuState]) {
-        unimplemented!()
     }
 
     fn state(&self) -> Result<GicState> {

--- a/hypervisor/src/mshv/aarch64/gic/mod.rs
+++ b/hypervisor/src/mshv/aarch64/gic/mod.rs
@@ -6,8 +6,8 @@ use std::any::Any;
 
 use serde::{Deserialize, Serialize};
 
+use crate::Vm;
 use crate::arch::aarch64::gic::{GicState, Result, Vgic, VgicConfig};
-use crate::{CpuState, Vm};
 
 pub struct MshvGicV2M {
     /// GIC distributor address
@@ -104,10 +104,6 @@ impl Vgic for MshvGicV2M {
         ]
     }
 
-    fn set_gicr_typers(&mut self, _vcpu_states: &[CpuState]) {
-        unimplemented!()
-    }
-
     fn state(&self) -> Result<GicState> {
         unimplemented!()
     }
@@ -123,4 +119,6 @@ impl Vgic for MshvGicV2M {
     fn save_data_tables(&self) -> Result<()> {
         Ok(())
     }
+
+    fn set_mpidrs(&mut self, _mpidrs: Vec<u64>) {}
 }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -43,6 +43,8 @@ use hypervisor::HypervisorType;
 use hypervisor::StandardRegisters;
 #[cfg(target_arch = "aarch64")]
 use hypervisor::arch::aarch64::gic::Vgic;
+#[cfg(target_arch = "aarch64")]
+use hypervisor::arch::aarch64::regs::MPIDR_EL1;
 #[cfg(all(target_arch = "aarch64", feature = "guest_debug"))]
 use hypervisor::arch::aarch64::regs::{ID_AA64MMFR0_EL1, TCR_EL1, TTBR1_EL1};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -237,6 +239,9 @@ pub enum Error {
 
     #[error("Error generating MSR configuration update")]
     MsrConfigurationUpdate(#[source] arch::Error),
+
+    #[error("Could not get vCPU MPIDR")]
+    VcpuGetMpidr(#[source] hypervisor::HypervisorCpuError),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -485,9 +490,6 @@ pub struct Vcpu {
     // The hypervisor abstracted CPU.
     vcpu: Box<dyn hypervisor::Vcpu>,
     id: u32,
-    #[cfg(target_arch = "aarch64")]
-    mpidr: u64,
-    saved_state: Option<CpuState>,
     #[cfg(target_arch = "x86_64")]
     vendor: CpuVendor,
 }
@@ -528,9 +530,6 @@ impl Vcpu {
         Ok(Vcpu {
             vcpu,
             id,
-            #[cfg(target_arch = "aarch64")]
-            mpidr: 0,
-            saved_state: None,
             #[cfg(target_arch = "x86_64")]
             vendor: cpu_vendor,
         })
@@ -557,7 +556,7 @@ impl Vcpu {
         {
             self.init(vm)?;
             self.finalize_sve()?;
-            self.mpidr = arch::configure_vcpu(self.vcpu.as_ref(), self.id, boot_setup)
+            arch::configure_vcpu(self.vcpu.as_ref(), self.id, boot_setup)
                 .map_err(Error::VcpuConfiguration)?;
         }
         #[cfg(target_arch = "riscv64")]
@@ -597,14 +596,10 @@ impl Vcpu {
 
     /// Gets the MPIDR register value.
     #[cfg(target_arch = "aarch64")]
-    pub fn get_mpidr(&self) -> u64 {
-        self.mpidr
-    }
-
-    /// Gets the saved vCPU state.
-    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-    pub fn get_saved_state(&self) -> Option<CpuState> {
-        self.saved_state.clone()
+    pub fn get_mpidr(&self) -> Result<u64> {
+        self.vcpu
+            .get_sys_reg(MPIDR_EL1)
+            .map_err(Error::VcpuGetMpidr)
     }
 
     /// Initializes an aarch64 specific vcpu for booting Linux.
@@ -697,8 +692,6 @@ impl Snapshottable for Vcpu {
             .vcpu
             .state()
             .map_err(|e| MigratableError::Snapshot(anyhow!("Could not get vCPU state {e:?}")))?;
-
-        self.saved_state = Some(saved_state.clone());
 
         Ok(Snapshot::from_data(SnapshotData::new_from_state(
             &saved_state,
@@ -994,7 +987,7 @@ impl CpuManager {
         #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
         let x2apic_id = cpu_id;
 
-        let mut vcpu = Vcpu::new(
+        let vcpu = Vcpu::new(
             cpu_id,
             x2apic_id,
             self.vm.as_ref(),
@@ -1025,8 +1018,6 @@ impl CpuManager {
             vcpu.vcpu
                 .set_state(&state)
                 .map_err(|e| Error::VcpuCreate(anyhow!("Could not set the vCPU state {e:?}")))?;
-
-            vcpu.saved_state = Some(state);
         }
 
         let vcpu = Arc::new(Mutex::new(vcpu));
@@ -1733,7 +1724,7 @@ impl CpuManager {
     }
 
     #[cfg(target_arch = "aarch64")]
-    pub fn get_mpidrs(&self) -> Vec<u64> {
+    pub fn get_mpidrs(&self) -> Result<Vec<u64>> {
         self.vcpus
             .iter()
             .map(|cpu| cpu.lock().unwrap().get_mpidr())
@@ -1743,14 +1734,6 @@ impl CpuManager {
     /// The boot vCPU (vCPU 0), or `None` before the vCPUs are created.
     pub fn boot_vcpu(&self) -> Option<Arc<Mutex<Vcpu>>> {
         self.vcpus.first().cloned()
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    pub fn get_saved_states(&self) -> Vec<CpuState> {
-        self.vcpus
-            .iter()
-            .map(|cpu| cpu.lock().unwrap().get_saved_state().unwrap())
-            .collect()
     }
 
     pub fn get_vcpu_topology(&self) -> Option<(u16, u16, u16, u16)> {
@@ -1823,7 +1806,11 @@ impl CpuManager {
             // See section 5.2.12.14 GIC CPU Interface (GICC) Structure in ACPI spec.
             for cpu in 0..self.config.boot_vcpus {
                 let vcpu = &self.vcpus[cpu as usize];
-                let mpidr = vcpu.lock().unwrap().get_mpidr();
+                let mpidr = vcpu
+                    .lock()
+                    .unwrap()
+                    .get_mpidr()
+                    .expect("Failed to read vCPU MPIDR for MADT");
                 /* ARMv8 MPIDR format:
                      Bits [63:40] Must be zero
                      Bits [39:32] Aff3 : Match Aff3 of target processor MPIDR

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -43,6 +43,10 @@ use hypervisor::HypervisorType;
 use hypervisor::StandardRegisters;
 #[cfg(target_arch = "aarch64")]
 use hypervisor::arch::aarch64::gic::Vgic;
+#[cfg(target_arch = "aarch64")]
+use hypervisor::arch::aarch64::mpidr_from_vcpu_id;
+#[cfg(target_arch = "aarch64")]
+use hypervisor::arch::aarch64::regs::MPIDR_EL1;
 #[cfg(all(target_arch = "aarch64", feature = "guest_debug"))]
 use hypervisor::arch::aarch64::regs::{ID_AA64MMFR0_EL1, TCR_EL1, TTBR1_EL1};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -488,8 +492,6 @@ pub struct Vcpu {
     // The hypervisor abstracted CPU.
     vcpu: Box<dyn hypervisor::Vcpu>,
     id: u32,
-    #[cfg(target_arch = "aarch64")]
-    mpidr: u64,
     saved_state: Option<CpuState>,
     #[cfg(target_arch = "x86_64")]
     vendor: CpuVendor,
@@ -531,8 +533,6 @@ impl Vcpu {
         Ok(Vcpu {
             vcpu,
             id,
-            #[cfg(target_arch = "aarch64")]
-            mpidr: 0,
             saved_state: None,
             #[cfg(target_arch = "x86_64")]
             vendor: cpu_vendor,
@@ -560,7 +560,8 @@ impl Vcpu {
         {
             self.init(vm)?;
             self.finalize_sve()?;
-            self.mpidr = arch::configure_vcpu(self.vcpu.as_ref(), self.id, boot_setup)
+            self.verify_mpidr();
+            arch::configure_vcpu(self.vcpu.as_ref(), self.id, boot_setup)
                 .map_err(Error::VcpuConfiguration)?;
         }
         #[cfg(target_arch = "riscv64")]
@@ -598,12 +599,6 @@ impl Vcpu {
         Ok(())
     }
 
-    /// Gets the MPIDR register value.
-    #[cfg(target_arch = "aarch64")]
-    pub fn get_mpidr(&self) -> u64 {
-        self.mpidr
-    }
-
     /// Gets the saved vCPU state.
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     pub fn get_saved_state(&self) -> Option<CpuState> {
@@ -625,6 +620,21 @@ impl Vcpu {
         self.vcpu.vcpu_init(&kvi).map_err(Error::VcpuArmInit)?;
 
         Ok(())
+    }
+
+    /// Panics if the MPIDR derived from the vCPU id has drifted away from the
+    /// one the hypervisor actually gives the guest.
+    #[cfg(target_arch = "aarch64")]
+    fn verify_mpidr(&self) {
+        let id = self.id as u64;
+        let derived = mpidr_from_vcpu_id(id);
+        let actual = self.vcpu.get_sys_reg(MPIDR_EL1).unwrap();
+
+        assert_eq!(
+            derived, actual,
+            "vCPU {id} MPIDR mismatch: mpidr_from_vcpu_id() ({derived:#x}) no longer matches \
+             the hypervisor's affinity assignment ({actual:#x})"
+        );
     }
 
     /// Finalizes SVE on the vCPU if the host supports it.
@@ -1026,6 +1036,7 @@ impl CpuManager {
                         .map_err(Error::VcpuSetPreFinalizeRegs)?;
                 }
                 vcpu.finalize_sve()?;
+                vcpu.verify_mpidr();
             }
 
             vcpu.vcpu
@@ -1745,9 +1756,8 @@ impl CpuManager {
 
     #[cfg(target_arch = "aarch64")]
     pub fn get_mpidrs(&self) -> Vec<u64> {
-        self.vcpus
-            .iter()
-            .map(|cpu| cpu.lock().unwrap().get_mpidr())
+        (0..self.vcpus.len() as u64)
+            .map(mpidr_from_vcpu_id)
             .collect()
     }
 
@@ -1833,8 +1843,7 @@ impl CpuManager {
 
             // See section 5.2.12.14 GIC CPU Interface (GICC) Structure in ACPI spec.
             for cpu in 0..self.config.boot_vcpus {
-                let vcpu = &self.vcpus[cpu as usize];
-                let mpidr = vcpu.lock().unwrap().get_mpidr();
+                let mpidr = mpidr_from_vcpu_id(cpu as u64);
                 /* ARMv8 MPIDR format:
                      Bits [63:40] Must be zero
                      Bits [39:32] Aff3 : Match Aff3 of target processor MPIDR
@@ -3611,6 +3620,7 @@ mod unit_tests {
     use std::mem::offset_of;
 
     use arch::layout;
+    use hypervisor::arch::aarch64::mpidr_from_vcpu_id;
     use hypervisor::arch::aarch64::regs::MPIDR_EL1;
     #[cfg(feature = "kvm")]
     use hypervisor::arm64_core_reg_id;
@@ -3622,6 +3632,8 @@ mod unit_tests {
     };
     use hypervisor::{HypervisorCpuError, HypervisorVmConfig};
     use vmm_sys_util::errno;
+
+    use super::Vcpu;
 
     #[test]
     fn test_setup_regs() {
@@ -3652,6 +3664,31 @@ mod unit_tests {
 
         vcpu.vcpu_init(&kvi).unwrap();
         assert_eq!(vcpu.get_sys_reg(MPIDR_EL1).unwrap(), 0x80000000);
+    }
+
+    #[test]
+    fn test_get_mpidr() {
+        let hv = hypervisor::new().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
+
+        // Bit 31 is RES1, Aff0 holds the low 4 bits of the vCPU id, and Aff1
+        // takes over past 16 vCPUs.
+        for (id, expected) in [
+            (0, 0x8000_0000),
+            (1, 0x8000_0001),
+            (15, 0x8000_000f),
+            (16, 0x8000_0100),
+            (17, 0x8000_0101),
+            (255, 0x8000_0f0f),
+        ] {
+            let vcpu = Vcpu::new(id, id, vm.as_ref(), None).unwrap();
+            assert_eq!(mpidr_from_vcpu_id(id as u64), expected, "vCPU {id}");
+
+            // Must be what the hypervisor itself calculates.
+            vcpu.init(vm.as_ref()).unwrap();
+            vcpu.finalize_sve().unwrap();
+            vcpu.verify_mpidr();
+        }
     }
 
     #[cfg(feature = "kvm")]

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -492,7 +492,6 @@ pub struct Vcpu {
     // The hypervisor abstracted CPU.
     vcpu: Box<dyn hypervisor::Vcpu>,
     id: u32,
-    saved_state: Option<CpuState>,
     #[cfg(target_arch = "x86_64")]
     vendor: CpuVendor,
 }
@@ -533,7 +532,6 @@ impl Vcpu {
         Ok(Vcpu {
             vcpu,
             id,
-            saved_state: None,
             #[cfg(target_arch = "x86_64")]
             vendor: cpu_vendor,
         })
@@ -597,12 +595,6 @@ impl Vcpu {
         }
 
         Ok(())
-    }
-
-    /// Gets the saved vCPU state.
-    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-    pub fn get_saved_state(&self) -> Option<CpuState> {
-        self.saved_state.clone()
     }
 
     /// Initializes an aarch64 specific vcpu for booting Linux.
@@ -710,8 +702,6 @@ impl Snapshottable for Vcpu {
             .vcpu
             .state()
             .map_err(|e| MigratableError::Snapshot(anyhow!("Could not get vCPU state {e:?}")))?;
-
-        self.saved_state = Some(saved_state.clone());
 
         Ok(Snapshot::from_data(SnapshotData::new_from_state(
             &saved_state,
@@ -1010,7 +1000,7 @@ impl CpuManager {
         #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
         let x2apic_id = cpu_id;
 
-        let mut vcpu = Vcpu::new(
+        let vcpu = Vcpu::new(
             cpu_id,
             x2apic_id,
             self.vm.as_ref(),
@@ -1042,8 +1032,6 @@ impl CpuManager {
             vcpu.vcpu
                 .set_state(&state)
                 .map_err(|e| Error::VcpuCreate(anyhow!("Could not set the vCPU state {e:?}")))?;
-
-            vcpu.saved_state = Some(state);
         }
 
         let vcpu = Arc::new(Mutex::new(vcpu));
@@ -1764,14 +1752,6 @@ impl CpuManager {
     /// The boot vCPU (vCPU 0), or `None` before the vCPUs are created.
     pub fn boot_vcpu(&self) -> Option<Arc<Mutex<Vcpu>>> {
         self.vcpus.first().cloned()
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    pub fn get_saved_states(&self) -> Vec<CpuState> {
-        self.vcpus
-            .iter()
-            .map(|cpu| cpu.lock().unwrap().get_saved_state().unwrap())
-            .collect()
     }
 
     pub fn get_vcpu_topology(&self) -> Option<(u16, u16, u16, u16)> {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1839,11 +1839,10 @@ impl DeviceManager {
             let vgic_state = vgic_snapshot
                 .to_state()
                 .map_err(DeviceManagerError::RestoreGetState)?;
-            let saved_vcpu_states = self.cpu_manager.lock().unwrap().get_saved_states();
             interrupt_controller
                 .lock()
                 .unwrap()
-                .restore_vgic(vgic_state, &saved_vcpu_states)
+                .restore_vgic(vgic_state)
                 .unwrap();
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -125,6 +125,8 @@ use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::console_devices::{ConsoleDeviceError, ConsoleInfo, ConsoleTransport};
+#[cfg(target_arch = "aarch64")]
+use crate::cpu::Error as CpuManagerError;
 use crate::cpu::{AcpiCpuHotplugController, CPU_MANAGER_ACPI_SIZE, CpuManager};
 use crate::device_tree::{DeviceNode, DeviceTree};
 use crate::interrupt::{LegacyUserspaceInterruptManager, MsiInterruptManager};
@@ -704,6 +706,11 @@ pub enum DeviceManagerError {
         specified: ImageType,
         detected: ImageType,
     },
+
+    #[cfg(target_arch = "aarch64")]
+    /// Error from CpuManager
+    #[error("Error from CpuManager")]
+    CpuManager(#[source] CpuManagerError),
 }
 
 pub type DeviceManagerResult<T> = result::Result<T, DeviceManagerError>;
@@ -1831,14 +1838,19 @@ impl DeviceManager {
                 info!("Failed to initialize PMU");
             }
 
+            let mpidrs = self
+                .cpu_manager
+                .lock()
+                .unwrap()
+                .get_mpidrs()
+                .map_err(DeviceManagerError::CpuManager)?;
             let vgic_state = vgic_snapshot
                 .to_state()
                 .map_err(DeviceManagerError::RestoreGetState)?;
-            let saved_vcpu_states = self.cpu_manager.lock().unwrap().get_saved_states();
             interrupt_controller
                 .lock()
                 .unwrap()
-                .restore_vgic(vgic_state, &saved_vcpu_states)
+                .restore_vgic(vgic_state, mpidrs)
                 .unwrap();
         }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1860,7 +1860,12 @@ impl Vm {
             self.config.lock().unwrap().payload.as_ref().unwrap(),
             &self.device_manager,
         )?;
-        let vcpu_mpidrs = self.cpu_manager.lock().unwrap().get_mpidrs();
+        let vcpu_mpidrs = self
+            .cpu_manager
+            .lock()
+            .unwrap()
+            .get_mpidrs()
+            .map_err(Error::CpuManager)?;
         let vcpu_topology = self.cpu_manager.lock().unwrap().get_vcpu_topology();
         let mem = self.memory_manager.lock().unwrap().boot_guest_memory();
         let mut pci_space_info: Vec<PciSpaceInfo> = Vec::new();
@@ -1910,6 +1915,8 @@ impl Vm {
                     arch::aarch64::Error::SetupGic,
                 ))
             })?;
+
+        vgic.lock().unwrap().set_mpidrs(vcpu_mpidrs.clone());
 
         // PMU interrupt sticks to PPI, so need to be added by 16 to get real irq number.
         let pmu_supported = self


### PR DESCRIPTION
### Summary

The GIC save path needs to read MPIDR values from `KvmGicV3Its.gicr_typers` for each vCPU to correctly save the Redistributor and ICC states. We  had left the `gicr_typers` field 0-initialised, which caused the save logic to assume every vCPU has vCPU0's Redistributor and ICC values. Restoring that snapshot would then write the wrong per-vCPU GIC state back into non-zero vCPUs. For example, we would end up incorrectly setting the LPI pending table base address, causing non-zero vCPUs to lose those interrupts.

In this PR, we fix this by passing the MPIDRs to the Vgic once at boot and after restore and let it correctly set up the internal `gicr_typers` needed for the `rdist` and `icc` states.

### Testing
Tested snapshot-restore on 2 vCPU guest.

#### Before the fix — the resulting rdist state has the same  GICR_PENDBASER value for each vCPU
```
"rdist": [
  0, 
  0,
  3934095,
  1, 
  4065152,  // vCPU0 GICR_PENDBASER low32
  1,        // vCPU0 GICR_PENDBASER high32
  7, 
  0,
  0,
  3934095,
  1,
  4065152,  // vCPU1 GICR_PENDBASER low32
  1,        // vCPU1 GICR_PENDBASER high32
...
]
```

#### After the fix — rdist state has distinct values for GICR_PENDBASER for each vCPU
```
"rdist": [
  0,
  0,
  3934095,
  1,
  4065152,  // vCPU0 GICR_PENDBASER low32
  1,        // vCPU0 GICR_PENDBASER high32
  7,
  0,
  0,
  3934095,
  1,
  4130688,  // vCPU1 GICR_PENDBASER low32
  1,        // vCPU1 GICR_PENDBASER high32
...
]
```

*GICR_PENDBASER is the base address of the LPI pending table which is meant to be distinct

