### PR TITLE
vmm: virtio-devices: serial_buffer: Console socket support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,6 +2263,9 @@ dependencies = [
 [[package]]
 name = "serial_buffer"
 version = "0.1.0"
+dependencies = [
+ "vmm-sys-util",
+]
 
 [[package]]
 name = "sha2"

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -2726,18 +2726,32 @@ mod common_parallel {
         handle_child_output(r, &output);
     }
 
-    #[test]
-    fn test_serial_socket_interaction() {
+    #[derive(Clone, Copy)]
+    enum ConsoleKind {
+        Serial,
+        Console,
+    }
+
+    fn _test_socket_interaction(kind: ConsoleKind) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
-        let serial_socket = guest.tmp_dir.as_path().join("serial.socket");
-        let serial_socket_pty = guest.tmp_dir.as_path().join("serial.pty");
-        let serial_option = if cfg!(target_arch = "x86_64") {
-            " console=ttyS0"
-        } else {
-            " console=ttyAMA0"
+        let socket = guest.tmp_dir.as_path().join("socket");
+        let socket_pty = guest.tmp_dir.as_path().join("socket.pty");
+
+        let mut cmdline = DIRECT_KERNEL_BOOT_CMDLINE.to_owned();
+        if let ConsoleKind::Serial = kind {
+            cmdline += if cfg!(target_arch = "x86_64") {
+                " console=ttyS0"
+            } else {
+                " console=ttyAMA0"
+            };
+        }
+
+        let socket_arg = format!("socket={}", socket.to_str().unwrap());
+        let (serial, console) = match kind {
+            ConsoleKind::Serial => (socket_arg.as_str(), "null"),
+            ConsoleKind::Console => ("null", socket_arg.as_str()),
         };
-        let cmdline = DIRECT_KERNEL_BOOT_CMDLINE.to_owned() + serial_option;
 
         let mut child = GuestCommand::new(&guest)
             .default_cpus()
@@ -2746,43 +2760,40 @@ mod common_parallel {
             .args(["--cmdline", &cmdline])
             .default_disks()
             .default_net()
-            .args(["--console", "null"])
-            .args([
-                "--serial",
-                format!("socket={}", serial_socket.to_str().unwrap()).as_str(),
-            ])
+            .args(["--serial", serial])
+            .args(["--console", console])
             .spawn()
             .unwrap();
 
-        let _ = panic::catch_unwind(|| {
+        let boot = panic::catch_unwind(|| {
             guest.wait_vm_boot().unwrap();
         });
 
         let mut socat_command = Command::new("socat");
         let socat_args = [
-            &format!("pty,link={},raw,echo=0", serial_socket_pty.display()),
-            &format!("UNIX-CONNECT:{}", serial_socket.display()),
+            &format!("pty,link={},raw,echo=0", socket_pty.display()),
+            &format!("UNIX-CONNECT:{}", socket.display()),
         ];
         socat_command.args(socat_args);
 
         let mut socat_child = socat_command.spawn().unwrap();
         thread::sleep(Duration::new(1, 0));
 
-        let _ = panic::catch_unwind(|| {
-            _test_pty_interaction(serial_socket_pty);
+        let interaction = panic::catch_unwind(|| {
+            _test_pty_interaction(socket_pty);
         });
 
         let _ = socat_child.kill();
         let _ = socat_child.wait();
 
-        let r = panic::catch_unwind(|| {
+        let shutdown = panic::catch_unwind(|| {
             guest.ssh_command("sudo shutdown -h now").unwrap();
         });
 
         let _ = child.wait_timeout(Duration::from_secs(20));
         kill_child(&mut child);
         let output = child.wait_with_output().unwrap();
-        handle_child_output(r, &output);
+        handle_child_output(boot.and(interaction).and(shutdown), &output);
 
         let r = panic::catch_unwind(|| {
             // Check that the cloud-hypervisor binary actually terminated
@@ -2794,6 +2805,16 @@ mod common_parallel {
             }
         });
         handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_serial_socket_interaction() {
+        _test_socket_interaction(ConsoleKind::Serial);
+    }
+
+    #[test]
+    fn test_console_socket_interaction() {
+        _test_socket_interaction(ConsoleKind::Console);
     }
 
     fn _test_serial_socket_stale_cleanup(reboot: bool) {

--- a/serial_buffer/Cargo.toml
+++ b/serial_buffer/Cargo.toml
@@ -5,5 +5,8 @@ name = "serial_buffer"
 rust-version.workspace = true
 version = "0.1.0"
 
+[dev-dependencies]
+vmm-sys-util = { workspace = true }
+
 [lints]
 workspace = true

--- a/serial_buffer/src/lib.rs
+++ b/serial_buffer/src/lib.rs
@@ -8,6 +8,9 @@ use std::io::{self, Write};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+mod socket;
+pub use socket::{SharedSerialBuffer, SocketConsole};
+
 const MAX_BUFFER_SIZE: usize = 1 << 20;
 
 // Circular buffer implementation for serial output.

--- a/serial_buffer/src/lib.rs
+++ b/serial_buffer/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 mod socket;
-pub use socket::{SharedSerialBuffer, SocketConsole};
+pub use socket::SocketConsole;
 
 const MAX_BUFFER_SIZE: usize = 1 << 20;
 

--- a/serial_buffer/src/socket.rs
+++ b/serial_buffer/src/socket.rs
@@ -108,3 +108,100 @@ impl Read for SocketConsole {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::thread;
+    use std::time::Duration;
+
+    use vmm_sys_util::tempdir::TempDir;
+
+    use super::SocketConsole;
+
+    fn read_retry(console: &mut SocketConsole, buf: &mut [u8]) -> usize {
+        for _ in 0..200 {
+            let n = console.read(buf).unwrap();
+            if n > 0 {
+                return n;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+        0
+    }
+
+    #[test]
+    fn replays_buffered_output_to_client_on_connect() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.as_path().join("socket");
+        let listener = UnixListener::bind(&path).unwrap();
+        let mut console = SocketConsole::new();
+
+        let mut sink = console.out_sink();
+        sink.write_all(b"boot\n").unwrap();
+
+        let mut client = UnixStream::connect(&path).unwrap();
+        console.accept(&listener).unwrap();
+
+        let mut got = [0u8; 5];
+        client.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"boot\n");
+    }
+
+    #[test]
+    fn reads_input_from_connected_client() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.as_path().join("socket");
+        let listener = UnixListener::bind(&path).unwrap();
+        let mut console = SocketConsole::new();
+
+        let mut client = UnixStream::connect(&path).unwrap();
+        console.accept(&listener).unwrap();
+
+        client.write_all(b"hi").unwrap();
+        client.flush().unwrap();
+
+        let mut buf = [0u8; 8];
+        let n = read_retry(&mut console, &mut buf);
+        assert_eq!(&buf[..n], b"hi");
+    }
+
+    #[test]
+    fn shutdown_then_accept_replaces_client() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.as_path().join("socket");
+        let listener = UnixListener::bind(&path).unwrap();
+        let mut console = SocketConsole::new();
+
+        let mut first = UnixStream::connect(&path).unwrap();
+        console.accept(&listener).unwrap();
+
+        let second = UnixStream::connect(&path).unwrap();
+        console.shutdown().unwrap();
+        console.accept(&listener).unwrap();
+
+        // shutdown() closed the first connection.
+        let mut discard = [0u8; 4];
+        assert_eq!(first.read(&mut discard).unwrap(), 0);
+
+        let mut sink = console.out_sink();
+        sink.write_all(b"hey\n").unwrap();
+        let mut got = [0u8; 4];
+        (&second).read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"hey\n");
+    }
+
+    #[test]
+    fn reports_connection_state() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.as_path().join("socket");
+        let listener = UnixListener::bind(&path).unwrap();
+        let mut console = SocketConsole::new();
+        assert!(console.client_fd().is_none());
+
+        let _client = UnixStream::connect(&path).unwrap();
+        console.accept(&listener).unwrap();
+        assert!(console.client_fd().is_some());
+    }
+}

--- a/serial_buffer/src/socket.rs
+++ b/serial_buffer/src/socket.rs
@@ -3,16 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::io::{self, Write};
-use std::os::unix::net::UnixStream;
+use std::io::{self, ErrorKind, Read, Write};
+use std::net::Shutdown;
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::SerialBuffer;
 
-/// A `Write` handle so the serial device and the serial-manager thread can
-/// share one `SerialBuffer` (the device holds it as its output sink).
-pub struct SharedSerialBuffer(pub Arc<Mutex<SerialBuffer>>);
+struct SharedSerialBuffer(Arc<Mutex<SerialBuffer>>);
 
 impl Write for SharedSerialBuffer {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -23,25 +23,88 @@ impl Write for SharedSerialBuffer {
     }
 }
 
-#[derive(Clone)]
+/// Serves a device byte stream over a socket to one client at a time, buffering
+/// output until a client connects.
 pub struct SocketConsole {
-    /// Persistent ring buffer: captures serial output while no client is
-    /// connected and replays it on connect. Shared with the serial device's
-    /// `out` sink and retargeted by the epoll thread.
-    pub buffer: Arc<Mutex<SerialBuffer>>,
-    pub write_out: Arc<AtomicBool>,
+    buffer: Arc<Mutex<SerialBuffer>>,
+    write_out: Arc<AtomicBool>,
+    reader: Option<UnixStream>,
+}
+
+impl Default for SocketConsole {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl SocketConsole {
-    pub fn attach_client(&self, writer: UnixStream) -> io::Result<()> {
+    pub fn new() -> Self {
+        let write_out = Arc::new(AtomicBool::new(false));
+        let buffer = Arc::new(Mutex::new(SerialBuffer::new(
+            Box::new(io::sink()),
+            write_out.clone(),
+        )));
+        Self {
+            buffer,
+            write_out,
+            reader: None,
+        }
+    }
+
+    pub fn out_sink(&self) -> Box<dyn Write + Send> {
+        Box::new(SharedSerialBuffer(self.buffer.clone()))
+    }
+
+    /// Returns the connected client fd, or None when no client is attached.
+    pub fn client_fd(&self) -> Option<RawFd> {
+        self.reader.as_ref().map(|stream| stream.as_raw_fd())
+    }
+
+    pub fn shutdown(&mut self) -> io::Result<()> {
+        if let Some(stream) = self.reader.take() {
+            let res = stream.shutdown(Shutdown::Both);
+            self.detach();
+            res?;
+        }
+        Ok(())
+    }
+
+    pub fn accept(&mut self, listener: &UnixListener) -> io::Result<()> {
+        let (stream, _) = listener.accept()?;
+        stream.set_nonblocking(true)?;
+        let writer = stream.try_clone()?;
+        self.attach(Box::new(writer))?;
+        self.reader = Some(stream);
+        Ok(())
+    }
+
+    fn attach(&self, writer: Box<dyn Write + Send>) -> io::Result<()> {
         let mut buffer = self.buffer.lock().unwrap();
-        buffer.set_out(Box::new(writer));
+        buffer.set_out(writer);
         self.write_out.store(true, Ordering::Release);
         buffer.flush()
     }
 
-    pub fn detach_client(&self) {
+    fn detach(&self) {
         self.write_out.store(false, Ordering::Release);
         self.buffer.lock().unwrap().set_out(Box::new(io::sink()));
+    }
+}
+
+impl Read for SocketConsole {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let Some(mut stream) = self.reader.as_ref() else {
+            return Ok(0);
+        };
+        match stream.read(buf) {
+            Ok(count) if count > 0 => Ok(count),
+            Err(e) if e.kind() == ErrorKind::WouldBlock => Ok(0),
+            ended => {
+                let _ = stream.shutdown(Shutdown::Both);
+                self.reader = None;
+                self.detach();
+                ended
+            }
+        }
     }
 }

--- a/serial_buffer/src/socket.rs
+++ b/serial_buffer/src/socket.rs
@@ -1,0 +1,47 @@
+// Copyright © 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::{self, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::SerialBuffer;
+
+/// A `Write` handle so the serial device and the serial-manager thread can
+/// share one `SerialBuffer` (the device holds it as its output sink).
+pub struct SharedSerialBuffer(pub Arc<Mutex<SerialBuffer>>);
+
+impl Write for SharedSerialBuffer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.lock().unwrap().flush()
+    }
+}
+
+#[derive(Clone)]
+pub struct SocketConsole {
+    /// Persistent ring buffer: captures serial output while no client is
+    /// connected and replays it on connect. Shared with the serial device's
+    /// `out` sink and retargeted by the epoll thread.
+    pub buffer: Arc<Mutex<SerialBuffer>>,
+    pub write_out: Arc<AtomicBool>,
+}
+
+impl SocketConsole {
+    pub fn attach_client(&self, writer: UnixStream) -> io::Result<()> {
+        let mut buffer = self.buffer.lock().unwrap();
+        buffer.set_out(Box::new(writer));
+        self.write_out.store(true, Ordering::Release);
+        buffer.flush()
+    }
+
+    pub fn detach_client(&self) {
+        self.write_out.store(false, Ordering::Release);
+        self.buffer.lock().unwrap().set_out(Box::new(io::sink()));
+    }
+}

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -5,6 +5,7 @@ use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::os::unix::io::AsRawFd;
+use std::os::unix::net::UnixListener;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{cmp, io, result};
@@ -15,7 +16,7 @@ use libc::{EFD_NONBLOCK, TIOCGWINSZ};
 use log::{error, info, warn};
 use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
-use serial_buffer::SerialBuffer;
+use serial_buffer::{SerialBuffer, SocketConsole};
 use smallvec::SmallVec;
 use thiserror::Error;
 use virtio_queue::{Queue, QueueT};
@@ -47,6 +48,8 @@ const CONFIG_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 3;
 const FILE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 4;
 // Console resized
 const RESIZE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 5;
+// New client on the listening socket
+const SOCKET_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 6;
 
 //Console size feature bit
 const VIRTIO_CONSOLE_F_SIZE: u64 = 0;
@@ -97,6 +100,7 @@ struct ConsoleEpollHandler {
     access_platform: Option<Arc<dyn AccessPlatform>>,
     out: Option<Box<dyn Write + Send>>,
     write_out: Option<Arc<AtomicBool>>,
+    socket_console: Option<SocketConsole>,
     file_event_registered: bool,
 }
 
@@ -105,6 +109,7 @@ pub enum Endpoint {
     File(Arc<File>),
     FilePair(Arc<File>, Arc<File>),
     PtyPair(Arc<File>, Arc<File>),
+    Socket(Arc<UnixListener>),
     Null,
 }
 
@@ -114,6 +119,7 @@ impl Endpoint {
             Self::File(f) => Some(f),
             Self::FilePair(f, _) => Some(f),
             Self::PtyPair(f, _) => Some(f),
+            Self::Socket(..) => None,
             Self::Null => None,
         }
     }
@@ -123,6 +129,7 @@ impl Endpoint {
             Self::File(_) => None,
             Self::FilePair(_, f) => Some(f),
             Self::PtyPair(_, f) => Some(f),
+            Self::Socket(..) => None,
             Self::Null => None,
         }
     }
@@ -150,19 +157,26 @@ impl ConsoleEpollHandler {
         pause_evt: EventFd,
         access_platform: Option<Arc<dyn AccessPlatform>>,
     ) -> Self {
-        let out_file = endpoint.out_file();
-        let (out, write_out) = if let Some(out_file) = out_file {
+        let (socket_console, out, write_out) = if let Endpoint::Socket(..) = &endpoint {
+            let console = SocketConsole::new();
+            let out = console.out_sink();
+            (Some(console), Some(out), None)
+        } else if let Some(out_file) = endpoint.out_file() {
             let writer = out_file.try_clone().unwrap();
             if endpoint.is_pty() {
                 let pty_write_out = Arc::new(AtomicBool::new(false));
                 let write_out = Some(pty_write_out.clone());
                 let buffer = SerialBuffer::new(Box::new(writer), pty_write_out);
-                (Some(Box::new(buffer) as Box<dyn Write + Send>), write_out)
+                (
+                    None,
+                    Some(Box::new(buffer) as Box<dyn Write + Send>),
+                    write_out,
+                )
             } else {
-                (Some(Box::new(writer) as Box<dyn Write + Send>), None)
+                (None, Some(Box::new(writer) as Box<dyn Write + Send>), None)
             }
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         ConsoleEpollHandler {
@@ -182,6 +196,7 @@ impl ConsoleEpollHandler {
             access_platform,
             out,
             write_out,
+            socket_console,
             file_event_registered: false,
         }
     }
@@ -326,6 +341,9 @@ impl ConsoleEpollHandler {
             helper.add_event_custom(in_file.as_raw_fd(), FILE_EVENT, events)?;
             self.file_event_registered = true;
         }
+        if let Endpoint::Socket(listener) = &self.endpoint {
+            helper.add_event(listener.as_raw_fd(), SOCKET_EVENT)?;
+        }
 
         // In case of PTY, we want to be able to detect a connection on the
         // other end of the PTY. This is done by detecting there's no event
@@ -437,27 +455,51 @@ impl EpollHelperHandler for ConsoleEpollHandler {
                     })?;
                 self.resizer.update_console_size();
             }
+            SOCKET_EVENT => {
+                // A new client is connecting, so replace the current client with it.
+                if let (Some(console), Endpoint::Socket(listener)) =
+                    (self.socket_console.as_mut(), &self.endpoint)
+                {
+                    if let Some(fd) = console.client_fd() {
+                        helper.del_event_custom(fd, FILE_EVENT, epoll::Events::EPOLLIN)?;
+                        console.shutdown().map_err(EpollHelperError::IoError)?;
+                    }
+                    console
+                        .accept(listener)
+                        .map_err(EpollHelperError::IoError)?;
+                    if let Some(fd) = console.client_fd() {
+                        helper.add_event_custom(fd, FILE_EVENT, epoll::Events::EPOLLIN)?;
+                    }
+                }
+            }
             FILE_EVENT => {
                 if event.events & libc::EPOLLIN as u32 != 0 {
                     let mut input = [0u8; 64];
-                    if let Some(ref mut in_file) = self.endpoint.in_file() {
-                        if let Ok(count) = in_file.read(&mut input) {
-                            let mut in_buffer = self.in_buffer.lock().unwrap();
-                            in_buffer.extend(&input[..count]);
-                        }
+                    let count = if let Some(console) = self.socket_console.as_mut() {
+                        console.read(&mut input).unwrap_or_else(|e| {
+                            warn!("Failed to read console input: {e}");
+                            0
+                        })
+                    } else if let Some(mut in_file) = self.endpoint.in_file() {
+                        in_file.read(&mut input).unwrap_or(0)
+                    } else {
+                        0
+                    };
+                    if count > 0 {
+                        self.in_buffer.lock().unwrap().extend(&input[..count]);
+                    }
 
-                        let needs_notification = self.process_input_queue().map_err(|e| {
+                    let needs_notification = self.process_input_queue().map_err(|e| {
+                        EpollHelperError::HandleEvent(anyhow!(
+                            "Failed to process input queue : {e:?}"
+                        ))
+                    })?;
+                    if needs_notification {
+                        self.signal_used_queue(0).map_err(|e| {
                             EpollHelperError::HandleEvent(anyhow!(
-                                "Failed to process input queue : {e:?}"
+                                "Failed to signal used queue: {e:?}"
                             ))
                         })?;
-                        if needs_notification {
-                            self.signal_used_queue(0).map_err(|e| {
-                                EpollHelperError::HandleEvent(anyhow!(
-                                    "Failed to signal used queue: {e:?}"
-                                ))
-                            })?;
-                        }
                     }
                 }
                 if self.endpoint.is_pty() {

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -82,6 +82,7 @@ fn create_mshv_sev_snp_ioctl_seccomp_rule() -> Vec<SeccompRule> {
 fn create_virtio_console_ioctl_seccomp_rule() -> Vec<SeccompRule> {
     or![
         and![Cond::new(1, ArgLen::Dword, Eq, TIOCGWINSZ as _).unwrap()],
+        and![Cond::new(1, ArgLen::Dword, Eq, FIONBIO as _).unwrap()],
         #[cfg(feature = "sev_snp")]
         mshv_sev_snp_ioctl_seccomp_rule(),
     ]
@@ -149,9 +150,13 @@ fn create_virtio_block_ioctl_seccomp_rule() -> Vec<SeccompRule> {
 
 fn virtio_console_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
+        (libc::SYS_accept4, vec![]),
         (libc::SYS_ioctl, create_virtio_console_ioctl_seccomp_rule()),
+        (libc::SYS_recvfrom, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
+        (libc::SYS_sendto, vec![]),
         (libc::SYS_set_robust_list, vec![]),
+        (libc::SYS_shutdown, vec![]),
     ]
 }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -205,6 +205,9 @@ pub enum ValidationError {
     /// Missing socket path for console
     #[error("Path missing when using socket console mode")]
     ConsoleSocketPathMissing,
+    /// Socket path given without socket console mode
+    #[error("Path only valid when using socket console mode")]
+    ConsoleSocketPathUnexpected,
     /// Max is less than boot
     #[error("Max CPUs ({0}) lower than boot CPUs ({1})")]
     CpusMaxLowerThanBoot(u32 /* max vCPUs */, u32 /* boot vCPUs */),
@@ -2385,6 +2388,16 @@ impl CommonConsoleConfig {
 
         Ok(Self { mode, file, socket })
     }
+
+    pub fn validate(&self) -> ValidationResult<()> {
+        if self.mode == ConsoleOutputMode::Socket && self.socket.is_none() {
+            return Err(ValidationError::ConsoleSocketPathMissing);
+        }
+        if self.socket.is_some() && self.mode != ConsoleOutputMode::Socket {
+            return Err(ValidationError::ConsoleSocketPathUnexpected);
+        }
+        Ok(())
+    }
 }
 
 impl ConsoleConfig {
@@ -2403,6 +2416,7 @@ impl ConsoleConfig {
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
+        self.common.validate()?;
         self.pci_common.validate(vm_config)
     }
 }
@@ -2417,6 +2431,10 @@ impl SerialConfig {
 
         let common = CommonConsoleConfig::parse(serial, Error::ParseSerial)?;
         Ok(Self { common })
+    }
+
+    pub fn validate(&self) -> ValidationResult<()> {
+        self.common.validate()
     }
 }
 
@@ -3454,6 +3472,8 @@ impl VmConfig {
         self.console.validate(self)?;
         Self::validate_identifier(&mut id_list, &self.console.pci_common.id)?;
         self.iommu |= self.console.pci_common.iommu;
+
+        self.serial.validate()?;
 
         if let Some(t) = &self.cpus.topology {
             if t.threads_per_core == 0
@@ -5987,6 +6007,22 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             invalid_config.validate(),
             Err(ValidationError::ConsoleFileMissing)
+        );
+
+        let mut invalid_config = valid_config.clone();
+        invalid_config.serial.common.mode = ConsoleOutputMode::Socket;
+        invalid_config.serial.common.socket = None;
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::ConsoleSocketPathMissing)
+        );
+
+        let mut invalid_config = valid_config.clone();
+        invalid_config.console.common.mode = ConsoleOutputMode::Tty;
+        invalid_config.console.common.socket = Some(PathBuf::from("/tmp/console.sock"));
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::ConsoleSocketPathUnexpected)
         );
 
         let mut invalid_config = valid_config.clone();

--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -45,6 +45,14 @@ pub enum ConsoleDeviceError {
     #[error("Serial socket {0:?} is already in use by another running instance")]
     SerialSocketInUse(PathBuf),
 
+    /// The console socket is already in use by another running instance
+    #[error("Console socket {0:?} is already in use by another running instance")]
+    ConsoleSocketInUse(PathBuf),
+
+    /// Socket path missing for socket console mode
+    #[error("Socket path missing for socket console mode")]
+    MissingSocketPath,
+
     /// Error setting pty raw mode
     #[error("Error setting pty raw mode")]
     SetPtyRaw(#[source] errno::Error),
@@ -229,7 +237,27 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                 ConsoleTransport::Tty(Arc::new(stdout))
             }
             ConsoleOutputMode::Socket => {
-                return Err(ConsoleDeviceError::NoSocketOptionSupportForConsoleDevice);
+                let socket_path = vmconfig
+                    .console
+                    .common
+                    .socket
+                    .as_ref()
+                    .ok_or(ConsoleDeviceError::MissingSocketPath)?;
+                if let Some(listener) = vmm.console_socket_listener.as_ref()
+                    && listener.path() == socket_path
+                {
+                    ConsoleTransport::Socket(Arc::clone(listener))
+                } else {
+                    let listener = LockedUnixListener::bind(socket_path).map_err(|e| match e {
+                        LockedUnixListenerError::InUse(path) => {
+                            ConsoleDeviceError::ConsoleSocketInUse(path)
+                        }
+                        LockedUnixListenerError::Io(e) => {
+                            ConsoleDeviceError::CreateConsoleDevice(e)
+                        }
+                    })?;
+                    ConsoleTransport::Socket(Arc::new(listener))
+                }
             }
             ConsoleOutputMode::Null => ConsoleTransport::Null,
             ConsoleOutputMode::Off => ConsoleTransport::Off,
@@ -313,6 +341,11 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
     };
 
     vmm.serial_socket_listener = match &console_info.serial {
+        ConsoleTransport::Socket(listener) => Some(Arc::clone(listener)),
+        _ => None,
+    };
+
+    vmm.console_socket_listener = match &console_info.console {
         ConsoleTransport::Socket(listener) => Some(Arc::clone(listener)),
         _ => None,
     };

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2445,7 +2445,6 @@ impl DeviceManager {
         console_resize_pipe: Option<Arc<File>>,
         snapshot: Option<&Snapshot>,
     ) -> DeviceManagerResult<Arc<Console>> {
-        let serial_config = self.config.lock().unwrap().serial.clone();
         let Some(console_info) = console_info else {
             return Err(DeviceManagerError::InvalidConsoleInfo);
         };
@@ -2466,12 +2465,8 @@ impl DeviceManager {
                 ConsoleTransport::Pty(_)
                 | ConsoleTransport::Tty(_)
                 | ConsoleTransport::Socket(_) => {
-                    let serial_manager = SerialManager::new(
-                        serial,
-                        console_info.serial,
-                        serial_config.common.socket,
-                    )
-                    .map_err(DeviceManagerError::CreateSerialManager)?;
+                    let serial_manager = SerialManager::new(serial, console_info.serial)
+                        .map_err(DeviceManagerError::CreateSerialManager)?;
                     if let Some(mut serial_manager) = serial_manager {
                         serial_manager
                             .start_thread(

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -127,6 +127,7 @@ use crate::console_devices::{ConsoleInfo, ConsoleTransport};
 use crate::cpu::{AcpiCpuHotplugController, CPU_MANAGER_ACPI_SIZE, CpuManager};
 use crate::device_tree::{DeviceNode, DeviceTree};
 use crate::interrupt::{LegacyUserspaceInterruptManager, MsiInterruptManager};
+use crate::locked_unix_listener::LockedUnixListener;
 use crate::memory_manager::{Error as MemoryManagerError, MEMORY_MANAGER_ACPI_SIZE, MemoryManager};
 use crate::pci_segment::PciSegment;
 use crate::serial_manager::{Error as SerialManagerError, SerialManager};
@@ -481,10 +482,6 @@ pub enum DeviceManagerError {
     #[error("No support for device passthrough")]
     NoDevicePassthroughSupport,
 
-    /// No socket option support for console device
-    #[error("No socket option support for console device")]
-    NoSocketOptionSupportForConsoleDevice,
-
     /// Failed to resize virtio-balloon
     #[error("Failed to resize virtio-balloon")]
     VirtioBalloonResize(#[source] balloon::Error),
@@ -622,6 +619,7 @@ const DEVICE_MANAGER_ACPI_SIZE: usize = 0x10;
 pub struct Console {
     console_resizer: Option<Arc<virtio_devices::ConsoleResizer>>,
     resize_pipe: Option<Arc<File>>,
+    socket: Option<Arc<LockedUnixListener>>,
 }
 
 impl Console {
@@ -2374,8 +2372,13 @@ impl DeviceManager {
                     Endpoint::File(stdout)
                 }
             }
-            ConsoleTransport::Socket(_) => {
-                return Err(DeviceManagerError::NoSocketOptionSupportForConsoleDevice);
+            ConsoleTransport::Socket(listener) => {
+                let inner = listener
+                    .listener()
+                    .try_clone()
+                    .map_err(DeviceManagerError::CreateVirtioConsole)?;
+                self.console.socket = Some(listener);
+                Endpoint::Socket(Arc::new(inner))
             }
             ConsoleTransport::Null => Endpoint::Null,
             ConsoleTransport::Off => return Ok(None),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -621,6 +621,7 @@ const DEVICE_MANAGER_ACPI_SIZE: usize = 0x10;
 #[derive(Default)]
 pub struct Console {
     console_resizer: Option<Arc<virtio_devices::ConsoleResizer>>,
+    resize_pipe: Option<Arc<File>>,
 }
 
 impl Console {
@@ -917,14 +918,11 @@ pub struct DeviceManager {
     // Manage address space related to devices
     address_manager: Arc<AddressManager>,
 
-    // Console abstraction
-    console: Arc<Console>,
+    // Console
+    console: Console,
 
     // Serial Manager
     serial_manager: Option<Arc<SerialManager>>,
-
-    // pty foreground status,
-    console_resize_pipe: Option<Arc<File>>,
 
     // To restore on exit.
     original_termios_opt: Arc<Mutex<Option<termios>>>,
@@ -1320,7 +1318,7 @@ impl DeviceManager {
 
         let device_manager = DeviceManager {
             address_manager: Arc::clone(&address_manager),
-            console: Arc::new(Console::default()),
+            console: Console::default(),
             interrupt_controller: None,
             #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
             cmdline_additions: Vec::new(),
@@ -1358,7 +1356,6 @@ impl DeviceManager {
             acpi_address,
             selected_segment: 0,
             serial_manager: None,
-            console_resize_pipe: None,
             original_termios_opt: Arc::new(Mutex::new(None)),
             virtio_mem_devices: Vec::new(),
             #[cfg(target_arch = "aarch64")]
@@ -1398,7 +1395,7 @@ impl DeviceManager {
     }
 
     pub fn console_resize_pipe(&self) -> Option<Arc<File>> {
-        self.console_resize_pipe.clone()
+        self.console.resize_pipe.clone()
     }
 
     pub fn create_interrupt_controller(
@@ -1469,7 +1466,7 @@ impl DeviceManager {
 
         self.original_termios_opt = original_termios_opt;
 
-        self.console = self.add_console_devices(
+        self.add_console_devices(
             legacy_interrupt_manager.as_ref(),
             console_info,
             console_resize_pipe,
@@ -2354,12 +2351,12 @@ impl DeviceManager {
         let endpoint = match transport {
             ConsoleTransport::File(file) => Endpoint::File(file),
             ConsoleTransport::Pty(file) => {
-                self.console_resize_pipe = resize_pipe;
+                self.console.resize_pipe = resize_pipe;
                 Endpoint::PtyPair(Arc::new(file.try_clone().unwrap()), file)
             }
             ConsoleTransport::Tty(stdout) => {
                 if stdout.is_terminal() {
-                    self.console_resize_pipe = resize_pipe;
+                    self.console.resize_pipe = resize_pipe;
                 }
 
                 // If an interactive TTY then we can accept input
@@ -2396,7 +2393,8 @@ impl DeviceManager {
         let (virtio_console_device, console_resizer) = virtio_devices::Console::new(
             id.clone(),
             endpoint,
-            self.console_resize_pipe
+            self.console
+                .resize_pipe
                 .as_ref()
                 .map(|p| p.try_clone().unwrap()),
             self.force_access_platform | console_config.pci_common.iommu,
@@ -2444,7 +2442,7 @@ impl DeviceManager {
         console_info: Option<ConsoleInfo>,
         console_resize_pipe: Option<Arc<File>>,
         snapshot: Option<&Snapshot>,
-    ) -> DeviceManagerResult<Arc<Console>> {
+    ) -> DeviceManagerResult<()> {
         let Some(console_info) = console_info else {
             return Err(DeviceManagerError::InvalidConsoleInfo);
         };
@@ -2499,10 +2497,10 @@ impl DeviceManager {
             }
         }
 
-        let console_resizer =
+        self.console.console_resizer =
             self.add_virtio_console_device(console_info.console, console_resize_pipe, snapshot)?;
 
-        Ok(Arc::new(Console { console_resizer }))
+        Ok(())
     }
 
     #[cfg(not(target_arch = "riscv64"))]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -716,6 +716,7 @@ pub struct Vmm {
     console_resize_pipe: Option<Arc<File>>,
     console_info: Option<ConsoleInfo>,
     serial_socket_listener: Option<Arc<LockedUnixListener>>,
+    console_socket_listener: Option<Arc<LockedUnixListener>>,
     no_shutdown: bool,
     check_migration_evt: EventFd,
 }
@@ -949,6 +950,7 @@ impl Vmm {
             console_resize_pipe: None,
             console_info: None,
             serial_socket_listener: None,
+            console_socket_listener: None,
             no_shutdown,
             check_migration_evt,
         })
@@ -2839,6 +2841,7 @@ impl RequestHandler for Vmm {
 
         self.console_info = None;
         self.serial_socket_listener = None;
+        self.console_socket_listener = None;
         self.vm_config = None;
         event!("vm", "deleted");
 

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -5,12 +5,9 @@
 
 use std::fs::File;
 use std::io::Read;
-use std::net::Shutdown;
 use std::os::fd::OwnedFd;
 use std::os::unix::io::{AsRawFd, FromRawFd};
-use std::os::unix::net::UnixStream;
 use std::panic::AssertUnwindSafe;
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::{io, panic, result, thread, time};
@@ -22,7 +19,7 @@ use devices::legacy::Serial;
 use libc::EFD_NONBLOCK;
 use log::{error, info, warn};
 use seccompiler::{SeccompAction, apply_filter};
-use serial_buffer::{SerialBuffer, SharedSerialBuffer, SocketConsole};
+use serial_buffer::{SerialBuffer, SocketConsole};
 use thiserror::Error;
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
@@ -67,10 +64,6 @@ pub enum Error {
     /// Cannot accept connection from Unix socket
     #[error("Error accepting connection")]
     AcceptConnection(#[source] io::Error),
-
-    /// Cannot clone the UnixStream
-    #[error("Error cloning UnixStream")]
-    CloneUnixStream(#[source] io::Error),
 
     /// Cannot shutdown the connection
     #[error("Error shutting down a connection")]
@@ -130,7 +123,6 @@ impl SerialManager {
         #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))] serial: Arc<Mutex<Serial>>,
         #[cfg(target_arch = "aarch64")] serial: Arc<Mutex<Pl011>>,
         mut transport: ConsoleTransport,
-        socket: Option<PathBuf>,
     ) -> Result<Option<Self>> {
         let epoll_fd = epoll::create(true).map_err(Error::Epoll)?;
         let kill_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
@@ -142,8 +134,6 @@ impl SerialManager {
             epoll::Event::new(epoll::Events::EPOLLIN, EpollDispatch::Kill as u64),
         )
         .map_err(Error::Epoll)?;
-
-        let mut socket_path: Option<PathBuf> = None;
 
         let in_fd = match transport {
             ConsoleTransport::Pty(ref fd) => fd.as_raw_fd(),
@@ -176,12 +166,7 @@ impl SerialManager {
             ConsoleTransport::Tty(_) => {
                 return Ok(None);
             }
-            ConsoleTransport::Socket(ref listener) => {
-                if let Some(path_in_socket) = socket {
-                    socket_path = Some(path_in_socket.clone());
-                }
-                listener.as_raw_fd()
-            }
+            ConsoleTransport::Socket(ref listener) => listener.as_raw_fd(),
             _ => return Ok(None),
         };
 
@@ -215,20 +200,14 @@ impl SerialManager {
         // Install the persistent buffer as the device's sink so output produced
         // before the first client connects is captured rather than dropped.
         let mut socket_console = None;
-        if let ConsoleTransport::Socket(_) = transport
-            && socket_path.is_some()
-        {
-            let write_out = Arc::new(AtomicBool::new(false));
-            let buffer = Arc::new(Mutex::new(SerialBuffer::new(
-                Box::new(io::sink()),
-                write_out.clone(),
-            )));
+        if let ConsoleTransport::Socket(_) = transport {
+            let console = SocketConsole::new();
             serial
                 .as_ref()
                 .lock()
                 .unwrap()
-                .set_out(Some(Box::new(SharedSerialBuffer(buffer.clone()))));
-            socket_console = Some(SocketConsole { buffer, write_out });
+                .set_out(Some(console.out_sink()));
+            socket_console = Some(console);
         }
 
         // Use 'OwnedFd' to manage lifetime
@@ -290,8 +269,7 @@ impl SerialManager {
         let transport = self.transport.clone();
         let serial = self.serial.clone();
         let pty_write_out = self.pty_write_out.clone();
-        let socket_console = self.socket_console.clone();
-        let mut reader: Option<UnixStream> = None;
+        let mut socket_console = self.socket_console.take();
 
         // In case of PTY, we want to be able to detect a connection on the
         // other end of the PTY. This is done by detecting there's no event
@@ -349,49 +327,40 @@ impl SerialManager {
                                     warn!("Unknown serial manager loop event: {event}");
                                 }
                                 EpollDispatch::Socket => {
-                                    // New connection request arrived.
-                                    // Shutdown the previous connection, if any
-                                    if let Some(previous_reader) = reader {
-                                        previous_reader
-                                            .shutdown(Shutdown::Both)
-                                            .map_err(Error::AcceptConnection)?;
-                                    }
-
                                     let ConsoleTransport::Socket(ref socket) = transport else {
                                         unreachable!();
                                     };
-
-                                    // Events on the listening socket will be connection requests.
-                                    // Accept them, create a reader and a writer.
-                                    let (unix_stream, _) = socket
-                                        .listener()
-                                        .accept()
-                                        .map_err(Error::AcceptConnection)?;
-                                    // Non-blocking so a slow client can't stall
-                                    // the vCPU (SerialBuffer re-buffers on WouldBlock).
-                                    unix_stream
-                                        .set_nonblocking(true)
-                                        .map_err(Error::SetNonBlocking)?;
-                                    let writer =
-                                        unix_stream.try_clone().map_err(Error::CloneUnixStream)?;
-
-                                    epoll::ctl(
-                                        epoll_fd.as_raw_fd(),
-                                        epoll::ControlOptions::EPOLL_CTL_ADD,
-                                        unix_stream.as_raw_fd(),
-                                        epoll::Event::new(
-                                            epoll::Events::EPOLLIN,
-                                            EpollDispatch::File as u64,
-                                        ),
-                                    )
-                                    .map_err(Error::Epoll)?;
-
-                                    reader = Some(unix_stream);
-
-                                    if let Some(ref socket_console) = socket_console {
-                                        socket_console
-                                            .attach_client(writer)
-                                            .map_err(Error::FlushOutput)?;
+                                    if let Some(console) = socket_console.as_mut() {
+                                        if let Some(fd) = console.client_fd() {
+                                            epoll::ctl(
+                                                epoll_fd.as_raw_fd(),
+                                                epoll::ControlOptions::EPOLL_CTL_DEL,
+                                                fd,
+                                                epoll::Event::new(
+                                                    epoll::Events::EPOLLIN,
+                                                    EpollDispatch::File as u64,
+                                                ),
+                                            )
+                                            .map_err(Error::Epoll)?;
+                                            console
+                                                .shutdown()
+                                                .map_err(Error::ShutdownConnection)?;
+                                        }
+                                        console
+                                            .accept(socket.listener())
+                                            .map_err(Error::AcceptConnection)?;
+                                        if let Some(fd) = console.client_fd() {
+                                            epoll::ctl(
+                                                epoll_fd.as_raw_fd(),
+                                                epoll::ControlOptions::EPOLL_CTL_ADD,
+                                                fd,
+                                                epoll::Event::new(
+                                                    epoll::Events::EPOLLIN,
+                                                    EpollDispatch::File as u64,
+                                                ),
+                                            )
+                                            .map_err(Error::Epoll)?;
+                                        }
                                     }
                                 }
                                 EpollDispatch::File => {
@@ -399,35 +368,15 @@ impl SerialManager {
                                         let mut input = [0u8; 64];
                                         let count = match &transport {
                                             ConsoleTransport::Socket(_) => {
-                                                if let Some(mut serial_reader) = reader.as_ref() {
-                                                    match serial_reader.read(&mut input) {
-                                                        Ok(0) => {
-                                                            info!(
-                                                                "Remote end closed serial socket"
-                                                            );
-                                                            serial_reader
-                                                                .shutdown(Shutdown::Both)
-                                                                .map_err(
-                                                                    Error::ShutdownConnection,
-                                                                )?;
-                                                            reader = None;
-                                                            if let Some(ref socket_console) =
-                                                                socket_console
-                                                            {
-                                                                socket_console.detach_client();
-                                                            }
-                                                            0
-                                                        }
+                                                if let Some(console) = socket_console.as_mut() {
+                                                    match console.read(&mut input) {
                                                         Ok(count) => count,
-                                                        // Non-blocking socket with no pending
-                                                        // input on this wakeup: nothing to do.
-                                                        Err(e)
-                                                            if e.kind()
-                                                                == io::ErrorKind::WouldBlock =>
-                                                        {
+                                                        Err(e) => {
+                                                            warn!(
+                                                                "Failed to read serial socket input: {e}"
+                                                            );
                                                             0
                                                         }
-                                                        Err(e) => return Err(Error::ReadInput(e)),
                                                     }
                                                 } else {
                                                     0

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -4,7 +4,7 @@
 //
 
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Read;
 use std::net::Shutdown;
 use std::os::fd::OwnedFd;
 use std::os::unix::io::{AsRawFd, FromRawFd};
@@ -22,7 +22,7 @@ use devices::legacy::Serial;
 use libc::EFD_NONBLOCK;
 use log::{error, info, warn};
 use seccompiler::{SeccompAction, apply_filter};
-use serial_buffer::SerialBuffer;
+use serial_buffer::{SerialBuffer, SharedSerialBuffer, SocketConsole};
 use thiserror::Error;
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
@@ -123,42 +123,6 @@ pub(crate) struct SerialManager {
     handle: Option<thread::JoinHandle<()>>,
     pty_write_out: Option<Arc<AtomicBool>>,
     socket_console: Option<SocketConsole>,
-}
-
-/// A `Write` handle so the serial device and the serial-manager thread can
-/// share one `SerialBuffer` (the device holds it as its output sink).
-struct SharedSerialBuffer(Arc<Mutex<SerialBuffer>>);
-
-impl Write for SharedSerialBuffer {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().write(buf)
-    }
-    fn flush(&mut self) -> io::Result<()> {
-        self.0.lock().unwrap().flush()
-    }
-}
-
-#[derive(Clone)]
-struct SocketConsole {
-    /// Persistent ring buffer: captures serial output while no client is
-    /// connected and replays it on connect. Shared with the serial device's
-    /// `out` sink and retargeted by the epoll thread.
-    buffer: Arc<Mutex<SerialBuffer>>,
-    write_out: Arc<AtomicBool>,
-}
-
-impl SocketConsole {
-    fn attach_client(&self, writer: UnixStream) -> Result<()> {
-        let mut buffer = self.buffer.lock().unwrap();
-        buffer.set_out(Box::new(writer));
-        self.write_out.store(true, Ordering::Release);
-        buffer.flush().map_err(Error::FlushOutput)
-    }
-
-    fn detach_client(&self) {
-        self.write_out.store(false, Ordering::Release);
-        self.buffer.lock().unwrap().set_out(Box::new(io::sink()));
-    }
 }
 
 impl SerialManager {
@@ -425,7 +389,9 @@ impl SerialManager {
                                     reader = Some(unix_stream);
 
                                     if let Some(ref socket_console) = socket_console {
-                                        socket_console.attach_client(writer)?;
+                                        socket_console
+                                            .attach_client(writer)
+                                            .map_err(Error::FlushOutput)?;
                                     }
                                 }
                                 EpollDispatch::File => {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -712,7 +712,7 @@ pub struct ConsoleConfig {
 }
 
 impl ConsoleConfig {
-    pub const SYNTAX: &str = "Control (virtio) console: \"off|null|pty|tty|file=<path>,iommu=on|off,id=<device_id>,pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
+    pub const SYNTAX: &str = "Control (virtio) console: \"off|null|pty|tty|file=<path>|socket=<path>,iommu=on|off,id=<device_id>,pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
 }
 
 impl Default for ConsoleConfig {


### PR DESCRIPTION
The serial device can be exposed over a Unix socket, but the virtio console cannot. This PR gives the console the same socket backend the serial path uses, driven from one shared implementation.

It is preparation work for the TCP transport implementation. It unifies serial and console on a shared backend and adds console socket support.

Ref: #8633