### PR TITLE
seccomp: allow pwritev2

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -128,6 +128,7 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_pread64, vec![]),
         (libc::SYS_preadv, vec![]),
         (libc::SYS_pwritev, vec![]),
+        (libc::SYS_pwritev2, vec![]),
         (libc::SYS_pwrite64, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
         (libc::SYS_sched_setaffinity, vec![]),

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -733,6 +733,7 @@ fn vmm_thread_rules(
         (libc::SYS_prlimit64, vec![]),
         (libc::SYS_pwrite64, vec![]),
         (libc::SYS_pwritev, vec![]),
+        (libc::SYS_pwritev2, vec![]),
         (libc::SYS_readv, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_readlink, vec![]),
@@ -940,6 +941,7 @@ fn vcpu_thread_rules(
         (libc::SYS_open, vec![]),
         (libc::SYS_pread64, vec![]),
         (libc::SYS_pwrite64, vec![]),
+        (libc::SYS_pwritev2, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_readlink, vec![]),
         #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]


### PR DESCRIPTION
Since the latest release, musl preferentially uses this syscall in its pwrite and pwritev implementations.