### PR TITLE
openapi: Fix generic_vhost_user property name in VmConfig

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -689,7 +689,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/FsConfig"
-        generic-vhost-user:
+        generic_vhost_user:
           type: array
           items:
             $ref: "#/components/schemas/GenericVhostUserConfig"

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1263,6 +1263,8 @@ components:
         pci_device_id:
           type: integer
           format: uint8
+        id:
+          type: string
         device_type:
           type: integer
           format: uint32


### PR DESCRIPTION
The OpenAPI document names the VmConfig property `generic-vhost-user`, but the
field in `vmm/src/vm_config.rs` has no serde rename, so the wire format is
`generic_vhost_user`. Since `VmConfig` deserialization does not reject unknown
fields, a client generated from the document sends a key that is silently
ignored — the devices are dropped on `vm.create` without any error.

The second commit adds the missing `id` property, which is accepted through
the flattened `PciDeviceCommonConfig` and already documented on the sibling
`FsConfig`.

Left untouched on purpose: `pci_segment: int16` (the format used by all 15
occurrences in the document) and `iommu` (also undocumented on `FsConfig`) —
happy to follow up separately if desired.

Complements #8543, which fixed the schema-internal property names introduced
by the same commit.

Fixes: df86b2864 ("vmm: add HTTP API endpoints for generic vhost-user")