### PR TITLE
 tests: unstick systemd-networkd after primary NIC add-net in live-migration tests

### DIFF
--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -1110,6 +1110,47 @@ pub(crate) fn bdf_from_hotplug_response(
     (segment_id, bus_id, device_id, function_id)
 }
 
+/// `--net` argument for the guest's management NIC, kept plugged during the
+/// primary NIC's remove-device/add-net cycle.
+pub(crate) fn mgmt_net_params(guest: &Guest) -> String {
+    format!(
+        "tap=,mac={},ip={},mask=255.255.255.128",
+        guest.network.guest_mac1, guest.network.host_ip1
+    )
+}
+
+fn mgmt_auth() -> PasswordAuth {
+    PasswordAuth {
+        username: String::from("cloud"),
+        password: String::from("cloud123"),
+    }
+}
+
+pub(crate) fn ensure_mgmt_nic_ready(guest: &Guest) {
+    wait_for_ssh(
+        "true",
+        &mgmt_auth(),
+        &guest.network.guest_ip1,
+        Duration::from_secs(30),
+    )
+    .expect("management NIC SSH not reachable");
+}
+
+/// Restart systemd-networkd on the guest over the management NIC and wait
+/// for the primary NIC to come back. Works around a udev-rename vs
+/// networkd race on Ubuntu 22.04 that otherwise leaves the re-plugged
+/// primary in `state DOWN, off (unmanaged)`.
+pub(crate) fn recover_primary_nic_via_mgmt(guest: &Guest) {
+    ssh_command_ip_with_auth(
+        "sudo systemctl restart systemd-networkd",
+        &mgmt_auth(),
+        &guest.network.guest_ip1,
+        Some(Duration::from_secs(30)),
+    )
+    .expect("failed to restart systemd-networkd via mgmt");
+    guest.wait_for_ssh(Duration::from_secs(60)).unwrap();
+}
+
 #[cfg(not(feature = "mshv"))]
 pub(crate) fn start_live_migration(
     migration_socket: &str,

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10334,6 +10334,7 @@ mod common_sequential {
             "id={},tap=,mac={},ip={},mask=255.255.255.128",
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
+        let mgmt_net_params = mgmt_net_params(&guest);
 
         let memory_param: &[&str] = if local {
             &[
@@ -10391,7 +10392,7 @@ mod common_sequential {
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .default_disks()
-            .args(["--net", net_params.as_str()])
+            .args(["--net", net_params.as_str(), mgmt_net_params.as_str()])
             .args(["--api-socket", &src_api_socket])
             .args([
                 "--pmem",
@@ -10453,6 +10454,8 @@ mod common_sequential {
             // not break the live-migration support for virtio-pci.
             #[cfg(target_arch = "x86_64")]
             {
+                ensure_mgmt_nic_ready(&guest);
+
                 assert!(remote_command(
                     &src_api_socket,
                     "remove-device",
@@ -10468,7 +10471,7 @@ mod common_sequential {
                     "add-net",
                     Some(net_params.as_str()),
                 ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
+                recover_primary_nic_via_mgmt(&guest);
             }
 
             // Start the live-migration

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6629,6 +6629,7 @@ mod common_parallel {
             "id={},tap=,mac={},ip={},mask=255.255.255.128",
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
+        let mgmt_net_params = mgmt_net_params(&guest);
 
         let memory_param: &[&str] = if local {
             &["--memory", "size=1500M,shared=on"]
@@ -6664,7 +6665,7 @@ mod common_parallel {
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .default_disks()
-            .args(["--net", net_params.as_str()])
+            .args(["--net", net_params.as_str(), mgmt_net_params.as_str()])
             .args(["--api-socket", &src_api_socket])
             .args([
                 "--pmem",
@@ -6699,6 +6700,8 @@ mod common_parallel {
             // not break the live-migration support for virtio-pci.
             #[cfg(target_arch = "x86_64")]
             {
+                ensure_mgmt_nic_ready(&guest);
+
                 assert!(remote_command(
                     &src_api_socket,
                     "remove-device",
@@ -6714,7 +6717,8 @@ mod common_parallel {
                     "add-net",
                     Some(net_params.as_str()),
                 ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
+
+                recover_primary_nic_via_mgmt(&guest);
             }
 
             // Start the live-migration

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10127,6 +10127,7 @@ mod common_sequential {
             "id={},tap=,mac={},ip={},mask=255.255.255.128",
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
+        let mgmt_net_params = mgmt_net_params(&guest);
 
         let memory_param: &[&str] = if local {
             &[
@@ -10172,7 +10173,7 @@ mod common_sequential {
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .default_disks()
-            .args(["--net", net_params.as_str()])
+            .args(["--net", net_params.as_str(), mgmt_net_params.as_str()])
             .args(["--api-socket", &src_api_socket])
             .args([
                 "--pmem",
@@ -10222,6 +10223,8 @@ mod common_sequential {
             // not break the live-migration support for virtio-pci.
             #[cfg(target_arch = "x86_64")]
             {
+                ensure_mgmt_nic_ready(&guest);
+
                 assert!(remote_command(
                     &src_api_socket,
                     "remove-device",
@@ -10237,7 +10240,7 @@ mod common_sequential {
                     "add-net",
                     Some(net_params.as_str()),
                 ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
+                recover_primary_nic_via_mgmt(&guest);
             }
 
             // Start the live-migration

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10783,6 +10783,7 @@ mod common_sequential {
             "id={},tap=,mac={},ip={},mask=255.255.255.128",
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
+        let mgmt_net_params = mgmt_net_params(&guest);
 
         let memory_param: &[&str] = if local {
             &["--memory", "size=1500M,shared=on"]
@@ -10818,7 +10819,7 @@ mod common_sequential {
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .default_disks()
-            .args(["--net", net_params.as_str()])
+            .args(["--net", net_params.as_str(), mgmt_net_params.as_str()])
             .args(["--api-socket", &src_api_socket])
             .args([
                 "--pmem",
@@ -10851,6 +10852,8 @@ mod common_sequential {
             // not break the live-migration support for virtio-pci.
             #[cfg(target_arch = "x86_64")]
             {
+                ensure_mgmt_nic_ready(&guest);
+
                 assert!(remote_command(
                     &src_api_socket,
                     "remove-device",
@@ -10866,7 +10869,7 @@ mod common_sequential {
                     "add-net",
                     Some(net_params.as_str()),
                 ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
+                recover_primary_nic_via_mgmt(&guest);
             }
 
             // Enable watchdog and ensure its functional

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7067,6 +7067,7 @@ mod common_parallel {
             "id={},tap=,mac={},ip={},mask=255.255.255.128",
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
+        let mgmt_net_params = mgmt_net_params(&guest);
         let memory_param: &[&str] = &["--memory", "size=1500M,shared=on"];
         let boot_vcpus = 2;
         let max_vcpus = 4;
@@ -7109,7 +7110,7 @@ mod common_parallel {
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .default_disks()
-            .args(["--net", net_params.as_str()])
+            .args(["--net", net_params.as_str(), mgmt_net_params.as_str()])
             .args(["--api-socket", &src_api_socket])
             .args([
                 "--pmem",
@@ -7148,6 +7149,8 @@ mod common_parallel {
             // using direct kernel boot, where ACPI support is missing.
             #[cfg(target_arch = "x86_64")]
             {
+                ensure_mgmt_nic_ready(&guest);
+
                 assert!(remote_command(
                     &src_api_socket,
                     "remove-device",
@@ -7162,7 +7165,7 @@ mod common_parallel {
                     "add-net",
                     Some(net_params.as_str()),
                 ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
+                recover_primary_nic_via_mgmt(&guest);
 
                 assert!(hotplug_disk_absent());
                 assert!(remote_command(


### PR DESCRIPTION
The upgrade and non-upgrade live-migration tests (`test_live_upgrade_basic`,`test_live_migration_tcp`, `_balloon`, `_numa`, `_watchdog`) have been flaky on the mshv host for a while and have been obsering flakiness in the KVM pieline as well. 
All of them hot-remove the primary virtio-net device and add it back mid-test, and every so often systemd-networkd on the
Ubuntu 22.04 guest leaves the re-plugged interface in `state DOWN, off (unmanaged)`. What happens is that udev renames the
freshly-plugged netdev (`eth0` -> `ens4`) *after* networkd has already processed the initial `RTM_NEWLINK`, so networkd never re-runs its Match logic against the new name. `networkctl reconfigure` won't un-stick it -- the whole networkd unit has to restart.

The workaround: plug a second (management) NIC that stays up across the remove/add cycle, and use it to `sudo systemctl restart systemd-networkd` right after `add-net`. That makes networkd re-enumerate everything from scratch, and the primary is reachable again within a few seconds.