### PR TITLE
block: qcow: Read a single full mapping into the op directly

### DIFF
--- a/block/src/formats/qcow/common.rs
+++ b/block/src/formats/qcow/common.rs
@@ -171,6 +171,18 @@ pub(super) fn scatter_read_sync(
     cluster_size: u64,
     decoder: &dyn Decoder,
 ) -> AsyncIoResult<()> {
+    if let [ClusterReadMapping::Allocated { offset, length }] = mappings.as_slice()
+        && op.is_read()
+        && *length as usize == op.total_len()
+    {
+        // SAFETY: the iovecs come from op, which owns the destination
+        // memory for the duration of this call.
+        let n = unsafe { data_file.file().read_vectored_at(op.iovecs(), *offset) };
+        if matches!(n, Ok(n) if n == op.total_len()) {
+            return Ok(());
+        }
+    }
+
     let mut buf_offset = 0usize;
     for mapping in mappings {
         match mapping {

--- a/block/src/formats/qcow/common.rs
+++ b/block/src/formats/qcow/common.rs
@@ -252,9 +252,14 @@ pub(crate) mod unit_tests {
 
     use flate2::Compression;
     use flate2::write::DeflateEncoder;
+    use vmm_sys_util::tempfile::TempFile;
 
     use super::super::decoder::ZlibDecoder;
-    use super::decompress_cluster;
+    use super::super::metadata::ClusterReadMapping;
+    use super::super::qcow_raw_file::QcowRawFile;
+    use super::{decompress_cluster, scatter_read_sync};
+    use crate::aligned_file::AlignedFile;
+    use crate::async_io::{AsyncIoOperation, OwnedIoBuffer};
 
     const COMPRESSED_FLAG: u64 = 1 << 62;
     const CLUSTER_USED_FLAG: u64 = 1 << 63;
@@ -369,5 +374,60 @@ pub(crate) mod unit_tests {
         let corrupt = vec![0xffu8; 64];
         let err = decompress_cluster(&corrupt, 65536, &ZlibDecoder {}).unwrap_err();
         assert_eq!(err.raw_os_error(), Some(libc::EIO));
+    }
+
+    #[test]
+    fn single_full_mapping_short_read_errors() {
+        // The mapping claims 200 bytes but the file holds only 100.
+        let src: Vec<u8> = (0..100u8).collect();
+        let tmp = TempFile::new().unwrap();
+        tmp.as_file().write_all(&src).unwrap();
+        tmp.as_file().sync_all().unwrap();
+
+        let aligned = AlignedFile::new(tmp.as_file().try_clone().unwrap(), false);
+        let data_file = QcowRawFile::from(aligned, 65536, 16).unwrap();
+
+        let mut op = AsyncIoOperation::read_to_vec(0, OwnedIoBuffer::from_vec(vec![0u8; 200]), 1);
+        let mappings = vec![ClusterReadMapping::Allocated {
+            offset: 0,
+            length: 200,
+        }];
+
+        assert!(
+            scatter_read_sync(mappings, &mut op, &data_file, &None, 65536, &ZlibDecoder {})
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn single_full_mapping_reads_fast_path() {
+        let cluster = 65536usize;
+        let src: Vec<u8> = (0..cluster).map(|i| (i % 251) as u8).collect();
+        let tmp = TempFile::new().unwrap();
+        tmp.as_file().write_all(&src).unwrap();
+        tmp.as_file().sync_all().unwrap();
+
+        let aligned = AlignedFile::new(tmp.as_file().try_clone().unwrap(), false);
+        let data_file = QcowRawFile::from(aligned, cluster as u64, 16).unwrap();
+
+        let mut op =
+            AsyncIoOperation::read_to_vec(0, OwnedIoBuffer::from_vec(vec![0u8; cluster]), 1);
+        let mappings = vec![ClusterReadMapping::Allocated {
+            offset: 0,
+            length: cluster as u64,
+        }];
+
+        scatter_read_sync(
+            mappings,
+            &mut op,
+            &data_file,
+            &None,
+            cluster as u64,
+            &ZlibDecoder {},
+        )
+        .unwrap();
+
+        let buffer = op.into_completion_buffer().unwrap();
+        assert_eq!(buffer.as_slice(), src.as_slice());
     }
 }

--- a/block/src/formats/qcow/engine_sync.rs
+++ b/block/src/formats/qcow/engine_sync.rs
@@ -145,12 +145,13 @@ mod unit_tests {
     use std::sync::Arc;
     use std::{env, thread};
 
+    use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
     use vmm_sys_util::tempdir::TempDir;
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
     use crate::aligned_file::AlignedFile;
-    use crate::async_io::{AsyncIoCompletion, OwnedIoBuffer};
+    use crate::async_io::{AsyncIoCompletion, GuestMemoryTarget, OwnedIoBuffer};
     use crate::disk_file::{AsyncDiskFile, DiskSize, MetadataSync, Resizable};
     use crate::error::BlockErrorKind;
     use crate::formats::qcow;
@@ -314,6 +315,32 @@ mod unit_tests {
         async_io.fsync(Some(7)).unwrap();
         let (user_data, _result) = next_completion(async_io.as_mut());
         assert_eq!(user_data, 7);
+    }
+
+    #[test]
+    fn many_iovecs_single_cluster_read_falls_back() {
+        let chunk = 32usize;
+        let ranges_count = libc::UIO_MAXIOV as usize + 1;
+        let total = ranges_count * chunk;
+        let data: Vec<u8> = (0..total).map(|i| (i % 251) as u8).collect();
+        let (_tmp, disk) = create_disk_with_data(65536 * 4, &data, 0, true, false);
+
+        let mem =
+            Arc::new(GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), total)]).unwrap());
+        let ranges: Vec<(GuestAddress, u32)> = (0..ranges_count)
+            .map(|i| (GuestAddress((i * chunk) as u64), chunk as u32))
+            .collect();
+        let target = GuestMemoryTarget::new(mem.clone(), &ranges).unwrap();
+
+        let mut async_io = disk.create_async_io(1).unwrap();
+        async_io.read_to_memory(0, target, 1).unwrap();
+        let (user_data, result) = next_completion(async_io.as_mut());
+        assert_eq!(user_data, 1);
+        assert_eq!(result as usize, total);
+
+        let mut got = vec![0u8; total];
+        mem.read_slice(&mut got, GuestAddress(0)).unwrap();
+        assert_eq!(got, data);
     }
 
     // Freed relocation clusters must be reused so committed blocks track


### PR DESCRIPTION
When a qcow2 read resolves to a single allocated mapping covering the whole request, read straight into the operation iovecs instead of staging through an allocated and zeroed buffer. This drops the allocation, the zero fill, and the extra copy and mirrors the single mapping detection the io_uring engine uses in `resolve_read`. Other read paths are unchanged.

A short read from that mapping means the data file is truncated, so it returns an error, matching `read_exact_at` in the staging loop. Reads with more iovecs than `UIO_MAXIOV` fall back to the staging loop unchanged.