### PR TITLE
vmm: Clean up seccomp handling for glibc overcommit sysctl

### DIFF
--- a/devices/src/ivshmem.rs
+++ b/devices/src/ivshmem.rs
@@ -49,6 +49,8 @@ pub enum IvshmemError {
     CreateUserspaceMapping(#[source] anyhow::Error),
     #[error("Failed to remove old userspace mapping.")]
     RemoveUserspaceMapping(#[source] anyhow::Error),
+    #[error("Missing memory region")]
+    MissingMemoryRegion,
 }
 
 #[derive(Copy, Clone)]
@@ -69,6 +71,12 @@ pub trait IvshmemOps: Send + Sync {
         size: usize,
         backing_file: Option<PathBuf>,
     ) -> Result<(Arc<MmapRegion>, UserspaceMapping), IvshmemError>;
+
+    fn create_userspace_mapping(
+        &mut self,
+        start_addr: u64,
+        region: Arc<MmapRegion>,
+    ) -> Result<UserspaceMapping, IvshmemError>;
 
     fn unmap_ram_region(&mut self, mapping: UserspaceMapping) -> Result<(), IvshmemError>;
 }
@@ -94,7 +102,6 @@ pub struct IvshmemDevice {
 
     region_size: u64,
     ivshmem_ops: Arc<Mutex<dyn IvshmemOps>>,
-    backend_file: Option<PathBuf>,
     region: Option<Arc<MmapRegion>>,
     userspace_mapping: Option<UserspaceMapping>,
 }
@@ -111,7 +118,6 @@ impl IvshmemDevice {
     pub fn new(
         id: String,
         region_size: u64,
-        backend_file: Option<PathBuf>,
         ivshmem_ops: Arc<Mutex<dyn IvshmemOps>>,
         snapshot: Option<&Snapshot>,
     ) -> Result<Self, IvshmemError> {
@@ -159,7 +165,6 @@ impl IvshmemDevice {
                 ivshmem_ops,
                 region: None,
                 userspace_mapping: None,
-                backend_file,
             }
         } else {
             IvshmemDevice {
@@ -174,7 +179,6 @@ impl IvshmemDevice {
                 ivshmem_ops,
                 region: None,
                 userspace_mapping: None,
-                backend_file,
             }
         };
         Ok(device)
@@ -353,6 +357,10 @@ impl PciDevice for IvshmemDevice {
 
     fn move_bar(&mut self, old_base: u64, new_base: u64) -> io::Result<()> {
         if new_base == self.data_bar_addr() {
+            let region = self
+                .region
+                .clone()
+                .ok_or_else(|| io::Error::other(IvshmemError::MissingMemoryRegion))?;
             if let Some(old_mapping) = self.userspace_mapping.take() {
                 self.ivshmem_ops
                     .lock()
@@ -360,17 +368,13 @@ impl PciDevice for IvshmemDevice {
                     .unmap_ram_region(old_mapping)
                     .map_err(io::Error::other)?;
             }
-            let (region, new_mapping) = self
+            let new_mapping = self
                 .ivshmem_ops
                 .lock()
                 .unwrap()
-                .map_ram_region(
-                    new_base,
-                    self.region_size as usize,
-                    self.backend_file.clone(),
-                )
+                .create_userspace_mapping(new_base, region)
                 .map_err(io::Error::other)?;
-            self.set_region(region, new_mapping);
+            self.userspace_mapping = Some(new_mapping);
         }
         for bar in self.bar_regions.iter_mut() {
             if bar.addr() == old_base {

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -8,7 +8,7 @@ use std::env;
 
 use block::{BLKDISCARD, BLKZEROOUT};
 use libc::{FIONBIO, TIOCGWINSZ, TUNSETOFFLOAD};
-use seccompiler::SeccompCmpOp::Eq;
+use seccompiler::SeccompCmpOp::{Eq, MaskedEq};
 use seccompiler::{
     BpfProgram, Error, SeccompAction, SeccompCmpArgLen as ArgLen, SeccompCondition as Cond,
     SeccompFilter, SeccompRule,
@@ -364,7 +364,18 @@ fn virtio_thread_common() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_mprotect, vec![]),
         (libc::SYS_mremap, vec![]),
         (libc::SYS_munmap, vec![]),
-        (libc::SYS_openat, vec![]),
+        (
+            libc::SYS_openat,
+            or![and![
+                Cond::new(
+                    2, // openat() flags argument
+                    ArgLen::Dword,
+                    MaskedEq(libc::O_ACCMODE as u64),
+                    libc::O_RDONLY as u64,
+                )
+                .unwrap()
+            ]],
+        ),
         (libc::SYS_read, vec![]),
         (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_rt_sigreturn, vec![]),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4676,7 +4676,6 @@ impl DeviceManager {
             devices::IvshmemDevice::new(
                 id.clone(),
                 ivshmem_cfg.size as u64,
-                Some(ivshmem_cfg.path.clone()),
                 ivshmem_ops.clone(),
                 snapshot,
             )
@@ -5601,6 +5600,16 @@ impl IvshmemOps for IvshmemHandler {
             false,
         )
         .map_err(|e| IvshmemError::CreateUserMemoryRegion(e.into()))?;
+        let region = Arc::new(region);
+        let mapping = self.create_userspace_mapping(start_addr, region.clone())?;
+        Ok((region, mapping))
+    }
+
+    fn create_userspace_mapping(
+        &mut self,
+        start_addr: u64,
+        region: Arc<MmapRegion<AtomicBitmap>>,
+    ) -> Result<UserspaceMapping, IvshmemError> {
         let mem_slot = {
             let mut manager = self.memory_manager.lock().unwrap();
             // SAFETY: guaranteed by MmapRegion invariants
@@ -5616,14 +5625,12 @@ impl IvshmemOps for IvshmemHandler {
             }
         }
         .map_err(|e| IvshmemError::CreateUserspaceMapping(e.into()))?;
-        let region = Arc::new(region);
-        let mapping = UserspaceMapping {
-            mapping: region.clone(),
+        Ok(UserspaceMapping {
+            mapping: region,
             mem_slot,
             addr: GuestAddress(start_addr),
             mergeable: false,
-        };
-        Ok((region, mapping))
+        })
     }
 
     fn unmap_ram_region(&mut self, mapping: UserspaceMapping) -> Result<(), IvshmemError> {

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -13,9 +13,7 @@ use libc::{
     TCGETS, TCGETS2, TCSETS, TCSETS2, TIOCGPGRP, TIOCGPTPEER, TIOCGWINSZ, TIOCSCTTY, TIOCSPGRP,
     TIOCSPTLCK, TUNGETFEATURES, TUNGETIFF, TUNSETIFF, TUNSETOFFLOAD, TUNSETVNETHDRSZ,
 };
-use seccompiler::SeccompCmpOp::Eq;
-#[cfg(all(feature = "sev_snp", feature = "kvm"))]
-use seccompiler::SeccompCmpOp::MaskedEq;
+use seccompiler::SeccompCmpOp::{Eq, MaskedEq};
 use seccompiler::{
     BackendError, BpfProgram, Error, SeccompAction, SeccompCmpArgLen as ArgLen,
     SeccompCondition as Cond, SeccompFilter, SeccompRule,
@@ -572,7 +570,11 @@ fn create_serial_manager_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Backen
 // Syscalls needed by all threads, because they are used in the seccomp signal
 // handler.
 fn common_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
-    Ok(vec![(libc::SYS_gettid, vec![]), (libc::SYS_write, vec![])])
+    Ok(vec![
+        (libc::SYS_gettid, vec![]),
+        (libc::SYS_read, vec![]),
+        (libc::SYS_write, vec![]),
+    ])
 }
 
 fn create_signal_handler_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, BackendError> {
@@ -632,7 +634,6 @@ fn pty_foreground_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, Backend
         (libc::SYS_poll, vec![]),
         #[cfg(target_arch = "aarch64")]
         (libc::SYS_ppoll, vec![]),
-        (libc::SYS_read, vec![]),
         (libc::SYS_restart_syscall, vec![]),
         (libc::SYS_rt_sigaction, vec![]),
         (libc::SYS_rt_sigreturn, vec![]),
@@ -732,7 +733,6 @@ fn vmm_thread_rules(
         (libc::SYS_prlimit64, vec![]),
         (libc::SYS_pwrite64, vec![]),
         (libc::SYS_pwritev, vec![]),
-        (libc::SYS_read, vec![]),
         (libc::SYS_readv, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_readlink, vec![]),
@@ -938,10 +938,8 @@ fn vcpu_thread_rules(
         (libc::SYS_newfstatat, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_open, vec![]),
-        (libc::SYS_openat, vec![]),
         (libc::SYS_pread64, vec![]),
         (libc::SYS_pwrite64, vec![]),
-        (libc::SYS_read, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_readlink, vec![]),
         #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
@@ -993,19 +991,7 @@ fn http_api_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError>
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
         (libc::SYS_munmap, vec![]),
-        #[cfg(all(feature = "sev_snp", feature = "kvm"))]
-        (
-            libc::SYS_openat,
-            or![and![Cond::new(
-                2, // openat() flags argument
-                ArgLen::Dword,
-                MaskedEq(libc::O_ACCMODE as u64),
-                libc::O_RDONLY as u64,
-            )?]],
-        ),
         (libc::SYS_prctl, vec![]),
-        #[cfg(all(feature = "sev_snp", feature = "kvm"))]
-        (libc::SYS_read, vec![]),
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_rt_sigprocmask, vec![]),
@@ -1097,7 +1083,6 @@ fn migration_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError
         #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
         (libc::SYS_ppoll, vec![]),
         (libc::SYS_prctl, vec![]),
-        (libc::SYS_read, vec![]),
         (libc::SYS_readv, vec![]),
         (libc::SYS_tkill, vec![]),
         (libc::SYS_recvfrom, vec![]),
@@ -1139,14 +1124,12 @@ fn migration_tcp_worker_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, B
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
         (libc::SYS_munmap, vec![]),
-        (libc::SYS_openat, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_poll, vec![]),
         #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
         (libc::SYS_ppoll, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_pwrite64, vec![]),
-        (libc::SYS_read, vec![]),
         (libc::SYS_readv, vec![]),
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_recvmsg, vec![]),
@@ -1184,7 +1167,6 @@ fn serial_manager_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, Backend
         (libc::SYS_mmap, vec![]),
         (libc::SYS_munmap, vec![]),
         (libc::SYS_nanosleep, vec![]),
-        (libc::SYS_read, vec![]),
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_rt_sigreturn, vec![]),
@@ -1208,7 +1190,6 @@ fn migrate_send_postcopy_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, 
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
         (libc::SYS_munmap, vec![]),
-        (libc::SYS_read, vec![]),
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_rt_sigprocmask, vec![]),
@@ -1244,6 +1225,21 @@ fn get_seccomp_rules(
         Thread::PtyForeground => pty_foreground_thread_rules()?,
         Thread::MigrateSendPostcopy => migrate_send_postcopy_thread_rules()?,
     };
+    if !rules
+        .iter()
+        .chain(specific_rules.iter())
+        .any(|(syscall, _)| *syscall == libc::SYS_openat)
+    {
+        rules.push((
+            libc::SYS_openat,
+            or![and![Cond::new(
+                2, // openat() flags argument
+                ArgLen::Dword,
+                MaskedEq(libc::O_ACCMODE as u64),
+                libc::O_RDONLY as u64,
+            )?]],
+        ));
+    }
     rules.extend(specific_rules);
     Ok(rules)
 }


### PR DESCRIPTION
Unfortunately glibc can read the overcommit sysctl from any thread. This
has lead to us adding a patchwork of openat/read syscalls to our allow
list when those threads don't necessarily need openat for their actual
uses.

Only the VMM and migration worker thread have a strict requirement for
the openat syscall. The syscall was added to the other threads to deal
with this glibc behaviour.

As read() is itself harmless move it to the common syscalls, strip
full openat() from all but the threads that need it and add limited,
read only, openat to all threads.

Signed-off-by: Rob Bradford <rbradford@meta.com>
