### PR TITLE
vmm: Introduce external userfaultfd backend framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sendfd"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b183bfd5b1bc64ab0c1ef3ee06b008a9ef1b68a7d3a99ba566fbfe7a7c6d745b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,6 +2777,7 @@ name = "vm-device"
 version = "0.1.0"
 dependencies = [
  "hypervisor",
+ "sendfd",
  "serde",
  "thiserror",
  "vfio-ioctls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ linux-loader = "0.14.0"
 mshv-bindings = "0.6.9"
 mshv-ioctls = "0.6.9"
 seccompiler = "0.5.0"
+sendfd = "0.4.4"
 vfio-bindings = { version = "0.6.2", default-features = false }
 vfio-ioctls = { version = "0.8.0", default-features = false }
 vfio_user = { version = "0.1.4", default-features = false }

--- a/docs/device_model.md
+++ b/docs/device_model.md
@@ -142,6 +142,23 @@ allows bypassing the guest page cache and improve the guest memory footprint.
 This device is always built-in, and it is enabled based on the presence of the
 flag `--pmem`.
 
+`readonly=on` exposes a read-only PMEM range and uses a shared, read-only host
+mapping. In this mode, `discard_writes` has no effect.
+
+An external userfaultfd backend can supply a read-only PMEM image on demand:
+
+```bash
+--pmem file=/run/external-uffd.sock,size=4G,backend_type=uffd,readonly=on
+```
+
+For this backend, `file` names the server's Unix socket and `size` is required.
+Cloud Hypervisor registers an empty PMEM mapping with userfaultfd and sends a
+stateful customized Handshake with the effective `MISSING` mode to the server.
+The server returns file-backed ranges that Cloud Hypervisor maps into the PMEM
+address space. Writable external PMEM is not currently supported. See
+[External userfaultfd backend](external-uffd-backend.md) for the protocol
+overview, operation, and current limitations.
+
 ### virtio-rng
 
 A VM does not generate entropy like a real machine would, which is an issue

--- a/docs/external-uffd-backend.md
+++ b/docs/external-uffd-backend.md
@@ -1,0 +1,64 @@
+# External userfaultfd backend
+
+The external userfaultfd backend lets Cloud Hypervisor obtain memory contents
+from a separate service on demand. The service receives a registered
+userfaultfd, monitors page faults, and supplies file-backed ranges without
+loading the complete image before VM startup.
+
+The common UFFD code in `vm-device` separates stateful actions from their wire
+encoding so both memory and device backends can use it. Its default transport
+uses a binary format over an `AF_UNIX`, `SOCK_STREAM` socket. File descriptors
+are transferred with `SCM_RIGHTS`, and all multi-byte fields are little-endian.
+A caller can provide another implementation of the small `Transport`
+interface without changing the actions or device code.
+
+## Protocol overview
+
+Every protocol message starts with a 16-byte header.
+
+| Offset | Request field | Response field | Size |
+|---:|---|---|---:|
+| 0 | `command` | `status` | 2 |
+| 2 | `command_headers` | `reply_type` and `reply_headers` | 6 |
+| 8 | payload `length` | payload `length` | 8 |
+
+The protocol establishes a stateful session with a `Handshake`. The Handshake
+transfers a userfaultfd, regions, session flags, and effective UFFD modes. The
+server then resolves faults directly or sends asynchronous `FdRanges`
+responses.
+
+| Command | Purpose |
+|---|---|
+| `Handshake` | Transfer the userfaultfd, regions, session flags, and effective UFFD modes |
+| `AddRegion` | Add or replace a complete region in a managed session |
+| `RemoveRegion` | Remove a complete region from a managed session |
+
+| Reply type | Purpose |
+|---|---|
+| `Legacy` | Empty acknowledgement or generic error |
+| `FdRanges` | File-backed device ranges with attached file descriptors |
+
+The Handshake command header contains `version: u16`, `flags: u8`,
+`uffd_modes: u8`, and `region_count: u16`. Each region is a 48-byte record:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `virt_addr` | `u64` | Start of the registered client VMA |
+| `size` | `u64` | Region length |
+| `offset` | `u64` | Region offset in the flattened device |
+| `fault_size` | `u64` | Preferred fault resolution granularity |
+| `prot` | `i32` | Effective mapping protection |
+| `flags` | `i32` | Effective mapping flags |
+| `backing_offset` | `u64` | Region offset in an optional client backing FD |
+
+Handshake flags select managed fault handling, prefault, an optional Legacy
+acknowledgement, and optional client backing FDs. UFFD modes independently
+describe `MISSING`, `WP`, and `WP_ASYNC`. A successful Handshake requires no
+response unless its `ACK_REQUIRED` flag is set. Without an acknowledgement, a
+failed Handshake is reported by closing the connection. With `BACKING_FDS`,
+the Handshake carries one backing FD per region after the UFFD, in region
+order; `backing_offset` selects the start of each region in its backing FD.
+
+An `FdRanges` response contains one 24-byte
+`(device_offset, blob_offset, len)` record per attached FD. Its `MORE` flag
+means that another response frame belongs to the same request.

--- a/docs/external-uffd-backend.md
+++ b/docs/external-uffd-backend.md
@@ -62,3 +62,153 @@ order; `backing_offset` selects the start of each region in its backing FD.
 An `FdRanges` response contains one 24-byte
 `(device_offset, blob_offset, len)` record per attached FD. Its `MORE` flag
 means that another response frame belongs to the same request.
+
+Cloud Hypervisor does not currently send `AddRegion`, `RemoveRegion`, or
+backing FDs for virtio-pmem.
+
+## Cloud Hypervisor operation
+
+1. Create a host mapping and register it with userfaultfd in missing-page mode.
+2. Connect to the external service and send a Handshake with the userfaultfd
+   and VMA regions, session flags, and effective UFFD modes.
+3. Let the service monitor faults for the lifetime of the connection.
+4. In managed mode, let the service resolve faults directly. Otherwise,
+   receive asynchronous `FdRanges` responses.
+5. With Cloud Hypervisor's customized handler, map the returned file ranges
+   into the registered VMA and wake the faulting thread.
+6. Stop monitoring and close the socket before destroying the device mapping.
+
+An unexpected disconnect or invalid response is treated as a backend failure.
+
+## Device support
+
+Only `virtio-pmem` is currently supported. It uses a stateful customized
+session and handles asynchronous responses in its existing device worker:
+
+```bash
+--pmem file=/run/external-uffd.sock,size=4G,backend_type=uffd,readonly=on
+```
+
+| Option | Requirement | Description |
+|---|---|---|
+| `file` | Required | Path of the external service's Unix socket |
+| `size` | Required | PMEM size; it must be 2 MiB aligned |
+| `backend_type` | `uffd` | Select the external userfaultfd backend |
+| `readonly` | `on` | Expose a read-only KVM memory slot |
+
+The PMEM mapping uses a 2 MiB fault granularity and registers
+`UFFD_MODE_MISSING`. The Handshake sets `ACK_REQUIRED` and leaves `MANAGED`,
+`PREFAULT`, and `BACKING_FDS` clear. Writable external PMEM and backend-specific
+migration are not currently supported. `discard_writes` has no effect when
+`readonly=on`.
+
+The default PMEM backend remains `file`, so existing configurations are
+unchanged.
+
+## Minimal Rust server
+
+A minimal Rust server for the currently supported `virtio-pmem` backend needs
+a Unix socket path and a read-only PMEM image. It only implements the
+customized Handshake and asynchronous `FdRanges` path.
+
+### 1. Receive the Handshake
+
+1. Bind `std::os::unix::net::UnixListener` and accept one client.
+2. Use `recvmsg()` to receive the first frame and its `SCM_RIGHTS` userfaultfd.
+3. Finish reading the 16-byte header and Handshake payload from the stream.
+4. Decode the 48-byte region entries and keep them with the received UFFD.
+5. Send an empty successful Legacy response to acknowledge the Handshake.
+
+Reject the connection unless the command and version are supported, `MANAGED`
+and `BACKING_FDS` are clear, `MISSING` is set in the UFFD modes, exactly one
+UFFD is attached, and the payload contains the declared number of valid
+regions. Cloud Hypervisor sets `ACK_REQUIRED`, so the server must acknowledge
+success or return an error before it starts sending asynchronous ranges.
+
+### 2. Read UFFD events
+
+Use `libc::poll()` to wait for the UFFD while also monitoring the client socket
+for disconnects. Linux returns a 32-byte `uffd_msg`; a page-fault message has
+event type `UFFD_EVENT_PAGEFAULT` (`0x12`) at offset 0 and the faulting host
+virtual address at offset 16.
+
+Find the Handshake region containing the fault and calculate:
+
+```text
+region_offset = fault_address - region.virt_addr
+range_offset  = floor(region_offset / region.fault_size) * region.fault_size
+device_offset = region.offset + range_offset
+range_length  = min(region.fault_size, region.size - range_offset)
+blob_offset   = device_offset
+```
+
+The resulting file range must fit within the PMEM image, and `blob_offset`
+must satisfy the host `mmap()` alignment requirement.
+
+### 3. Send FdRanges
+
+Encode an `Ok/FdRanges` response with `flags=0`, `fd_count=1`, and one 24-byte
+entry containing `device_offset`, `blob_offset`, and `len`. Send the
+header and entry with the PMEM image FD attached through `SCM_RIGHTS`.
+
+Cloud Hypervisor maps the range and performs `UFFDIO_WAKE`; the server must not
+wake the fault itself.
+
+### Rust-style pseudocode
+
+The following intentionally omits syscall wrappers and error types. It shows
+the ownership and control flow expected from a minimal implementation:
+
+```rust,ignore
+fn main() -> Result<()> {
+    let image = File::open(image_path)?;
+    let listener = UnixListener::bind(socket_path)?;
+    let (socket, _) = listener.accept()?;
+
+    // recv_handshake() must use recvmsg() for the first read so it receives
+    // the SCM_RIGHTS file descriptor attached to the Handshake.
+    let handshake = recv_handshake(&socket)?;
+    ensure!(handshake.flags & MANAGED == 0);
+    ensure!(handshake.flags & BACKING_FDS == 0);
+    ensure!(handshake.uffd_modes & MISSING != 0);
+    let uffd = handshake.uffd;
+    let regions = handshake.regions;
+    send_handshake_ack(&socket)?;
+
+    loop {
+        match poll_uffd_and_socket(&uffd, &socket)? {
+            Event::Disconnected => break,
+            Event::PageFault(fault_address) => {
+                let region = regions
+                    .iter()
+                    .find(|r| r.contains(fault_address))
+                    .ok_or(Error::FaultOutsideRegions)?;
+
+                let region_offset = fault_address - region.virt_addr;
+                let range_offset =
+                    region_offset / region.fault_size * region.fault_size;
+                let device_offset = region.offset + range_offset;
+                let range_length =
+                    region.fault_size.min(region.size - range_offset);
+
+                validate_image_range(&image, device_offset, range_length)?;
+                send_fd_range(
+                    &socket,
+                    &image,
+                    FdRange {
+                        device_offset,
+                        blob_offset: device_offset,
+                        len: range_length,
+                    },
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+```
+
+A first implementation can remain single-threaded and serve one VM. A
+multi-VM server should keep the socket, UFFD, and regions in independent
+per-connection state.

--- a/fuzz/fuzz_targets/pmem.rs
+++ b/fuzz/fuzz_targets/pmem.rs
@@ -137,6 +137,7 @@ fn create_dummy_pmem() -> Pmem {
         guest_addr,
         dummy_user_mapping,
         false,
+        None,
         SeccompAction::Allow,
         EventFd::new(EFD_NONBLOCK).unwrap(),
         None,

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -54,7 +54,7 @@ pub use self::epoll_helper::{
 pub use self::iommu::{AccessPlatformMapping, Iommu, IommuMapping};
 pub use self::mem::{BlocksState, Mem, VIRTIO_MEM_ALIGN_SIZE, VirtioMemMappingSource};
 pub use self::net::{Net, NetCtrlEpollHandler};
-pub use self::pmem::Pmem;
+pub use self::pmem::{MmapUffdHandler, Pmem};
 pub use self::rng::Rng;
 pub use self::rtc::Rtc;
 pub use self::vdpa::{Vdpa, VdpaDmaMapping};

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -7,8 +7,8 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::fs::File;
-use std::os::unix::io::AsRawFd;
-use std::sync::atomic::AtomicBool;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::{io, result};
 
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use virtio_queue::{DescriptorChain, Queue, QueueT};
 use vm_device::UserspaceMapping;
+use vm_device::uffd::{Response as UffdResponse, UffdBlock, VmaRegion};
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
     GuestMemoryError, GuestMemoryLoadGuard,
@@ -47,6 +48,120 @@ const VIRTIO_PMEM_RESP_TYPE_EIO: u32 = 1;
 
 // New descriptors are pending on the virtio queue.
 const QUEUE_AVAIL_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
+const UFFD_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
+
+const UFFDIO_WAKE: u64 = 0x8010_aa02;
+
+#[repr(C)]
+struct UffdioRange {
+    start: u64,
+    len: u64,
+}
+
+pub struct MmapUffdHandler {
+    block: UffdBlock,
+    uffd: OwnedFd,
+    regions: Vec<VmaRegion>,
+}
+
+impl MmapUffdHandler {
+    pub fn new(block: UffdBlock, uffd: OwnedFd, regions: Vec<VmaRegion>) -> Self {
+        Self {
+            block,
+            uffd,
+            regions,
+        }
+    }
+
+    fn handle_event(&self) -> io::Result<bool> {
+        match self.block.recv_response()? {
+            None => Ok(false),
+            Some(UffdResponse::Ack) => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Unexpected UFFD acknowledgement",
+            )),
+            Some(UffdResponse::FdRanges {
+                more: _,
+                ranges,
+                fds,
+            }) => {
+                for (range, fd) in ranges.iter().zip(fds) {
+                    let range_end = range
+                        .device_offset
+                        .checked_add(range.len)
+                        .ok_or_else(|| io::Error::other("UFFD range overflow"))?;
+                    let region = self
+                        .regions
+                        .iter()
+                        .find(|region| {
+                            range.device_offset >= region.offset
+                                && region
+                                    .offset
+                                    .checked_add(region.size)
+                                    .is_some_and(|region_end| range_end <= region_end)
+                        })
+                        .ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "UFFD range is outside registered regions",
+                            )
+                        })?;
+                    let target_addr = region
+                        .virt_addr
+                        .checked_add(range.device_offset - region.offset)
+                        .ok_or_else(|| io::Error::other("UFFD address overflow"))?;
+                    let len = usize::try_from(range.len)
+                        .map_err(|_| io::Error::other("UFFD range is too large"))?;
+
+                    // SAFETY: the range is checked against the VMA metadata sent in
+                    // the handshake and the received file descriptor remains valid.
+                    let mapped = unsafe {
+                        libc::mmap(
+                            target_addr as *mut libc::c_void,
+                            len,
+                            region.prot,
+                            region.flags | libc::MAP_FIXED,
+                            fd.as_raw_fd(),
+                            range.blob_offset as libc::off_t,
+                        )
+                    };
+                    if mapped == libc::MAP_FAILED {
+                        // If a large number of mappings exhausts the process VMA
+                        // limit, this can later fall back to UFFDIO_COPY.
+                        return Err(io::Error::last_os_error());
+                    }
+                    self.wake(target_addr, range.len)?;
+                }
+                Ok(true)
+            }
+        }
+    }
+
+    fn wake(&self, addr: u64, len: u64) -> io::Result<()> {
+        let mut range = UffdioRange { start: addr, len };
+        // SAFETY: range is valid for the UFFDIO_WAKE ioctl.
+        if unsafe {
+            libc::ioctl(
+                self.uffd.as_raw_fd(),
+                UFFDIO_WAKE as libc::Ioctl,
+                &mut range,
+            )
+        } < 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    fn socket_fd(&self) -> RawFd {
+        self.block.socket_fd()
+    }
+
+    fn shutdown(&self) {
+        // SAFETY: block owns a valid socket for the duration of this call.
+        unsafe { libc::shutdown(self.block.socket_fd(), libc::SHUT_RDWR) };
+    }
+}
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
 #[repr(C)]
@@ -163,6 +278,8 @@ struct PmemEpollHandler {
     kill_evt: EventFd,
     pause_evt: EventFd,
     access_platform: Option<Arc<dyn AccessPlatform>>,
+    uffd: Option<Arc<MmapUffdHandler>>,
+    shutting_down: Arc<AtomicBool>,
 }
 
 impl PmemEpollHandler {
@@ -225,6 +342,13 @@ impl PmemEpollHandler {
     ) -> result::Result<(), EpollHelperError> {
         let mut helper = EpollHelper::new(&self.kill_evt, &self.pause_evt)?;
         helper.add_event(self.queue_evt.as_raw_fd(), QUEUE_AVAIL_EVENT)?;
+        if let Some(uffd) = self.uffd.as_ref() {
+            helper.add_event_custom(
+                uffd.socket_fd(),
+                UFFD_EVENT,
+                epoll::Events::EPOLLIN | epoll::Events::EPOLLHUP,
+            )?;
+        }
         helper.run(paused, paused_sync, self)?;
 
         Ok(())
@@ -254,6 +378,33 @@ impl EpollHelperHandler for PmemEpollHandler {
                     })?;
                 }
             }
+            UFFD_EVENT => {
+                if event.events & epoll::Events::EPOLLIN.bits() == 0 {
+                    if self.shutting_down.load(Ordering::Acquire) {
+                        return Ok(());
+                    }
+                    return Err(EpollHelperError::HandleEvent(anyhow!(
+                        "UFFD server closed the socket"
+                    )));
+                }
+                let uffd = self.uffd.as_ref().ok_or_else(|| {
+                    EpollHelperError::HandleEvent(anyhow!(
+                        "UFFD event without a configured handler"
+                    ))
+                })?;
+                loop {
+                    let handled = match uffd.handle_event() {
+                        Ok(handled) => handled,
+                        Err(_) if self.shutting_down.load(Ordering::Acquire) => return Ok(()),
+                        Err(error) => {
+                            return Err(EpollHelperError::HandleEvent(anyhow!(error)));
+                        }
+                    };
+                    if !handled {
+                        break;
+                    }
+                }
+            }
             _ => {
                 return Err(EpollHelperError::HandleEvent(anyhow!(
                     "Unexpected event: {ev_type}"
@@ -269,6 +420,8 @@ pub struct Pmem {
     id: String,
     disk: Option<File>,
     config: VirtioPmemConfig,
+    uffd: Option<Arc<MmapUffdHandler>>,
+    shutting_down: Arc<AtomicBool>,
     mapping: UserspaceMapping,
     seccomp_action: SeccompAction,
     exit_evt: EventFd,
@@ -289,6 +442,7 @@ impl Pmem {
         addr: GuestAddress,
         mapping: UserspaceMapping,
         access_platform_enabled: bool,
+        uffd: Option<Arc<MmapUffdHandler>>,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
         state: Option<PmemState>,
@@ -329,6 +483,8 @@ impl Pmem {
             id,
             disk: Some(disk),
             config,
+            uffd,
+            shutting_down: Arc::new(AtomicBool::new(false)),
             mapping,
             seccomp_action,
             exit_evt,
@@ -345,6 +501,19 @@ impl Pmem {
 
     #[cfg(fuzzing)]
     pub fn wait_for_epoll_threads(&mut self) {
+        self.common.wait_for_epoll_threads();
+    }
+}
+
+impl Drop for Pmem {
+    fn drop(&mut self) {
+        if let Some(uffd) = self.uffd.as_ref() {
+            self.shutting_down.store(true, Ordering::Release);
+            if let Some(workers) = self.common.workers.as_ref() {
+                workers.signal_exit().ok();
+            }
+            uffd.shutdown();
+        }
         self.common.wait_for_epoll_threads();
     }
 }
@@ -396,15 +565,22 @@ impl VirtioDevice for Pmem {
                 kill_evt,
                 pause_evt,
                 access_platform: self.common.access_platform(),
+                uffd: self.uffd.clone(),
+                shutting_down: Arc::clone(&self.shutting_down),
             };
 
             let paused = self.common.paused.clone();
             let paused_sync = self.common.paused_sync.clone();
 
+            let thread_type = if self.uffd.is_some() {
+                Thread::VirtioPmemUffd
+            } else {
+                Thread::VirtioPmem
+            };
             self.common.spawn_worker(
                 &self.id,
                 &self.seccomp_action,
-                Thread::VirtioPmem,
+                thread_type,
                 &self.exit_evt,
                 device_status.clone(),
                 interrupt_cb.clone(),

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -24,6 +24,7 @@ pub enum Thread {
     VirtioNet,
     VirtioNetCtl,
     VirtioPmem,
+    VirtioPmemUffd,
     VirtioRng,
     VirtioRtc,
     VirtioVhostBlock,
@@ -60,6 +61,8 @@ const VFIO_IOMMU_UNMAP_DMA: u64 = 0x3b72;
 // See include/uapi/linux/iommufd.h in the kernel code.
 const IOMMU_IOAS_MAP: u64 = 0x3b85;
 const IOMMU_IOAS_UNMAP: u64 = 0x3b86;
+
+const UFFDIO_WAKE: u64 = 0x8010_aa02;
 
 #[cfg(feature = "sev_snp")]
 fn mshv_sev_snp_ioctl_seccomp_rule() -> SeccompRule {
@@ -197,6 +200,18 @@ fn virtio_pmem_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![(libc::SYS_fsync, vec![])]
 }
 
+fn virtio_pmem_uffd_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
+    vec![
+        (libc::SYS_fsync, vec![]),
+        (libc::SYS_mmap, vec![]),
+        (libc::SYS_recvmsg, vec![]),
+        (
+            libc::SYS_ioctl,
+            vec![and![Cond::new(1, ArgLen::Dword, Eq, UFFDIO_WAKE).unwrap()]],
+        ),
+    ]
+}
+
 fn virtio_rng_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
         (libc::SYS_sched_getaffinity, vec![]),
@@ -331,6 +346,7 @@ fn get_seccomp_rules(thread_type: Thread) -> Vec<(i64, Vec<SeccompRule>)> {
         Thread::VirtioNet => virtio_net_thread_rules(),
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules(),
         Thread::VirtioPmem => virtio_pmem_thread_rules(),
+        Thread::VirtioPmemUffd => virtio_pmem_uffd_thread_rules(),
         Thread::VirtioRng => virtio_rng_thread_rules(),
         Thread::VirtioRtc => virtio_rtc_thread_rules(),
         Thread::VirtioVhostBlock => virtio_vhost_block_thread_rules(),

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -12,6 +12,7 @@ mshv = ["vfio-ioctls/mshv"]
 
 [dependencies]
 hypervisor = { path = "../hypervisor" }
+sendfd = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 thiserror = { workspace = true }
 vfio-ioctls = { workspace = true, default-features = false }

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -12,6 +12,7 @@ use vm_memory::{GuestAddress, MmapRegion};
 mod bus;
 pub mod dma_mapping;
 pub mod interrupt;
+pub mod uffd;
 
 pub use self::bus::{Bus, BusDevice, BusDeviceSync, Error as BusError};
 

--- a/vm-device/src/uffd.rs
+++ b/vm-device/src/uffd.rs
@@ -1,0 +1,370 @@
+// Copyright © 2026 Cloud Hypervisor Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transport-independent actions for an external userfaultfd backend.
+
+use std::io::{self, Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::{iter, thread};
+
+use sendfd::{RecvWithFd, SendWithFd};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VmaRegion {
+    pub virt_addr: u64,
+    pub size: u64,
+    pub offset: u64,
+    pub fault_size: u64,
+    pub prot: i32,
+    pub flags: i32,
+    pub backing_offset: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlobRange {
+    pub device_offset: u64,
+    pub blob_offset: u64,
+    pub len: u64,
+}
+
+pub enum Request<'a> {
+    Handshake {
+        uffd: RawFd,
+        register_mode: u64,
+        features: u64,
+        regions: &'a [VmaRegion],
+        backing_fds: &'a [RawFd],
+        managed: bool,
+    },
+    AddRegion {
+        region: &'a VmaRegion,
+        backing_fd: Option<RawFd>,
+    },
+    RemoveRegion {
+        host_addr: u64,
+        len: u64,
+    },
+}
+
+#[derive(Debug)]
+pub enum Response {
+    Ack,
+    FdRanges {
+        more: bool,
+        ranges: Vec<BlobRange>,
+        fds: Vec<OwnedFd>,
+    },
+}
+
+pub trait Transport: Send + Sync {
+    fn send_request(&self, sock: &UnixStream, request: &Request<'_>) -> io::Result<()>;
+
+    fn recv_response(&self, sock: &UnixStream, nonblocking: bool) -> io::Result<Option<Response>>;
+}
+
+pub struct UffdBlock {
+    sock: UnixStream,
+    transport: Box<dyn Transport>,
+    managed: bool,
+}
+
+impl UffdBlock {
+    pub fn new(sock_path: impl AsRef<Path>, managed: bool) -> io::Result<Self> {
+        Self::new_with_transport(sock_path, managed, BinaryTransport)
+    }
+
+    pub fn new_with_transport<T: Transport + 'static>(
+        sock_path: impl AsRef<Path>,
+        managed: bool,
+        transport: T,
+    ) -> io::Result<Self> {
+        Ok(Self {
+            sock: UnixStream::connect(sock_path)?,
+            transport: Box::new(transport),
+            managed,
+        })
+    }
+
+    pub fn handshake(
+        &self,
+        uffd: RawFd,
+        register_mode: u64,
+        features: u64,
+        regions: &[VmaRegion],
+        backing_fds: &[RawFd],
+    ) -> io::Result<()> {
+        self.send_and_ack(&Request::Handshake {
+            uffd,
+            register_mode,
+            features,
+            regions,
+            backing_fds,
+            managed: self.managed,
+        })?;
+        self.sock.set_nonblocking(!self.managed)
+    }
+
+    pub fn recv_response(&self) -> io::Result<Option<Response>> {
+        self.transport.recv_response(&self.sock, true)
+    }
+
+    pub fn add_region(&self, region: &VmaRegion, backing_fd: Option<RawFd>) -> io::Result<()> {
+        self.send_and_ack(&Request::AddRegion { region, backing_fd })
+    }
+
+    pub fn remove_region(&self, host_addr: u64, len: u64) -> io::Result<()> {
+        self.send_and_ack(&Request::RemoveRegion { host_addr, len })
+    }
+
+    pub fn socket_fd(&self) -> RawFd {
+        self.sock.as_raw_fd()
+    }
+
+    fn send_and_ack(&self, request: &Request<'_>) -> io::Result<()> {
+        self.transport.send_request(&self.sock, request)?;
+        match self
+            .transport
+            .recv_response(&self.sock, false)?
+            .ok_or_else(|| io::Error::new(io::ErrorKind::WouldBlock, "Response is not available"))?
+        {
+            Response::Ack => Ok(()),
+            Response::FdRanges { .. } => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Expected acknowledgement response",
+            )),
+        }
+    }
+}
+
+// Binary transport
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct BinaryTransport;
+
+const COMMAND_HANDSHAKE: u16 = 0x0a;
+const COMMAND_ADD_REGION: u16 = 0x0b;
+const COMMAND_REMOVE_REGION: u16 = 0x0c;
+const PROTOCOL_VERSION: u16 = 1;
+
+const HANDSHAKE_FLAG_MANAGED: u8 = 1 << 0;
+const HANDSHAKE_FLAG_ACK_REQUIRED: u8 = 1 << 2;
+const HANDSHAKE_FLAG_BACKING_FDS: u8 = 1 << 3;
+const UFFD_MODE_MISSING: u8 = 1 << 0;
+const UFFD_MODE_WP: u8 = 1 << 1;
+const UFFD_MODE_WP_ASYNC: u8 = 1 << 2;
+const UFFDIO_REGISTER_MODE_MISSING: u64 = 1 << 0;
+const UFFDIO_REGISTER_MODE_WP: u64 = 1 << 1;
+const UFFD_FEATURE_WP_ASYNC: u64 = 1 << 15;
+
+const STATUS_OK: u16 = 1;
+const REPLY_ACK: u16 = 0;
+const REPLY_FD_RANGES: u16 = 1;
+const FD_RANGES_FLAG_MORE: u16 = 1 << 0;
+
+const HEADER_SIZE: usize = 16;
+const REGION_SIZE: usize = 48;
+const REMOVE_REGION_SIZE: usize = 16;
+const RANGE_SIZE: usize = 24;
+const MAX_RECV_FDS: usize = 64;
+
+impl Transport for BinaryTransport {
+    fn send_request(&self, sock: &UnixStream, request: &Request<'_>) -> io::Result<()> {
+        let (message, fds) = encode_request(request);
+        if fds.is_empty() {
+            (&*sock).write_all(&message)
+        } else {
+            sock.send_with_fd(&message, &fds)?;
+            Ok(())
+        }
+    }
+
+    fn recv_response(&self, sock: &UnixStream, nonblocking: bool) -> io::Result<Option<Response>> {
+        let Some((header, fds)) = recv_header(sock, nonblocking)? else {
+            return Ok(None);
+        };
+        let status = u16::from_le_bytes(header[0..2].try_into().unwrap());
+        let reply_type = u16::from_le_bytes(header[2..4].try_into().unwrap());
+        let reply_headers = &header[4..8];
+        let len = u64::from_le_bytes(header[8..16].try_into().unwrap());
+        if status != STATUS_OK {
+            return Err(io::Error::other("External UFFD server returned an error"));
+        }
+
+        match reply_type {
+            REPLY_ACK if len == 0 && fds.is_empty() => Ok(Some(Response::Ack)),
+            REPLY_ACK => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Acknowledgement carries data",
+            )),
+            REPLY_FD_RANGES => {
+                let mut payload = vec![0; len as usize];
+                recv_exact(sock, &mut payload, nonblocking)?;
+                let ranges = decode_ranges(&payload)?;
+                let fd_count = u16::from_le_bytes(reply_headers[2..4].try_into().unwrap());
+                if ranges.len() != usize::from(fd_count) || ranges.len() != fds.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "FdRanges count does not match attached file descriptors",
+                    ));
+                }
+                let flags = u16::from_le_bytes(reply_headers[0..2].try_into().unwrap());
+                Ok(Some(Response::FdRanges {
+                    more: flags & FD_RANGES_FLAG_MORE != 0,
+                    ranges,
+                    fds,
+                }))
+            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Unexpected reply type 0x{reply_type:04x}"),
+            )),
+        }
+    }
+}
+
+fn encode_request(request: &Request<'_>) -> (Vec<u8>, Vec<RawFd>) {
+    match request {
+        Request::Handshake {
+            uffd,
+            register_mode,
+            features,
+            regions,
+            backing_fds,
+            managed,
+        } => {
+            let mut flags = HANDSHAKE_FLAG_ACK_REQUIRED;
+            if *managed {
+                flags |= HANDSHAKE_FLAG_MANAGED;
+            }
+            if !backing_fds.is_empty() {
+                flags |= HANDSHAKE_FLAG_BACKING_FDS;
+            }
+            let mut headers = [0; 6];
+            headers[0..2].copy_from_slice(&PROTOCOL_VERSION.to_le_bytes());
+            headers[2] = flags;
+            headers[3] = encode_uffd_modes(*register_mode, *features);
+            headers[4..6].copy_from_slice(&(regions.len() as u16).to_le_bytes());
+
+            let mut message =
+                encode_header(COMMAND_HANDSHAKE, headers, regions.len() * REGION_SIZE);
+            for region in *regions {
+                encode_region(&mut message, region);
+            }
+            let fds = iter::once(*uffd)
+                .chain(backing_fds.iter().copied())
+                .collect();
+            (message, fds)
+        }
+        Request::AddRegion { region, backing_fd } => {
+            let mut message = encode_header(COMMAND_ADD_REGION, [0; 6], REGION_SIZE);
+            encode_region(&mut message, region);
+            (message, backing_fd.iter().copied().collect())
+        }
+        Request::RemoveRegion { host_addr, len } => {
+            let mut message = encode_header(COMMAND_REMOVE_REGION, [0; 6], REMOVE_REGION_SIZE);
+            message.extend_from_slice(&host_addr.to_le_bytes());
+            message.extend_from_slice(&len.to_le_bytes());
+            (message, Vec::new())
+        }
+    }
+}
+
+fn encode_header(command: u16, headers: [u8; 6], payload_len: usize) -> Vec<u8> {
+    let mut message = Vec::with_capacity(HEADER_SIZE + payload_len);
+    message.extend_from_slice(&command.to_le_bytes());
+    message.extend_from_slice(&headers);
+    message.extend_from_slice(&(payload_len as u64).to_le_bytes());
+    message
+}
+
+fn encode_uffd_modes(register_mode: u64, features: u64) -> u8 {
+    let mut modes = 0;
+    if register_mode & UFFDIO_REGISTER_MODE_MISSING != 0 {
+        modes |= UFFD_MODE_MISSING;
+    }
+    if register_mode & UFFDIO_REGISTER_MODE_WP != 0 {
+        modes |= UFFD_MODE_WP;
+        if features & UFFD_FEATURE_WP_ASYNC != 0 {
+            modes |= UFFD_MODE_WP_ASYNC;
+        }
+    }
+    modes
+}
+
+fn encode_region(message: &mut Vec<u8>, region: &VmaRegion) {
+    message.extend_from_slice(&region.virt_addr.to_le_bytes());
+    message.extend_from_slice(&region.size.to_le_bytes());
+    message.extend_from_slice(&region.offset.to_le_bytes());
+    message.extend_from_slice(&region.fault_size.to_le_bytes());
+    message.extend_from_slice(&region.prot.to_le_bytes());
+    message.extend_from_slice(&region.flags.to_le_bytes());
+    message.extend_from_slice(&region.backing_offset.to_le_bytes());
+}
+
+fn decode_ranges(payload: &[u8]) -> io::Result<Vec<BlobRange>> {
+    let (entries, remainder) = payload.as_chunks::<RANGE_SIZE>();
+    if !remainder.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Invalid FdRanges payload",
+        ));
+    }
+    Ok(entries
+        .iter()
+        .map(|entry| BlobRange {
+            device_offset: u64::from_le_bytes(entry[0..8].try_into().unwrap()),
+            blob_offset: u64::from_le_bytes(entry[8..16].try_into().unwrap()),
+            len: u64::from_le_bytes(entry[16..24].try_into().unwrap()),
+        })
+        .collect())
+}
+
+fn recv_header(
+    sock: &UnixStream,
+    nonblocking: bool,
+) -> io::Result<Option<([u8; HEADER_SIZE], Vec<OwnedFd>)>> {
+    let mut header = [0; HEADER_SIZE];
+    let mut raw_fds = [0; MAX_RECV_FDS];
+    let (read, fd_count) = match sock.recv_with_fd(&mut header, &mut raw_fds) {
+        Ok(value) => value,
+        Err(error) if nonblocking && error.kind() == io::ErrorKind::WouldBlock => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    if read == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "External UFFD server closed the socket",
+        ));
+    }
+    let fds = raw_fds[..fd_count]
+        .iter()
+        // SAFETY: recv_with_fd returned each descriptor with ownership.
+        .map(|fd| unsafe { OwnedFd::from_raw_fd(*fd) })
+        .collect();
+    recv_exact(sock, &mut header[read..], nonblocking)?;
+    Ok(Some((header, fds)))
+}
+
+fn recv_exact(sock: &UnixStream, buf: &mut [u8], nonblocking: bool) -> io::Result<()> {
+    let mut offset = 0;
+    while offset < buf.len() {
+        match (&*sock).read(&mut buf[offset..]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "External UFFD server closed while reading a response",
+                ));
+            }
+            Ok(count) => offset += count,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if nonblocking && error.kind() == io::ErrorKind::WouldBlock => {
+                thread::yield_now();
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1276,10 +1276,17 @@ components:
       properties:
         file:
           type: string
+        backend_type:
+          type: string
+          enum: ["file", "uffd"]
+          default: "file"
         size:
           type: integer
           format: int64
         iommu:
+          type: boolean
+          default: false
+        readonly:
           type: boolean
           default: false
         discard_writes:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -81,6 +81,9 @@ pub enum Error {
     /// Missing persistent memory file parameter.
     #[error("Error parsing --pmem: file missing")]
     ParsePmemFileMissing,
+    /// Invalid persistent memory backend type.
+    #[error("Error parsing --pmem: backend_type must be 'file' or 'uffd'")]
+    ParsePmemBackendType,
     /// Missing vsock socket path parameter.
     #[error("Error parsing --vsock: socket missing")]
     ParseVsockSockMissing,
@@ -429,6 +432,12 @@ pub enum ValidationError {
     /// Invalid NUMA Configuration
     #[error("Invalid NUMA configuration: {0}")]
     InvalidNumaConfig(String),
+    /// UFFD-backed persistent memory requires an explicit size.
+    #[error("UFFD-backed persistent memory requires size")]
+    PmemUffdSizeMissing,
+    /// UFFD-backed persistent memory is read-only.
+    #[error("UFFD-backed persistent memory requires readonly=on")]
+    PmemUffdRequiresReadonly,
     /// The supplied PCI ID was greater then the max. supported number
     /// of devices per Bus
     #[error("Given PCI device ID ({0}) is out of the supported range of 0..{NUM_DEVICE_IDS}")]
@@ -2295,25 +2304,37 @@ impl FwCfgItem {
 
 impl PmemConfig {
     pub const SYNTAX: &'static str = "Persistent memory parameters \
-    \"file=<backing_file_path>,size=<persistent_memory_size>,iommu=on|off,\
-    discard_writes=on|off,id=<device_id>,\
-    pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
+    \"file=<backing_file_or_socket_path>,size=<persistent_memory_size>,\
+    backend_type=file|uffd,iommu=on|off,readonly=on|off,discard_writes=on|off,\
+    id=<device_id>,pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
 
     pub fn parse(pmem: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
             .add("size")
             .add("file")
+            .add("backend_type")
+            .add("readonly")
             .add("discard_writes")
             .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
         parser.parse(pmem).map_err(Error::ParsePersistentMemory)?;
 
         let pci_common = PciDeviceCommonConfig::parse(pmem)?;
         let file = PathBuf::from(parser.get("file").ok_or(Error::ParsePmemFileMissing)?);
+        let backend_type = match parser.get("backend_type").as_deref() {
+            None | Some("file") => PmemBackendType::File,
+            Some("uffd") => PmemBackendType::Uffd,
+            Some(_) => return Err(Error::ParsePmemBackendType),
+        };
         let size = parser
             .convert::<ByteSized>("size")
             .map_err(Error::ParsePersistentMemory)?
             .map(|v| v.0);
+        let readonly = parser
+            .convert::<Toggle>("readonly")
+            .map_err(Error::ParsePersistentMemory)?
+            .unwrap_or(Toggle(false))
+            .0;
         let discard_writes = parser
             .convert::<Toggle>("discard_writes")
             .map_err(Error::ParsePersistentMemory)?
@@ -2323,13 +2344,24 @@ impl PmemConfig {
         Ok(PmemConfig {
             pci_common,
             file,
+            backend_type,
             size,
+            readonly,
             discard_writes,
         })
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        self.pci_common.validate(vm_config)
+        self.pci_common.validate(vm_config)?;
+        if self.backend_type == PmemBackendType::Uffd {
+            if self.size.is_none() {
+                return Err(ValidationError::PmemUffdSizeMissing);
+            }
+            if !self.readonly {
+                return Err(ValidationError::PmemUffdRequiresReadonly);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -4836,7 +4868,9 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         PmemConfig {
             pci_common: PciDeviceCommonConfig::default(),
             file: PathBuf::from("/tmp/pmem"),
+            backend_type: PmemBackendType::File,
             size: Some(128 << 20),
+            readonly: false,
             discard_writes: false,
         }
     }
@@ -4846,9 +4880,19 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         // Must always give a file and size
         PmemConfig::parse("").unwrap_err();
         PmemConfig::parse("size=128M").unwrap_err();
+        PmemConfig::parse("file=/tmp/pmem,backend_type=invalid").unwrap_err();
         assert_eq!(
             PmemConfig::parse("file=/tmp/pmem,size=128M")?,
             pmem_fixture()
+        );
+        assert_eq!(
+            PmemConfig::parse("file=/tmp/pmem.sock,size=128M,backend_type=uffd,readonly=on")?,
+            PmemConfig {
+                file: PathBuf::from("/tmp/pmem.sock"),
+                backend_type: PmemBackendType::Uffd,
+                readonly: true,
+                ..pmem_fixture()
+            }
         );
         assert_eq!(
             PmemConfig::parse("file=/tmp/pmem,size=128M,id=mypmem0")?,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -12,6 +12,7 @@
 #[cfg(target_arch = "x86_64")]
 use std::cmp;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::ffi::CString;
 #[cfg(feature = "sev_snp")]
 use std::fmt;
 #[cfg(feature = "kvm")]
@@ -19,6 +20,7 @@ use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::{self, IsTerminal, Seek, SeekFrom, stdout};
 use std::num::Wrapping;
+use std::os::fd::AsFd;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 #[cfg(not(target_arch = "riscv64"))]
@@ -107,6 +109,7 @@ use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, LegacyIrqGroupConfig, MsiIrqGroupConfig,
 };
+use vm_device::uffd::{UffdBlock, VmaRegion};
 use vm_device::{Bus, BusDevice, BusDeviceSync, Resource, UserspaceMapping};
 #[cfg(feature = "ivshmem")]
 use vm_memory::bitmap::AtomicBitmap;
@@ -137,9 +140,11 @@ use crate::vm_config::IvshmemConfig;
 use crate::vm_config::{
     ConsoleOutputMode, DEFAULT_IOMMU_ADDRESS_WIDTH_BITS, DEFAULT_PCI_SEGMENT_APERTURE_WEIGHT,
     DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, NetConfig, PciDeviceCommonConfig,
-    PmemConfig, UserDeviceConfig, VdpaConfig, VhostMode, VmConfig, VsockConfig,
+    PmemBackendType, PmemConfig, UserDeviceConfig, VdpaConfig, VhostMode, VmConfig, VsockConfig,
 };
-use crate::{DEVICE_MANAGER_SNAPSHOT_ID, GuestRegionMmap, PciDeviceInfo, device_node};
+use crate::{
+    DEVICE_MANAGER_SNAPSHOT_ID, GuestRegionMmap, PciDeviceInfo, device_node, uffd, userfaultfd,
+};
 
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 const MMIO_LEN: u64 = 0x1000;
@@ -170,6 +175,7 @@ const FS_DEVICE_NAME_PREFIX: &str = "_fs";
 const NET_DEVICE_NAME_PREFIX: &str = "_net";
 const GENERIC_VHOST_USER_DEVICE_NAME_PREFIX: &str = "_generic_vhost_user";
 const PMEM_DEVICE_NAME_PREFIX: &str = "_pmem";
+const PMD_SIZE: u64 = 0x20_0000;
 const VDPA_DEVICE_NAME_PREFIX: &str = "_vdpa";
 const VSOCK_DEVICE_NAME_PREFIX: &str = "_vsock";
 const WATCHDOG_DEVICE_NAME: &str = "__watchdog";
@@ -336,6 +342,10 @@ pub enum DeviceManagerError {
     /// Cannot set persistent memory file size
     #[error("Cannot set persistent memory file size")]
     PmemFileSetLen(#[source] io::Error),
+
+    /// Cannot create UFFD-backed persistent memory
+    #[error("Cannot create UFFD-backed persistent memory")]
+    PmemUffdCreate(#[source] io::Error),
 
     /// Cannot find a memory range for persistent memory
     #[error("Cannot find a memory range for persistent memory")]
@@ -3369,31 +3379,60 @@ impl DeviceManager {
             None
         };
 
-        let (custom_flags, set_len) = if pmem_cfg.file.is_dir() {
-            if pmem_cfg.size.is_none() {
-                return Err(DeviceManagerError::PmemWithDirectorySizeMissing);
+        let (file, size) = if pmem_cfg.backend_type == PmemBackendType::Uffd {
+            let size = pmem_cfg
+                .size
+                .ok_or(DeviceManagerError::PmemUffdCreate(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "UFFD-backed persistent memory requires size",
+                )))?;
+            let name = CString::new(format!("ch_pmem_{id}")).map_err(|_| {
+                DeviceManagerError::PmemUffdCreate(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "PMEM device ID contains a NUL byte",
+                ))
+            })?;
+            // SAFETY: memfd_create is a self-contained syscall and the return
+            // value is checked below.
+            let raw_fd = unsafe { libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC) };
+            if raw_fd < 0 {
+                return Err(DeviceManagerError::PmemUffdCreate(
+                    io::Error::last_os_error(),
+                ));
             }
-            (O_TMPFILE, true)
+            // SAFETY: memfd_create returned a fresh descriptor owned here.
+            let file = unsafe { File::from_raw_fd(raw_fd) };
+            file.set_len(size)
+                .map_err(DeviceManagerError::PmemUffdCreate)?;
+            (file, size)
         } else {
-            (0, false)
-        };
+            let (custom_flags, set_len) = if pmem_cfg.file.is_dir() {
+                if pmem_cfg.size.is_none() {
+                    return Err(DeviceManagerError::PmemWithDirectorySizeMissing);
+                }
+                (O_TMPFILE, true)
+            } else {
+                (0, false)
+            };
 
-        let mut file = OpenOptions::new()
-            .read(true)
-            .write(!pmem_cfg.discard_writes)
-            .custom_flags(custom_flags)
-            .open(&pmem_cfg.file)
-            .map_err(DeviceManagerError::PmemFileOpen)?;
+            let mut file = OpenOptions::new()
+                .read(true)
+                .write(!pmem_cfg.readonly && !pmem_cfg.discard_writes)
+                .custom_flags(custom_flags)
+                .open(&pmem_cfg.file)
+                .map_err(DeviceManagerError::PmemFileOpen)?;
 
-        let size = if let Some(size) = pmem_cfg.size {
-            if set_len {
-                file.set_len(size)
-                    .map_err(DeviceManagerError::PmemFileSetLen)?;
-            }
-            size
-        } else {
-            file.seek(SeekFrom::End(0))
-                .map_err(DeviceManagerError::PmemFileSetLen)?
+            let size = if let Some(size) = pmem_cfg.size {
+                if set_len {
+                    file.set_len(size)
+                        .map_err(DeviceManagerError::PmemFileSetLen)?;
+                }
+                size
+            } else {
+                file.seek(SeekFrom::End(0))
+                    .map_err(DeviceManagerError::PmemFileSetLen)?
+            };
+            (file, size)
         };
 
         if size % 0x20_0000 != 0 {
@@ -3429,16 +3468,24 @@ impl DeviceManager {
         };
 
         let cloned_file = file.try_clone().map_err(DeviceManagerError::CloneFile)?;
+        let mmap_prot = if pmem_cfg.readonly {
+            PROT_READ
+        } else {
+            PROT_READ | PROT_WRITE
+        };
+        let mmap_flags = MAP_NORESERVE
+            | if pmem_cfg.readonly {
+                MAP_SHARED
+            } else if pmem_cfg.discard_writes {
+                MAP_PRIVATE
+            } else {
+                MAP_SHARED
+            };
         let mmap_region = MmapRegion::build(
             Some(FileOffset::new(cloned_file, 0)),
             region_size as usize,
-            PROT_READ | PROT_WRITE,
-            MAP_NORESERVE
-                | if pmem_cfg.discard_writes {
-                    MAP_PRIVATE
-                } else {
-                    MAP_SHARED
-                },
+            mmap_prot,
+            mmap_flags,
         )
         .map_err(DeviceManagerError::NewMmapRegion)?;
         let host_addr = mmap_region.as_ptr();
@@ -3449,7 +3496,14 @@ impl DeviceManager {
             self.memory_manager
                 .lock()
                 .unwrap()
-                .create_userspace_mapping(region_base, region_size, host_addr, false, false, false)
+                .create_userspace_mapping(
+                    region_base,
+                    region_size,
+                    host_addr,
+                    false,
+                    pmem_cfg.readonly,
+                    false,
+                )
                 .map_err(DeviceManagerError::MemoryManager)
         }?;
 
@@ -3459,6 +3513,45 @@ impl DeviceManager {
             mapping: Arc::new(mmap_region),
             mergeable: false,
         };
+        let pmem_uffd: Option<Arc<virtio_devices::MmapUffdHandler>> =
+            if pmem_cfg.backend_type == PmemBackendType::Uffd {
+                let uffd_fd = uffd::create(0).map_err(DeviceManagerError::PmemUffdCreate)?;
+                let ioctls = uffd::register(uffd_fd.as_fd(), host_addr as u64, region_size, false)
+                    .map_err(DeviceManagerError::PmemUffdCreate)?;
+                if ioctls & userfaultfd::UFFD_API_RANGE_IOCTLS_BASIC
+                    != userfaultfd::UFFD_API_RANGE_IOCTLS_BASIC
+                {
+                    return Err(DeviceManagerError::PmemUffdCreate(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "UFFD-backed PMEM mapping does not support the required ioctls",
+                    )));
+                }
+                let regions = vec![VmaRegion {
+                    virt_addr: host_addr as u64,
+                    size: region_size,
+                    offset: 0,
+                    fault_size: PMD_SIZE,
+                    prot: mmap_prot,
+                    flags: mmap_flags,
+                    backing_offset: 0,
+                }];
+                let block = UffdBlock::new(&pmem_cfg.file, false)
+                    .map_err(DeviceManagerError::PmemUffdCreate)?;
+                block
+                    .handshake(
+                        uffd_fd.as_raw_fd(),
+                        userfaultfd::UFFDIO_REGISTER_MODE_MISSING,
+                        0,
+                        &regions,
+                        &[],
+                    )
+                    .map_err(DeviceManagerError::PmemUffdCreate)?;
+                Some(Arc::new(virtio_devices::MmapUffdHandler::new(
+                    block, uffd_fd, regions,
+                )))
+            } else {
+                None
+            };
 
         let virtio_pmem_device = Arc::new(Mutex::new(
             virtio_devices::Pmem::new(
@@ -3467,6 +3560,7 @@ impl DeviceManager {
                 GuestAddress(region_base),
                 mapping,
                 self.force_access_platform | pmem_cfg.pci_common.iommu,
+                pmem_uffd,
                 self.seccomp_action.clone(),
                 self.exit_evt
                     .try_clone()

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -614,6 +614,14 @@ impl ApplyLandlock for GenericVhostUserConfig {
     }
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PmemBackendType {
+    #[default]
+    File,
+    Uffd,
+}
+
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PmemConfig {
@@ -621,14 +629,24 @@ pub struct PmemConfig {
     pub pci_common: PciDeviceCommonConfig,
     pub file: PathBuf,
     #[serde(default)]
+    pub backend_type: PmemBackendType,
+    #[serde(default)]
     pub size: Option<u64>,
+    #[serde(default)]
+    pub readonly: bool,
     #[serde(default)]
     pub discard_writes: bool,
 }
 
 impl ApplyLandlock for PmemConfig {
     fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
-        let access = if self.discard_writes { "r" } else { "rw" };
+        let access = if self.backend_type == PmemBackendType::File
+            && (self.readonly || self.discard_writes)
+        {
+            "r"
+        } else {
+            "rw"
+        };
         landlock.add_rule_with_access(&self.file, access)?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

This draft introduces a reusable external userfaultfd backend framework and uses `virtio-pmem` as its first Cloud Hypervisor consumer.

The goal is to let an external service handle memory faults or provide file-backed ranges without coupling Cloud Hypervisor to a particular storage, decoding, or caching implementation.

This work is based on the design discussion in [#8554](https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8554).

## Protocol design

The initial proposal considered extending the existing live-migration`PageFault` exchange.

While implementing the protocol, it became clear that explicit external-backend commands and reply types provide a cleaner abstraction. The existing `PageFault` request uses live-migration-specific GPA semantics, whereas an external backend operates on generic flattened-device offsets and may return file ranges, inline data, or resolve faults directly.

The external UFFD protocol therefore follows the style of the existing live-migration request/response protocol, including its 16-byte framing, but does not modify the existing live-migration protocol or its `PageFault` messages.

Every request and response begins with a 16-byte header:

| Offset | Request | Response | Size |
|---:|---|---|---:|
| 0 | `command` | `status` | 2 |
| 2 | command-specific headers | `reply_type` and reply-specific headers | 6 |
| 8 | payload length | payload length | 8 |

The protocol defines explicit commands including:

- `Handshake`
- `Stat`
- `Fetch`
- `FetchLegacy`
- `Probe`
- `AddRegion`
- `RemoveRegion`

Responses use explicit reply types:

- `Legacy`
- `FdRanges`
- `Stat`

`Legacy` preserves the existing status-and-payload response semantics.
`FdRanges` returns file-backed ranges with file descriptors transferred through `SCM_RIGHTS`.

## Protocol operation

The protocol supports two operation models.

### Stateful

The client sends a `Handshake` containing:

- a registered UFFD;
- VMA region metadata;
- session flags;
- effective UFFD modes;
- optional backing file descriptors.

The connection remains active while UFFD events are handled.

A stateful session supports two data-handling strategies:

- **Managed:** the external service polls the transferred UFFD and resolves faults directly.
- **Customized:** the service returns asynchronous `FdRanges` responses, and the client installs the mappings and wakes the faulting range.

The effective UFFD modes currently represented by the protocol are:

- `MISSING`
- `WP`
- `WP_ASYNC`

### Stateless

A client may use the following requests without establishing UFFD state on the server:

- `Stat`
- `Fetch`
- `FetchLegacy`
- `Probe`

These requests allow a client to query metadata or obtain data for a specific range without transferring a UFFD.

Stateful and stateless are client operation models rather than server-enforced connection states. Stateless requests may also be issued on an established stateful connection, and the client distinguishes responses through their reply types.

## Common framework

This draft adds a common external UFFD handler that:

- transfers UFFDs and optional backing FDs through `SCM_RIGHTS`;
- sends VMA metadata and effective UFFD modes;
- supports stateful managed and customized handling;
- supports `AddRegion` and `RemoveRegion`;
- manages the customized response worker and its shutdown lifecycle;
- can be reused by device mappings and Guest RAM.

The protocol definitions and common client/server operations should eventually live in a small shared crate. This would allow Cloud Hypervisor and external services to use the same wire-format implementation instead of maintaining separate encoders and decoders.

For development and review, this draft temporarily depends on my personal [`ondemand-block`](https://github.com/joy-allen/ondemand-block) repository. The final crate location, ownership, and maintenance model still need to be agreed before this work is ready for merge.

## virtio-pmem support

`virtio-pmem` is the first supported device. It currently uses:

- a **stateful** session;
- **customized** fault handling;
- `UFFD_MODE_MISSING`;
- asynchronous `FdRanges` responses for zero-copy mapping.

The current implementation does not request a Handshake acknowledgement or transfer client backing FDs.

External UFFD-backed `virtio-pmem` is currently restricted to read-only operation. The existing file-backed implementation remains the default backend, so existing configurations are unchanged.

(The same`virtio-pmem` use case could also be implemented with the stateless `Fetch` or `FetchLegacy` requests.)

## Relationship to #8657

The framework can also support the Guest RAM reclamation work proposed in [#8657](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8657).

For that use case, Cloud Hypervisor can:

- create and register a UFFD for Guest RAM;
- describe the registered VMA regions in a stateful Handshake;
- communicate effective `MISSING`, `WP`, and `WP_ASYNC` modes;
- transfer shared backing FDs so the external service can reclaim memory by
  punching holes;
- use `AddRegion` and `RemoveRegion` to keep the service synchronized with
  changes to the Guest RAM layout.

A minimal demonstration is available in the [`feat/uffd-ram-demo`](https://github.com/joy-allen/cloud-hypervisor/tree/feat/uffd-ram-demo) branch. It:

- registers Guest RAM using caller-provided UFFD register modes and features;
- transfers the UFFD, region metadata, and backing FDs through the common
  framework;
- uses a stateful managed session;
- sends `AddRegion` when RAM is hot-plugged.

The demo intentionally omits configuration and HTTP API plumbing, reconnect handling, and integration tests. Its purpose is to demonstrate how the common framework can be reused by the Guest RAM reclamation implementation.

## Current scope

This draft includes:

- the common external UFFD framework;
- protocol and usage documentation;
- read-only external UFFD support for `virtio-pmem`;
- a minimal external server description and pseudocode;
- a separate Guest RAM reuse demonstration.

The main open question is where the common protocol crate should live and how it should be maintained.