### PR TITLE
vmm: allow openat in the event-monitor seccomp filter

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -1059,6 +1059,7 @@ fn event_monitor_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendE
         (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
         (libc::SYS_munmap, vec![]),
+        (libc::SYS_openat, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_sched_yield, vec![]),
     ])


### PR DESCRIPTION
Fix a seccomp SIGSYS on the event-monitor thread during live migration shutdown. When the VM exits the recv() loop ends and glibc's thread teardown lazily loads libgcc_s.so.1 for stack unwinding, which calls openat(2).

Add openat to the allow-list.