### PR TITLE
openapi: Add missing BreakPoint variant to VmState

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -582,7 +582,7 @@ components:
 
     VmState:
       type: string
-      enum: [Created, Running, Shutdown, Paused]
+      enum: [Created, Running, Shutdown, Paused, BreakPoint]
 
     VmInfo:
       required:


### PR DESCRIPTION
The VmState enum in vmm/src/vm.rs has five variants (Created, Running, Shutdown, Paused, BreakPoint) but the OpenAPI document only lists four. BreakPoint is observable through vm.info when a guest_debug build is paused by the GDB stub (Vm::debug_pause).

Clients generated with strict enum handling (e.g. via openapi-generator) fail to deserialize the vm.info response in that state. The document already covers guest_debug-gated surface such as /vm.coredump, so the enum should be complete as well.