### PR TITLE
pci, vmm: Identify a moving PCI BAR by index, not by address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
+ "serde_json",
  "thiserror",
  "vfio-bindings",
  "vfio-ioctls",

--- a/devices/src/ivshmem.rs
+++ b/devices/src/ivshmem.rs
@@ -26,7 +26,7 @@ use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottabl
 
 const IVSHMEM_BAR0_IDX: usize = 0;
 const IVSHMEM_BAR1_IDX: usize = 1;
-const IVSHMEM_DATA_BAR_IDX: usize = 2;
+pub const IVSHMEM_DATA_BAR_IDX: usize = 2;
 
 const IVSHMEM_VENDOR_ID: u16 = 0x1af4;
 const IVSHMEM_DEVICE_ID: u16 = 0x1110;

--- a/devices/src/ivshmem.rs
+++ b/devices/src/ivshmem.rs
@@ -353,8 +353,8 @@ impl PciDevice for IvshmemDevice {
         None
     }
 
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> io::Result<()> {
-        if new_base == self.data_bar_addr() {
+    fn move_bar(&mut self, bar_idx: usize, new_base: u64) -> io::Result<()> {
+        if bar_idx == IVSHMEM_DATA_BAR_IDX {
             let region = self
                 .region
                 .clone()
@@ -375,7 +375,7 @@ impl PciDevice for IvshmemDevice {
             self.userspace_mapping = Some(new_mapping);
         }
         for bar in self.bar_regions.iter_mut() {
-            if bar.addr() == old_base {
+            if bar.idx() == bar_idx {
                 *bar = bar.set_address(new_base);
             }
         }

--- a/devices/src/ivshmem.rs
+++ b/devices/src/ivshmem.rs
@@ -225,7 +225,7 @@ impl PciDevice for IvshmemDevice {
     ) -> result::Result<Vec<PciBarConfiguration>, PciDeviceError> {
         let mut bars = Vec::new();
         let mut bar0_addr = None;
-        let mut bar2_addr = None;
+        let mut data_bar_addr = None;
 
         let restoring = resources.is_some();
         if let Some(resources) = resources {
@@ -237,7 +237,7 @@ impl PciDevice for IvshmemDevice {
                         }
                         IVSHMEM_BAR1_IDX => {}
                         IVSHMEM_DATA_BAR_IDX => {
-                            bar2_addr = Some(GuestAddress(base));
+                            data_bar_addr = Some(GuestAddress(base));
                         }
                         _ => {
                             error!("Unexpected pci bar index {index}");
@@ -248,7 +248,7 @@ impl PciDevice for IvshmemDevice {
                     }
                 }
             }
-            if bar0_addr.is_none() || bar2_addr.is_none() {
+            if bar0_addr.is_none() || data_bar_addr.is_none() {
                 return Err(PciDeviceError::MissingResource);
             }
         }
@@ -268,17 +268,17 @@ impl PciDevice for IvshmemDevice {
 
         // BAR1 holds MSI-X table and PBA (only ivshmem-doorbell).
 
-        // BAR2 maps the shared memory object
-        let bar2_size = self.region_size;
-        let bar2_addr = mmio64_allocator
-            .allocate(bar2_addr, bar2_size, None)
-            .ok_or(PciDeviceError::IoAllocationFailed(bar2_size))?;
-        debug!("ivshmem bar2 address 0x{:x}", bar2_addr.0);
+        // The data BAR maps the shared memory object
+        let data_bar_size = self.region_size;
+        let data_bar_addr = mmio64_allocator
+            .allocate(data_bar_addr, data_bar_size, None)
+            .ok_or(PciDeviceError::IoAllocationFailed(data_bar_size))?;
+        debug!("ivshmem data BAR address 0x{:x}", data_bar_addr.0);
 
-        let bar2 = PciBarConfiguration::default()
+        let data_bar = PciBarConfiguration::default()
             .set_index(IVSHMEM_DATA_BAR_IDX)
-            .set_address(bar2_addr.raw_value())
-            .set_size(bar2_size)
+            .set_address(data_bar_addr.raw_value())
+            .set_size(data_bar_size)
             .set_region_type(PciBarRegionType::Memory64BitRegion)
             .set_prefetchable(PciBarPrefetchable::Prefetchable);
 
@@ -287,12 +287,12 @@ impl PciDevice for IvshmemDevice {
                 .add_pci_bar(&bar0)
                 .map_err(|e| PciDeviceError::IoRegistrationFailed(bar0_addr.raw_value(), e))?;
             self.configuration
-                .add_pci_bar(&bar2)
-                .map_err(|e| PciDeviceError::IoRegistrationFailed(bar2_addr.raw_value(), e))?;
+                .add_pci_bar(&data_bar)
+                .map_err(|e| PciDeviceError::IoRegistrationFailed(data_bar_addr.raw_value(), e))?;
         }
 
         bars.push(bar0);
-        bars.push(bar2);
+        bars.push(data_bar);
         self.bar_regions = bars.clone();
 
         Ok(bars)

--- a/devices/src/ivshmem.rs
+++ b/devices/src/ivshmem.rs
@@ -26,7 +26,7 @@ use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottabl
 
 const IVSHMEM_BAR0_IDX: usize = 0;
 const IVSHMEM_BAR1_IDX: usize = 1;
-const IVSHMEM_BAR2_IDX: usize = 2;
+const IVSHMEM_DATA_BAR_IDX: usize = 2;
 
 const IVSHMEM_VENDOR_ID: u16 = 0x1af4;
 const IVSHMEM_DEVICE_ID: u16 = 0x1110;
@@ -192,7 +192,7 @@ impl IvshmemDevice {
     }
 
     pub fn data_bar_addr(&self) -> u64 {
-        self.configuration.get_bar_addr(IVSHMEM_BAR2_IDX)
+        self.configuration.get_bar_addr(IVSHMEM_DATA_BAR_IDX)
     }
 
     fn state(&self) -> IvshmemDeviceState {
@@ -236,7 +236,7 @@ impl PciDevice for IvshmemDevice {
                             bar0_addr = Some(GuestAddress(base));
                         }
                         IVSHMEM_BAR1_IDX => {}
-                        IVSHMEM_BAR2_IDX => {
+                        IVSHMEM_DATA_BAR_IDX => {
                             bar2_addr = Some(GuestAddress(base));
                         }
                         _ => {
@@ -276,7 +276,7 @@ impl PciDevice for IvshmemDevice {
         debug!("ivshmem bar2 address 0x{:x}", bar2_addr.0);
 
         let bar2 = PciBarConfiguration::default()
-            .set_index(IVSHMEM_BAR2_IDX)
+            .set_index(IVSHMEM_DATA_BAR_IDX)
             .set_address(bar2_addr.raw_value())
             .set_size(bar2_size)
             .set_region_type(PciBarRegionType::Memory64BitRegion)

--- a/devices/src/ivshmem.rs
+++ b/devices/src/ivshmem.rs
@@ -187,14 +187,6 @@ impl IvshmemDevice {
         self.userspace_mapping = Some(userspace_mapping);
     }
 
-    pub fn config_bar_addr(&self) -> u64 {
-        self.configuration.get_bar_addr(IVSHMEM_BAR0_IDX)
-    }
-
-    pub fn data_bar_addr(&self) -> u64 {
-        self.configuration.get_bar_addr(IVSHMEM_DATA_BAR_IDX)
-    }
-
     fn state(&self) -> IvshmemDeviceState {
         IvshmemDeviceState {
             interrupt_mask: self._interrupt_mask,

--- a/devices/src/pvmemcontrol.rs
+++ b/devices/src/pvmemcontrol.rs
@@ -761,9 +761,9 @@ impl PciDevice for PvmemcontrolPciDevice {
         Ok(())
     }
 
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> io::Result<()> {
+    fn move_bar(&mut self, bar_idx: usize, new_base: u64) -> io::Result<()> {
         for bar in self.bar_regions.iter_mut() {
-            if bar.addr() == old_base {
+            if bar.idx() == bar_idx {
                 *bar = bar.set_address(new_base);
             }
         }

--- a/devices/src/pvpanic.rs
+++ b/devices/src/pvpanic.rs
@@ -221,9 +221,9 @@ impl PciDevice for PvPanicDevice {
         Ok(())
     }
 
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> io::Result<()> {
+    fn move_bar(&mut self, bar_idx: usize, new_base: u64) -> io::Result<()> {
         for bar in self.bar_regions.iter_mut() {
-            if bar.addr() == old_base {
+            if bar.idx() == bar_idx {
                 *bar = bar.set_address(new_base);
             }
         }

--- a/devices/src/pvpanic.rs
+++ b/devices/src/pvpanic.rs
@@ -135,10 +135,6 @@ impl PvPanicDevice {
             events: self.events,
         }
     }
-
-    pub fn config_bar_addr(&self) -> u64 {
-        self.configuration.get_bar_addr(0)
-    }
 }
 
 impl BusDevice for PvPanicDevice {

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -32,5 +32,8 @@ vm-memory = { workspace = true, features = [
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { workspace = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [lints]
 workspace = true

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -223,7 +223,17 @@ impl PciBus {
 
     fn apply_bar_reprogramming(&self, device: &mut dyn PciDevice, bars: &[BarReprogrammingParams]) {
         for bar in bars {
+            let Some(bar_idx) = bar.bar_idx else {
+                // Migration case: the previous version doesn't snapshot the BAR index being moved.
+                warn!(
+                    "BAR reprogramming without a BAR index: 0x{:x}->0x{:x}(0x{:x}), keeping old BAR",
+                    bar.old_base, bar.new_base, bar.len
+                );
+                device.restore_bar_addr(bar);
+                continue;
+            };
             if let Err(e) = self.device_reloc.move_bar(
+                bar_idx,
                 bar.old_base,
                 bar.new_base,
                 bar.len,
@@ -516,6 +526,7 @@ mod tests {
     impl DeviceRelocation for MockDeviceRelocation {
         fn move_bar(
             &self,
+            _bar_idx: usize,
             _old_base: u64,
             _new_base: u64,
             _len: u64,

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -220,6 +220,25 @@ impl PciBus {
             Err(PciRootError::InvalidPciDeviceSlot(id as usize))
         }
     }
+
+    fn apply_bar_reprogramming(&self, device: &mut dyn PciDevice, bars: &[BarReprogrammingParams]) {
+        for bar in bars {
+            if let Err(e) = self.device_reloc.move_bar(
+                bar.old_base,
+                bar.new_base,
+                bar.len,
+                device,
+                bar.region_type,
+            ) {
+                // Rollback the changes from detect_bar_reprogramming().
+                warn!(
+                    "Failed moving device BAR: {}: 0x{:x}->0x{:x}(0x{:x}), keeping old BAR",
+                    e, bar.old_base, bar.new_base, bar.len
+                );
+                device.restore_bar_addr(bar);
+            }
+        }
+    }
 }
 
 pub struct PciConfigIo {
@@ -292,25 +311,7 @@ impl PciConfigIo {
             let (bar_reprogram, ret) = device.write_config_register(register, offset, data);
 
             // Move the device's BAR if needed
-            for params in &bar_reprogram {
-                if let Err(e) = pci_bus.device_reloc.move_bar(
-                    params.old_base,
-                    params.new_base,
-                    params.len,
-                    device.deref_mut(),
-                    params.region_type,
-                ) {
-                    warn!(
-                        "Failed moving device BAR: {}: 0x{:x}->0x{:x}(0x{:x}), keeping old BAR",
-                        e, params.old_base, params.new_base, params.len
-                    );
-                    // Rollback: the config register was already updated to
-                    // new_base by detect_bar_reprogramming(). Restore it by
-                    // writing back the old address so device state stays
-                    // consistent with the MMIO bus mapping.
-                    device.restore_bar_addr(params);
-                }
-            }
+            pci_bus.apply_bar_reprogramming(device.deref_mut(), &bar_reprogram);
 
             ret
         } else {
@@ -422,21 +423,7 @@ impl PciConfigMmio {
             let (bar_reprogram, _) = device.write_config_register(register, offset, data);
 
             // Move the device's BAR if needed
-            for params in &bar_reprogram {
-                if let Err(e) = pci_bus.device_reloc.move_bar(
-                    params.old_base,
-                    params.new_base,
-                    params.len,
-                    device.deref_mut(),
-                    params.region_type,
-                ) {
-                    warn!(
-                        "Failed moving device BAR: {}: 0x{:x}->0x{:x}(0x{:x}), keeping old BAR",
-                        e, params.old_base, params.new_base, params.len
-                    );
-                    device.restore_bar_addr(params);
-                }
-            }
+            pci_bus.apply_bar_reprogramming(device.deref_mut(), &bar_reprogram);
         }
     }
 }

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -519,32 +519,36 @@ mod tests {
     use super::*;
     use crate::configuration::PciBarRegionType;
 
-    #[derive(Debug)]
-    /// Helper struct that mocks the implementation of DeviceRelocation
-    struct MockDeviceRelocation;
+    #[derive(Debug, Default)]
+    /// Helper struct that mocks the implementation of DeviceRelocation and
+    /// records the BAR indexes it was asked to move.
+    struct MockDeviceRelocation {
+        moved: Mutex<Vec<usize>>,
+    }
 
     impl DeviceRelocation for MockDeviceRelocation {
         fn move_bar(
             &self,
-            _bar_idx: usize,
+            bar_idx: usize,
             _old_base: u64,
             _new_base: u64,
             _len: u64,
             _pci_dev: &mut dyn PciDevice,
             _region_type: PciBarRegionType,
         ) -> Result<(), io::Error> {
+            self.moved.lock().unwrap().push(bar_idx);
             Ok(())
         }
     }
 
     fn setup_bus() -> PciBus {
         let pci_root = PciRoot::new(None);
-        let mock_device_reloc = Arc::new(MockDeviceRelocation {});
+        let mock_device_reloc = Arc::new(MockDeviceRelocation::default());
         PciBus::new(Some(pci_root), mock_device_reloc)
     }
 
     fn setup_bus_without_host_bridge() -> PciBus {
-        PciBus::new(None, Arc::new(MockDeviceRelocation {}))
+        PciBus::new(None, Arc::new(MockDeviceRelocation::default()))
     }
 
     #[test]
@@ -690,5 +694,76 @@ mod tests {
             result,
             Err(PciRootError::NoPciDeviceSlotAvailable),
         ));
+    }
+
+    /// PciDevice that counts the rollbacks asked of it.
+    #[derive(Default)]
+    struct RecordingDevice {
+        restored: usize,
+    }
+
+    impl BusDevice for RecordingDevice {}
+
+    impl PciDevice for RecordingDevice {
+        fn write_config_register(
+            &mut self,
+            _reg_idx: usize,
+            _offset: u64,
+            _data: &[u8],
+        ) -> (Vec<BarReprogrammingParams>, Option<Arc<Barrier>>) {
+            (Vec::new(), None)
+        }
+
+        fn read_config_register(&mut self, _reg_idx: usize) -> u32 {
+            0
+        }
+
+        fn restore_bar_addr(&mut self, _params: &BarReprogrammingParams) {
+            self.restored += 1;
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+
+        fn id(&self) -> Option<String> {
+            None
+        }
+    }
+
+    fn reprogram_params(bar_idx: Option<usize>) -> BarReprogrammingParams {
+        BarReprogrammingParams {
+            bar_idx,
+            old_base: 0xc000_0000,
+            new_base: 0xd000_0000,
+            len: 0x8_0000,
+            region_type: PciBarRegionType::Memory32BitRegion,
+        }
+    }
+
+    #[test]
+    fn apply_bar_reprogramming_moves_the_named_bar() {
+        let reloc = Arc::new(MockDeviceRelocation::default());
+        let bus = PciBus::new(Some(PciRoot::new(None)), reloc.clone());
+        let mut device = RecordingDevice::default();
+
+        bus.apply_bar_reprogramming(&mut device, &[reprogram_params(Some(2))]);
+
+        assert_eq!(*reloc.moved.lock().unwrap(), vec![2]);
+        assert_eq!(device.restored, 0);
+    }
+
+    #[test]
+    fn apply_bar_reprogramming_rolls_back_when_the_bar_is_unnamed() {
+        let reloc = Arc::new(MockDeviceRelocation::default());
+        let bus = PciBus::new(Some(PciRoot::new(None)), reloc.clone());
+        let mut device = RecordingDevice::default();
+
+        // An entry restored from a snapshot predating bar_idx. Moving BAR 0 by
+        // default would relocate the wrong BAR, so nothing must be moved.
+        bus.apply_bar_reprogramming(&mut device, &[reprogram_params(None)]);
+
+        assert!(reloc.moved.lock().unwrap().is_empty());
+        assert_eq!(device.restored, 1);
     }
 }

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -1423,4 +1423,168 @@ mod tests {
         assert!(reprogram.is_empty());
         assert_eq!(cfg.get_bar_addr(0), bar_addr);
     }
+
+    const RELOC_BAR_SIZE: u64 = 0x8_0000;
+
+    fn reloc_config(state: Option<PciConfigurationState>) -> PciConfiguration {
+        PciConfiguration::new(
+            0x1234,
+            0x5678,
+            0x1,
+            PciClassCode::MultimediaController,
+            &PciMultimediaSubclass::AudioController,
+            None,
+            PciHeaderType::Device,
+            0xABCD,
+            0x2468,
+            None,
+            state,
+        )
+    }
+
+    /// Adds a 32-bit memory BAR at `idx` and enables memory space decoding, so
+    /// that subsequent BAR writes are reported as reprogramming requests.
+    fn add_reloc_bar(cfg: &mut PciConfiguration, idx: usize, addr: u64) {
+        let bar = PciBarConfiguration::new(
+            idx,
+            RELOC_BAR_SIZE,
+            PciBarRegionType::Memory32BitRegion,
+            PciBarPrefetchable::NotPrefetchable,
+        )
+        .set_address(addr);
+        cfg.add_pci_bar(&bar).unwrap();
+        cfg.write_reg(COMMAND_REG, COMMAND_REG_MEMORY_SPACE_MASK);
+    }
+
+    #[test]
+    fn bar_reprogramming_reports_the_moved_bar_index() {
+        let mut cfg = reloc_config(None);
+        add_reloc_bar(&mut cfg, 0, 0xc000_0000);
+        add_reloc_bar(&mut cfg, 1, 0xd000_0000);
+
+        let reprogram = cfg.write_config_register(BAR0_REG + 1, 0, &0xe000_0000u32.to_le_bytes());
+
+        assert_eq!(reprogram.len(), 1);
+        assert_eq!(reprogram[0].bar_idx, Some(1));
+        assert_eq!(reprogram[0].old_base, 0xd000_0000);
+        assert_eq!(reprogram[0].new_base, 0xe000_0000);
+        assert_eq!(reprogram[0].len, RELOC_BAR_SIZE);
+    }
+
+    #[test]
+    fn bar_reprogramming_distinguishes_bars_sharing_a_base() {
+        let mut cfg = reloc_config(None);
+        add_reloc_bar(&mut cfg, 0, 0xc000_0000);
+        add_reloc_bar(&mut cfg, 1, 0xd000_0000);
+
+        // Point BAR 0 at BAR 1's base. A guest is free to do this, and both
+        // BARs now read back the same address.
+        let aliased = cfg.write_config_register(BAR0_REG, 0, &0xd000_0000u32.to_le_bytes());
+        assert_eq!(aliased.len(), 1);
+        assert_eq!(aliased[0].bar_idx, Some(0));
+        assert_eq!(cfg.get_bar_addr(0), cfg.get_bar_addr(1));
+
+        // Moving BAR 1 away must name BAR 1, even though its old base no
+        // longer identifies it: an address comparison would match BAR 0 too.
+        let reprogram = cfg.write_config_register(BAR0_REG + 1, 0, &0xe000_0000u32.to_le_bytes());
+
+        assert_eq!(reprogram.len(), 1);
+        assert_eq!(reprogram[0].bar_idx, Some(1));
+        assert_eq!(reprogram[0].old_base, 0xd000_0000);
+        assert_eq!(reprogram[0].new_base, 0xe000_0000);
+        assert_eq!(cfg.get_bar_addr(0), 0xd000_0000);
+    }
+
+    #[test]
+    fn bar_reprogramming_of_64bit_bar_reports_the_low_slot() {
+        let mut cfg = reloc_config(None);
+        let bar = PciBarConfiguration::new(
+            0,
+            RELOC_BAR_SIZE,
+            PciBarRegionType::Memory64BitRegion,
+            PciBarPrefetchable::NotPrefetchable,
+        )
+        .set_address(0x4_0000_0000);
+        cfg.add_pci_bar(&bar).unwrap();
+        cfg.write_reg(COMMAND_REG, COMMAND_REG_MEMORY_SPACE_MASK);
+
+        // The low-dword write alone must not move anything: the address is
+        // only complete once the high dword lands.
+        assert!(
+            cfg.write_config_register(BAR0_REG, 0, &0u32.to_le_bytes())
+                .is_empty()
+        );
+
+        // The high-dword write completes the move. It must report the low
+        // slot, which is the slot devices record their BAR under.
+        let reprogram = cfg.write_config_register(BAR0_REG + 1, 0, &8u32.to_le_bytes());
+
+        assert_eq!(reprogram.len(), 1);
+        assert_eq!(reprogram[0].bar_idx, Some(0));
+        assert_eq!(reprogram[0].old_base, 0x4_0000_0000);
+        assert_eq!(reprogram[0].new_base, 0x8_0000_0000);
+    }
+
+    #[test]
+    fn rom_bar_reprogramming_reports_the_rom_slot() {
+        let mut cfg = reloc_config(None);
+        let bar = PciBarConfiguration::new(
+            ROM_BAR_IDX,
+            RELOC_BAR_SIZE,
+            PciBarRegionType::Memory32BitRegion,
+            PciBarPrefetchable::NotPrefetchable,
+        )
+        .set_address(0xf000_0000);
+        cfg.add_pci_rom_bar(&bar, 0).unwrap();
+        cfg.write_reg(COMMAND_REG, COMMAND_REG_MEMORY_SPACE_MASK);
+
+        let reprogram = cfg.write_config_register(ROM_BAR_REG, 0, &0xf100_0000u32.to_le_bytes());
+
+        assert_eq!(reprogram.len(), 1);
+        assert_eq!(reprogram[0].bar_idx, Some(ROM_BAR_IDX));
+        assert_eq!(reprogram[0].old_base, 0xf000_0000);
+        assert_eq!(reprogram[0].new_base, 0xf100_0000);
+    }
+
+    fn bar_with_idx_and_addr(idx: usize, addr: u64) -> PciBarConfiguration {
+        PciBarConfiguration::new(
+            idx,
+            0x1000,
+            PciBarRegionType::Memory64BitRegion,
+            PciBarPrefetchable::NotPrefetchable,
+        )
+        .set_address(addr)
+    }
+
+    #[test]
+    fn addr_of_idx_returns_the_matching_bar_address() {
+        // The list is not ordered by index, so the lookup must not rely on
+        // the BAR's position in it.
+        let bars = [
+            bar_with_idx_and_addr(2, 0xd000_0000),
+            bar_with_idx_and_addr(0, 0xc000_0000),
+            bar_with_idx_and_addr(4, 0xe000_0000),
+        ];
+
+        assert_eq!(
+            PciBarConfiguration::addr_of_idx(&bars, 0),
+            Some(0xc000_0000)
+        );
+        assert_eq!(
+            PciBarConfiguration::addr_of_idx(&bars, 2),
+            Some(0xd000_0000)
+        );
+        assert_eq!(
+            PciBarConfiguration::addr_of_idx(&bars, 4),
+            Some(0xe000_0000)
+        );
+    }
+
+    #[test]
+    fn addr_of_idx_returns_none_on_missing_bar() {
+        let bars = [bar_with_idx_and_addr(0, 0xc000_0000)];
+
+        assert_eq!(PciBarConfiguration::addr_of_idx(&bars, 2), None);
+        assert_eq!(PciBarConfiguration::addr_of_idx(&[], 0), None);
+    }
 }

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -1233,6 +1233,12 @@ impl PciBarConfiguration {
     pub fn prefetchable(&self) -> PciBarPrefetchable {
         self.prefetchable
     }
+
+    pub fn addr_of_idx(bars: &[PciBarConfiguration], idx: usize) -> Option<u64> {
+        bars.iter()
+            .find(|bar| bar.idx() == idx)
+            .map(PciBarConfiguration::addr)
+    }
 }
 
 #[cfg(test)]

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -999,6 +999,7 @@ impl PciConfiguration {
                 self.bars[bar_idx].addr = value;
 
                 return Some(BarReprogrammingParams {
+                    bar_idx: Some(bar_idx),
                     old_base,
                     new_base,
                     len,
@@ -1027,6 +1028,9 @@ impl PciConfiguration {
                 self.bars[bar_idx - 1].addr = self.registers[reg_idx - 1];
 
                 return Some(BarReprogrammingParams {
+                    // The high-dword write completes the move for a 64-bit BAR.
+                    // Report the low slot.
+                    bar_idx: Some(bar_idx - 1),
                     old_base,
                     new_base,
                     len,
@@ -1055,6 +1059,7 @@ impl PciConfiguration {
             self.rom_bar_addr = value;
 
             return Some(BarReprogrammingParams {
+                bar_idx: Some(ROM_BAR_IDX),
                 old_base,
                 new_base,
                 len,

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -38,6 +38,9 @@ pub(crate) type Result<T> = result::Result<T, Error>;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct BarReprogrammingParams {
+    /// Index of the PCI BAR being moved.
+    #[serde(default)]
+    pub bar_idx: Option<usize>,
     pub old_base: u64,
     pub new_base: u64,
     pub len: u64,
@@ -90,7 +93,7 @@ pub trait PciDevice: Send {
         None
     }
     /// Relocates the BAR to a different address in guest address space.
-    fn move_bar(&mut self, _old_base: u64, _new_base: u64) -> result::Result<(), io::Error> {
+    fn move_bar(&mut self, _bar_idx: usize, _new_base: u64) -> result::Result<(), io::Error> {
         Ok(())
     }
     /// Restore BAR address in config space after a failed move_bar.
@@ -110,8 +113,10 @@ pub trait PciDevice: Send {
 pub trait DeviceRelocation: Send + Sync {
     /// The BAR needs to be moved to a different location in the guest address
     /// space. This follows a decision from the software running in the guest.
+    /// The BAR is identified by its BAR index.
     fn move_bar(
         &self,
+        bar_idx: usize,
         old_base: u64,
         new_base: u64,
         len: u64,

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -2464,9 +2464,10 @@ impl PciDevice for VfioPciDevice {
         self.common.write_bar(base, offset, data)
     }
 
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> Result<(), io::Error> {
+    fn move_bar(&mut self, bar_idx: usize, new_base: u64) -> Result<(), io::Error> {
         for region in self.common.mmio_regions.iter_mut() {
-            if region.start.raw_value() == old_base {
+            if region.index as usize == bar_idx {
+                let old_base = region.start.raw_value();
                 region.start = GuestAddress(new_base);
 
                 for user_memory_region in region.user_memory_regions.iter_mut() {

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -450,10 +450,11 @@ impl PciDevice for VfioUserPciDevice {
         self.common.write_bar(base, offset, data)
     }
 
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> Result<(), io::Error> {
-        info!("Moving BAR 0x{old_base:x} -> 0x{new_base:x}");
+    fn move_bar(&mut self, bar_idx: usize, new_base: u64) -> Result<(), io::Error> {
+        info!("Moving BAR {bar_idx} -> 0x{new_base:x}");
         for mmio_region in self.common.mmio_regions.iter_mut() {
-            if mmio_region.start.raw_value() == old_base {
+            if mmio_region.index as usize == bar_idx {
+                let old_base = mmio_region.start.raw_value();
                 mmio_region.start = GuestAddress(new_base);
 
                 for user_memory_region in mmio_region.user_memory_regions.iter_mut() {

--- a/virtio-devices/src/transport/mod.rs
+++ b/virtio-devices/src/transport/mod.rs
@@ -7,7 +7,8 @@ mod pci_common_config;
 mod pci_device;
 pub use pci_common_config::{VIRTIO_PCI_COMMON_CONFIG_ID, VirtioPciCommonConfig};
 pub use pci_device::{
-    VIRTIO_CONFIG_BAR_INDEX, VirtioPciDevice, VirtioPciDeviceActivator, VirtioPciDeviceError,
+    VIRTIO_CONFIG_BAR_INDEX, VIRTIO_SHM_BAR_INDEX, VirtioPciDevice, VirtioPciDeviceActivator,
+    VirtioPciDeviceError,
 };
 
 pub trait VirtioTransport {

--- a/virtio-devices/src/transport/mod.rs
+++ b/virtio-devices/src/transport/mod.rs
@@ -6,7 +6,9 @@ use vmm_sys_util::eventfd::EventFd;
 mod pci_common_config;
 mod pci_device;
 pub use pci_common_config::{VIRTIO_PCI_COMMON_CONFIG_ID, VirtioPciCommonConfig};
-pub use pci_device::{VirtioPciDevice, VirtioPciDeviceActivator, VirtioPciDeviceError};
+pub use pci_device::{
+    VIRTIO_CONFIG_BAR_INDEX, VirtioPciDevice, VirtioPciDeviceActivator, VirtioPciDeviceError,
+};
 
 pub trait VirtioTransport {
     fn ioeventfds(&self, base_addr: u64) -> impl Iterator<Item = (&EventFd, u64)>;

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -290,7 +290,7 @@ const MSIX_PBA_SIZE: u64 = 0x800;
 const CAPABILITY_BAR_SIZE: u64 = (MSIX_PBA_BAR_OFFSET + MSIX_PBA_SIZE).next_power_of_two();
 // Align larger than natural alignment to work around Windows driver issues
 const VIRTIO_PCI_BAR_ALIGN: u64 = 0x80_0000;
-const VIRTIO_CONFIG_BAR_INDEX: usize = 0;
+pub const VIRTIO_CONFIG_BAR_INDEX: usize = 0;
 const VIRTIO_SHM_BAR_INDEX: usize = 2;
 
 const NOTIFY_OFF_MULTIPLIER: u32 = 4; // A dword per notification address.

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -290,7 +290,7 @@ const MSIX_PBA_SIZE: u64 = 0x800;
 const CAPABILITY_BAR_SIZE: u64 = (MSIX_PBA_BAR_OFFSET + MSIX_PBA_SIZE).next_power_of_two();
 // Align larger than natural alignment to work around Windows driver issues
 const VIRTIO_PCI_BAR_ALIGN: u64 = 0x80_0000;
-const VIRTIO_COMMON_BAR_INDEX: u8 = 0;
+const VIRTIO_CONFIG_BAR_INDEX: usize = 0;
 const VIRTIO_SHM_BAR_INDEX: usize = 2;
 
 const NOTIFY_OFF_MULTIPLIER: u32 = 4; // A dword per notification address.
@@ -698,8 +698,7 @@ impl VirtioPciDevice {
     }
 
     pub fn config_bar_addr(&self) -> u64 {
-        self.configuration
-            .get_bar_addr(VIRTIO_COMMON_BAR_INDEX.into())
+        self.configuration.get_bar_addr(VIRTIO_CONFIG_BAR_INDEX)
     }
 
     fn add_pci_capabilities(
@@ -709,7 +708,7 @@ impl VirtioPciDevice {
         // Add pointers to the different configuration structures from the PCI capabilities.
         let common_cap = VirtioPciCap::new(
             PciCapabilityType::Common,
-            VIRTIO_COMMON_BAR_INDEX,
+            VIRTIO_CONFIG_BAR_INDEX as u8,
             COMMON_CONFIG_BAR_OFFSET as u32,
             COMMON_CONFIG_SIZE as u32,
         );
@@ -719,7 +718,7 @@ impl VirtioPciDevice {
 
         let isr_cap = VirtioPciCap::new(
             PciCapabilityType::Isr,
-            VIRTIO_COMMON_BAR_INDEX,
+            VIRTIO_CONFIG_BAR_INDEX as u8,
             ISR_CONFIG_BAR_OFFSET as u32,
             ISR_CONFIG_SIZE as u32,
         );
@@ -730,7 +729,7 @@ impl VirtioPciDevice {
         if device_config_size > 0 {
             let device_cap = VirtioPciCap::new(
                 PciCapabilityType::Device,
-                VIRTIO_COMMON_BAR_INDEX,
+                VIRTIO_CONFIG_BAR_INDEX as u8,
                 DEVICE_CONFIG_BAR_OFFSET as u32,
                 device_config_size as u32,
             );
@@ -741,7 +740,7 @@ impl VirtioPciDevice {
 
         let notify_cap = VirtioPciNotifyCap::new(
             PciCapabilityType::Notify,
-            VIRTIO_COMMON_BAR_INDEX,
+            VIRTIO_CONFIG_BAR_INDEX as u8,
             NOTIFICATION_BAR_OFFSET as u32,
             NOTIFICATION_SIZE as u32,
             Le32::from(NOTIFY_OFF_MULTIPLIER),
@@ -759,10 +758,10 @@ impl VirtioPciDevice {
         self.cap_pci_cfg_info.cap = configuration_cap;
 
         let msix_cap = MsixCap::new(
-            VIRTIO_COMMON_BAR_INDEX,
+            VIRTIO_CONFIG_BAR_INDEX as u8,
             self.msix_num,
             MSIX_TABLE_BAR_OFFSET as u32,
-            VIRTIO_COMMON_BAR_INDEX,
+            VIRTIO_CONFIG_BAR_INDEX as u8,
             MSIX_PBA_BAR_OFFSET as u32,
         );
         self.configuration
@@ -1042,7 +1041,7 @@ impl PciDevice for VirtioPciDevice {
                 if let Resource::PciBar {
                     index, base, type_, ..
                 } = resource
-                    && index == usize::from(VIRTIO_COMMON_BAR_INDEX)
+                    && index == VIRTIO_CONFIG_BAR_INDEX
                 {
                     settings_bar_addr = Some(GuestAddress(base));
                     use_64bit_bar = match type_ {
@@ -1087,7 +1086,7 @@ impl PciDevice for VirtioPciDevice {
         };
 
         let bar = PciBarConfiguration::default()
-            .set_index(VIRTIO_COMMON_BAR_INDEX.into())
+            .set_index(VIRTIO_CONFIG_BAR_INDEX)
             .set_address(virtio_pci_bar_addr.raw_value())
             .set_size(CAPABILITY_BAR_SIZE)
             .set_region_type(region_type);

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -291,7 +291,7 @@ const CAPABILITY_BAR_SIZE: u64 = (MSIX_PBA_BAR_OFFSET + MSIX_PBA_SIZE).next_powe
 // Align larger than natural alignment to work around Windows driver issues
 const VIRTIO_PCI_BAR_ALIGN: u64 = 0x80_0000;
 pub const VIRTIO_CONFIG_BAR_INDEX: usize = 0;
-const VIRTIO_SHM_BAR_INDEX: usize = 2;
+pub const VIRTIO_SHM_BAR_INDEX: usize = 2;
 
 const NOTIFY_OFF_MULTIPLIER: u32 = 4; // A dword per notification address.
 
@@ -1165,11 +1165,11 @@ impl PciDevice for VirtioPciDevice {
         Ok(())
     }
 
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> io::Result<()> {
+    fn move_bar(&mut self, bar_idx: usize, new_base: u64) -> io::Result<()> {
         // We only update our idea of the bar in order to support free_bars() above.
         // The majority of the reallocation is done inside DeviceManager.
         for bar in self.bar_regions.iter_mut() {
-            if bar.addr() == old_base {
+            if bar.idx() == bar_idx {
                 *bar = bar.set_address(new_base);
             }
         }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -697,10 +697,6 @@ impl VirtioPciDevice {
         self.common_config.driver_status.load(Ordering::SeqCst) == DEVICE_INIT as u8
     }
 
-    pub fn config_bar_addr(&self) -> u64 {
-        self.configuration.get_bar_addr(VIRTIO_CONFIG_BAR_INDEX)
-    }
-
     fn add_pci_capabilities(
         &mut self,
         device_config_size: u64,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -53,7 +53,7 @@ use devices::interrupt_controller::InterruptController;
 #[cfg(target_arch = "x86_64")]
 use devices::ioapic;
 #[cfg(feature = "ivshmem")]
-use devices::ivshmem::{IvshmemError, IvshmemOps};
+use devices::ivshmem::{IVSHMEM_DATA_BAR_IDX, IvshmemError, IvshmemOps};
 #[cfg(target_arch = "aarch64")]
 use devices::legacy::Pl011;
 #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
@@ -96,7 +96,9 @@ use tracer::trace_scoped;
 use vfio_ioctls::VfioIommufd;
 use vfio_ioctls::{VfioContainer, VfioDevice, VfioDeviceFd, VfioOps};
 use virtio_devices::block::Error as VirtioBlockError;
-use virtio_devices::transport::{VirtioPciDevice, VirtioPciDeviceActivator, VirtioTransport};
+use virtio_devices::transport::{
+    VIRTIO_CONFIG_BAR_INDEX, VirtioPciDevice, VirtioPciDeviceActivator, VirtioTransport,
+};
 use virtio_devices::vhost_user::VhostUserConfig;
 use virtio_devices::{
     AccessPlatformMapping, Block, Endpoint, IommuMapping, VdpaDmaMapping, VirtioMemMappingSource,
@@ -409,6 +411,10 @@ pub enum DeviceManagerError {
     /// Missing PCI device.
     #[error("Missing PCI device")]
     MissingPciDevice,
+
+    /// Missing PCI BAR.
+    #[error("Missing PCI BAR at index {0:#x}")]
+    MissingPciBar(usize),
 
     /// Failed to remove a PCI device from the PCI bus.
     #[error("Failed to remove a PCI device from the PCI bus")]
@@ -4516,7 +4522,8 @@ impl DeviceManager {
         let (bars, new_resources) =
             self.allocate_pci_bars(virtio_pci_device.clone(), pci_segment_id, resources)?;
 
-        let bar_addr = virtio_pci_device.lock().unwrap().config_bar_addr();
+        let bar_addr = PciBarConfiguration::addr_of_idx(&bars, VIRTIO_CONFIG_BAR_INDEX)
+            .ok_or(DeviceManagerError::MissingPciBar(VIRTIO_CONFIG_BAR_INDEX))?;
         for (event, addr) in virtio_pci_device.lock().unwrap().ioeventfds(bar_addr) {
             let io_addr = IoEventAddress::Mmio(addr);
             self.address_manager
@@ -4622,7 +4629,8 @@ impl DeviceManager {
         let (bars, new_resources) =
             self.allocate_pci_bars(ivshmem_device.clone(), pci_segment_id, resources)?;
 
-        let start_addr = ivshmem_device.lock().unwrap().data_bar_addr();
+        let start_addr = PciBarConfiguration::addr_of_idx(&bars, IVSHMEM_DATA_BAR_IDX)
+            .ok_or(DeviceManagerError::MissingPciBar(IVSHMEM_DATA_BAR_IDX))?;
         let (region, mapping) = ivshmem_ops
             .lock()
             .unwrap()

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -97,7 +97,8 @@ use vfio_ioctls::VfioIommufd;
 use vfio_ioctls::{VfioContainer, VfioDevice, VfioDeviceFd, VfioOps};
 use virtio_devices::block::Error as VirtioBlockError;
 use virtio_devices::transport::{
-    VIRTIO_CONFIG_BAR_INDEX, VirtioPciDevice, VirtioPciDeviceActivator, VirtioTransport,
+    VIRTIO_CONFIG_BAR_INDEX, VIRTIO_SHM_BAR_INDEX, VirtioPciDevice, VirtioPciDeviceActivator,
+    VirtioTransport,
 };
 use virtio_devices::vhost_user::VhostUserConfig;
 use virtio_devices::{
@@ -653,6 +654,7 @@ pub(crate) struct AddressManager {
 impl DeviceRelocation for AddressManager {
     fn move_bar(
         &self,
+        bar_idx: usize,
         old_base: u64,
         new_base: u64,
         len: u64,
@@ -743,9 +745,8 @@ impl DeviceRelocation for AddressManager {
             if let Some(node) = self.device_tree.lock().unwrap().get_mut(&id) {
                 let mut resource_updated = false;
                 for resource in node.resources.iter_mut() {
-                    if let Resource::PciBar { base, type_, .. } = resource
-                        && PciBarRegionType::from(*type_) == region_type
-                        && *base == old_base
+                    if let Resource::PciBar { index, base, .. } = resource
+                        && *index == bar_idx
                     {
                         *base = new_base;
                         resource_updated = true;
@@ -755,7 +756,7 @@ impl DeviceRelocation for AddressManager {
 
                 if !resource_updated {
                     return Err(io::Error::other(format!(
-                        "Couldn't find a resource with base 0x{old_base:x} for device {id}"
+                        "Couldn't find a resource for BAR {bar_idx} of device {id}"
                     )));
                 }
             } else {
@@ -767,8 +768,7 @@ impl DeviceRelocation for AddressManager {
 
         let any_dev = pci_dev.as_any_mut();
         if let Some(virtio_pci_dev) = any_dev.downcast_ref::<VirtioPciDevice>() {
-            let bar_addr = virtio_pci_dev.config_bar_addr();
-            if bar_addr == new_base {
+            if bar_idx == VIRTIO_CONFIG_BAR_INDEX {
                 for (event, addr) in virtio_pci_dev.ioeventfds(old_base) {
                     let io_addr = IoEventAddress::Mmio(addr);
                     self.vm.unregister_ioevent(event, &io_addr).map_err(|e| {
@@ -783,12 +783,10 @@ impl DeviceRelocation for AddressManager {
                             io::Error::other(format!("failed to register ioevent: {e:?}"))
                         })?;
                 }
-            } else {
+            } else if bar_idx == VIRTIO_SHM_BAR_INDEX {
                 let virtio_dev = virtio_pci_dev.virtio_device();
                 let mut virtio_dev = virtio_dev.lock().unwrap();
-                if let Some(mut shm_regions) = virtio_dev.get_shm_regions()
-                    && shm_regions.addr.raw_value() == old_base
-                {
+                if let Some(mut shm_regions) = virtio_dev.get_shm_regions() {
                     // SAFETY: guaranteed by MmapRegion invariants
                     unsafe {
                         // Remove old mapping
@@ -833,7 +831,7 @@ impl DeviceRelocation for AddressManager {
             }
         }
 
-        pci_dev.move_bar(old_base, new_base)
+        pci_dev.move_bar(bar_idx, new_base)
     }
 }
 
@@ -5073,7 +5071,7 @@ impl DeviceManager {
             .free_device_id(device_id)
             .map_err(DeviceManagerError::FreePciDeviceId)?;
 
-        let (pci_device_handle, id) = {
+        let (pci_device_handle, id, pci_bar_resources) = {
             // Remove the device from the device tree along with its children.
             let mut device_tree = self.device_tree.lock().unwrap();
             let pci_device_node = device_tree
@@ -5099,7 +5097,7 @@ impl DeviceManager {
                 device_tree.remove(child);
             }
 
-            (pci_device_handle, id)
+            (pci_device_handle, id, pci_device_node.resources)
         };
 
         let mut iommu_attached = false;
@@ -5143,13 +5141,27 @@ impl DeviceManager {
             }
             PciDeviceHandle::Virtio(virtio_pci_device) => {
                 let dev = virtio_pci_device.lock().unwrap();
-                let bar_addr = dev.config_bar_addr();
-                for (event, addr) in dev.ioeventfds(bar_addr) {
-                    let io_addr = IoEventAddress::Mmio(addr);
-                    self.address_manager
-                        .vm
-                        .unregister_ioevent(event, &io_addr)
-                        .map_err(|e| DeviceManagerError::UnRegisterIoevent(e.into()))?;
+                let config_bar_idx = VIRTIO_CONFIG_BAR_INDEX;
+                let bar_addr = pci_bar_resources.iter().find_map(|r| match r {
+                    Resource::PciBar { index, base, .. } if *index == config_bar_idx => Some(*base),
+                    _ => None,
+                });
+                // The device was already removed from the device
+                // tree, so a missing resource must not abort the eject.
+                // Warn and leave the ioeventfds registered rather
+                // than bail out half way through.
+                if let Some(bar_addr) = bar_addr {
+                    for (event, addr) in dev.ioeventfds(bar_addr) {
+                        let io_addr = IoEventAddress::Mmio(addr);
+                        self.address_manager
+                            .vm
+                            .unregister_ioevent(event, &io_addr)
+                            .map_err(|e| DeviceManagerError::UnRegisterIoevent(e.into()))?;
+                    }
+                } else {
+                    warn!(
+                        "No BAR {config_bar_idx} resource for {id}, not unregistering ioeventfds"
+                    );
                 }
 
                 if let Some(dma_handler) = dev.dma_handler()

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -566,6 +566,7 @@ mod tests {
     impl DeviceRelocation for MockDeviceRelocation {
         fn move_bar(
             &self,
+            _bar_idx: usize,
             _old_base: u64,
             _new_base: u64,
             _len: u64,


### PR DESCRIPTION
A BAR being relocated is currently identified by its current base
address. A guest is free to program two BARs to the same base, in which
case the address comparison can match the wrong BAR. A BAR is uniquely
identified by (PCI device, BAR index), so pass the index down the
relocation path and match on that instead. Where the base address is
still needed, it is taken from the device's own BAR records rather than
read back from config space.

This is preparation for #8572.

1. pci: Factor out the BAR reprogramming loop for BAR moves
   PciConfigIo and PciConfigMmio carried two copies of the same loop.
   No functional change.
2. devices, virtio-devices, vmm: Place ioeventfds and ivshmem RAM by index
   Take the creation-time base from the allocated BAR list, already the
   source of truth for the MMIO bus mapping.
3. devices, pci, virtio-devices, vmm: Identify PCI BARs by index
   The functional change: bar_idx through both move_bar() traits.
4. devices: Remove unused config_bar_addr()
   Two accessors that never had a caller.
5. pci, vmm: Add tests for BAR index identification

Migration compatibility: BarReprogrammingParams is passed on the snapshot
state as part of PciConfigurationState::pending_bar_reprogram, so the new
bar_idx field is an Option. An entry restored from a snapshot written
before this series cannot identify its BAR, and is rolled back rather than
applied to a guessed slot -- the same thing that already happens when a
move fails.

Ref: #8572
The whole tree is found at https://github.com/yamahata/cloud-hypervisor/tree/202607/pci-bus-eagar-unmap , it needs some updates, though. It give an idea how thing will be.