### PR TITLE
block: vhdx: use a proper error type for write errors

### DIFF
--- a/block/src/formats/vhdx/io.rs
+++ b/block/src/formats/vhdx/io.rs
@@ -31,6 +31,8 @@ pub enum VhdxIoError {
     UnsupportedMode,
     #[error("Failed writing BAT to file {0}")]
     WriteBat(#[source] VhdxBatError),
+    #[error("Failed writing sector blocks from file {0}")]
+    WriteSectorBlock(#[source] io::Error),
 }
 
 pub(super) type Result<T> = result::Result<T, VhdxIoError>;
@@ -201,7 +203,7 @@ pub(super) fn write(
                     &buf[write_count..(write_count + sector.free_bytes as usize)],
                     file_offset,
                 )
-                .map_err(VhdxIoError::ReadSectorBlock)?;
+                .map_err(VhdxIoError::WriteSectorBlock)?;
             }
             bat::PAYLOAD_BLOCK_FULLY_PRESENT => {
                 if sector.file_offset < metadata::BLOCK_SIZE_MIN as u64 {
@@ -212,7 +214,7 @@ pub(super) fn write(
                     &buf[write_count..(write_count + sector.free_bytes as usize)],
                     sector.file_offset,
                 )
-                .map_err(VhdxIoError::ReadSectorBlock)?;
+                .map_err(VhdxIoError::WriteSectorBlock)?;
             }
             bat::PAYLOAD_BLOCK_PARTIALLY_PRESENT => {
                 return Err(VhdxIoError::UnsupportedMode);


### PR DESCRIPTION
The write function shouldn't return a ReadSectorBlock error. Introduce an error type for write.

Found this as I went through the code.