### PR TITLE
block: qcow: Open backing files with direct I/O

### DIFF
--- a/block/src/formats/qcow/backing.rs
+++ b/block/src/formats/qcow/backing.rs
@@ -6,21 +6,20 @@
 
 //! Thread safe backing file readers for QCOW2 images.
 
-use std::fs::File;
 use std::io;
-use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::fs::FileExt;
 use std::sync::Arc;
 
 use super::decoder::Decoder;
 use super::metadata::{BackingRead, ClusterReadMapping, QcowMetadata};
 use super::parser::{BackingFile, BackingKind, Error as QcowError};
-use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
+use crate::aligned_file::AlignedFile;
+use crate::error::{BlockError, BlockErrorKind, BlockResult};
 use crate::formats::qcow::common::decompress_cluster;
 
-/// Raw backing file using position-independent reads on a duplicated fd.
+/// Raw backing file using position-independent reads.
 pub(crate) struct RawBacking {
-    pub(crate) file: File,
+    pub(crate) file: AlignedFile,
     pub(crate) virtual_size: u64,
 }
 
@@ -53,7 +52,7 @@ impl BackingRead for RawBacking {
 /// are handled recursively via the optional `backing_file` field.
 pub(crate) struct Qcow2Backing {
     pub(crate) metadata: Arc<QcowMetadata>,
-    pub(crate) data_file: File,
+    pub(crate) data_file: AlignedFile,
     pub(crate) backing_file: Option<Arc<dyn BackingRead>>,
     pub(crate) cluster_size: u64,
     pub(crate) decoder: Arc<dyn Decoder>,
@@ -143,23 +142,13 @@ impl Qcow2Backing {
 pub(super) fn shared_backing_from(bf: BackingFile) -> BlockResult<Arc<dyn BackingRead>> {
     let (kind, virtual_size) = bf.into_kind();
 
-    let dup_fd = |fd: BorrowedFd<'_>| -> BlockResult<OwnedFd> {
-        fd.try_clone_to_owned().map_err(|e| {
-            BlockError::new(
-                BlockErrorKind::Io,
-                QcowError::BackingFileIo(String::new(), e),
-            )
-            .with_op(ErrorOp::DupBackingFd)
-        })
-    };
-
     match kind {
-        BackingKind::Raw(raw_file) => {
-            let file = File::from(dup_fd(raw_file.as_fd())?);
-            Ok(Arc::new(RawBacking { file, virtual_size }))
-        }
+        BackingKind::Raw(file) => Ok(Arc::new(RawBacking { file, virtual_size })),
         BackingKind::Qcow { inner, backing } => {
-            let data_file = File::from(dup_fd(inner.raw_file.as_fd())?);
+            let data_file =
+                inner.raw_file.file().try_clone().map_err(|e| {
+                    BlockError::new(BlockErrorKind::Io, QcowError::CloneBackingFile(e))
+                })?;
             let metadata = Arc::new(QcowMetadata::new(*inner));
             Ok(Arc::new(Qcow2Backing {
                 cluster_size: metadata.cluster_size(),

--- a/block/src/formats/qcow/engine_sync.rs
+++ b/block/src/formats/qcow/engine_sync.rs
@@ -161,6 +161,7 @@ mod unit_tests {
     use crate::formats::qcow::{
         BackingFileConfig, Error as QcowError, ImageType, QcowDisk, QcowHeader, QcowTempDisk,
     };
+    use crate::test_util::require_direct_io;
 
     const TEST_L1_L2_ADDR_MASK: u64 = 0x00ff_ffff_ffff_fe00;
     const TEST_HEADER_L1_TABLE_OFFSET: u64 = 40;
@@ -849,6 +850,7 @@ mod unit_tests {
 
     #[test]
     fn test_backing_file_read_direct_io() {
+        require_direct_io!();
         test_backing_file_read_impl(true);
     }
 
@@ -1084,6 +1086,7 @@ mod unit_tests {
 
     #[test]
     fn test_partial_write_after_write_zeroes_must_not_reintroduce_backing_data_direct_io() {
+        require_direct_io!();
         test_partial_write_after_write_zeroes_must_not_reintroduce_backing_data_impl(true);
     }
 
@@ -1152,6 +1155,7 @@ mod unit_tests {
 
     #[test]
     fn test_backing_file_read_qcow2_backing_direct_io() {
+        require_direct_io!();
         test_backing_file_read_qcow2_backing_impl(true);
     }
 
@@ -1253,6 +1257,7 @@ mod unit_tests {
 
     #[test]
     fn test_multi_queue_concurrent_reads_qcow2_backing_direct_io() {
+        require_direct_io!();
         test_multi_queue_concurrent_reads_qcow2_backing_impl(true);
     }
 
@@ -1345,6 +1350,7 @@ mod unit_tests {
 
     #[test]
     fn test_three_layer_backing_chain_direct_io() {
+        require_direct_io!();
         test_three_layer_backing_chain_impl(true);
     }
 
@@ -1411,6 +1417,7 @@ mod unit_tests {
 
     #[test]
     fn test_backing_cow_preserves_all_unwritten_clusters_direct_io() {
+        require_direct_io!();
         test_backing_cow_preserves_all_unwritten_clusters_impl(true);
     }
 
@@ -1454,6 +1461,7 @@ mod unit_tests {
 
     #[test]
     fn test_qcow2_backing_read_beyond_virtual_size_direct_io() {
+        require_direct_io!();
         test_qcow2_backing_read_beyond_virtual_size_impl(true);
     }
 
@@ -1506,6 +1514,7 @@ mod unit_tests {
 
     #[test]
     fn test_qcow2_backing_read_spanning_virtual_size_direct_io() {
+        require_direct_io!();
         test_qcow2_backing_read_spanning_virtual_size_impl(true);
     }
 
@@ -1560,6 +1569,7 @@ mod unit_tests {
 
     #[test]
     fn test_raw_backing_read_beyond_virtual_size_direct_io() {
+        require_direct_io!();
         test_raw_backing_read_beyond_virtual_size_impl(true);
     }
 
@@ -1614,6 +1624,7 @@ mod unit_tests {
 
     #[test]
     fn test_qcow2_backing_cross_cluster_read_direct_io() {
+        require_direct_io!();
         test_qcow2_backing_cross_cluster_read_impl(true);
     }
 
@@ -1683,6 +1694,7 @@ mod unit_tests {
 
     #[test]
     fn test_punch_hole_with_backing_fallthrough_direct_io() {
+        require_direct_io!();
         test_punch_hole_with_backing_fallthrough_impl(true);
     }
 
@@ -1788,6 +1800,7 @@ mod unit_tests {
 
     #[test]
     fn test_partial_cluster_write_with_backing_cow_direct_io() {
+        require_direct_io!();
         test_partial_cluster_write_with_backing_cow_impl(true);
     }
 

--- a/block/src/formats/qcow/engine_uring.rs
+++ b/block/src/formats/qcow/engine_uring.rs
@@ -296,6 +296,7 @@ mod unit_tests {
     use crate::disk_file::AsyncDiskFile;
     use crate::formats::qcow::common::unit_tests::compress_allocated_clusters;
     use crate::formats::qcow::{BackingFileConfig, ImageType, QcowDisk, QcowTempDisk};
+    use crate::test_util::require_direct_io;
 
     fn create_disk_with_data(
         file_size: u64,
@@ -814,26 +815,16 @@ mod unit_tests {
 
     #[test]
     fn test_qcow_async_alignment_with_direct_io() {
-        let tmp_disk = match QcowTempDisk::new(100 * 1024 * 1024, None, true, true, true) {
-            Ok(d) => d,
-            Err(_) => {
-                eprintln!("skipping: O_DIRECT not supported on this filesystem");
-                return;
-            }
-        };
+        require_direct_io!();
+        let tmp_disk = QcowTempDisk::new(100 * 1024 * 1024, None, true, true, true).unwrap();
         let async_io = tmp_disk.disk().create_async_io(1).unwrap();
         assert!(async_io.alignment() >= SECTOR_SIZE);
     }
 
     #[test]
     fn test_qcow_async_sub_sector_read_with_direct_io() {
-        let tmp_disk = match QcowTempDisk::new(100 * 1024 * 1024, None, true, true, true) {
-            Ok(d) => d,
-            Err(_) => {
-                eprintln!("skipping: O_DIRECT not supported on this filesystem");
-                return;
-            }
-        };
+        require_direct_io!();
+        let tmp_disk = QcowTempDisk::new(100 * 1024 * 1024, None, true, true, true).unwrap();
 
         let pattern = vec![0xAB; 65536];
         async_write(tmp_disk.disk(), 0, &pattern);
@@ -847,13 +838,8 @@ mod unit_tests {
 
     #[test]
     fn test_qcow_async_direct_io_write_read_roundtrip() {
-        let tmp_disk = match QcowTempDisk::new(100 * 1024 * 1024, None, true, true, true) {
-            Ok(d) => d,
-            Err(_) => {
-                eprintln!("skipping: O_DIRECT not supported on this filesystem");
-                return;
-            }
-        };
+        require_direct_io!();
+        let tmp_disk = QcowTempDisk::new(100 * 1024 * 1024, None, true, true, true).unwrap();
 
         let pattern: Vec<u8> = (0..128 * 1024).map(|i| (i % 251) as u8).collect();
         async_write(tmp_disk.disk(), 0, &pattern);

--- a/block/src/formats/qcow/parser.rs
+++ b/block/src/formats/qcow/parser.rs
@@ -917,6 +917,7 @@ mod unit_tests {
     use super::super::util::{self, ZERO_FLAG};
     use super::*;
     use crate::formats::qcow::{QcowDisk, QcowTempDisk};
+    use crate::test_util::require_direct_io;
 
     fn valid_header_v3() -> Vec<u8> {
         vec![
@@ -1212,6 +1213,30 @@ mod unit_tests {
             read_header_with_patched_backing(cluster_size - 16, 16).expect("Header should parse.");
         assert_eq!(header.backing_file_offset, cluster_size - 16);
         assert_eq!(header.backing_file_size, 16);
+    }
+
+    #[test]
+    fn raw_backing_file_uses_direct_io() {
+        require_direct_io!();
+        let tmp = TempFile::new().unwrap();
+        tmp.as_file().write_all(&[0u8; 4096]).unwrap();
+        let config = BackingFileConfig {
+            path: tmp.as_path().to_string_lossy().into_owned(),
+            format: Some(ImageType::Raw),
+        };
+
+        let backing = BackingFile::new(Some(&config), true, 1, false)
+            .unwrap()
+            .unwrap();
+        let (kind, _) = backing.into_kind();
+        let BackingKind::Raw(file) = kind else {
+            panic!("Expected raw backing file");
+        };
+
+        // SAFETY: file owns a valid descriptor for the duration of this call.
+        let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+        assert!(flags >= 0);
+        assert_ne!(flags & libc::O_DIRECT, 0);
     }
 
     /// Helper to create a test file with header extensions

--- a/block/src/formats/qcow/parser.rs
+++ b/block/src/formats/qcow/parser.rs
@@ -8,7 +8,7 @@ use std::cmp::{max, min};
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::fs::{OpenOptions, read_link};
 use std::os::fd::AsRawFd;
-use std::os::unix::fs::FileExt;
+use std::os::unix::fs::{FileExt, OpenOptionsExt};
 use std::path::Path;
 use std::{io, result, str};
 
@@ -56,6 +56,8 @@ pub enum Error {
     BackingFilesDisabled,
     #[error("Backing file name is too long: {0} bytes over")]
     BackingFileTooLong(usize),
+    #[error("Failed to clone backing file")]
+    CloneBackingFile(#[source] io::Error),
     #[error("Image is marked corrupt and cannot be opened for writing")]
     CorruptImage,
     #[error("Failed to evict cache")]
@@ -189,15 +191,17 @@ impl BackingFile {
             ));
         }
 
-        let backing_raw_file = OpenOptions::new()
-            .read(true)
-            .open(&config.path)
-            .map_err(|e| {
-                BlockError::new(
-                    BlockErrorKind::Io,
-                    Error::BackingFileIo(config.path.clone(), e),
-                )
-            })?;
+        let mut options = OpenOptions::new();
+        options.read(true);
+        if direct_io {
+            options.custom_flags(libc::O_DIRECT);
+        }
+        let backing_raw_file = options.open(&config.path).map_err(|e| {
+            BlockError::new(
+                BlockErrorKind::Io,
+                Error::BackingFileIo(config.path.clone(), e),
+            )
+        })?;
 
         let mut raw_file = AlignedFile::new(backing_raw_file, direct_io);
 

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -18,6 +18,8 @@ pub(crate) mod aligned_buffer;
 pub mod aligned_file;
 pub mod formats;
 mod sparse;
+#[cfg(test)]
+pub(crate) mod test_util;
 use std::fmt::{self, Debug};
 use std::fs::{File, OpenOptions};
 use std::os::linux::fs::MetadataExt;

--- a/block/src/test_util.rs
+++ b/block/src/test_util.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helpers for block unit tests.
+
+use std::fs::OpenOptions;
+use std::os::unix::fs::OpenOptionsExt;
+
+use vmm_sys_util::tempfile::TempFile;
+
+use crate::aligned_buffer::AlignedBuffer;
+
+/// Returns whether the filesystem supports O_DIRECT reads.
+pub(crate) fn direct_io_supported() -> bool {
+    let Ok(tmp) = TempFile::new() else {
+        return false;
+    };
+    if tmp.as_file().set_len(1 << 20).is_err() {
+        return false;
+    }
+    let Ok(file) = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECT)
+        .open(tmp.as_path())
+    else {
+        return false;
+    };
+    let Ok(mut buf) = AlignedBuffer::new(0, 4096, 4096) else {
+        return false;
+    };
+    buf.read_from(&file).is_ok()
+}
+
+/// Skips the current test when the filesystem does not support O_DIRECT.
+macro_rules! require_direct_io {
+    () => {
+        if !$crate::test_util::direct_io_supported() {
+            eprintln!("skipping: O_DIRECT not supported on this filesystem");
+            return;
+        }
+    };
+}
+
+pub(crate) use require_direct_io;


### PR DESCRIPTION
Backing file reads use buffered I/O even when direct I/O is requested. The AlignedFile wrapper has direct I/O alignment, but the file descriptor does not have O_DIRECT.

Open backing file descriptors with O_DIRECT when requested.