### PR TITLE
hypervisor: mshv: Clear interrupt_bitmap so restore does not EINVAL

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -9682,6 +9682,32 @@ mod common_sequential {
 
     use crate::*;
 
+    // Fails with EINVAL before the set_sregs interrupt_bitmap fix.
+    #[test]
+    #[cfg(feature = "mshv")]
+    #[cfg(target_arch = "x86_64")]
+    fn test_mshv_set_sregs_pending_interrupt_bitmap() {
+        use hypervisor::HypervisorVmConfig;
+        use hypervisor::mshv::MshvHypervisor;
+
+        if !PathBuf::from("/dev/mshv").exists() {
+            println!("SKIPPED: /dev/mshv not present, host is not running MSHV");
+            return;
+        }
+
+        let hv = MshvHypervisor::new().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
+        vm.init().unwrap();
+        let vcpu = vm.create_vcpu(0, None, None).unwrap();
+
+        let mut sregs = vcpu.get_sregs().unwrap();
+        vcpu.set_sregs(&sregs).unwrap();
+
+        sregs.interrupt_bitmap[0] = 1;
+        vcpu.set_sregs(&sregs)
+            .expect("set_sregs rejected a non zero interrupt_bitmap (EINVAL)");
+    }
+
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_memory_mergeable_on() {

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -2598,3 +2598,54 @@ impl vm::Vm for MshvVm {
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[cfg(target_arch = "x86_64")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mshv_sregs_for_set_clears_interrupt_bitmap() {
+        let sregs = SpecialRegisters {
+            interrupt_bitmap: [1, 2, 3, 4],
+            cr0: 0x8000_0011,
+            cr3: 0x1_2000,
+            efer: 0x500,
+            apic_base: 0xfee0_0900,
+            ..Default::default()
+        };
+
+        let out = mshv_sregs_for_set(&sregs);
+
+        assert_eq!(out.interrupt_bitmap, [0; 4]);
+        assert_eq!(out.cr0, sregs.cr0);
+        assert_eq!(out.cr3, sregs.cr3);
+        assert_eq!(out.efer, sregs.efer);
+        assert_eq!(out.apic_base, sregs.apic_base);
+    }
+
+    #[test]
+    fn pending_interrupt_survives_snapshot_restore() {
+        const PENDING_INTERRUPTION: u64 = 0x8000_0000_0000_0030;
+        let sregs = SpecialRegisters {
+            interrupt_bitmap: [0, 0, 0, 1 << 16],
+            ..Default::default()
+        };
+        let events = VcpuEvents {
+            pending_interruption: PENDING_INTERRUPTION,
+            ..Default::default()
+        };
+
+        let sregs: MshvSpecialRegisters = sregs.into();
+        let sregs: MshvSpecialRegisters =
+            serde_json::from_str(&serde_json::to_string(&sregs).unwrap()).unwrap();
+        let events: VcpuEvents =
+            serde_json::from_str(&serde_json::to_string(&events).unwrap()).unwrap();
+
+        let restored: SpecialRegisters = sregs.into();
+        let out = mshv_sregs_for_set(&restored);
+
+        assert_eq!(events.pending_interruption, PENDING_INTERRUPTION);
+        assert_eq!(out.interrupt_bitmap, [0; 4]);
+    }
+}

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -171,6 +171,15 @@ impl From<crate::StandardRegisters> for mshv_bindings::StandardRegisters {
     }
 }
 
+/// Microsoft Hypervisor rejects set_sregs when interrupt_bitmap is non zero, so
+/// clear it. A pending interrupt is restored through set_vcpu_events instead.
+#[cfg(target_arch = "x86_64")]
+fn mshv_sregs_for_set(sregs: &SpecialRegisters) -> MshvSpecialRegisters {
+    let mut sregs: MshvSpecialRegisters = (*sregs).into();
+    sregs.interrupt_bitmap.fill(0);
+    sregs
+}
+
 impl From<mshv_user_irq_entry> for IrqRoutingEntry {
     fn from(s: mshv_user_irq_entry) -> Self {
         IrqRoutingEntry::Mshv(s)
@@ -528,7 +537,7 @@ impl cpu::Vcpu for MshvVcpu {
     /// Sets the vCPU special registers.
     ///
     fn set_sregs(&self, sregs: &SpecialRegisters) -> cpu::Result<()> {
-        let sregs = (*sregs).into();
+        let sregs = mshv_sregs_for_set(sregs);
         self.fd
             .set_sregs(&sregs)
             .map_err(|e| cpu::HypervisorCpuError::SetSpecialRegs(e.into()))


### PR DESCRIPTION
MSHV restore and live migration fail with `SetSpecialRegs` EINVAL when a snapshot is taken while a vCPU has a pending external interrupt.

`get_sregs` sets `sregs.interrupt_bitmap`, but `set_sregs` rejects a non zero bitmap. The pending interrupt is restored via `set_vcpu_events`, which writes `HV_REGISTER_PENDING_INTERRUPTION`. Hence, the bitmap in `sregs` is redundant and is cleared before the ioctl.