### PR TITLE
block: vmdk: Propagate caller's readonly request to per-extent access.

### DIFF
--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -223,7 +223,8 @@ fn open_flat_vmdk(
 ) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
     info!("Opening VMDK disk file with synchronous backend");
     Ok(Box::new(
-        VmdkDisk::new(file, options.path, options.direct).map_err(|e| e.with_path(options.path))?,
+        VmdkDisk::new(file, options.path, options.readonly, options.direct)
+            .map_err(|e| e.with_path(options.path))?,
     ))
 }
 

--- a/block/src/formats/vmdk/descriptor.rs
+++ b/block/src/formats/vmdk/descriptor.rs
@@ -12,7 +12,7 @@ use std::fs::File;
 use std::io;
 use std::os::unix::fs::FileExt;
 use std::path::Path;
-use std::str::Lines;
+use std::str::{FromStr, Lines};
 
 use crate::AlignedFile;
 
@@ -30,12 +30,39 @@ pub enum VMDKDiskType {
     TwoGbMaxExtentFlat,
 }
 
+/// Extents Access Mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExtentAccess {
+    /// "RW": readable and writable.
+    ReadWrite,
+    /// "RDONLY": readable only, writes must be rejected.
+    ReadOnly,
+    /// "NOACCESS": cannot be accessed, reads and writes must be rejected.
+    NoAccess,
+}
+
+impl FromStr for ExtentAccess {
+    type Err = io::Error;
+
+    fn from_str(token: &str) -> Result<Self, Self::Err> {
+        match token {
+            "RW" => Ok(Self::ReadWrite),
+            "RDONLY" => Ok(Self::ReadOnly),
+            "NOACCESS" => Ok(Self::NoAccess),
+            other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported VMDK extent access mode '{other}'"),
+            )),
+        }
+    }
+}
+
 /// Flat VMDK extent line fields.
 /// Format of each extent line:
 /// `<access> <sectors> <type> "<file>" [offset]`.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct VmdkExtentHeader {
-    pub access: String,
+    pub access: ExtentAccess,
     pub size_in_sectors: u64,
     pub extent_type: String,
     pub filename: String,
@@ -207,7 +234,7 @@ pub(crate) fn parse_extents(
                 None => 0,
             };
             extents.extents.push(VmdkExtentHeader {
-                access: parts[0].to_string(),
+                access: parts[0].parse::<ExtentAccess>()?,
                 size_in_sectors,
                 extent_type: parts[2].to_string(),
                 filename: parts[3].trim_matches('"').to_string(),
@@ -336,7 +363,7 @@ mod tests {
 
         assert_eq!(extents.extents.len(), 1);
         let e = &extents.extents[0];
-        assert_eq!(e.access, "RW");
+        assert_eq!(e.access, ExtentAccess::ReadWrite);
         assert_eq!(e.size_in_sectors, 2_097_152);
         assert_eq!(e.extent_type, "FLAT");
         assert_eq!(e.filename, "disk-flat.vmdk");
@@ -377,8 +404,8 @@ mod tests {
         let extents = parse_body("# Extent description", body).unwrap();
 
         assert_eq!(extents.extents.len(), 2);
-        assert_eq!(extents.extents[0].access, "RDONLY");
-        assert_eq!(extents.extents[1].access, "NOACCESS");
+        assert_eq!(extents.extents[0].access, ExtentAccess::ReadOnly);
+        assert_eq!(extents.extents[1].access, ExtentAccess::NoAccess);
     }
 
     #[test]
@@ -392,6 +419,13 @@ mod tests {
     fn rejects_malformed_extent_line() {
         // Only three fields -> malformed.
         let body: &str = "RW 2097152 FLAT\n";
+        parse_body("# Extent description", body).unwrap_err();
+    }
+
+    #[test]
+    fn rejects_unsupported_access_mode() {
+        // Access must be one of RW / RDONLY / NOACCESS.
+        let body: &str = "BOGUS 2097152 FLAT \"disk-flat.vmdk\"\n";
         parse_body("# Extent description", body).unwrap_err();
     }
 
@@ -477,7 +511,7 @@ mod tests {
 
         assert!(matches!(header.create_type, VMDKDiskType::MonolithicFlat));
         assert_eq!(extents.extents.len(), 1);
-        assert_eq!(extents.extents[0].access, "RW");
+        assert_eq!(extents.extents[0].access, ExtentAccess::ReadWrite);
     }
 
     #[test]
@@ -523,7 +557,7 @@ mod tests {
 
         assert!(matches!(header.create_type, VMDKDiskType::MonolithicFlat));
         assert_eq!(extents.extents.len(), 1);
-        assert_eq!(extents.extents[0].access, "RW");
+        assert_eq!(extents.extents[0].access, ExtentAccess::ReadWrite);
         assert_eq!(extents.extents[0].size_in_sectors, 6_291_456);
         assert_eq!(extents.extents[0].extent_type, "FLAT");
         assert_eq!(extents.extents[0].filename, "t-flat.vmdk");

--- a/block/src/formats/vmdk/engine_sync.rs
+++ b/block/src/formats/vmdk/engine_sync.rs
@@ -12,7 +12,8 @@ use crate::AlignedFile;
 use crate::async_io::{
     AsyncIo, AsyncIoCompletion, AsyncIoError, AsyncIoOperation, AsyncIoResult, CompletionCommon,
 };
-use crate::formats::vmdk::flat::{ExtentAccess, VmdkExtent};
+use crate::formats::vmdk::descriptor::ExtentAccess;
+use crate::formats::vmdk::flat::VmdkExtent;
 
 /// Synchronous, extent-aware I/O worker for flat VMDK images.
 ///

--- a/block/src/formats/vmdk/flat.rs
+++ b/block/src/formats/vmdk/flat.rs
@@ -16,20 +16,10 @@ use std::sync::Arc;
 
 use log::warn;
 
-use crate::formats::vmdk::descriptor::VmdkDescriptor;
+use crate::formats::vmdk::descriptor::{ExtentAccess, VmdkDescriptor};
 use crate::{AlignedFile, DiskTopology, query_device_size};
 
 const VMDK_SECTOR_SIZE: u64 = 512;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ExtentAccess {
-    /// "RW": readable and writable.
-    ReadWrite,
-    /// "RDONLY": readable only, writes must be rejected.
-    ReadOnly,
-    /// "NOACCESS": cannot be accessed, reads and writes must be rejected.
-    NoAccess,
-}
 
 /// A single Flat VMDK extent
 ///
@@ -293,27 +283,25 @@ impl FlatVmdk {
             //   "RW"       -> read + write
             //   "RDONLY"   -> read only
             //   "NOACCESS" -> not accessible, do not open the file at all
-            let (access, extent_file) = match extent.access.as_str() {
-                "RW" => {
-                    let f = open_extent(&descriptor.base_path, &extent.filename, true, direct)?;
-                    (ExtentAccess::ReadWrite, Some(f))
-                }
-                "RDONLY" => {
-                    let f = open_extent(&descriptor.base_path, &extent.filename, false, direct)?;
-                    (ExtentAccess::ReadOnly, Some(f))
-                }
-                "NOACCESS" => (ExtentAccess::NoAccess, None),
-                other => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("unsupported VMDK extent access mode '{other}'"),
-                    ));
-                }
+            let extent_file = match extent.access {
+                ExtentAccess::ReadWrite => Some(open_extent(
+                    &descriptor.base_path,
+                    &extent.filename,
+                    true,
+                    direct,
+                )?),
+                ExtentAccess::ReadOnly => Some(open_extent(
+                    &descriptor.base_path,
+                    &extent.filename,
+                    false,
+                    direct,
+                )?),
+                ExtentAccess::NoAccess => None,
             };
 
             extents.push(VmdkExtent {
                 file: extent_file,
-                access,
+                access: extent.access,
                 virtual_start,
                 length,
                 file_base_offset,

--- a/block/src/formats/vmdk/flat.rs
+++ b/block/src/formats/vmdk/flat.rs
@@ -240,7 +240,7 @@ fn overflow_error(what: &str) -> io::Error {
 
 impl FlatVmdk {
     /// Opens a flat VMDK image from its already-open descriptor file.
-    pub fn new(file: File, path: &Path, direct: bool) -> io::Result<Self> {
+    pub fn new(file: File, path: &Path, readonly: bool, direct: bool) -> io::Result<Self> {
         let descriptor = VmdkDescriptor::new(&file, path)?;
 
         if descriptor.extents_list.extents.is_empty() {
@@ -278,12 +278,14 @@ impl FlatVmdk {
                 .checked_add(length)
                 .ok_or_else(|| overflow_error("extent file range"))?;
 
-            // Open the backing file using exactly the access declared for this
-            // extent. The VMDK spec defines three values:
-            //   "RW"       -> read + write
-            //   "RDONLY"   -> read only
-            //   "NOACCESS" -> not accessible, do not open the file at all
-            let extent_file = match extent.access {
+            // Downgrade "RW" to read-only if the caller requested a read-only open.
+            let access = if readonly && matches!(extent.access, ExtentAccess::ReadWrite) {
+                ExtentAccess::ReadOnly
+            } else {
+                extent.access
+            };
+
+            let extent_file = match access {
                 ExtentAccess::ReadWrite => Some(open_extent(
                     &descriptor.base_path,
                     &extent.filename,
@@ -301,7 +303,7 @@ impl FlatVmdk {
 
             extents.push(VmdkExtent {
                 file: extent_file,
-                access: extent.access,
+                access,
                 virtual_start,
                 length,
                 file_base_offset,

--- a/block/src/formats/vmdk/mod.rs
+++ b/block/src/formats/vmdk/mod.rs
@@ -31,8 +31,8 @@ pub struct VmdkDisk {
 
 impl VmdkDisk {
     /// Builds a Flat VMDK disk backend.
-    pub fn new(file: File, path: &Path, direct: bool) -> Result<Self, BlockError> {
-        let inner = FlatVmdk::new(file, path, direct)?;
+    pub fn new(file: File, path: &Path, readonly: bool, direct: bool) -> Result<Self, BlockError> {
+        let inner = FlatVmdk::new(file, path, readonly, direct)?;
         Ok(VmdkDisk { inner })
     }
 }
@@ -110,6 +110,7 @@ mod tests {
     use super::*;
     use crate::async_io::OwnedIoBuffer;
     use crate::disk_file::{AsyncDiskFile, DiskFd, DiskSize, PhysicalSize, Resizable};
+    use crate::formats::vmdk::descriptor::ExtentAccess;
 
     const SECTOR: u64 = 512;
 
@@ -205,7 +206,7 @@ mod tests {
             "monolithicFlat",
             &[("disk-flat.vmdk", "RW", 2048)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         assert_eq!(disk.logical_size().unwrap(), 2048 * SECTOR);
         // The extent is created sparse (`set_len`), so no blocks are allocated
@@ -221,7 +222,7 @@ mod tests {
             "twoGbMaxExtentFlat",
             &[("s001.vmdk", "RW", 2048), ("s002.vmdk", "RW", 1024)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         assert_eq!(disk.logical_size().unwrap(), (2048 + 1024) * SECTOR);
         // Sparse extents: no blocks are allocated, so physical size is 0.
@@ -236,7 +237,7 @@ mod tests {
             "twoGbMaxExtentFlat",
             &[("s001.vmdk", "RW", 2048), ("s002.vmdk", "RW", 1024)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         // Fully pre-allocated extents: host allocation (st_blocks) equals the
         // declared logical size.
@@ -255,7 +256,7 @@ mod tests {
         let file = open_descriptor(&path);
         let expected = file.as_raw_fd();
 
-        let disk = VmdkDisk::new(file, &path, false).unwrap();
+        let disk = VmdkDisk::new(file, &path, false, false).unwrap();
 
         assert_eq!(disk.fd().as_raw_fd(), expected);
     }
@@ -276,13 +277,77 @@ mod tests {
             .write(true)
             .open(&path)
             .unwrap();
-        let disk = VmdkDisk::new(file, &path, false).unwrap();
+        let disk = VmdkDisk::new(file, &path, false, false).unwrap();
         let mut io = disk.create_async_io(1).unwrap();
 
         let buffer = OwnedIoBuffer::from_vec(vec![0u8; 512]);
         let result = io.read_to_vec(u64::MAX as libc::off_t, buffer, 0);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn readonly_open_downgrades_rw_extent() {
+        // The caller asked for a read-only disk, so the "RW" extent must be
+        // opened without write access even though the descriptor allows it.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-ro-test").unwrap();
+        let path = write_flat_vmdk_allocated(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RW", 8)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, true, false).unwrap();
+
+        let extents = disk.inner.extents();
+        assert_eq!(extents.len(), 1);
+        assert_eq!(extents[0].access, ExtentAccess::ReadOnly);
+        assert!(
+            !extents[0].file.as_ref().unwrap().is_writable(),
+            "extent fd must not carry write access for a readonly open"
+        );
+
+        // And a write through the disk is refused rather than silently
+        // reaching the host file.
+        let mut io = disk.create_async_io(1).unwrap();
+        let buffer = OwnedIoBuffer::from_vec(vec![0xAAu8; 512]);
+        assert!(io.write_from_vec(0, buffer, 0).is_err());
+    }
+
+    #[test]
+    fn writable_open_keeps_rw_extent_writable() {
+        // Without a readonly request the descriptor's "RW" is honoured.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-rw-test").unwrap();
+        let path = write_flat_vmdk_allocated(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RW", 8)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
+
+        let extents = disk.inner.extents();
+        assert_eq!(extents[0].access, ExtentAccess::ReadWrite);
+        assert!(extents[0].file.as_ref().unwrap().is_writable());
+    }
+
+    #[test]
+    fn descriptor_rdonly_extent_stays_readonly_for_writable_open() {
+        // A descriptor-declared RDONLY extent stays read-only even when the
+        // caller did not ask for a readonly disk.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-rdonly-test").unwrap();
+        let path = write_flat_vmdk_allocated(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RDONLY", 8)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
+
+        let extents = disk.inner.extents();
+        assert_eq!(extents[0].access, ExtentAccess::ReadOnly);
+        assert!(!extents[0].file.as_ref().unwrap().is_writable());
+
+        let mut io = disk.create_async_io(1).unwrap();
+        let buffer = OwnedIoBuffer::from_vec(vec![0xAAu8; 512]);
+        assert!(io.write_from_vec(0, buffer, 0).is_err());
     }
 
     #[test]
@@ -293,7 +358,7 @@ mod tests {
             "monolithicFlat",
             &[("disk-flat.vmdk", "RW", 64)],
         );
-        let mut disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let mut disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         let err = disk.resize(4096).unwrap_err();
         assert_eq!(err.kind(), BlockErrorKind::UnsupportedFeature);
@@ -307,7 +372,7 @@ mod tests {
             "monolithicFlat",
             &[("disk-flat.vmdk", "RW", 2048)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         let cloned = disk.try_clone().unwrap();
         assert_eq!(cloned.logical_size().unwrap(), disk.logical_size().unwrap());
@@ -321,7 +386,7 @@ mod tests {
             "monolithicFlat",
             &[("disk-flat.vmdk", "RW", 2048)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         // Ring depth is ignored by the synchronous VMDK worker.
         disk.create_async_io(0).unwrap();
@@ -335,7 +400,7 @@ mod tests {
             "twoGbMaxExtentFlat",
             &[("s001.vmdk", "RW", 2048), ("s002.vmdk", "RW", 2048)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         disk.create_async_io(32).unwrap();
     }
@@ -349,7 +414,7 @@ mod tests {
             &["RW 0 FLAT \"disk-flat.vmdk\""],
         );
 
-        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
@@ -360,7 +425,7 @@ mod tests {
         let line = format!("RW {} FLAT \"disk-flat.vmdk\"", u64::MAX);
         let path = write_descriptor(dir.as_path(), "monolithicFlat", &[line.as_str()]);
 
-        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
@@ -371,7 +436,7 @@ mod tests {
         let line = format!("RW 1 FLAT \"disk-flat.vmdk\" {}", u64::MAX);
         let path = write_descriptor(dir.as_path(), "monolithicFlat", &[line.as_str()]);
 
-        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
@@ -386,7 +451,7 @@ mod tests {
         let line = format!("RW 1 FLAT \"disk-flat.vmdk\" {offset}");
         let path = write_descriptor(dir.as_path(), "monolithicFlat", &[line.as_str()]);
 
-        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
@@ -405,7 +470,7 @@ mod tests {
             &[l1.as_str(), l2.as_str()],
         );
 
-        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 }


### PR DESCRIPTION
Passes the `DiskConfig::readonly` config to correctly set the per-extent access on top of individual access set in per-extent section line in the descriptor text file.

Fixes: #8690 found by fuzzing.
