### PR TITLE
performance-metrics: Report restore child exit status on failure

### DIFF
--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -519,8 +519,10 @@ fn measure_restore_time(
 
     parse_restore_time_output(&json_events).inspect_err(|_| {
         eprintln!(
-            "\n\n==== Start child stdout ====\n\n{}\n\n==== End child stdout ====\
+            "\n\n==== Restore child exit status: {} ====\
+            \n\n==== Start child stdout ====\n\n{}\n\n==== End child stdout ====\
             \n\n==== Start child stderr ====\n\n{}\n\n==== End child stderr ====",
+            output.status,
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );


### PR DESCRIPTION
When the restore event is missing, the restore latency test panics with a generic RestoreTimeParse error that gives no clue about the cause.

Include the exit status of the restore child in the diagnostic. Status 1 means Cloud Hypervisor aborted the restore, while SIGKILL means the test killed a still running child at its timeout.

Assisted-by: Claude:Opus-4.8