### PR TITLE
Return 404 (not 500) for unknown device/disk id

### DIFF
--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -33,6 +33,7 @@ use crate::api::{
     VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk,
     VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
+use crate::device_manager::DeviceManagerError;
 use crate::landlock::Landlock;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::util::{error_chain_messages, flatten_error_chain_to_string};
@@ -87,7 +88,12 @@ impl HttpError {
 /// Maps an [`ApiError`] to an HTTP [`StatusCode`].
 fn api_error_status_code(error: &ApiError) -> StatusCode {
     match error.source().and_then(|e| e.downcast_ref::<VmError>()) {
-        Some(VmError::VmNotCreated | VmError::VmMissingConfig) => StatusCode::NotFound,
+        Some(
+            VmError::VmNotCreated
+            | VmError::VmMissingConfig
+            | VmError::NoDeviceToRemove(_)
+            | VmError::DeviceManager(DeviceManagerError::UnknownDeviceId(_)),
+        ) => StatusCode::NotFound,
         _ => StatusCode::InternalServerError,
     }
 }
@@ -494,4 +500,43 @@ pub fn http_api_graceful_shutdown(http_handle: HttpApiHandle) -> Result<()> {
 
     api_shutdown_fd.write(1).unwrap();
     api_thread.join().map_err(VmmError::ThreadCleanup)?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_target_maps_to_not_found() {
+        assert_eq!(
+            api_error_status_code(&ApiError::VmInfo(VmError::VmNotCreated)),
+            StatusCode::NotFound
+        );
+        assert_eq!(
+            api_error_status_code(&ApiError::VmRemoveDevice(VmError::NoDeviceToRemove(
+                "dev0".to_string()
+            ))),
+            StatusCode::NotFound
+        );
+        assert_eq!(
+            api_error_status_code(&ApiError::VmRemoveDevice(VmError::DeviceManager(
+                DeviceManagerError::UnknownDeviceId("dev0".to_string())
+            ))),
+            StatusCode::NotFound
+        );
+        assert_eq!(
+            api_error_status_code(&ApiError::VmResizeDisk(VmError::DeviceManager(
+                DeviceManagerError::UnknownDeviceId("disk0".to_string())
+            ))),
+            StatusCode::NotFound
+        );
+    }
+
+    #[test]
+    fn test_other_errors_map_to_internal_server_error() {
+        assert_eq!(
+            api_error_status_code(&ApiError::VmRemoveDevice(VmError::VmMigrating)),
+            StatusCode::InternalServerError
+        );
+    }
 }

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -179,7 +179,7 @@ paths:
         204:
           description: The disk was successfully resized.
         404:
-          description: The disk could not be resized because the VM is not created.
+          description: The disk could not be resized because the VM is not created, or no disk with the given identifier exists.
         500:
           description: The disk could not be resized.
 
@@ -237,7 +237,7 @@ paths:
         204:
           description: The device was successfully removed from the VM instance.
         404:
-          description: The device could not be removed from the VM instance.
+          description: The device could not be removed because the VM is not created, or no device with the given identifier exists.
 
   /vm.add-disk:
     put:


### PR DESCRIPTION
## Summary

vm.remove-device and vm.resize-disk mapped a "device id not found" error to
500 Internal Server Error, even though the request is well-formed and the
only problem is that the named device or disk does not exist. This maps those
cases to 404 Not Found instead, consistent with the existing
VmNotCreated/VmMissingConfig handling.

## Changes

- vmm/api/http: extend `api_error_status_code()` so the following map to
  404 Not Found:
  - `VmError::NoDeviceToRemove` — cold path, id absent from the VM config.
  - `DeviceManager(UnknownDeviceId)` — hot path, id absent from a booted
    VM's device tree (also raised by resize-disk).
- OpenAPI: update the 404 descriptions for `/vm.remove-device` and
  `/vm.resize-disk` to reflect the unknown-id case.

## Testing

- `cargo test -p vmm` (new tests in `vmm/src/api/http/mod.rs`).

## LLM assistance

Drafted with Claude (Opus 4.8) and reviewed and understood by the author
(`Assisted-by: Claude:Opus-4.8` in the commit).