### PR TITLE
block: qcow: Deduplicate the qcow2 I/O paths between the sync and uring engines

### DIFF
--- a/block/src/formats/qcow/common.rs
+++ b/block/src/formats/qcow/common.rs
@@ -8,14 +8,17 @@
 
 //! Shared helpers for QCOW2 sync and async backends.
 
+use std::cmp::min;
 use std::io;
+use std::os::unix::fs::FileExt;
+use std::sync::Arc;
 
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
 use super::decoder::Decoder;
-use super::metadata::{BackingRead, DeallocAction, QcowMetadata};
+use super::metadata::{BackingRead, ClusterWriteMapping, DeallocAction, QcowMetadata};
 use super::qcow_raw_file::QcowRawFile;
-use crate::async_io::AsyncIoError;
+use crate::async_io::{AsyncIoError, AsyncIoOperation, AsyncIoResult};
 
 /// Decompress a full QCOW2 cluster from compressed data.
 ///
@@ -97,6 +100,62 @@ pub(super) fn deallocate_range_result(
         }
         Err(_) => -libc::EIO,
     }
+}
+
+/// Writes an operation to the data file cluster by cluster, allocating
+/// and copying up backing data as needed. Writes are synchronous because
+/// the host offset is only known after the metadata allocation.
+pub(super) fn cow_write_sync(
+    address: u64,
+    op: &AsyncIoOperation,
+    metadata: &QcowMetadata,
+    data_file: &QcowRawFile,
+    backing_file: &Option<Arc<dyn BackingRead>>,
+    cluster_size: u64,
+) -> AsyncIoResult<()> {
+    let total_len = op.total_len();
+    let mut buf_offset = 0usize;
+
+    while buf_offset < total_len {
+        let curr_addr = address + buf_offset as u64;
+        let intra_offset = curr_addr & (cluster_size - 1);
+        let remaining_in_cluster = (cluster_size - intra_offset) as usize;
+        let count = min(total_len - buf_offset, remaining_in_cluster);
+
+        let backing_data = if let Some(backing) = backing_file
+            .as_ref()
+            .filter(|_| intra_offset != 0 || count < cluster_size as usize)
+        {
+            let cluster_begin = curr_addr - intra_offset;
+            let mut data = vec![0u8; cluster_size as usize];
+            backing
+                .read_at(cluster_begin, &mut data)
+                .map_err(AsyncIoError::WriteVectored)?;
+            Some(data)
+        } else {
+            None
+        };
+
+        let mapping = metadata
+            .map_cluster_for_write(curr_addr, backing_data)
+            .map_err(AsyncIoError::WriteVectored)?;
+
+        match mapping {
+            ClusterWriteMapping::Allocated {
+                offset: host_offset,
+            } => {
+                let mut buf = vec![0u8; count];
+                op.read_bytes_at(buf_offset, &mut buf)
+                    .map_err(AsyncIoError::WriteVectored)?;
+                data_file
+                    .file()
+                    .write_all_at(&buf, host_offset)
+                    .map_err(AsyncIoError::WriteVectored)?;
+            }
+        }
+        buf_offset += count;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/block/src/formats/qcow/common.rs
+++ b/block/src/formats/qcow/common.rs
@@ -16,7 +16,9 @@ use std::sync::Arc;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
 use super::decoder::Decoder;
-use super::metadata::{BackingRead, ClusterWriteMapping, DeallocAction, QcowMetadata};
+use super::metadata::{
+    BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
+};
 use super::qcow_raw_file::QcowRawFile;
 use crate::async_io::{AsyncIoError, AsyncIoOperation, AsyncIoResult};
 
@@ -154,6 +156,78 @@ pub(super) fn cow_write_sync(
             }
         }
         buf_offset += count;
+    }
+    Ok(())
+}
+
+/// Reads cluster mappings synchronously into an owned operation, filling
+/// holes, decompressing, and reading from the backing file as each
+/// mapping requires.
+pub(super) fn scatter_read_sync(
+    mappings: Vec<ClusterReadMapping>,
+    op: &mut AsyncIoOperation,
+    data_file: &QcowRawFile,
+    backing_file: &Option<Arc<dyn BackingRead>>,
+    cluster_size: u64,
+    decoder: &dyn Decoder,
+) -> AsyncIoResult<()> {
+    let mut buf_offset = 0usize;
+    for mapping in mappings {
+        match mapping {
+            ClusterReadMapping::Zero { length } => {
+                op.fill_zeroes_at(buf_offset, length as usize)
+                    .map_err(AsyncIoError::ReadVectored)?;
+                buf_offset += length as usize;
+            }
+            ClusterReadMapping::Allocated {
+                offset: host_offset,
+                length,
+            } => {
+                let len = length as usize;
+                let mut buf = vec![0u8; len];
+                data_file
+                    .file()
+                    .read_exact_at(&mut buf, host_offset)
+                    .map_err(AsyncIoError::ReadVectored)?;
+                op.write_bytes_at(buf_offset, &buf)
+                    .map_err(AsyncIoError::ReadVectored)?;
+                buf_offset += len;
+            }
+            ClusterReadMapping::Compressed {
+                host_offset,
+                compressed_size,
+                cluster_offset,
+                length,
+            } => {
+                let mut compressed = vec![0u8; compressed_size];
+                data_file
+                    .file()
+                    .read_exact_at(&mut compressed, host_offset)
+                    .map_err(AsyncIoError::ReadVectored)?;
+                let decompressed = decompress_cluster(&compressed, cluster_size as usize, decoder)
+                    .map_err(AsyncIoError::ReadVectored)?;
+                op.write_bytes_at(
+                    buf_offset,
+                    &decompressed[cluster_offset..cluster_offset + length],
+                )
+                .map_err(AsyncIoError::ReadVectored)?;
+                buf_offset += length;
+            }
+            ClusterReadMapping::Backing {
+                offset: backing_offset,
+                length,
+            } => {
+                let mut buf = vec![0u8; length as usize];
+                backing_file
+                    .as_ref()
+                    .unwrap()
+                    .read_at(backing_offset, &mut buf)
+                    .map_err(AsyncIoError::ReadVectored)?;
+                op.write_bytes_at(buf_offset, &buf)
+                    .map_err(AsyncIoError::ReadVectored)?;
+                buf_offset += length as usize;
+            }
+        }
     }
     Ok(())
 }

--- a/block/src/formats/qcow/common.rs
+++ b/block/src/formats/qcow/common.rs
@@ -10,7 +10,12 @@
 
 use std::io;
 
+use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
+
 use super::decoder::Decoder;
+use super::metadata::{BackingRead, DeallocAction, QcowMetadata};
+use super::qcow_raw_file::QcowRawFile;
+use crate::async_io::AsyncIoError;
 
 /// Decompress a full QCOW2 cluster from compressed data.
 ///
@@ -30,6 +35,68 @@ pub(super) fn decompress_cluster(
         return Err(io::Error::from_raw_os_error(libc::EIO));
     }
     Ok(decompressed)
+}
+
+/// Applies one deallocation action to the data file and refcount table.
+pub(super) fn apply_dealloc_action(
+    metadata: &QcowMetadata,
+    data_file: &mut QcowRawFile,
+    action: &DeallocAction,
+) -> io::Result<()> {
+    match action {
+        DeallocAction::PunchHole {
+            host_offset,
+            length,
+        } => {
+            data_file.file_mut().punch_hole(*host_offset, *length)?;
+            metadata.complete_punch_hole(*host_offset);
+            Ok(())
+        }
+        DeallocAction::WriteZeroes {
+            host_offset,
+            length,
+        } => data_file
+            .file_mut()
+            .write_zeroes_at(*host_offset, *length)
+            .map(|_| ()),
+    }
+}
+
+/// Deallocates a byte range and returns the completion result, 0 on
+/// success or a negative errno on the first failing action.
+pub(super) fn deallocate_range_result(
+    metadata: &QcowMetadata,
+    data_file: &mut QcowRawFile,
+    offset: u64,
+    length: usize,
+    sparse: bool,
+    write_zeroes: bool,
+    backing_file: Option<&dyn BackingRead>,
+) -> i32 {
+    let wrap_error: fn(io::Error) -> AsyncIoError = if write_zeroes {
+        AsyncIoError::WriteZeroes
+    } else {
+        AsyncIoError::PunchHole
+    };
+    let result = metadata
+        .deallocate_bytes(offset, length, sparse, write_zeroes, backing_file)
+        .and_then(|actions| {
+            let mut first_error = None;
+            for action in &actions {
+                if let Err(e) = apply_dealloc_action(metadata, data_file, action) {
+                    first_error.get_or_insert(e);
+                }
+            }
+            first_error.map_or(Ok(()), Err)
+        })
+        .map_err(wrap_error);
+    match result {
+        Ok(()) => 0,
+        Err(AsyncIoError::PunchHole(e) | AsyncIoError::WriteZeroes(e)) => {
+            -e.raw_os_error().unwrap_or(libc::EIO)
+        }
+        Err(_) => -libc::EIO,
+    }
 }
 
 #[cfg(test)]

--- a/block/src/formats/qcow/engine_sync.rs
+++ b/block/src/formats/qcow/engine_sync.rs
@@ -5,18 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::cmp::min;
-use std::io;
 use std::os::unix::fs::FileExt;
 use std::sync::Arc;
 
 use vmm_sys_util::eventfd::EventFd;
-use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
-use super::common::decompress_cluster;
+use super::common::{deallocate_range_result, decompress_cluster};
 use super::decoder::Decoder;
-use super::metadata::{
-    BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
-};
+use super::metadata::{BackingRead, ClusterReadMapping, ClusterWriteMapping, QcowMetadata};
 use super::qcow_raw_file::QcowRawFile;
 use crate::async_io::{
     AsyncIo, AsyncIoCompletion, AsyncIoError, AsyncIoOperation, AsyncIoResult, CompletionCommon,
@@ -48,29 +44,6 @@ impl QcowSync {
             backing_file,
             sparse,
             completions: CompletionCommon::new(),
-        }
-    }
-
-    fn apply_dealloc_action(&mut self, action: &DeallocAction) -> io::Result<()> {
-        match action {
-            DeallocAction::PunchHole {
-                host_offset,
-                length,
-            } => {
-                self.data_file
-                    .file_mut()
-                    .punch_hole(*host_offset, *length)?;
-                self.metadata.complete_punch_hole(*host_offset);
-                Ok(())
-            }
-            DeallocAction::WriteZeroes {
-                host_offset,
-                length,
-            } => self
-                .data_file
-                .file_mut()
-                .write_zeroes_at(*host_offset, *length)
-                .map(|_| ()),
         }
     }
 
@@ -231,83 +204,33 @@ impl AsyncIo for QcowSync {
     }
 
     fn punch_hole(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
-        let result = self
-            .metadata
-            .deallocate_bytes(
-                offset,
-                length as usize,
-                self.sparse,
-                false,
-                self.backing_file.as_deref(),
-            )
-            .and_then(|actions| {
-                let mut first_error = None;
-                for action in &actions {
-                    if let Err(e) = self.apply_dealloc_action(action) {
-                        first_error.get_or_insert(e);
-                    }
-                }
-                first_error.map_or(Ok(()), Err)
-            })
-            .map_err(AsyncIoError::PunchHole);
-
-        match result {
-            Ok(()) => {
-                self.completions
-                    .complete(AsyncIoCompletion::new(user_data, 0, None));
-                Ok(())
-            }
-            Err(e) => {
-                let errno = if let AsyncIoError::PunchHole(ref io_err) = e {
-                    -io_err.raw_os_error().unwrap_or(libc::EIO)
-                } else {
-                    -libc::EIO
-                };
-                self.completions
-                    .complete(AsyncIoCompletion::new(user_data, errno, None));
-                Ok(())
-            }
-        }
+        let result = deallocate_range_result(
+            &self.metadata,
+            &mut self.data_file,
+            offset,
+            length as usize,
+            self.sparse,
+            false,
+            self.backing_file.as_deref(),
+        );
+        self.completions
+            .complete(AsyncIoCompletion::new(user_data, result, None));
+        Ok(())
     }
 
     fn write_zeroes(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
-        let result = self
-            .metadata
-            .deallocate_bytes(
-                offset,
-                length as usize,
-                self.sparse,
-                true,
-                self.backing_file.as_deref(),
-            )
-            .and_then(|actions| {
-                let mut first_error = None;
-                for action in &actions {
-                    if let Err(e) = self.apply_dealloc_action(action) {
-                        first_error.get_or_insert(e);
-                    }
-                }
-                first_error.map_or(Ok(()), Err)
-            })
-            .map_err(AsyncIoError::WriteZeroes);
-
-        match result {
-            Ok(()) => {
-                self.completions
-                    .complete(AsyncIoCompletion::new(user_data, 0, None));
-                Ok(())
-            }
-            Err(e) => {
-                let errno = if let AsyncIoError::WriteZeroes(ref io_err) = e {
-                    -io_err.raw_os_error().unwrap_or(libc::EIO)
-                } else {
-                    -libc::EIO
-                };
-                self.completions
-                    .complete(AsyncIoCompletion::new(user_data, errno, None));
-                Ok(())
-            }
-        }
+        let result = deallocate_range_result(
+            &self.metadata,
+            &mut self.data_file,
+            offset,
+            length as usize,
+            self.sparse,
+            true,
+            self.backing_file.as_deref(),
+        );
+        self.completions
+            .complete(AsyncIoCompletion::new(user_data, result, None));
+        Ok(())
     }
 }
 
@@ -329,7 +252,9 @@ mod unit_tests {
     use crate::disk_file::{AsyncDiskFile, DiskSize, MetadataSync, Resizable};
     use crate::error::BlockErrorKind;
     use crate::formats::qcow;
+    use crate::formats::qcow::common::apply_dealloc_action;
     use crate::formats::qcow::common::unit_tests::compress_allocated_clusters;
+    use crate::formats::qcow::metadata::DeallocAction;
     use crate::formats::qcow::{
         BackingFileConfig, Error as QcowError, ImageType, QcowDisk, QcowHeader, QcowTempDisk,
     };
@@ -2311,7 +2236,7 @@ mod unit_tests {
 
         // Queue A resumes. Completing the old action must not touch the new
         // L2, and only now may the old data cluster enter unref_clusters.
-        aio.apply_dealloc_action(&actions[0]).unwrap();
+        apply_dealloc_action(&aio.metadata, &mut aio.data_file, &actions[0]).unwrap();
         metadata.flush().unwrap();
         drop(aio);
         drop(metadata);

--- a/block/src/formats/qcow/engine_sync.rs
+++ b/block/src/formats/qcow/engine_sync.rs
@@ -4,15 +4,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::cmp::min;
 use std::os::unix::fs::FileExt;
 use std::sync::Arc;
 
 use vmm_sys_util::eventfd::EventFd;
 
-use super::common::{deallocate_range_result, decompress_cluster};
+use super::common::{cow_write_sync, deallocate_range_result, decompress_cluster};
 use super::decoder::Decoder;
-use super::metadata::{BackingRead, ClusterReadMapping, ClusterWriteMapping, QcowMetadata};
+use super::metadata::{BackingRead, ClusterReadMapping, QcowMetadata};
 use super::qcow_raw_file::QcowRawFile;
 use crate::async_io::{
     AsyncIo, AsyncIoCompletion, AsyncIoError, AsyncIoOperation, AsyncIoResult, CompletionCommon,
@@ -119,58 +118,6 @@ impl QcowSync {
 
         Ok(total_len)
     }
-
-    fn write_operation(&mut self, op: &AsyncIoOperation) -> AsyncIoResult<usize> {
-        let address = op.offset() as u64;
-        let total_len = op.total_len();
-        let mut buf_offset = 0usize;
-
-        while buf_offset < total_len {
-            let curr_addr = address + buf_offset as u64;
-            let intra_offset = curr_addr & (self.cluster_size - 1);
-            let remaining_in_cluster = (self.cluster_size - intra_offset) as usize;
-            let count = min(total_len - buf_offset, remaining_in_cluster);
-
-            // Read backing data for COW if this is a partial cluster
-            // write to an unallocated cluster with a backing file.
-            let backing_data = if let Some(backing) = self
-                .backing_file
-                .as_ref()
-                .filter(|_| intra_offset != 0 || count < self.cluster_size as usize)
-            {
-                let cluster_begin = curr_addr - intra_offset;
-                let mut data = vec![0u8; self.cluster_size as usize];
-                backing
-                    .read_at(cluster_begin, &mut data)
-                    .map_err(AsyncIoError::WriteVectored)?;
-                Some(data)
-            } else {
-                None
-            };
-
-            let mapping = self
-                .metadata
-                .map_cluster_for_write(curr_addr, backing_data)
-                .map_err(AsyncIoError::WriteVectored)?;
-
-            match mapping {
-                ClusterWriteMapping::Allocated {
-                    offset: host_offset,
-                } => {
-                    let mut buf = vec![0u8; count];
-                    op.read_bytes_at(buf_offset, &mut buf)
-                        .map_err(AsyncIoError::WriteVectored)?;
-                    self.data_file
-                        .file()
-                        .write_all_at(&buf, host_offset)
-                        .map_err(AsyncIoError::WriteVectored)?;
-                }
-            }
-            buf_offset += count;
-        }
-
-        Ok(total_len)
-    }
 }
 
 impl AsyncIo for QcowSync {
@@ -179,11 +126,18 @@ impl AsyncIo for QcowSync {
     }
 
     fn submit_data_operation(&mut self, mut op: AsyncIoOperation) -> AsyncIoResult<()> {
-        let is_read = op.is_read();
-        let total_len = if is_read {
+        let total_len = if op.is_read() {
             self.read_operation(&mut op)?
         } else {
-            self.write_operation(&op)?
+            cow_write_sync(
+                op.offset() as u64,
+                &op,
+                &self.metadata,
+                &self.data_file,
+                &self.backing_file,
+                self.cluster_size,
+            )?;
+            op.total_len()
         };
         self.completions
             .complete(AsyncIoCompletion::from_operation(op, total_len as i32));

--- a/block/src/formats/qcow/engine_sync.rs
+++ b/block/src/formats/qcow/engine_sync.rs
@@ -4,14 +4,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::os::unix::fs::FileExt;
 use std::sync::Arc;
 
 use vmm_sys_util::eventfd::EventFd;
 
-use super::common::{cow_write_sync, deallocate_range_result, decompress_cluster};
+use super::common::{cow_write_sync, deallocate_range_result, scatter_read_sync};
 use super::decoder::Decoder;
-use super::metadata::{BackingRead, ClusterReadMapping, QcowMetadata};
+use super::metadata::{BackingRead, QcowMetadata};
 use super::qcow_raw_file::QcowRawFile;
 use crate::async_io::{
     AsyncIo, AsyncIoCompletion, AsyncIoError, AsyncIoOperation, AsyncIoResult, CompletionCommon,
@@ -56,65 +55,14 @@ impl QcowSync {
             .map_clusters_for_read(address, total_len, has_backing)
             .map_err(AsyncIoError::ReadVectored)?;
 
-        let mut buf_offset = 0usize;
-        for mapping in mappings {
-            match mapping {
-                ClusterReadMapping::Zero { length } => {
-                    op.fill_zeroes_at(buf_offset, length as usize)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    buf_offset += length as usize;
-                }
-                ClusterReadMapping::Allocated {
-                    offset: host_offset,
-                    length,
-                } => {
-                    let len = length as usize;
-                    let mut buf = vec![0u8; len];
-                    self.data_file
-                        .file()
-                        .read_exact_at(&mut buf, host_offset)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    op.write_bytes_at(buf_offset, &buf)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    buf_offset += len;
-                }
-                ClusterReadMapping::Compressed {
-                    host_offset,
-                    compressed_size,
-                    cluster_offset,
-                    length,
-                } => {
-                    let mut compressed = vec![0u8; compressed_size];
-                    self.data_file
-                        .file()
-                        .read_exact_at(&mut compressed, host_offset)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    let decompressed =
-                        decompress_cluster(&compressed, self.cluster_size as usize, &*self.decoder)
-                            .map_err(AsyncIoError::ReadVectored)?;
-                    op.write_bytes_at(
-                        buf_offset,
-                        &decompressed[cluster_offset..cluster_offset + length],
-                    )
-                    .map_err(AsyncIoError::ReadVectored)?;
-                    buf_offset += length;
-                }
-                ClusterReadMapping::Backing {
-                    offset: backing_offset,
-                    length,
-                } => {
-                    let mut buf = vec![0u8; length as usize];
-                    self.backing_file
-                        .as_ref()
-                        .unwrap()
-                        .read_at(backing_offset, &mut buf)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    op.write_bytes_at(buf_offset, &buf)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    buf_offset += length as usize;
-                }
-            }
-        }
+        scatter_read_sync(
+            mappings,
+            op,
+            &self.data_file,
+            &self.backing_file,
+            self.cluster_size,
+            &*self.decoder,
+        )?;
 
         Ok(total_len)
     }
@@ -208,7 +156,7 @@ mod unit_tests {
     use crate::formats::qcow;
     use crate::formats::qcow::common::apply_dealloc_action;
     use crate::formats::qcow::common::unit_tests::compress_allocated_clusters;
-    use crate::formats::qcow::metadata::DeallocAction;
+    use crate::formats::qcow::metadata::{ClusterReadMapping, DeallocAction};
     use crate::formats::qcow::{
         BackingFileConfig, Error as QcowError, ImageType, QcowDisk, QcowHeader, QcowTempDisk,
     };

--- a/block/src/formats/qcow/engine_uring.rs
+++ b/block/src/formats/qcow/engine_uring.rs
@@ -9,13 +9,12 @@
 //! QCOW2 async disk backend.
 
 use std::io;
-use std::os::unix::fs::FileExt;
 use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
 
 use vmm_sys_util::eventfd::EventFd;
 
-use super::common::{cow_write_sync, deallocate_range_result, decompress_cluster};
+use super::common::{cow_write_sync, deallocate_range_result, scatter_read_sync};
 use super::decoder::Decoder;
 use super::metadata::{BackingRead, ClusterReadMapping, QcowMetadata};
 use super::qcow_raw_file::QcowRawFile;
@@ -277,79 +276,8 @@ impl QcowAsync {
             return Ok(Some(*host_offset));
         }
 
-        Self::scatter_read_sync(mappings, op, data_file, backing_file, cluster_size, decoder)?;
+        scatter_read_sync(mappings, op, data_file, backing_file, cluster_size, decoder)?;
         Ok(None)
-    }
-
-    /// Scatter-read cluster mappings synchronously into an owned operation.
-    fn scatter_read_sync(
-        mappings: Vec<ClusterReadMapping>,
-        op: &mut AsyncIoOperation,
-        data_file: &QcowRawFile,
-        backing_file: &Option<Arc<dyn BackingRead>>,
-        cluster_size: u64,
-        decoder: &dyn Decoder,
-    ) -> AsyncIoResult<()> {
-        let mut buf_offset = 0usize;
-        for mapping in mappings {
-            match mapping {
-                ClusterReadMapping::Zero { length } => {
-                    op.fill_zeroes_at(buf_offset, length as usize)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    buf_offset += length as usize;
-                }
-                ClusterReadMapping::Allocated {
-                    offset: host_offset,
-                    length,
-                } => {
-                    let len = length as usize;
-                    let mut buf = vec![0u8; len];
-                    data_file
-                        .file()
-                        .read_exact_at(&mut buf, host_offset)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    op.write_bytes_at(buf_offset, &buf)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    buf_offset += len;
-                }
-                ClusterReadMapping::Compressed {
-                    host_offset,
-                    compressed_size,
-                    cluster_offset,
-                    length,
-                } => {
-                    let mut compressed = vec![0u8; compressed_size];
-                    data_file
-                        .file()
-                        .read_exact_at(&mut compressed, host_offset)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    let decompressed =
-                        decompress_cluster(&compressed, cluster_size as usize, decoder)
-                            .map_err(AsyncIoError::ReadVectored)?;
-                    op.write_bytes_at(
-                        buf_offset,
-                        &decompressed[cluster_offset..cluster_offset + length],
-                    )
-                    .map_err(AsyncIoError::ReadVectored)?;
-                    buf_offset += length;
-                }
-                ClusterReadMapping::Backing {
-                    offset: backing_offset,
-                    length,
-                } => {
-                    let mut buf = vec![0u8; length as usize];
-                    backing_file
-                        .as_ref()
-                        .unwrap()
-                        .read_at(backing_offset, &mut buf)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    op.write_bytes_at(buf_offset, &buf)
-                        .map_err(AsyncIoError::ReadVectored)?;
-                    buf_offset += length as usize;
-                }
-            }
-        }
-        Ok(())
     }
 }
 

--- a/block/src/formats/qcow/engine_uring.rs
+++ b/block/src/formats/qcow/engine_uring.rs
@@ -15,13 +15,10 @@ use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
 
 use vmm_sys_util::eventfd::EventFd;
-use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
-use super::common::decompress_cluster;
+use super::common::{deallocate_range_result, decompress_cluster};
 use super::decoder::Decoder;
-use super::metadata::{
-    BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
-};
+use super::metadata::{BackingRead, ClusterReadMapping, ClusterWriteMapping, QcowMetadata};
 use super::qcow_raw_file::QcowRawFile;
 use crate::async_io::{
     AsyncIo, AsyncIoCompletion, AsyncIoError, AsyncIoOperation, AsyncIoResult, UringDataIo,
@@ -64,29 +61,6 @@ impl QcowAsync {
             backing_file,
             sparse,
         })
-    }
-
-    fn apply_dealloc_action(&mut self, action: &DeallocAction) -> io::Result<()> {
-        match action {
-            DeallocAction::PunchHole {
-                host_offset,
-                length,
-            } => {
-                self.data_file
-                    .file_mut()
-                    .punch_hole(*host_offset, *length)?;
-                self.metadata.complete_punch_hole(*host_offset);
-                Ok(())
-            }
-            DeallocAction::WriteZeroes {
-                host_offset,
-                length,
-            } => self
-                .data_file
-                .file_mut()
-                .write_zeroes_at(*host_offset, *length)
-                .map(|_| ()),
-        }
     }
 
     fn async_error_result(error: &AsyncIoError) -> i32 {
@@ -196,83 +170,33 @@ impl AsyncIo for QcowAsync {
     }
 
     fn punch_hole(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
-        let result = self
-            .metadata
-            .deallocate_bytes(
-                offset,
-                length as usize,
-                self.sparse,
-                false,
-                self.backing_file.as_deref(),
-            )
-            .and_then(|actions| {
-                let mut first_error = None;
-                for action in &actions {
-                    if let Err(e) = self.apply_dealloc_action(action) {
-                        first_error.get_or_insert(e);
-                    }
-                }
-                first_error.map_or(Ok(()), Err)
-            })
-            .map_err(AsyncIoError::PunchHole);
-
-        match result {
-            Ok(()) => {
-                self.data_io
-                    .inject_completion(AsyncIoCompletion::new(user_data, 0, None));
-                Ok(())
-            }
-            Err(e) => {
-                let errno = if let AsyncIoError::PunchHole(ref io_err) = e {
-                    -io_err.raw_os_error().unwrap_or(libc::EIO)
-                } else {
-                    -libc::EIO
-                };
-                self.data_io
-                    .inject_completion(AsyncIoCompletion::new(user_data, errno, None));
-                Ok(())
-            }
-        }
+        let result = deallocate_range_result(
+            &self.metadata,
+            &mut self.data_file,
+            offset,
+            length as usize,
+            self.sparse,
+            false,
+            self.backing_file.as_deref(),
+        );
+        self.data_io
+            .inject_completion(AsyncIoCompletion::new(user_data, result, None));
+        Ok(())
     }
 
     fn write_zeroes(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
-        let result = self
-            .metadata
-            .deallocate_bytes(
-                offset,
-                length as usize,
-                self.sparse,
-                true,
-                self.backing_file.as_deref(),
-            )
-            .and_then(|actions| {
-                let mut first_error = None;
-                for action in &actions {
-                    if let Err(e) = self.apply_dealloc_action(action) {
-                        first_error.get_or_insert(e);
-                    }
-                }
-                first_error.map_or(Ok(()), Err)
-            })
-            .map_err(AsyncIoError::WriteZeroes);
-
-        match result {
-            Ok(()) => {
-                self.data_io
-                    .inject_completion(AsyncIoCompletion::new(user_data, 0, None));
-                Ok(())
-            }
-            Err(e) => {
-                let errno = if let AsyncIoError::WriteZeroes(ref io_err) = e {
-                    -io_err.raw_os_error().unwrap_or(libc::EIO)
-                } else {
-                    -libc::EIO
-                };
-                self.data_io
-                    .inject_completion(AsyncIoCompletion::new(user_data, errno, None));
-                Ok(())
-            }
-        }
+        let result = deallocate_range_result(
+            &self.metadata,
+            &mut self.data_file,
+            offset,
+            length as usize,
+            self.sparse,
+            true,
+            self.backing_file.as_deref(),
+        );
+        self.data_io
+            .inject_completion(AsyncIoCompletion::new(user_data, result, None));
+        Ok(())
     }
 
     fn batch_requests_enabled(&self) -> bool {

--- a/block/src/formats/qcow/engine_uring.rs
+++ b/block/src/formats/qcow/engine_uring.rs
@@ -8,7 +8,6 @@
 
 //! QCOW2 async disk backend.
 
-use std::cmp::min;
 use std::io;
 use std::os::unix::fs::FileExt;
 use std::os::unix::io::AsRawFd;
@@ -16,9 +15,9 @@ use std::sync::Arc;
 
 use vmm_sys_util::eventfd::EventFd;
 
-use super::common::{deallocate_range_result, decompress_cluster};
+use super::common::{cow_write_sync, deallocate_range_result, decompress_cluster};
 use super::decoder::Decoder;
-use super::metadata::{BackingRead, ClusterReadMapping, ClusterWriteMapping, QcowMetadata};
+use super::metadata::{BackingRead, ClusterReadMapping, QcowMetadata};
 use super::qcow_raw_file::QcowRawFile;
 use crate::async_io::{
     AsyncIo, AsyncIoCompletion, AsyncIoError, AsyncIoOperation, AsyncIoResult, UringDataIo,
@@ -118,7 +117,7 @@ impl QcowAsync {
         // write, L2 commit) with per request buffer lifetime tracking
         // and write ordering.
         let total_len = op.total_len();
-        if let Err(e) = Self::cow_write_sync(
+        if let Err(e) = cow_write_sync(
             op.offset() as u64,
             &op,
             &self.metadata,
@@ -349,60 +348,6 @@ impl QcowAsync {
                     buf_offset += length as usize;
                 }
             }
-        }
-        Ok(())
-    }
-
-    /// Write owned operation data cluster-by-cluster with COW from backing file.
-    fn cow_write_sync(
-        address: u64,
-        op: &AsyncIoOperation,
-        metadata: &QcowMetadata,
-        data_file: &QcowRawFile,
-        backing_file: &Option<Arc<dyn BackingRead>>,
-        cluster_size: u64,
-    ) -> AsyncIoResult<()> {
-        let total_len = op.total_len();
-        let mut buf_offset = 0usize;
-
-        while buf_offset < total_len {
-            let curr_addr = address + buf_offset as u64;
-            let intra_offset = curr_addr & (cluster_size - 1);
-            let remaining_in_cluster = (cluster_size - intra_offset) as usize;
-            let count = min(total_len - buf_offset, remaining_in_cluster);
-
-            let backing_data = if let Some(backing) = backing_file
-                .as_ref()
-                .filter(|_| intra_offset != 0 || count < cluster_size as usize)
-            {
-                let cluster_begin = curr_addr - intra_offset;
-                let mut data = vec![0u8; cluster_size as usize];
-                backing
-                    .read_at(cluster_begin, &mut data)
-                    .map_err(AsyncIoError::WriteVectored)?;
-                Some(data)
-            } else {
-                None
-            };
-
-            let mapping = metadata
-                .map_cluster_for_write(curr_addr, backing_data)
-                .map_err(AsyncIoError::WriteVectored)?;
-
-            match mapping {
-                ClusterWriteMapping::Allocated {
-                    offset: host_offset,
-                } => {
-                    let mut buf = vec![0u8; count];
-                    op.read_bytes_at(buf_offset, &mut buf)
-                        .map_err(AsyncIoError::WriteVectored)?;
-                    data_file
-                        .file()
-                        .write_all_at(&buf, host_offset)
-                        .map_err(AsyncIoError::WriteVectored)?;
-                }
-            }
-            buf_offset += count;
         }
         Ok(())
     }


### PR DESCRIPTION
The sync and io_uring QCOW2 engines kept private copies of the same synchronous deallocation, COW write, and read logic. This series moves each of those into the shared helper module so both engines call one implementation and keep only their own completion plumbing. The io_uring fast path that offloads a contiguous read to the ring stays engine local by design.

No functional change.