### PR TITLE
vmm: switch to UFFDIO_CONTINUE for on-demand restores over a socket memory source

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -945,16 +945,22 @@ impl MemoryManager {
         exit_evt: &EventFd,
     ) -> Result<(), Error> {
         let mut file_offset: u64 = 0;
-        let Some((uffd_fd, ranges)) = self.prepare_uffd(saved_regions, |r| {
-            let o = file_offset;
-            file_offset += r.length;
-            o
-        })?
+
+        let snapshot_file = File::open(file_path).map_err(Error::SnapshotOpen)?;
+        let source: Box<dyn UffdMemorySource> = Box::new(FileUffdMemorySource::new(snapshot_file));
+
+        let Some((uffd_fd, ranges)) = self.prepare_uffd(
+            saved_regions,
+            |r| {
+                let o = file_offset;
+                file_offset += r.length;
+                o
+            },
+            source.requires_uffd_minor_mode(),
+        )?
         else {
             return Ok(());
         };
-        let snapshot_file = File::open(file_path).map_err(Error::SnapshotOpen)?;
-        let source: Box<dyn UffdMemorySource> = Box::new(FileUffdMemorySource::new(snapshot_file));
         self.spawn_uffd_handler(uffd_fd, None, ranges, source, exit_evt)?;
         info!("UFFD restore: demand-paged restore enabled");
         Ok(())
@@ -969,10 +975,6 @@ impl MemoryManager {
         socket: SocketStream,
         exit_evt: &EventFd,
     ) -> Result<(), Error> {
-        // PageFault uses the GPA as the page identifier on the wire.
-        let Some((uffd_fd, ranges)) = self.prepare_uffd(saved_regions, |r| r.gpa)? else {
-            return Ok(());
-        };
         // Make every fault a small request/response round-trip.
         socket.set_nodelay(true).map_err(UffdError::SetSocket)?;
         let socket_fd = socket
@@ -981,6 +983,14 @@ impl MemoryManager {
             .map_err(UffdError::SetSocket)?;
         let source: Box<dyn UffdMemorySource> =
             Box::new(SocketUffdMemorySource::new(socket, shared_backing));
+
+        // PageFault uses the GPA as the page identifier on the wire.
+        let Some((uffd_fd, ranges)) =
+            self.prepare_uffd(saved_regions, |r| r.gpa, source.requires_uffd_minor_mode())?
+        else {
+            return Ok(());
+        };
+
         self.spawn_uffd_handler(uffd_fd, Some(socket_fd), ranges, source, exit_evt)
     }
 
@@ -989,6 +999,7 @@ impl MemoryManager {
         &mut self,
         saved_regions: &MemoryRangeTable,
         mut source_offset_for: F,
+        uffd_requires_minor_mode: bool,
     ) -> Result<Option<(OwnedFd, Vec<UffdRange>)>, Error>
     where
         F: FnMut(&MemoryRange) -> u64,
@@ -998,7 +1009,7 @@ impl MemoryManager {
         }
 
         let guest_memory = self.guest_memory.memory();
-        let required_uffd_features = self.required_uffd_features();
+        let required_uffd_features = self.required_uffd_features(uffd_requires_minor_mode);
 
         // SAFETY: FFI call. Trivially safe.
         let base_page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
@@ -1028,17 +1039,25 @@ impl MemoryManager {
                     source: e,
                 })? as u64;
 
-            let ioctls = uffd::register(uffd_fd.as_fd(), host_addr, range.length).map_err(|e| {
-                UffdError::Register {
-                    addr: host_addr,
-                    len: range.length,
-                    source: e,
-                }
+            let ioctls = uffd::register(
+                uffd_fd.as_fd(),
+                host_addr,
+                range.length,
+                uffd_requires_minor_mode,
+            )
+            .map_err(|e| UffdError::Register {
+                addr: host_addr,
+                len: range.length,
+                source: e,
             })?;
 
-            if ioctls & userfaultfd::UFFD_API_RANGE_IOCTLS_BASIC
-                != userfaultfd::UFFD_API_RANGE_IOCTLS_BASIC
-            {
+            let required_ioctls = if uffd_requires_minor_mode {
+                userfaultfd::UFFD_API_RANGE_IOCTLS_MINOR
+            } else {
+                userfaultfd::UFFD_API_RANGE_IOCTLS_BASIC
+            };
+
+            if ioctls & required_ioctls != required_ioctls {
                 return Err(UffdError::MissingIoctlSupport {
                     addr: host_addr,
                     len: range.length,
@@ -1134,13 +1153,19 @@ impl MemoryManager {
         Ok(())
     }
 
-    fn required_uffd_features(&self) -> u64 {
+    fn required_uffd_features(&self, uffd_requires_minor_mode: bool) -> u64 {
         let mut features = 0u64;
         if self.memory_zones.values().any(|z| z.shared || !z.hugepages) {
             features |= userfaultfd::UFFD_FEATURE_MISSING_SHMEM;
+            if uffd_requires_minor_mode {
+                features |= userfaultfd::UFFD_FEATURE_MINOR_SHMEM;
+            }
         }
         if self.memory_zones.values().any(|z| z.hugepages) {
             features |= userfaultfd::UFFD_FEATURE_MISSING_HUGETLBFS;
+            if uffd_requires_minor_mode {
+                features |= userfaultfd::UFFD_FEATURE_MINOR_HUGETLBFS;
+            }
         }
         features
     }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -28,7 +28,7 @@ use vhost::vhost_kern::vhost_binding::{
 };
 
 use crate::userfaultfd::{
-    UFFDIO_API, UFFDIO_COPY, UFFDIO_REGISTER, UFFDIO_WAKE, USERFAULTFD_IOC_NEW,
+    UFFDIO_API, UFFDIO_CONTINUE, UFFDIO_COPY, UFFDIO_REGISTER, UFFDIO_WAKE, USERFAULTFD_IOC_NEW,
 };
 
 #[derive(Copy, Clone)]
@@ -436,6 +436,7 @@ fn create_vmm_ioctl_seccomp_rule_common(
         and![Cond::new(1, ArgLen::Dword, Eq, UFFDIO_COPY)?],
         and![Cond::new(1, ArgLen::Dword, Eq, UFFDIO_REGISTER)?],
         and![Cond::new(1, ArgLen::Dword, Eq, UFFDIO_WAKE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, UFFDIO_CONTINUE)?],
         and![Cond::new(1, ArgLen::Dword, Eq, USERFAULTFD_IOC_NEW)?],
     ];
 

--- a/vmm/src/uffd.rs
+++ b/vmm/src/uffd.rs
@@ -141,11 +141,22 @@ pub(crate) fn create(required_features: u64) -> Result<OwnedFd, Error> {
 }
 
 /// Register a memory range for missing-page fault handling.
-pub(crate) fn register(fd: BorrowedFd<'_>, addr: u64, len: u64) -> Result<u64, Error> {
+pub(crate) fn register(
+    fd: BorrowedFd<'_>,
+    addr: u64,
+    len: u64,
+    uffd_requires_minor_mode: bool,
+) -> Result<u64, Error> {
+    let mode = if uffd_requires_minor_mode {
+        userfaultfd::UFFDIO_REGISTER_MODE_MISSING | userfaultfd::UFFDIO_REGISTER_MODE_MINOR
+    } else {
+        userfaultfd::UFFDIO_REGISTER_MODE_MISSING
+    };
+
     let mut reg = UffdioRegister {
         range_start: addr,
         range_len: len,
-        mode: userfaultfd::UFFDIO_REGISTER_MODE_MISSING,
+        mode,
         ioctls: 0,
     };
     // SAFETY: `reg` is a valid, correctly-sized struct for this ioctl.
@@ -258,6 +269,8 @@ pub(crate) trait UffdMemorySource: Send {
         range: &UffdRange,
         page_idx: u64,
     ) -> Result<FaultResolution, io::Error>;
+
+    fn requires_uffd_minor_mode(&self) -> bool;
 }
 
 /// Source that reads pages from a local snapshot file.
@@ -304,6 +317,10 @@ impl UffdMemorySource for FileUffdMemorySource {
             Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => Ok(FaultResolution::Retry),
             Err(e) => Err(e),
         }
+    }
+
+    fn requires_uffd_minor_mode(&self) -> bool {
+        false
     }
 }
 
@@ -362,8 +379,15 @@ impl UffdMemorySource for SocketUffdMemorySource {
                     "shared-backing PageFault response carried {resp_len} unexpected bytes",
                 )));
             }
-            match wake(uffd_fd, page_addr, page_size) {
+            match uffd_continue(uffd_fd, page_addr, page_size) {
                 Ok(()) => Ok(FaultResolution::Served),
+                // This is fine, someone mapped the page before us.
+                Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
+                    if let Err(e) = wake(uffd_fd, page_addr, page_size) {
+                        log::warn!("UFFDIO_WAKE failed at {page_addr:#x}: {e}");
+                    }
+                    Ok(FaultResolution::Served)
+                }
                 Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => Ok(FaultResolution::Retry),
                 Err(e) => Err(e),
             }
@@ -390,6 +414,10 @@ impl UffdMemorySource for SocketUffdMemorySource {
                 Err(e) => Err(e),
             }
         }
+    }
+
+    fn requires_uffd_minor_mode(&self) -> bool {
+        self.shared_backing
     }
 }
 

--- a/vmm/src/uffd.rs
+++ b/vmm/src/uffd.rs
@@ -48,6 +48,14 @@ pub(crate) struct UffdioCopy {
     pub copy: i64,
 }
 
+#[repr(C)]
+pub(crate) struct UffdioContinue {
+    pub range_start: u64,
+    pub range_len: u64,
+    pub mode: u64,
+    pub mapped: i64,
+}
+
 /// Flat representation of `struct uffd_msg` (32 bytes).
 ///
 /// The kernel struct contains an 8-byte header followed by a 24-byte
@@ -169,6 +177,28 @@ pub(crate) fn copy(fd: BorrowedFd<'_>, dst: u64, src: *const u8, len: u64) -> Re
             fd.as_raw_fd(),
             userfaultfd::UFFDIO_COPY as libc::Ioctl,
             &mut cp,
+        )
+    };
+    if ret < 0 {
+        return Err(Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Resolves a minor page fault by installing PTEs for a range.
+pub(crate) fn uffd_continue(fd: BorrowedFd<'_>, dst: u64, len: u64) -> Result<(), Error> {
+    let mut cont = UffdioContinue {
+        range_start: dst,
+        range_len: len,
+        mode: 0,
+        mapped: 0,
+    };
+    // SAFETY: `cont` is a valid, correctly-sized struct for this ioctl.
+    let ret = unsafe {
+        libc::ioctl(
+            fd.as_raw_fd(),
+            userfaultfd::UFFDIO_CONTINUE as libc::Ioctl,
+            &mut cont,
         )
     };
     if ret < 0 {
@@ -376,9 +406,9 @@ fn io_other<E: fmt::Display>(e: E) -> io::Error {
 
 /// Wake threads waiting on a fault in the given range without copying data.
 ///
-/// Needed after UFFDIO_COPY returns EEXIST: the page was already resolved
-/// by a concurrent fault, but any additional threads blocked on that page
-/// may not have been woken.
+/// Needed after UFFDIO_COPY or UFFDIO_CONTINUE returns EEXIST: the page was
+/// already resolved by a concurrent fault, but any additional threads blocked
+/// on that page may not have been woken.
 pub(crate) fn wake(fd: BorrowedFd<'_>, addr: u64, len: u64) -> Result<(), Error> {
     let mut range = UffdioRange { start: addr, len };
     // SAFETY: `range` is a valid, correctly-sized struct for this ioctl.

--- a/vmm/src/userfaultfd.rs
+++ b/vmm/src/userfaultfd.rs
@@ -7,6 +7,7 @@ pub const UFFDIO_API: u64 = 0xc018_aa3f; // _IOWR(0xAA, 0x3F, struct uffdio_api)
 pub const UFFDIO_REGISTER: u64 = 0xc020_aa00; // _IOWR(0xAA, 0x00, struct uffdio_register)
 pub const UFFDIO_COPY: u64 = 0xc028_aa03; // _IOWR(0xAA, 0x03, struct uffdio_copy)
 pub const UFFDIO_WAKE: u64 = 0x8010_aa02; // _IOR(0xAA, 0x02, struct uffdio_range)
+pub const UFFDIO_CONTINUE: u64 = 0xc020_aa07; // _IOWR(0xAA, 0x07, struct uffdio_continue)
 
 // Validate ioctl encoding against the _IO{R,W,WR}(type, nr, size) formula so
 // transposed direction bits or sizes are caught at compile time.
@@ -19,12 +20,14 @@ const _: () = assert!(UFFDIO_API == ioctl_ioc(IOC_READWRITE, 0xAA, 0x3F, 24));
 const _: () = assert!(UFFDIO_REGISTER == ioctl_ioc(IOC_READWRITE, 0xAA, 0x00, 32));
 const _: () = assert!(UFFDIO_COPY == ioctl_ioc(IOC_READWRITE, 0xAA, 0x03, 40));
 const _: () = assert!(UFFDIO_WAKE == ioctl_ioc(IOC_READ, 0xAA, 0x02, 16));
+const _: () = assert!(UFFDIO_CONTINUE == ioctl_ioc(IOC_READWRITE, 0xAA, 0x07, 32));
 
 // Seccomp compares these as Dword (u32); ensure they fit.
 const _: () = assert!(UFFDIO_API <= u32::MAX as u64);
 const _: () = assert!(UFFDIO_REGISTER <= u32::MAX as u64);
 const _: () = assert!(UFFDIO_COPY <= u32::MAX as u64);
 const _: () = assert!(UFFDIO_WAKE <= u32::MAX as u64);
+const _: () = assert!(UFFDIO_CONTINUE <= u32::MAX as u64);
 
 // /dev/userfaultfd ioctl: _IO(0xAA, 0x00)
 pub const USERFAULTFD_IOC_NEW: u64 = 0x0000_AA00;
@@ -33,10 +36,15 @@ const _: () = assert!(USERFAULTFD_IOC_NEW <= u32::MAX as u64);
 
 pub const UFFD_API: u64 = 0xAA;
 pub const UFFDIO_REGISTER_MODE_MISSING: u64 = 1;
+pub const UFFDIO_REGISTER_MODE_MINOR: u64 = 1 << 2;
 pub const UFFD_EVENT_PAGEFAULT: u8 = 0x12;
 pub const UFFD_FEATURE_MISSING_HUGETLBFS: u64 = 1 << 4;
 pub const UFFD_FEATURE_MISSING_SHMEM: u64 = 1 << 5;
+pub const UFFD_FEATURE_MINOR_HUGETLBFS: u64 = 1 << 9;
+pub const UFFD_FEATURE_MINOR_SHMEM: u64 = 1 << 10;
 
 const _UFFDIO_COPY: u64 = 0x03;
 const _UFFDIO_WAKE: u64 = 0x02;
+const _UFFDIO_CONTINUE: u64 = 0x07;
 pub const UFFD_API_RANGE_IOCTLS_BASIC: u64 = (1 << _UFFDIO_WAKE) | (1 << _UFFDIO_COPY);
+pub const UFFD_API_RANGE_IOCTLS_MINOR: u64 = UFFD_API_RANGE_IOCTLS_BASIC | (1 << _UFFDIO_CONTINUE);


### PR DESCRIPTION
Fixes a bug where the guest would triple fault during on-demand restore with the offload daemon with THPs enabled. More details at #8663.

The PR introduces UFFDIO_CONTINUE support and uses it for on-demand, memfd restores, and replaces the "daemon installs, CH wakes" model.

Fixes #8663 