### PR TITLE
Add missing CPUID compatibility checks for sub-leaves of 0x7

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -451,6 +451,12 @@ impl CpuidFeatureEntry {
                 feature_reg: CpuidReg::EAX,
                 compatible_check: CpuidCompatibleCheck::BitwiseSubset,
             },
+            CpuidFeatureEntry {
+                function: 7,
+                index: 1,
+                feature_reg: CpuidReg::ECX,
+                compatible_check: CpuidCompatibleCheck::BitwiseSubset,
+            },
             // Leaf 0x8000_0001, ECX/EDX, CPUID features bits
             CpuidFeatureEntry {
                 function: 0x8000_0001,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -457,6 +457,12 @@ impl CpuidFeatureEntry {
                 feature_reg: CpuidReg::ECX,
                 compatible_check: CpuidCompatibleCheck::BitwiseSubset,
             },
+            CpuidFeatureEntry {
+                function: 7,
+                index: 1,
+                feature_reg: CpuidReg::EDX,
+                compatible_check: CpuidCompatibleCheck::BitwiseSubset,
+            },
             // Leaf 0x8000_0001, ECX/EDX, CPUID features bits
             CpuidFeatureEntry {
                 function: 0x8000_0001,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -463,6 +463,12 @@ impl CpuidFeatureEntry {
                 feature_reg: CpuidReg::EDX,
                 compatible_check: CpuidCompatibleCheck::BitwiseSubset,
             },
+            CpuidFeatureEntry {
+                function: 7,
+                index: 2,
+                feature_reg: CpuidReg::EDX,
+                compatible_check: CpuidCompatibleCheck::BitwiseSubset,
+            },
             // Leaf 0x8000_0001, ECX/EDX, CPUID features bits
             CpuidFeatureEntry {
                 function: 0x8000_0001,


### PR DESCRIPTION
Part of https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8494. We introduce missing CPUID compatibility checks for Structured Extended Feature Enumeration Sub-leaves. This is necessary for safe live migration and also for the upcoming CPU profiles feature.

This may break existing deployments: With this change it will certainly not be possible to live migrate from Intel Granite Rapids to Intel Sapphire Rapids, but that might have "worked" before.

When the CPU profiles feature is complete then one can perform such live migrations again by booting the VM with a Sapphire Rapids CPU profile.

Open question: We skipped adding checks for CPUID 0x7.0x1.EBX, because we were not able to confirm that KVM supports any feature enumerated in that case. Intel does however enumerate features in that output value. Would it perhaps be better to also take this register into account?
