### PR TITLE
tests: exercize disk plug/unplug instead of primary NIC

### DIFF
--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use std::collections::HashMap;
+#[cfg(target_arch = "x86_64")]
+use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -12,6 +14,8 @@ use std::string::String;
 use std::sync::mpsc;
 use std::sync::mpsc::Receiver;
 use std::time::{Duration, Instant};
+#[cfg(target_arch = "x86_64")]
+use std::time::{SystemTime, UNIX_EPOCH};
 use std::{cmp, fs, io, panic, thread};
 
 use block::formats::qcow::ImageType as QcowImageType;
@@ -1112,29 +1116,61 @@ pub(crate) fn bdf_from_hotplug_response(
 
 #[cfg(target_arch = "x86_64")]
 /// Shared hotplug-disk probe used by live-migration tests to verify that
-/// hot(re)plugging keeps working across a migration or upgrade.
+/// hot-added block devices and their on-disk data survive a migration or
+/// upgrade.
 ///
-/// Uses the 16 MiB `blk.img` workload disk that is already fetched for the
-/// disk-hotplug tests; when hot-added it appears in the guest as `/dev/vdc`.
+/// Creates a fresh 128 MiB backing file on the host, hot-adds it as `/dev/vdc`
+/// on the source, formats it with ext4, mounts it, writes a nonce file, and
+/// unmounts. After migration the destination re-mounts the disk, checks the
+/// nonce, unmounts, and hot-removes the device.
 pub(crate) struct HotplugDiskProbe {
     disk_id: &'static str,
+    disk_path: PathBuf,
     params: String,
+    mount_point: &'static str,
+    file_name: &'static str,
+    token: String,
 }
 
 #[cfg(target_arch = "x86_64")]
 impl HotplugDiskProbe {
     pub(crate) fn new() -> Self {
-        let mut path = dirs::home_dir().unwrap();
-        path.push("workloads");
-        path.push("blk.img");
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let disk_path = env::temp_dir().join(format!("clh-mig-probe-{nanos:x}.img"));
+        let status = Command::new("dd")
+            .args([
+                "if=/dev/zero",
+                &format!("of={}", disk_path.to_str().unwrap()),
+                "bs=1M",
+                "count=128",
+                "status=none",
+            ])
+            .status()
+            .expect("failed to spawn dd");
+        assert!(status.success(), "failed to create hotplug probe image");
+
         let disk_id = "test0";
-        let params = format!("path={},id={disk_id},readonly=true", path.to_str().unwrap());
-        Self { disk_id, params }
+        let params = format!(
+            "path={},id={disk_id},image_type=raw",
+            disk_path.to_str().unwrap()
+        );
+        let token = format!("clh-mig-{nanos:x}");
+        Self {
+            disk_id,
+            disk_path,
+            params,
+            mount_point: "/tmp/probe_mnt",
+            file_name: "probe.txt",
+            token,
+        }
     }
 
     fn count_is(guest: &Guest, expected: u32) -> bool {
         guest
-            .ssh_command("lsblk | grep -c 'vdc.*16M' || true")
+            .ssh_command("lsblk | grep -c 'vdc.*128M' || true")
             .is_ok_and(|s| s.trim().parse::<u32>().is_ok_and(|c| c == expected))
     }
 
@@ -1146,8 +1182,8 @@ impl HotplugDiskProbe {
         Self::count_is(guest, 0)
     }
 
-    /// Before migration: assert the probe disk is absent, hot-add it, and
-    /// wait for the guest to enumerate it.
+    /// Before migration: hot-add the probe disk, format it, mount, write a
+    /// nonce file, and unmount.
     pub(crate) fn pre_migration_add(&self, guest: &Guest, src_api_socket: &str) {
         assert!(Self::absent(guest));
         assert!(remote_command(
@@ -1156,24 +1192,58 @@ impl HotplugDiskProbe {
             Some(self.params.as_str()),
         ));
         assert!(wait_until(Duration::from_secs(10), || Self::exists(guest)));
+
+        guest.ssh_command("sudo mkfs.ext4 -F /dev/vdc").unwrap();
+        guest
+            .ssh_command(&format!("sudo mkdir -p {}", self.mount_point))
+            .unwrap();
+        guest
+            .ssh_command(&format!("sudo mount /dev/vdc {}", self.mount_point))
+            .unwrap();
+        guest
+            .ssh_command(&format!(
+                "echo -n {} | sudo tee {}/{} > /dev/null",
+                self.token, self.mount_point, self.file_name
+            ))
+            .unwrap();
+        guest
+            .ssh_command(&format!("sudo umount {}", self.mount_point))
+            .unwrap();
     }
 
-    /// After migration: assert the probe disk carried over, then remove and
-    /// re-add it on the destination to prove hot(re)plug still works.
+    /// After migration: re-mount the probe disk, verify the nonce, unmount,
+    /// then hot-remove the device on the destination.
     pub(crate) fn post_migration_recheck(&self, guest: &Guest, dest_api_socket: &str) {
         assert!(Self::exists(guest));
+
+        // release that doesn't propagate `image_type=raw`, so the destination
+        // re-auto-detects the disk as raw and re-arms the sector-0 write
+        // guard. A read-write mount would then fail trying to update the
+        // ext4 superblock.
+        guest
+            .ssh_command(&format!("sudo mount -o ro /dev/vdc {}", self.mount_point))
+            .unwrap();
+        let content = guest
+            .ssh_command(&format!("cat {}/{}", self.mount_point, self.file_name))
+            .unwrap();
+        assert_eq!(content.trim(), self.token);
+        guest
+            .ssh_command(&format!("sudo umount {}", self.mount_point))
+            .unwrap();
+
         assert!(remote_command(
             dest_api_socket,
             "remove-device",
             Some(self.disk_id),
         ));
         assert!(wait_until(Duration::from_secs(10), || Self::absent(guest)));
-        assert!(remote_command(
-            dest_api_socket,
-            "add-disk",
-            Some(self.params.as_str()),
-        ));
-        assert!(wait_until(Duration::from_secs(10), || Self::exists(guest)));
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Drop for HotplugDiskProbe {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.disk_path);
     }
 }
 

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -1110,6 +1110,73 @@ pub(crate) fn bdf_from_hotplug_response(
     (segment_id, bus_id, device_id, function_id)
 }
 
+#[cfg(target_arch = "x86_64")]
+/// Shared hotplug-disk probe used by live-migration tests to verify that
+/// hot(re)plugging keeps working across a migration or upgrade.
+///
+/// Uses the 16 MiB `blk.img` workload disk that is already fetched for the
+/// disk-hotplug tests; when hot-added it appears in the guest as `/dev/vdc`.
+pub(crate) struct HotplugDiskProbe {
+    disk_id: &'static str,
+    params: String,
+}
+
+#[cfg(target_arch = "x86_64")]
+impl HotplugDiskProbe {
+    pub(crate) fn new() -> Self {
+        let mut path = dirs::home_dir().unwrap();
+        path.push("workloads");
+        path.push("blk.img");
+        let disk_id = "test0";
+        let params = format!("path={},id={disk_id},readonly=true", path.to_str().unwrap());
+        Self { disk_id, params }
+    }
+
+    fn count_is(guest: &Guest, expected: u32) -> bool {
+        guest
+            .ssh_command("lsblk | grep -c 'vdc.*16M' || true")
+            .is_ok_and(|s| s.trim().parse::<u32>().is_ok_and(|c| c == expected))
+    }
+
+    fn exists(guest: &Guest) -> bool {
+        Self::count_is(guest, 1)
+    }
+
+    fn absent(guest: &Guest) -> bool {
+        Self::count_is(guest, 0)
+    }
+
+    /// Before migration: assert the probe disk is absent, hot-add it, and
+    /// wait for the guest to enumerate it.
+    pub(crate) fn pre_migration_add(&self, guest: &Guest, src_api_socket: &str) {
+        assert!(Self::absent(guest));
+        assert!(remote_command(
+            src_api_socket,
+            "add-disk",
+            Some(self.params.as_str()),
+        ));
+        assert!(wait_until(Duration::from_secs(10), || Self::exists(guest)));
+    }
+
+    /// After migration: assert the probe disk carried over, then remove and
+    /// re-add it on the destination to prove hot(re)plug still works.
+    pub(crate) fn post_migration_recheck(&self, guest: &Guest, dest_api_socket: &str) {
+        assert!(Self::exists(guest));
+        assert!(remote_command(
+            dest_api_socket,
+            "remove-device",
+            Some(self.disk_id),
+        ));
+        assert!(wait_until(Duration::from_secs(10), || Self::absent(guest)));
+        assert!(remote_command(
+            dest_api_socket,
+            "add-disk",
+            Some(self.params.as_str()),
+        ));
+        assert!(wait_until(Duration::from_secs(10), || Self::exists(guest)));
+    }
+}
+
 #[cfg(not(feature = "mshv"))]
 pub(crate) fn start_live_migration(
     migration_socket: &str,

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6694,29 +6694,6 @@ mod common_parallel {
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
-            // x86_64: Following what's done in the `test_snapshot_restore`, we need
-            // to make sure that removing and adding back the virtio-net device does
-            // not break the live-migration support for virtio-pci.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), || {
-                    guest.wait_for_ssh(Duration::from_secs(1)).is_err()
-                }));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
-            }
-
             // Start the live-migration
             let migration_socket = String::from(
                 guest
@@ -7144,22 +7121,6 @@ mod common_parallel {
             // using direct kernel boot, where ACPI support is missing.
             #[cfg(target_arch = "x86_64")]
             {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), || {
-                    guest.wait_for_ssh(Duration::from_secs(1)).is_err()
-                }));
-                // Re-add the virtio-net device
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
-
                 assert!(hotplug_disk_absent());
                 assert!(remote_command(
                     &src_api_socket,
@@ -8022,26 +7983,6 @@ mod ivshmem {
             assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
-            // x86_64: Following what's done in the `test_snapshot_restore`, we need
-            // to make sure that removing and adding back the virtio-net device does
-            // not break the live-migration support for virtio-pci.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                thread::sleep(Duration::new(10, 0));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                thread::sleep(Duration::new(10, 0));
-            }
 
             // Check ivshmem device in src guest.
             _test_ivshmem(&guest, &ivshmem_file_path, file_size);
@@ -8662,39 +8603,6 @@ mod snapshot_restore_common {
             }
             // Check the guest virtio-devices, e.g. block, rng, vsock, console, and net
             guest.check_devices_common(Some(&socket), Some(&console_text), None);
-
-            // x86_64: We check that removing and adding back the virtio-net device
-            // does not break the snapshot/restore support for virtio-pci.
-            // This is an important thing to test as the hotplug will
-            // trigger a PCI BAR reprogramming, which is a good way of
-            // checking if the stored resources are correctly restored.
-            // Unplug the virtio-net device
-            // AArch64: Device hotplug is currently not supported, skipping here.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &api_socket_source,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                let latest_events = [&MetaEvent {
-                    event: "device-removed".to_string(),
-                    device_id: Some(net_id.to_string()),
-                }];
-                assert!(wait_for_latest_events_exact(
-                    Duration::from_secs(30),
-                    &latest_events,
-                    &event_path
-                ));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &api_socket_source,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                thread::sleep(Duration::new(10, 0));
-            }
 
             snapshot_restore_common::snapshot_and_check_events(
                 &api_socket_source,
@@ -10211,29 +10119,6 @@ mod common_sequential {
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
-            // x86_64: Following what's done in the `test_snapshot_restore`, we need
-            // to make sure that removing and adding back the virtio-net device does
-            // not break the live-migration support for virtio-pci.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), || {
-                    guest.wait_for_ssh(Duration::from_secs(1)).is_err()
-                }));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
-            }
-
             // Start the live-migration
             let migration_socket = String::from(
                 guest
@@ -10437,29 +10322,6 @@ mod common_sequential {
 
                     guest.check_numa_common(Some(&[1_920_000, 1_920_000, 1_920_000]), None, None);
                 }
-            }
-
-            // x86_64: Following what's done in the `test_snapshot_restore`, we need
-            // to make sure that removing and adding back the virtio-net device does
-            // not break the live-migration support for virtio-pci.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), || {
-                    guest.wait_for_ssh(Duration::from_secs(1)).is_err()
-                }));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
             }
 
             // Start the live-migration
@@ -10834,28 +10696,6 @@ mod common_sequential {
             assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
-            // x86_64: Following what's done in the `test_snapshot_restore`, we need
-            // to make sure that removing and adding back the virtio-net device does
-            // not break the live-migration support for virtio-pci.
-            #[cfg(target_arch = "x86_64")]
-            {
-                assert!(remote_command(
-                    &src_api_socket,
-                    "remove-device",
-                    Some(net_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), || {
-                    guest.wait_for_ssh(Duration::from_secs(1)).is_err()
-                }));
-
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
-            }
 
             // Enable watchdog and ensure its functional
             let expected_reboot_count = 1;

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7450,7 +7450,9 @@ mod common_parallel {
 
                     thread::sleep(Duration::from_secs(3));
                     assert!(
-                        src_child.try_wait().unwrap().is_some(),
+                        wait_until(Duration::from_secs(30), || {
+                            matches!(src_child.try_wait(), Ok(Some(_)))
+                        }),
                         "Source VM should have terminated after a forced migration"
                     );
 

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6647,6 +6647,9 @@ mod common_parallel {
             .expect("Expect creating disk image to succeed");
         let pmem_path = String::from("/dev/pmem0");
 
+        #[cfg(target_arch = "x86_64")]
+        let hotplug_probe = HotplugDiskProbe::new();
+
         // Start the source VM
         let src_vm_path = if upgrade_test {
             cloud_hypervisor_release_path()
@@ -6693,6 +6696,10 @@ mod common_parallel {
 
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
+
+            // Test hot(re)plugging works before a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.pre_migration_add(&guest, &src_api_socket);
 
             // Start the live-migration
             let migration_socket = String::from(
@@ -6745,6 +6752,10 @@ mod common_parallel {
             assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
 
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
+
+            // Test hot(re)plugging works after a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.post_migration_recheck(&guest, &dest_api_socket);
         });
 
         // Clean-up the destination VM and make sure it terminated correctly
@@ -7051,23 +7062,8 @@ mod common_parallel {
             .output()
             .expect("Expect creating disk image to succeed");
         let pmem_path = String::from("/dev/pmem0");
-        let mut hotplug_blk_file_path = dirs::home_dir().unwrap();
-        hotplug_blk_file_path.push("workloads");
-        hotplug_blk_file_path.push("blk.img");
-        let hotplug_disk_id = "test0";
-        let hotplug_disk_params = format!(
-            "path={},id={hotplug_disk_id},readonly=true",
-            hotplug_blk_file_path.to_str().unwrap()
-        );
-        // The hotplugged disk is expected to appear as /dev/vdc and blk.img is
-        // the 16 MiB workload image used by the disk hotplug tests.
-        let hotplug_disk_count_is = |expected| {
-            guest
-                .ssh_command("lsblk | grep -c 'vdc.*16M' || true")
-                .is_ok_and(|s| s.trim().parse::<u32>().is_ok_and(|count| count == expected))
-        };
-        let hotplug_disk_exists = || hotplug_disk_count_is(1);
-        let hotplug_disk_absent = || hotplug_disk_count_is(0);
+        #[cfg(target_arch = "x86_64")]
+        let hotplug_probe = HotplugDiskProbe::new();
 
         // Start the source VM
         let src_vm_path = clh_command("cloud-hypervisor");
@@ -7116,19 +7112,8 @@ mod common_parallel {
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
             // Test hot(re)plugging works before a migration.
-            //
-            // This currently excludes ARM, because on ARM we boot without OVMF,
-            // using direct kernel boot, where ACPI support is missing.
             #[cfg(target_arch = "x86_64")]
-            {
-                assert!(hotplug_disk_absent());
-                assert!(remote_command(
-                    &src_api_socket,
-                    "add-disk",
-                    Some(hotplug_disk_params.as_str()),
-                ));
-                assert!(wait_until(Duration::from_secs(10), hotplug_disk_exists));
-            }
+            hotplug_probe.pre_migration_add(&guest, &src_api_socket);
             // Start TCP live migration
             assert!(
                 start_live_migration_tcp(
@@ -7171,27 +7156,8 @@ mod common_parallel {
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
             // Test hot(re)plugging works after a migration.
-            //
-            // This currently excludes ARM, because on ARM we boot without OVMF,
-            // using direct kernel boot, where ACPI support is missing.
             #[cfg(target_arch = "x86_64")]
-            {
-                assert!(hotplug_disk_exists());
-
-                assert!(remote_command(
-                    &dest_api_socket,
-                    "remove-device",
-                    Some(hotplug_disk_id),
-                ));
-                assert!(wait_until(Duration::from_secs(10), hotplug_disk_absent));
-
-                assert!(remote_command(
-                    &dest_api_socket,
-                    "add-disk",
-                    Some(hotplug_disk_params.as_str()),
-                ));
-                assert!(wait_until(Duration::from_secs(10), hotplug_disk_exists));
-            }
+            hotplug_probe.post_migration_recheck(&guest, &dest_api_socket);
         });
 
         // Clean up the destination VM and ensure it terminates properly
@@ -7204,13 +7170,6 @@ mod common_parallel {
             assert!(String::from_utf8_lossy(&dest_output.stdout).contains(&console_text));
         });
         handle_child_output(r, &dest_output);
-
-        #[cfg(not(target_arch = "x86_64"))]
-        {
-            let _ = hotplug_disk_params;
-            let _ = hotplug_disk_exists;
-            let _ = hotplug_disk_absent;
-        }
     }
 
     // Postcopy live migration. Verifies the destination boots a guest
@@ -7229,6 +7188,9 @@ mod common_parallel {
         );
         let memory_param: &[&str] = &["--memory", "size=512M"];
         let boot_vcpus = 2;
+
+        #[cfg(target_arch = "x86_64")]
+        let hotplug_probe = HotplugDiskProbe::new();
 
         let src_vm_path = clh_command("cloud-hypervisor");
         let src_api_socket = temp_api_path(&guest.tmp_dir);
@@ -7262,6 +7224,10 @@ mod common_parallel {
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
             assert!(guest.get_total_memory().unwrap_or_default() > 400_000);
             guest.check_devices_common(None, Some(&console_text), None);
+
+            // Test hot(re)plugging works before a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.pre_migration_add(&guest, &src_api_socket);
 
             assert!(
                 start_live_migration_tcp_with_flags(
@@ -7302,6 +7268,10 @@ mod common_parallel {
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
             assert!(guest.get_total_memory().unwrap_or_default() > 400_000);
             guest.check_devices_common(None, Some(&console_text), None);
+
+            // Test hot(re)plugging works after a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.post_migration_recheck(&guest, &dest_api_socket);
         });
 
         let _ = dest_child.kill();
@@ -7587,6 +7557,8 @@ mod common_parallel {
             prepare_virtiofsd(&guest.tmp_dir, shared_dir.to_str().unwrap());
 
         let src_api_socket = temp_api_path(&guest.tmp_dir);
+        #[cfg(target_arch = "x86_64")]
+        let hotplug_probe = HotplugDiskProbe::new();
 
         // Start the source VM
         let mut src_child = GuestCommand::new(&guest)
@@ -7665,6 +7637,10 @@ mod common_parallel {
                 "pre_migration_data"
             );
 
+            // Test hot(re)plugging works before a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.pre_migration_add(&guest, &src_api_socket);
+
             let migration_socket = String::from(
                 guest
                     .tmp_dir
@@ -7735,6 +7711,10 @@ mod common_parallel {
             // Verify the new file exists on the host
             let post_content = fs::read_to_string(shared_dir.join("post_migration_file")).unwrap();
             assert_eq!(post_content.trim(), "post_migration_data");
+
+            // Test hot(re)plugging works after a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.post_migration_recheck(&guest, &dest_api_socket);
         });
 
         // Clean up
@@ -7939,6 +7919,9 @@ mod ivshmem {
             .status()
             .unwrap();
 
+        #[cfg(target_arch = "x86_64")]
+        let hotplug_probe = HotplugDiskProbe::new();
+
         // Start the source VM
         let src_vm_path = clh_command("cloud-hypervisor");
         let src_api_socket = temp_api_path(&guest.tmp_dir);
@@ -7988,6 +7971,10 @@ mod ivshmem {
             _test_ivshmem(&guest, &ivshmem_file_path, file_size);
             // Allow some normal time to elapse to check we don't get spurious reboots
             thread::sleep(Duration::new(40, 0));
+
+            // Test hot(re)plugging works before a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.pre_migration_add(&guest, &src_api_socket);
 
             // Start the live-migration
             let migration_socket = String::from(
@@ -8043,6 +8030,10 @@ mod ivshmem {
 
             // Check ivshmem device
             _test_ivshmem(&guest, &ivshmem_file_path, file_size);
+
+            // Test hot(re)plugging works after a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.post_migration_recheck(&guest, &dest_api_socket);
         });
 
         // Clean-up the destination VM and make sure it terminated correctly
@@ -10057,6 +10048,9 @@ mod common_sequential {
             .expect("Expect creating disk image to succeed");
         let pmem_path = String::from("/dev/pmem0");
 
+        #[cfg(target_arch = "x86_64")]
+        let hotplug_probe = HotplugDiskProbe::new();
+
         // Start the source VM
         let src_vm_path = if upgrade_test {
             cloud_hypervisor_release_path()
@@ -10118,6 +10112,10 @@ mod common_sequential {
 
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
+
+            // Test hot(re)plugging works before a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.pre_migration_add(&guest, &src_api_socket);
 
             // Start the live-migration
             let migration_socket = String::from(
@@ -10185,6 +10183,10 @@ mod common_sequential {
             let total_memory = guest.get_total_memory().unwrap_or_default();
             assert!(total_memory > 4_800_000);
             assert!(total_memory < 5_760_000);
+
+            // Test hot(re)plugging works after a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.post_migration_recheck(&guest, &dest_api_socket);
         });
 
         // Clean-up the destination VM and make sure it terminated correctly
@@ -10249,6 +10251,9 @@ mod common_sequential {
             .output()
             .expect("Expect creating disk image to succeed");
         let pmem_path = String::from("/dev/pmem0");
+
+        #[cfg(target_arch = "x86_64")]
+        let hotplug_probe = HotplugDiskProbe::new();
 
         // Start the source VM
         let src_vm_path = if upgrade_test {
@@ -10323,6 +10328,10 @@ mod common_sequential {
                     guest.check_numa_common(Some(&[1_920_000, 1_920_000, 1_920_000]), None, None);
                 }
             }
+
+            // Test hot(re)plugging works before a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.pre_migration_add(&guest, &src_api_socket);
 
             // Start the live-migration
             let migration_socket = String::from(
@@ -10419,6 +10428,10 @@ mod common_sequential {
                     );
                 }
             }
+
+            // Test hot(re)plugging works after a migration.
+            #[cfg(target_arch = "x86_64")]
+            hotplug_probe.post_migration_recheck(&guest, &dest_api_socket);
         });
 
         // Clean-up the destination VM and make sure it terminated correctly


### PR DESCRIPTION
Several live-migration, snapshot/restore, upgrade, and ivshmem tests hot-remove the primary virtio-net device and add it back mid-test to exercise PCI BAR reprogramming across a migration or restore. On the Ubuntu 22.04 guest this ometimes acily leaves the re-plugged interface in state DOWN (unmanaged): udev renames the freshly-plugged netdev (eth0 -> ensX) after systemd-networkd has already processed the initial RTM_NEWLINK, so networkd never re-runs its Match logic against the new name. The primary IP is never restored and the subsequent SSH check fails. This check makes several test cases flaky.

Drop the remove/add-back sequence from these tests. PCI BAR reprogramming on hotplug is already exercised by dedicated hotplug tests, and the migration/restore paths do not require it.

Instead, exercise hotplug during live migration/upgrade.