### PR TITLE
ci: increase timeout for MSHV

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -766,7 +766,7 @@ jobs:
     needs: [preflight, dco, quality, build]
     if: >-
       github.event_name == 'merge_group' && needs.preflight.outputs.full == 'true' && needs.dco.result == 'success' && needs.quality.result == 'success' && needs.build.result == 'success'
-    timeout-minutes: 35
+    timeout-minutes: 50
     runs-on: mshv
     steps:
       # mshv runner user is "lsgunner"
@@ -781,7 +781,7 @@ jobs:
       - name: Prepare for VDPA
         run: scripts/prepare_vdpa.sh
       - name: Run integration tests
-        timeout-minutes: 30
+        timeout-minutes: 45
         run: scripts/dev_cli.sh tests --integration
   # Rate-limiter host is not available
   # integration-rate-limiter:


### PR DESCRIPTION
Increase timeout for MSHV integration tests as enabling live_migration/upgrade tests asks for more time to finish.