### PR TITLE
RFC: A comprehensive disk engine fuzzer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,4 +138,9 @@ unnecessary_semicolon = "deny"
 
 [workspace.lints.rust]
 # `level = warn` is irrelevant here but mandatory for rustc/cargo
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(devcli_testenv)'] }
+# `fuzzing` is set by `cargo fuzz`; `block` gates the VMDK extent walk switch
+# on it (block/src/formats/vmdk/flat.rs).
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(devcli_testenv)',
+  'cfg(fuzzing)',
+] }

--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -223,7 +223,8 @@ fn open_flat_vmdk(
 ) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
     info!("Opening VMDK disk file with synchronous backend");
     Ok(Box::new(
-        VmdkDisk::new(file, options.path, options.direct).map_err(|e| e.with_path(options.path))?,
+        VmdkDisk::new(file, options.path, options.readonly, options.direct)
+            .map_err(|e| e.with_path(options.path))?,
     ))
 }
 

--- a/block/src/formats/qcow/header.rs
+++ b/block/src/formats/qcow/header.rs
@@ -511,12 +511,33 @@ impl QcowHeader {
         size: u64,
         backing_file: Option<&str>,
     ) -> Result<QcowHeader> {
+        Self::create_for_size_path_and_cluster_bits(
+            version,
+            size,
+            backing_file,
+            DEFAULT_CLUSTER_BITS,
+        )
+    }
+
+    /// Builds a header for an image with an explicit cluster size.
+    ///
+    /// Every derived field, the L1 size and the table offsets alike, follows
+    /// from `cluster_bits`, so this is the same computation the default
+    /// cluster size gets rather than a second layout.
+    pub fn create_for_size_path_and_cluster_bits(
+        version: u32,
+        size: u64,
+        backing_file: Option<&str>,
+        cluster_bits: u32,
+    ) -> Result<QcowHeader> {
+        if !(MIN_CLUSTER_BITS..=MAX_CLUSTER_BITS).contains(&cluster_bits) {
+            return Err(Error::InvalidClusterSize);
+        }
         let header_size = if version == 2 {
             V2_BARE_HEADER_SIZE
         } else {
             V3_BARE_HEADER_SIZE + QCOW_EMPTY_HEADER_EXTENSION_SIZE
         };
-        let cluster_bits: u32 = DEFAULT_CLUSTER_BITS;
         let cluster_size: u32 = 0x01 << cluster_bits;
         let max_length: usize = (cluster_size - header_size) as usize;
         if let Some(path) = backing_file
@@ -543,7 +564,7 @@ impl QcowHeader {
                     }
             }) as u64,
             backing_file_size: backing_file.map_or(0, |x| x.len()) as u32,
-            cluster_bits: DEFAULT_CLUSTER_BITS,
+            cluster_bits,
             size,
             crypt_method: 0,
             l1_size: num_l2_clusters,

--- a/block/src/formats/qcow/mod.rs
+++ b/block/src/formats/qcow/mod.rs
@@ -160,15 +160,32 @@ impl QcowDisk {
 }
 
 /// Writes a fresh qcow2 layout into `file`
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(test)]
 pub(crate) fn create_image(
     file: &File,
     virtual_size: u64,
     backing_config: Option<&BackingFileConfig>,
 ) -> BlockResult<()> {
+    create_image_with_cluster_bits(
+        file,
+        virtual_size,
+        backing_config,
+        header::DEFAULT_CLUSTER_BITS,
+    )
+}
+
+/// Writes a fresh qcow2 layout with an explicit cluster size into `file`
+#[cfg(any(test, feature = "test-utils"))]
+pub(crate) fn create_image_with_cluster_bits(
+    file: &File,
+    virtual_size: u64,
+    backing_config: Option<&BackingFileConfig>,
+    cluster_bits: u32,
+) -> BlockResult<()> {
     let path = backing_config.map(|cfg| cfg.path.as_str());
-    let mut header = QcowHeader::create_for_size_and_path(3, virtual_size, path)
-        .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
+    let mut header =
+        QcowHeader::create_for_size_path_and_cluster_bits(3, virtual_size, path, cluster_bits)
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
     if let Some(cfg) = backing_config
         && let Some(backing_file) = &mut header.backing_file
     {
@@ -206,8 +223,31 @@ impl QcowTempDisk {
         sparse: bool,
         use_io_uring: bool,
     ) -> BlockResult<Self> {
+        Self::new_with_cluster_bits(
+            virtual_size,
+            backing_config,
+            direct_io,
+            sparse,
+            use_io_uring,
+            header::DEFAULT_CLUSTER_BITS,
+        )
+    }
+
+    /// Creates a new qcow2 image with an explicit cluster size.
+    ///
+    /// A smaller cluster means more L2 tables for the same virtual size,
+    /// which is the only way to reach the L2 cache eviction path with an
+    /// image small enough to model.
+    pub fn new_with_cluster_bits(
+        virtual_size: u64,
+        backing_config: Option<&BackingFileConfig>,
+        direct_io: bool,
+        sparse: bool,
+        use_io_uring: bool,
+        cluster_bits: u32,
+    ) -> BlockResult<Self> {
         let tmp = TempFile::new().map_err(io::Error::from)?;
-        create_image(tmp.as_file(), virtual_size, backing_config)?;
+        create_image_with_cluster_bits(tmp.as_file(), virtual_size, backing_config, cluster_bits)?;
         let file = tmp
             .as_file()
             .try_clone()

--- a/block/src/formats/vmdk/flat.rs
+++ b/block/src/formats/vmdk/flat.rs
@@ -13,6 +13,8 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::{Component, Path};
 use std::sync::Arc;
+#[cfg(fuzzing)]
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use log::warn;
 
@@ -85,6 +87,32 @@ const RESOLVE_NO_MAGICLINKS: u64 = 0x02;
 // are all rejected with EXDEV.
 const RESOLVE_BENEATH: u64 = 0x08;
 
+/// Selects the `openat2(2)` fallback walk in a fuzz build.
+///
+/// `open_extent` prefers `openat2(2)` and only walks the path component by
+/// component when the syscall is missing or blocked. On any kernel a fuzzer
+/// runs on the first call succeeds, so the walk, which carries its own path
+/// traversal rejection because there is no `RESOLVE_BENEATH` behind it, is
+/// never entered and cannot be fuzzed at all.
+///
+/// A fuzz target therefore sets this from its input, before it opens an
+/// image, so that the resolution path is a property of the input and a crash
+/// still reproduces from the input alone. It only exists in a build with
+/// `cfg(fuzzing)`, which is what `cargo fuzz` sets and what no shipped build
+/// has.
+#[cfg(fuzzing)]
+pub fn set_force_extent_walk(force: bool) {
+    FORCE_EXTENT_WALK.store(force, Ordering::Relaxed);
+}
+
+#[cfg(fuzzing)]
+static FORCE_EXTENT_WALK: AtomicBool = AtomicBool::new(false);
+
+#[cfg(fuzzing)]
+fn force_extent_walk() -> bool {
+    FORCE_EXTENT_WALK.load(Ordering::Relaxed)
+}
+
 // Splits an untrusted extent `filename` into its `Normal` path components for
 // the fallback walk, rejecting any `..`/`.` traversal.
 fn extent_components(filename: &str) -> io::Result<Vec<&OsStr>> {
@@ -132,6 +160,8 @@ fn extent_components(filename: &str) -> io::Result<Vec<&OsStr>> {
 // Resolution prefers openat2(2). On kernels without it (< 5.6, ENOSYS) or
 // where it is blocked (EPERM, e.g. a seccomp filter), it falls back to a
 // per-component openat walk.
+//
+// A fuzz build can select the fallback directly, see `force_extent_walk`.
 fn open_extent(
     base_path: &str,
     filename: &str,
@@ -148,6 +178,12 @@ fn open_extent(
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
         .open(anchor)?;
+
+    #[cfg(fuzzing)]
+    if force_extent_walk() {
+        let components = extent_components(filename)?;
+        return open_extent_walk(dir, &components, writable, direct);
+    }
 
     match open_extent_openat2(dir.as_raw_fd(), filename, writable, direct) {
         Ok(file) => Ok(AlignedFile::new(file, direct)),

--- a/block/src/formats/vmdk/flat.rs
+++ b/block/src/formats/vmdk/flat.rs
@@ -72,6 +72,19 @@ struct OpenHow {
     resolve: u64,
 }
 
+// `open_how.resolve` flags from openat2(2). The libc crate does not export
+// them, so they are defined here with the values from the kernel UAPI
+// (include/uapi/linux/openat2.h).
+//
+// RESOLVE_NO_MAGICLINKS: refuse to traverse "magic links" such as
+// /proc/self/mem or /proc/<pid>/fd/N, which docs/threat-model.md calls out as
+// able to corrupt the VMM's own memory.
+const RESOLVE_NO_MAGICLINKS: u64 = 0x02;
+// RESOLVE_BENEATH: every component of the resolution must stay beneath the
+// anchor directory fd. '..' escapes, escaping symlinks and absolute pathnames
+// are all rejected with EXDEV.
+const RESOLVE_BENEATH: u64 = 0x08;
+
 // Splits an untrusted extent `filename` into its `Normal` path components for
 // the fallback walk, rejecting any `..`/`.` traversal.
 fn extent_components(filename: &str) -> io::Result<Vec<&OsStr>> {
@@ -108,6 +121,13 @@ fn extent_components(filename: &str) -> io::Result<Vec<&OsStr>> {
 //   - relative -> colocated with descriptor file
 //   - absolute -> the filesystem root
 // The symlink policy rejects the final component if it is a symlink (O_NOFOLLOW).
+//
+// A relative extent name is confined beneath the descriptor directory: an
+// attacker-supplied '..' (or a symlink leading out of it) is refused with
+// EXDEV by openat2(2)'s RESOLVE_BENEATH and by the fallback walk's
+// `extent_components`. EXDEV is not part of the fallback condition below, so
+// a confinement failure is a hard error and never degrades to the permissive
+// walk.
 //
 // Resolution prefers openat2(2). On kernels without it (< 5.6, ENOSYS) or
 // where it is blocked (EPERM, e.g. a seccomp filter), it falls back to a
@@ -162,10 +182,19 @@ fn open_extent_openat2(
     if direct {
         flags |= libc::O_DIRECT;
     }
+    // Confine a relative extent name beneath the descriptor directory. An
+    // absolute name is anchored at the filesystem root by the caller and its
+    // policy is deliberately left unchanged here, so RESOLVE_BENEATH (which
+    // rejects absolute pathnames outright) is not applied to it.
+    let mut resolve = RESOLVE_NO_MAGICLINKS;
+    if !Path::new(filename).is_absolute() {
+        resolve |= RESOLVE_BENEATH;
+    }
+
     let how = OpenHow {
         flags: flags as u64,
         mode: 0,
-        resolve: 0,
+        resolve,
     };
 
     // SAFETY: FFI syscall. `cname` is NUL-terminated and outlives the call,
@@ -597,16 +626,77 @@ mod tests {
         use vmm_sys_util::tempdir::TempDir;
 
         // A relative path may traverse a symlinked intermediate directory
-        // (only the final component is guarded).
+        // (only the final component is guarded), as long as the symlink stays
+        // beneath the descriptor directory.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-rel-symdir-test").unwrap();
+        let base = dir.as_path();
+        fs::create_dir(base.join("extents")).unwrap();
+        fs::write(base.join("extents").join("s001.vmdk"), b"data").unwrap();
+        symlink("extents", base.join("sub")).unwrap();
+
+        let (openat2_res, walk_res) = open_both(base, "sub/s001.vmdk", false, false);
+        check_openat2(&openat2_res, true);
+        check_walk(&walk_res, true);
+    }
+
+    #[test]
+    fn open_extent_rejects_relative_traversal() {
+        use vmm_sys_util::tempdir::TempDir;
+
+        // Regression test for the extent path traversal: a descriptor naming
+        // its extent "../escape.vmdk" must not reach a file outside the
+        // descriptor's own directory. Both implementations refuse it, openat2
+        // via RESOLVE_BENEATH (EXDEV) and the walk via `extent_components`.
+        let outer = TempDir::new_with_prefix("/tmp/vmdk-traversal-test").unwrap();
+        fs::write(outer.as_path().join("escape.vmdk"), b"secret").unwrap();
+        let base = outer.as_path().join("descriptor-dir");
+        fs::create_dir(&base).unwrap();
+
+        for name in [
+            "../escape.vmdk",
+            "./../escape.vmdk",
+            "sub/../../escape.vmdk",
+        ] {
+            let (openat2_res, walk_res) = open_both(&base, name, true, false);
+            check_openat2(&openat2_res, false);
+            check_walk(&walk_res, false);
+        }
+
+        // And the refusal surfaces from `open_extent` itself: EXDEV is not in
+        // the ENOSYS/EPERM fallback condition, so it is a hard error rather
+        // than a silent downgrade to the permissive walk.
+        let err = open_extent(base.to_str().unwrap(), "../escape.vmdk", true, false).unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::EXDEV),
+            "extent traversal must fail with EXDEV, not fall back to the walk"
+        );
+    }
+
+    #[test]
+    fn open_extent_rejects_symlinked_intermediate_directory_escaping_relative() {
+        use std::os::unix::fs::symlink;
+
+        use vmm_sys_util::tempdir::TempDir;
+
+        // A relative extent name may not leave the descriptor directory
+        // through a symlinked intermediate directory either: openat2 refuses
+        // it with EXDEV. (The fallback walk, which can only inspect the name
+        // and not the resolution, still follows it.)
         let real = TempDir::new_with_prefix("/tmp/vmdk-rel-real-test").unwrap();
         fs::write(real.as_path().join("s001.vmdk"), b"data").unwrap();
 
-        let dir = TempDir::new_with_prefix("/tmp/vmdk-rel-symdir-test").unwrap();
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-rel-escapedir-test").unwrap();
         let base = dir.as_path();
         symlink(real.as_path(), base.join("sub")).unwrap();
 
         let (openat2_res, walk_res) = open_both(base, "sub/s001.vmdk", false, false);
-        check_openat2(&openat2_res, true);
+        if openat2_available(&openat2_res) {
+            assert_eq!(
+                openat2_res.as_ref().err().and_then(|e| e.raw_os_error()),
+                Some(libc::EXDEV)
+            );
+        }
         check_walk(&walk_res, true);
     }
 

--- a/block/src/formats/vmdk/flat.rs
+++ b/block/src/formats/vmdk/flat.rs
@@ -279,7 +279,11 @@ fn overflow_error(what: &str) -> io::Error {
 
 impl FlatVmdk {
     /// Opens a flat VMDK image from its already-open descriptor file.
-    pub fn new(file: File, path: &Path, direct: bool) -> io::Result<Self> {
+    ///
+    /// `readonly` is the access mode the caller asked for and is
+    /// authoritative: when it is set, every extent is opened without write
+    /// access no matter what the (untrusted) descriptor declares.
+    pub fn new(file: File, path: &Path, readonly: bool, direct: bool) -> io::Result<Self> {
         let descriptor = VmdkDescriptor::new(&file, path)?;
 
         if descriptor.extents_list.extents.is_empty() {
@@ -322,10 +326,17 @@ impl FlatVmdk {
             //   "RW"       -> read + write
             //   "RDONLY"   -> read only
             //   "NOACCESS" -> not accessible, do not open the file at all
+            //
+            // A caller-requested read-only open downgrades "RW" to read-only:
+            // the descriptor may never widen the access the operator asked for.
             let (access, extent_file) = match extent.access.as_str() {
-                "RW" => {
+                "RW" if !readonly => {
                     let f = open_extent(&descriptor.base_path, &extent.filename, true, direct)?;
                     (ExtentAccess::ReadWrite, Some(f))
+                }
+                "RW" => {
+                    let f = open_extent(&descriptor.base_path, &extent.filename, false, direct)?;
+                    (ExtentAccess::ReadOnly, Some(f))
                 }
                 "RDONLY" => {
                     let f = open_extent(&descriptor.base_path, &extent.filename, false, direct)?;

--- a/block/src/formats/vmdk/mod.rs
+++ b/block/src/formats/vmdk/mod.rs
@@ -17,6 +17,8 @@ use std::os::unix::io::AsRawFd;
 use std::path::Path;
 
 pub use descriptor::{has_descriptor_header, is_flat_vmdk};
+#[cfg(fuzzing)]
+pub use flat::set_force_extent_walk;
 
 use self::engine_sync::FlatVmdkSync;
 use self::flat::FlatVmdk;

--- a/block/src/formats/vmdk/mod.rs
+++ b/block/src/formats/vmdk/mod.rs
@@ -31,8 +31,11 @@ pub struct VmdkDisk {
 
 impl VmdkDisk {
     /// Builds a Flat VMDK disk backend.
-    pub fn new(file: File, path: &Path, direct: bool) -> Result<Self, BlockError> {
-        let inner = FlatVmdk::new(file, path, direct)?;
+    ///
+    /// When `readonly` is set, the data extents are opened without write
+    /// access even if the descriptor declares them `RW`.
+    pub fn new(file: File, path: &Path, readonly: bool, direct: bool) -> Result<Self, BlockError> {
+        let inner = FlatVmdk::new(file, path, readonly, direct)?;
         Ok(VmdkDisk { inner })
     }
 }
@@ -110,6 +113,7 @@ mod tests {
     use super::*;
     use crate::async_io::OwnedIoBuffer;
     use crate::disk_file::{AsyncDiskFile, DiskFd, DiskSize, PhysicalSize, Resizable};
+    use crate::formats::vmdk::flat::ExtentAccess;
 
     const SECTOR: u64 = 512;
 
@@ -205,7 +209,7 @@ mod tests {
             "monolithicFlat",
             &[("disk-flat.vmdk", "RW", 2048)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         assert_eq!(disk.logical_size().unwrap(), 2048 * SECTOR);
         // The extent is created sparse (`set_len`), so no blocks are allocated
@@ -221,7 +225,7 @@ mod tests {
             "twoGbMaxExtentFlat",
             &[("s001.vmdk", "RW", 2048), ("s002.vmdk", "RW", 1024)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         assert_eq!(disk.logical_size().unwrap(), (2048 + 1024) * SECTOR);
         // Sparse extents: no blocks are allocated, so physical size is 0.
@@ -236,7 +240,7 @@ mod tests {
             "twoGbMaxExtentFlat",
             &[("s001.vmdk", "RW", 2048), ("s002.vmdk", "RW", 1024)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         // Fully pre-allocated extents: host allocation (st_blocks) equals the
         // declared logical size.
@@ -255,7 +259,7 @@ mod tests {
         let file = open_descriptor(&path);
         let expected = file.as_raw_fd();
 
-        let disk = VmdkDisk::new(file, &path, false).unwrap();
+        let disk = VmdkDisk::new(file, &path, false, false).unwrap();
 
         assert_eq!(disk.fd().as_raw_fd(), expected);
     }
@@ -276,13 +280,77 @@ mod tests {
             .write(true)
             .open(&path)
             .unwrap();
-        let disk = VmdkDisk::new(file, &path, false).unwrap();
+        let disk = VmdkDisk::new(file, &path, false, false).unwrap();
         let mut io = disk.create_async_io(1).unwrap();
 
         let buffer = OwnedIoBuffer::from_vec(vec![0u8; 512]);
         let result = io.read_to_vec(u64::MAX as libc::off_t, buffer, 0);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn readonly_open_downgrades_rw_extent() {
+        // The caller asked for a read-only disk, so the "RW" extent must be
+        // opened without write access even though the descriptor allows it.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-ro-test").unwrap();
+        let path = write_flat_vmdk_allocated(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RW", 8)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, true, false).unwrap();
+
+        let extents = disk.inner.extents();
+        assert_eq!(extents.len(), 1);
+        assert_eq!(extents[0].access, ExtentAccess::ReadOnly);
+        assert!(
+            !extents[0].file.as_ref().unwrap().is_writable(),
+            "extent fd must not carry write access for a readonly open"
+        );
+
+        // And a write through the disk is refused rather than silently
+        // reaching the host file.
+        let mut io = disk.create_async_io(1).unwrap();
+        let buffer = OwnedIoBuffer::from_vec(vec![0xAAu8; 512]);
+        assert!(io.write_from_vec(0, buffer, 0).is_err());
+    }
+
+    #[test]
+    fn writable_open_keeps_rw_extent_writable() {
+        // Without a readonly request the descriptor's "RW" is honoured.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-rw-test").unwrap();
+        let path = write_flat_vmdk_allocated(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RW", 8)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
+
+        let extents = disk.inner.extents();
+        assert_eq!(extents[0].access, ExtentAccess::ReadWrite);
+        assert!(extents[0].file.as_ref().unwrap().is_writable());
+    }
+
+    #[test]
+    fn descriptor_rdonly_extent_stays_readonly_for_writable_open() {
+        // A descriptor-declared RDONLY extent stays read-only even when the
+        // caller did not ask for a readonly disk.
+        let dir = TempDir::new_with_prefix("/tmp/vmdk-rdonly-test").unwrap();
+        let path = write_flat_vmdk_allocated(
+            dir.as_path(),
+            "monolithicFlat",
+            &[("disk-flat.vmdk", "RDONLY", 8)],
+        );
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
+
+        let extents = disk.inner.extents();
+        assert_eq!(extents[0].access, ExtentAccess::ReadOnly);
+        assert!(!extents[0].file.as_ref().unwrap().is_writable());
+
+        let mut io = disk.create_async_io(1).unwrap();
+        let buffer = OwnedIoBuffer::from_vec(vec![0xAAu8; 512]);
+        assert!(io.write_from_vec(0, buffer, 0).is_err());
     }
 
     #[test]
@@ -293,7 +361,7 @@ mod tests {
             "monolithicFlat",
             &[("disk-flat.vmdk", "RW", 64)],
         );
-        let mut disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let mut disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         let err = disk.resize(4096).unwrap_err();
         assert_eq!(err.kind(), BlockErrorKind::UnsupportedFeature);
@@ -307,7 +375,7 @@ mod tests {
             "monolithicFlat",
             &[("disk-flat.vmdk", "RW", 2048)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         let cloned = disk.try_clone().unwrap();
         assert_eq!(cloned.logical_size().unwrap(), disk.logical_size().unwrap());
@@ -321,7 +389,7 @@ mod tests {
             "monolithicFlat",
             &[("disk-flat.vmdk", "RW", 2048)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         // Ring depth is ignored by the synchronous VMDK worker.
         disk.create_async_io(0).unwrap();
@@ -335,7 +403,7 @@ mod tests {
             "twoGbMaxExtentFlat",
             &[("s001.vmdk", "RW", 2048), ("s002.vmdk", "RW", 2048)],
         );
-        let disk = VmdkDisk::new(open_descriptor(&path), &path, false).unwrap();
+        let disk = VmdkDisk::new(open_descriptor(&path), &path, false, false).unwrap();
 
         disk.create_async_io(32).unwrap();
     }
@@ -349,7 +417,7 @@ mod tests {
             &["RW 0 FLAT \"disk-flat.vmdk\""],
         );
 
-        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
@@ -360,7 +428,7 @@ mod tests {
         let line = format!("RW {} FLAT \"disk-flat.vmdk\"", u64::MAX);
         let path = write_descriptor(dir.as_path(), "monolithicFlat", &[line.as_str()]);
 
-        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
@@ -371,7 +439,7 @@ mod tests {
         let line = format!("RW 1 FLAT \"disk-flat.vmdk\" {}", u64::MAX);
         let path = write_descriptor(dir.as_path(), "monolithicFlat", &[line.as_str()]);
 
-        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
@@ -386,7 +454,7 @@ mod tests {
         let line = format!("RW 1 FLAT \"disk-flat.vmdk\" {offset}");
         let path = write_descriptor(dir.as_path(), "monolithicFlat", &[line.as_str()]);
 
-        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
@@ -405,7 +473,7 @@ mod tests {
             &[l1.as_str(), l2.as_str()],
         );
 
-        let err = FlatVmdk::new(open_descriptor(&path), &path, false).unwrap_err();
+        let err = FlatVmdk::new(open_descriptor(&path), &path, false, false).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 }

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -126,6 +126,48 @@ The same limit is why `DiskFormat::MAX_IMAGE_LEN` is a per format constant:
 the harness rejects anything larger, and a format whose metadata reaches far
 into the file needs a bigger budget than the 8 MiB default.
 
+### Keeping the corpus openable
+
+A seeded corpus is not enough on its own, because libFuzzer keeps every input
+that found a new edge, including the ones that only found new edges in the
+rejection path. Measured on a campaign corpus, that is what the disk targets
+had become: 6 of 764 `disk_vhd` entries opened (0.8%), 17 of 872 `disk_vhdx`
+(1.9%) and 131 of 1198 `disk_vmdk` (10.9%). For VHD, 634 of the 666 rejections
+were the `conectix` cookie alone, so nearly the whole mutation budget was
+spent on byte strings that could never reach the parser.
+
+`DiskFormat::magic_ok` is the harness side mirror of the first check the
+parser makes, and `fuzz_image` uses it to decide what to retain:
+
+| Format | Magic | Parser check it mirrors |
+| ------ | ----- | ----------------------- |
+| qcow2 | `QFI\xfb` at offset 0 | `QcowHeader::new` |
+| VHDX | `vhdxfile` at offset 0 | `FileTypeIdentifier::new` |
+| fixed VHD | `conectix` at the start of the last 512 bytes | `VhdFooter::validate_fixed` |
+| flat VMDK | a first line of `# Disk DescriptorFile` | `parse_header` |
+
+An input that fails it is still opened, so the parser's own rejection path is
+still fuzzed, but it is returned as `Corpus::Reject` and never retained. It
+cannot be a blanket rejection, because a parser does real work before it looks
+at the magic: `VhdFooter::new` queries the device size, does the length
+arithmetic that finds the footer and computes the footer checksum, and
+`VhdxHeader::new` reads and checksums both headers, all before their signature
+tests. Those paths are reached by exactly the inputs that then fail the magic,
+and the cost of dropping them was measured per region on the campaign
+corpora: 7 `block` regions lost for `disk_vhd`, 3 for `disk_vhdx`, 9 for
+`disk_vmdk` and 2 for `disk_qcow2`.
+
+So the harness keeps a bounded number of them instead: 8 distinct inputs per
+length class, per process, where the class is the binary magnitude of the
+input length. The budget is per class rather than flat because what the code
+in front of a magic check branches on is the length, and the shortest inputs
+are the rarest: a flat budget of 64 still lost the eight byte read failure in
+`FileTypeIdentifier::new` and the four byte length check in the VMDK
+descriptor reader. With the per class budget the retained subsets of the
+campaign corpora, 110 of 764 entries for `disk_vhd`, 265 of 872 for
+`disk_vhdx`, 1056 of 1198 for `disk_vmdk` and 1633 of 2129 for `disk_qcow2`,
+cover every region the full corpora cover.
+
 `disk_<format>_ops` builds its own valid image, so it needs no corpus:
 
 ```
@@ -197,6 +239,9 @@ and which invariants hold for it: `NEEDS_PATH`, `MAX_IMAGE_LEN`,
 `COMPLETES_INLINE`, `PUNCH_HOLE_READS_ZEROES`, `FIXED_CAPACITY`,
 `CAPACITY_FILE_TAIL` and `NO_SHORT_READS`. Each defaults to the value that
 checks nothing, so a format only gains an invariant it can actually keep.
+Override `magic_ok` with the format's identifying bytes, mirroring the first
+check the parser makes, so the image target does not retain inputs that can
+never reach it. Then
 add the targets, the image target always and the operation target when there
 is a template, each a single call into the framework, and register them in
 `fuzz/Cargo.toml`.

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -57,6 +57,7 @@ The formats covered today:
 | Format | Image target | Operation target |
 | ------ | ------------ | ---------------- |
 | qcow2 | `disk_qcow2` | `disk_qcow2_ops` |
+| fixed VHD | `disk_vhd` | none |
 
 An operation target needs a valid image that the harness can build in process
 and that reads back as zeroes, which is what `DiskFormat::template` returns. A
@@ -64,6 +65,11 @@ format without one gets no operation target and so no shadow model, which
 means nothing anywhere can catch it returning the *wrong bytes*: an engine
 that loses or misplaces a guest write passes every other check the framework
 makes.
+
+Fixed VHD deliberately stays without one. `FixedVhdSync` is a bounds check in
+front of `preadv`/`pwritev` on the image file, so a shadow model over it would
+be asserting that the kernel implements `pwritev`, not that the `block` crate
+is correct.
 
 ### Operation targets and the shadow model
 
@@ -103,6 +109,8 @@ at least the size of the largest seed:
 ```
 cargo fuzz run disk_vhdx -j `nproc` -- -max_len=16777216 \
     -dict=fuzz/dictionaries/vhdx.dict
+cargo fuzz run disk_vhd -j `nproc` -- -max_len=4194304 \
+    -dict=fuzz/dictionaries/vhd.dict
 ```
 
 The same limit is why `DiskFormat::MAX_IMAGE_LEN` is a per format constant:

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -139,6 +139,12 @@ also check the trait contract itself: an accepted operation completes exactly
 once and carries its own user data, a rejected operation does not complete at
 all, a completion never reports more bytes than were requested, and a format
 with a fixed capacity neither changes its reported size without a successful
+resize nor transfers bytes beyond it. Two more invariants are opt in, because
+they follow from a format's layout rather than from the trait contract: a
+format whose data sits in the image file never advertises more capacity than
+the file holds, and a format whose read path is all or nothing never completes
+a read successfully with fewer bytes than were asked for.
+
 ### Running in OSS-Fuzz
 
 Cloud Hypervisor is an [OSS-Fuzz](https://github.com/google/oss-fuzz) project,
@@ -186,6 +192,11 @@ impl DiskFormat for MyFormat {
 `path` is `Some` only when the format sets `NEEDS_PATH`, and a format whose
 `template` returns `None` gets no operation target.
 
+Set the associated constants that decide how the framework drives the format
+and which invariants hold for it: `NEEDS_PATH`, `MAX_IMAGE_LEN`,
+`COMPLETES_INLINE`, `PUNCH_HOLE_READS_ZEROES`, `FIXED_CAPACITY`,
+`CAPACITY_FILE_TAIL` and `NO_SHORT_READS`. Each defaults to the value that
+checks nothing, so a format only gains an invariant it can actually keep.
 add the targets, the image target always and the operation target when there
 is a template, each a single call into the framework, and register them in
 `fuzz/Cargo.toml`.

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -70,6 +70,7 @@ The formats covered today:
 | Format | Image target | Operation target |
 | ------ | ------------ | ---------------- |
 | qcow2 | `disk_qcow2` | `disk_qcow2_ops` |
+| VHDX | `disk_vhdx` | `disk_vhdx_ops` |
 | fixed VHD | `disk_vhd` | none |
 
 The sniffer in front of them all is fuzzed by `disk_detect`, and qcow2 backing
@@ -91,10 +92,27 @@ is correct.
 
 ```
 cargo fuzz run disk_qcow2_ops -j `nproc`
+cargo fuzz run disk_vhdx_ops -j `nproc`
 ```
 
 None of them needs `-max_len` or a seed corpus: the input is an operation
 program, not an image.
+
+VHDX is the format that most needs this. It has the most involved write path
+in the tree - BAT lookup, block state transitions, allocation at the end of
+the file, and sector offset arithmetic within the allocated block - and until
+`disk_vhdx_ops` existed none of it had a data correctness oracle. That is not
+hypothetical: the block allocating arm of `vhdx::io::write` used to write the
+payload at the *block base* rather than at the sector's offset within the
+block, so a guest write to any sector but the first of an unallocated block
+was silently misplaced and the data lost. It was found by a hand written two
+operation probe rather than by the fuzzer, precisely because no VHDX operation
+target existed.
+
+VHDX also gets *better* oracle coverage per execution than qcow2 does. It does
+not support resize, so `Op::Resize` always fails and the model is never wiped
+mid program; in `disk_qcow2_ops` a successful resize drops everything the
+model knew and the rest of the program runs unchecked.
 
 Two pieces of the framework exist for these targets:
 

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -52,6 +52,12 @@ mix well in a single one:
 | `disk_<format>` | the whole input is the disk image | parser bugs: headers, tables, region descriptors |
 | `disk_<format>_ops` | an operation program run against a valid image | engine bugs: offset translation, allocation, discard, resize |
 
+The formats covered today:
+
+| Format | Image target | Operation target |
+| ------ | ------------ | ---------------- |
+| qcow2 | `disk_qcow2` | `disk_qcow2_ops` |
+
 An operation target needs a valid image that the harness can build in process
 and that reads back as zeroes, which is what `DiskFormat::template` returns. A
 format without one gets no operation target and so no shadow model, which
@@ -61,6 +67,19 @@ makes.
 
 ### Operation targets and the shadow model
 
+```
+cargo fuzz run disk_qcow2_ops -j `nproc`
+```
+
+None of them needs `-max_len` or a seed corpus: the input is an operation
+program, not an image.
+
+`disk_<format>_ops` builds its own valid image, so it needs no corpus:
+
+```
+cargo fuzz run disk_qcow2_ops -j `nproc`
+```
+
 Because that image is valid and starts out reading as zeroes, the framework
 keeps a shadow model of the disk contents and compares every read against it,
 which turns a silent offset translation bug into a crash. Both target families
@@ -68,3 +87,54 @@ also check the trait contract itself: an accepted operation completes exactly
 once and carries its own user data, a rejected operation does not complete at
 all, a completion never reports more bytes than were requested, and a format
 with a fixed capacity neither changes its reported size without a successful
+### Running in OSS-Fuzz
+
+Cloud Hypervisor is an [OSS-Fuzz](https://github.com/google/oss-fuzz) project,
+which builds every target in `fuzz/fuzz_targets` and runs it continuously.
+Staging these targets there - the `$OUT` layout, the seed corpora and the
+dictionaries - is left to a later change. Two properties matter for a target
+that runs there, and both are worth preserving when adding a format:
+
+- A target must be self contained at run time. It may read nothing from the
+  source tree, because only `$OUT` is shipped to the fuzzing machines. Images
+  live in a memfd, or, for a format that has to be opened from a directory,
+  in a scratch directory the target creates, and an `_ops` target builds its
+  template once per process through a temporary file and keeps it in memory
+  afterwards.
+- A crash must reproduce in a fresh process from its input alone. A template
+  image therefore has to be byte identical on every run, which rules out
+  timestamps, random identifiers and anything else that varies per process.
+
+Seed generation needs `qemu-img`, so an OSS-Fuzz build would have to install
+`qemu-utils`; without it the targets still build and run, just unseeded.
+
+### Adding a disk format
+
+Implement `DiskFormat` in `fuzz/src/disk_engine/formats/`:
+
+```rust
+impl DiskFormat for MyFormat {
+    const NAME: &'static str = "myformat";
+
+    fn open(
+        file: File,
+        path: Option<&Path>,
+        config: &OpenConfig,
+    ) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+        Ok(Box::new(MyDisk::new(file, config.direct)?))
+    }
+
+    fn template() -> Option<&'static [u8]> {
+        // A freshly created image of this format, built once per process,
+        // or None for a format the `block` crate cannot write.
+    }
+}
+```
+
+`path` is `Some` only when the format sets `NEEDS_PATH`, and a format whose
+`template` returns `None` gets no operation target.
+
+add the targets, the image target always and the operation target when there
+is a template, each a single call into the framework, and register them in
+`fuzz/Cargo.toml`.
+

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -33,3 +33,14 @@ cargo fuzz add <new_fuzzer>
 ```
 
 Inspiration for fuzzers can be found in [crosvm](https://chromium.googlesource.com/chromiumos/platform/crosvm/+/refs/heads/master/fuzz/)
+
+## Fuzzing disk image formats
+
+The `disk_*` targets share a format agnostic framework in
+`fuzz/src/disk_engine`. It fuzzes the disk image engine of the `block`
+crate: everything between the point where untrusted image bytes are parsed
+(`factory::open_disk` and the per format constructors) and the trait contract
+the rest of the VMM consumes (`disk_file::AsyncFullDiskFile` and
+`async_io::AsyncIo`). Virtio request parsing sits above that boundary and is
+covered by the `block` target instead.
+

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -113,6 +113,15 @@ cargo fuzz run disk_vhd -j `nproc` -- -max_len=4194304 \
     -dict=fuzz/dictionaries/vhd.dict
 ```
 
+A VMDK image is the text descriptor, not the data: the extents it names are
+separate files that the harness provides in a scratch directory. Its inputs
+are therefore small, and the limit is set accordingly:
+
+```
+cargo fuzz run disk_vmdk -j `nproc` -- -max_len=65536 \
+    -dict=fuzz/dictionaries/vmdk.dict
+```
+
 The same limit is why `DiskFormat::MAX_IMAGE_LEN` is a per format constant:
 the harness rejects anything larger, and a format whose metadata reaches far
 into the file needs a bigger budget than the 8 MiB default.

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -142,6 +142,31 @@ The same limit is why `DiskFormat::MAX_IMAGE_LEN` is a per format constant:
 the harness rejects anything larger, and a format whose metadata reaches far
 into the file needs a bigger budget than the 8 MiB default.
 
+#### How a VMDK extent name is resolved
+
+The extent opener has two arms the harness has to reach on purpose, and both
+are security relevant.
+
+The second is the absolute name. An extent name may be absolute, and then the
+engine anchors resolution at the filesystem root and deliberately does not
+apply `RESOLVE_BENEATH`. A fuzzer may only open an absolute path inside its
+own scratch directory, whose name carries the process id, so no fixed corpus
+entry can name it. A descriptor therefore writes the placeholder
+`/@fuzz-scratch@`, which the harness expands into the scratch directory
+before the parser reads the file, and the name guard accepts an absolute name
+only when it starts with that directory and every component after it is a
+plain name. The expansion is a function of the input alone, and
+`scripts/generate-fuzz-seeds.sh` writes a seed that uses it.
+
+That name guard is lexical, and for an absolute name a lexical guard is not
+enough on its own. `<scratch>/link/victim` is all plain components and still
+leaves the directory when `link` is a symlink, because the absolute arm has no
+`RESOLVE_BENEATH` behind it and `O_NOFOLLOW` only guards the final component -
+and the extent is opened writable. `disk_vmdk` therefore confines the process
+with the same Landlock sandbox `disk_qcow2_chain` uses before the first
+iteration, and fails closed: with no confinement it refuses every absolute
+name and keeps fuzzing the relative arm, which the kernel still confines.
+
 ### QCOW2 backing chains
 
 A qcow2 image may name a backing file, and `disk_qcow2` reaches none of the
@@ -206,6 +231,9 @@ target refuses every input rather than running unconfined. This second belt
 exists because, unlike the VMDK extent path, the engine takes no `openat2`
 `RESOLVE_BENEATH` precaution for a qcow2 backing file, deliberately, so the
 harness guard would otherwise be the only thing between a corpus entry and a
+host path. The same sandbox is used by `disk_vmdk`, where the absolute extent
+arm gives up `RESOLVE_BENEATH` on a *writable* open; there the fail closed
+behaviour is to refuse absolute extent names rather than the whole input.
 
 #### Why it is a separate target
 

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -90,6 +90,25 @@ the target rarely gets past the header check. On a short run of the qcow2
 target an empty corpus reached 479 edges, a single image reached 1605, and the
 generated seeds with the dictionary reached 2073.
 
+**Always pass `-max_len`.** Left to itself libFuzzer derives the limit from
+the corpus but never above 1 MiB, and it truncates larger corpus entries to
+that limit. A truncated image is a rejected image, so the target then fuzzes
+nothing but its own rejection path. It is not hypothetical: `disk_vhdx` covers
+268 edges without the flag and 1071 with it, because the VHDX layout places
+its BAT region at 2 MiB and its metadata region at 3 MiB, so a parseable image
+is 8 MiB when empty and 9 to 10 MiB once it holds data. A fixed VHD keeps its footer in the last 512
+bytes, so truncation removes exactly the part that identifies the format. Use
+at least the size of the largest seed:
+
+```
+cargo fuzz run disk_vhdx -j `nproc` -- -max_len=16777216 \
+    -dict=fuzz/dictionaries/vhdx.dict
+```
+
+The same limit is why `DiskFormat::MAX_IMAGE_LEN` is a per format constant:
+the harness rejects anything larger, and a format whose metadata reaches far
+into the file needs a bigger budget than the 8 MiB default.
+
 `disk_<format>_ops` builds its own valid image, so it needs no corpus:
 
 ```

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -111,6 +111,27 @@ copy: a template is the same buffer every time, so its page map is computed
 once per format and reused. `image_memfd`, which materializes fuzzer input,
 keeps writing it whole - that input is dense and different every time.
 
+#### The template self test
+
+Every templated format has a `#[test]` that asserts four things about its
+template, and it is a merge condition for adding one:
+
+1. the template opens through the format adapter;
+2. `logical_size()` equals an exact pinned constant;
+3. reading the whole disk returns nothing but zero bytes;
+4. the fixed operation program runs through the executor with the shadow model
+   enabled without panicking.
+
+The failure this guards against is not a template that fails to open, which
+`fuzz_program` panics on within one iteration. It is a template that *opens
+but is subtly wrong* - the wrong size, or one extracted from an image that had
+already been written to. The model is initialised to "all zeroes, this many
+bytes"; if the image disagrees, either every read trips the oracle, which is
+loud, or the disk is not the disk the program addresses and the target quietly
+checks nothing. It then reports a 100% pass rate forever, and neither the
+coverage report, nor the crash count, nor CI can tell that state from a
+healthy one.
+
 Corpus entries for `disk_<format>` are ordinary disk images, so anything
 `qemu-img` can write is a usable seed. `scripts/generate-fuzz-seeds.sh` writes
 a set of them per format, covering header versions, compression, cluster sizes

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -168,6 +168,33 @@ campaign corpora, 110 of 764 entries for `disk_vhd`, 265 of 872 for
 `disk_vhdx`, 1056 of 1198 for `disk_vmdk` and 1633 of 2129 for `disk_qcow2`,
 cover every region the full corpora cover.
 
+A checksum protected format needs one more thing: a custom mutator. `disk_vhd`
+and `disk_vhdx` both have one, because their parsers verify a signature and a
+checksum before they look at anything else, so a plain byte mutation is
+rejected at open and the fuzzer never reaches the structure it changed. Each
+target runs `libfuzzer_sys::fuzzer_mutate` and then restores the identifying
+bytes and recomputes the checksums over the result:
+
+| Target | What it restores | What it repairs | Why |
+| ------ | ---------------- | --------------- | --- |
+| `disk_vhdx` | the `vhdxfile` file type identifier and the `head` and `regi` signatures | the CRC-32C of both headers and both region tables | `VhdxHeader::new` refuses an image whose signatures or four checksums do not match |
+| `disk_vhd` | the `conectix` cookie in the last 512 bytes | the fixed VHD footer checksum, big endian | `VhdFooter::validate_fixed` refuses an image whose cookie or footer checksum does not match |
+
+The order matters: the identifying bytes sit inside the checksummed areas, so
+they are written first and the checksum is computed over them.
+
+The offsets and the algorithms are taken from the parser under test rather
+than from the specification, so the mutator and the code it feeds cannot
+disagree. Repair is necessary but not sufficient: the other validated fields
+still reject a mutation on their own merits. Neither repair is unconditional,
+so both rejection branches stay reachable and stay separable. One mutation in
+eight keeps its mutated magic with the checksums repaired, which is the only
+way to reach the signature branch with otherwise valid structures, and a
+different one in eight keeps its mutated checksum with the magic restored,
+which is the only way to reach the checksum branch at all, since the magic is
+tested first. Both targets still take arbitrary bytes, since the corpus
+holds images the mutator never produced.
+
 `disk_<format>_ops` builds its own valid image, so it needs no corpus:
 
 ```
@@ -245,4 +272,10 @@ never reach it. Then
 add the targets, the image target always and the operation target when there
 is a template, each a single call into the framework, and register them in
 `fuzz/Cargo.toml`.
+
+Finally give the image target something to start from: a `seed_<format>`
+function in `scripts/generate-fuzz-seeds.sh` and, when the format is magic
+heavy, a dictionary in `fuzz/dictionaries/`. If the parser checksums part of
+the image, add a repair function next to the adapter and a `fuzz_mutator!`
+that restores the magic and calls it, as `disk_vhd` and `disk_vhdx` do.
 

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -44,3 +44,12 @@ the rest of the VMM consumes (`disk_file::AsyncFullDiskFile` and
 `async_io::AsyncIo`). Virtio request parsing sits above that boundary and is
 covered by the `block` target instead.
 
+### Operation targets and the shadow model
+
+Because that image is valid and starts out reading as zeroes, the framework
+keeps a shadow model of the disk contents and compares every read against it,
+which turns a silent offset translation bug into a crash. Both target families
+also check the trait contract itself: an accepted operation completes exactly
+once and carries its own user data, a rejected operation does not complete at
+all, a completion never reports more bytes than were requested, and a format
+with a fixed capacity neither changes its reported size without a successful

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -74,6 +74,22 @@ cargo fuzz run disk_qcow2_ops -j `nproc`
 None of them needs `-max_len` or a seed corpus: the input is an operation
 program, not an image.
 
+Corpus entries for `disk_<format>` are ordinary disk images, so anything
+`qemu-img` can write is a usable seed. `scripts/generate-fuzz-seeds.sh` writes
+a set of them per format, covering header versions, compression, cluster sizes
+and preallocation:
+
+```
+scripts/generate-fuzz-seeds.sh
+cargo fuzz run disk_qcow2 -j `nproc` -- -max_len=2097152 \
+    -dict=fuzz/dictionaries/qcow2.dict
+```
+
+Seeds matter here: without them libFuzzer caps generated inputs at 4 KiB and
+the target rarely gets past the header check. On a short run of the qcow2
+target an empty corpus reached 479 edges, a single image reached 1605, and the
+generated seeds with the dictionary reached 2073.
+
 `disk_<format>_ops` builds its own valid image, so it needs no corpus:
 
 ```

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -72,6 +72,7 @@ The formats covered today:
 | qcow2 | `disk_qcow2` | `disk_qcow2_ops` |
 | VHDX | `disk_vhdx` | `disk_vhdx_ops` |
 | fixed VHD | `disk_vhd` | none |
+| flat VMDK | `disk_vmdk` | `disk_vmdk_ops` |
 
 The sniffer in front of them all is fuzzed by `disk_detect`, and qcow2 backing
 chains by `disk_qcow2_chain`.
@@ -93,6 +94,7 @@ is correct.
 ```
 cargo fuzz run disk_qcow2_ops -j `nproc`
 cargo fuzz run disk_vhdx_ops -j `nproc`
+cargo fuzz run disk_vmdk_ops -j `nproc`
 ```
 
 None of them needs `-max_len` or a seed corpus: the input is an operation
@@ -179,6 +181,88 @@ loud, or the disk is not the disk the program addresses and the target quietly
 checks nothing. It then reports a 100% pass rate forever, and neither the
 coverage report, nor the crash count, nor CI can tell that state from a
 healthy one.
+
+#### The flat VMDK template, and why it is two extents
+
+Flat VMDK is the third format with an operation target, and the last one with
+translation logic worth an oracle. `FlatVmdkSync` picks an extent for an
+offset, computes `file_base_offset + (offset - virtual_start)` inside it, and
+for a request that crosses an extent boundary splits it into per extent
+segments and counts the bytes each one moved. None of that is the kernel
+doing the work at the same offset the guest asked for, which is what rules
+fixed VHD out, and all of it is invisible to every check the framework makes
+other than reading the data back.
+
+The image file for a flat VMDK *is* its descriptor - the data lives in the
+extent files it names - so the template is two hundred bytes of ASCII rather
+than a binary run table, and there is nothing to expand and nothing to
+checksum:
+
+```
+# Disk DescriptorFile
+version=1
+CID=fffffffe
+parentCID=ffffffff
+createType="twoGbMaxExtentFlat"
+
+# Extent description
+RW 2048 FLAT "image-f001.vmdk" 0
+RW 1024 FLAT "image-f002.vmdk" 1
+
+# The Disk Data Base
+ddb.virtualHWVersion = "4"
+```
+
+That is 1,572,864 bytes of virtual disk, which is the pinned constant the self
+test checks, with the extent boundary at virtual offset 1,048,576. Each part
+of the shape earns its place:
+
+- **two extents**, so a request can straddle the boundary and take
+  `spanning_io`; a one extent descriptor leaves that path, where the byte
+  accounting lives, entirely unexercised;
+- **a non-zero base offset on the second extent**, one sector, because with a
+  zero base offset the `file_base_offset` term vanishes and an error in it
+  cannot be observed;
+- **different extent lengths**, so a bug that used the wrong extent's start or
+  length is not masked by the two being interchangeable;
+- **both extents `RW`**, because a `NOACCESS` extent cannot be read at all and
+  a template containing one could not satisfy the self test's "reads back as
+  zeroes" assertion. `check_access` under `RDONLY` and `NOACCESS` stays with
+  `disk_vmdk`, whose descriptors are fuzzer generated.
+
+Both extent names are relative and both are in the adapter's `EXTENTS` list,
+which is what makes the harness create them and truncate and zero fill them
+before every open - exactly the "reads back as all zeroes" precondition the
+shadow model starts from.
+
+One trap is worth stating, because it applies to any format whose engine
+translates offsets. Writing through a path and reading back through the *same*
+path does not test the translation: an offset error that both the write and
+the read make cancels out and the data comes back where the oracle expects it.
+The adapter's fixed probe therefore reads every write back both ways, once
+spanning and once as a plain single extent read of each side of the boundary,
+and a randomly generated program mixes the two by construction.
+
+There is no known VMDK data corruption bug to point at, and a prior run of ten
+thousand random operations against this shape found no mismatch, so this
+target is a regression net rather than a bug hunt. That it is an *armed* net
+was checked the only way available: a deliberate `+ 512` added to the file
+offset expression, in `single_extent_io` and in `spanning_io` in turn, is
+caught by the fixed probe immediately and by the fuzzer within 24,000 to
+134,000 executions from an empty corpus, or 326 executions when an existing
+corpus is replayed.
+
+The measured effect on `block/src/formats/vmdk/`, with `disk_vmdk` on a 1311
+entry campaign corpus before and the two targets' profiles merged after:
+
+| File | Regions before | after | Branches before | after |
+| ---- | -------------- | ----- | --------------- | ----- |
+| `engine_sync.rs` | 82.11% | 89.82% | 82.00% | 92.00% |
+| `flat.rs` | 88.92% | 89.24% | 73.33% | 76.67% |
+| `descriptor.rs` | 71.06% | 71.06% | 72.22% | 72.22% |
+
+`descriptor.rs` does not move and is not meant to: the operation target parses
+one fixed descriptor. The I/O engine is what it is for.
 
 Corpus entries for `disk_<format>` are ordinary disk images, so anything
 `qemu-img` can write is a usable seed. `scripts/generate-fuzz-seeds.sh` writes

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -52,6 +52,19 @@ mix well in a single one:
 | `disk_<format>` | the whole input is the disk image | parser bugs: headers, tables, region descriptors |
 | `disk_<format>_ops` | an operation program run against a valid image | engine bugs: offset translation, allocation, discard, resize |
 
+One target sits outside that scheme. `disk_detect` drives
+`block::detect_image_type`, the sniffer `factory::open_disk` runs before it
+chooses a parser. Its input space is every format at once, so it cannot live
+inside a per format target: an input that finds a new edge in the VHD sniffer
+says nothing about the VHDX parser, and keeping it in the `disk_vhdx` corpus
+only spends that target's budget on images it can never open. Its seed corpus
+is the union of the per format seeds, which
+`scripts/generate-fuzz-seeds.sh` writes to `fuzz/corpus/disk_detect`:
+
+```
+cargo fuzz run disk_detect -j `nproc` -- -max_len=16777216
+```
+
 The formats covered today:
 
 | Format | Image target | Operation target |

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -513,6 +513,28 @@ the shadow model can then hold more tables than the cache does, so nothing
 ever evicted. The second qcow2 template is 4 MiB with 512 byte clusters,
 which is 128 L2 tables and still under the model's 8 MiB limit.
 
+A template alone is not enough either: with `MAX_OPS` at 64, no program of
+ordinary operations can keep 101 tables live however its offsets fall. The
+`Sweep` operation writes one sector into each of up to 192 consecutive L2
+tables and then reads every one of them back. The write pass outruns the
+cache; the read back pass is what makes the eviction testable rather than
+merely reachable, since a table written back to the wrong place, or dropped
+without a write back, only shows up when the data behind it is read after the
+cache has moved on. Because the sweep runs under the shadow model, that shows
+up as a read back mismatch.
+
+A sweep only walks its full run against a template that can actually evict.
+The stride is one L2 table of the small cluster image, 32 KiB, but the
+program picks the template by index and an even index selects the default
+one, whose single L2 table maps the whole disk: half of all programs were
+paying up to 384 I/Os per `Sweep` to write and read back the same table,
+which cannot evict anything. A format now declares which of its templates has
+more tables than the engine caches, and a sweep against any other walks a
+single table, so the operation stays live on both layouts and only the
+repeats go. Measured on `disk_qcow2_ops`, replaying a fixed 1080 entry corpus
+fell from 11.1s to 10.6s, and dirty evictions over that corpus were identical
+at 7000, so the saving costs no eviction coverage at all.
+
 Because that image is valid and starts out reading as zeroes, the framework
 keeps a shadow model of the disk contents and compares every read against it,
 which turns a silent offset translation bug into a crash. Both target families

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -168,6 +168,13 @@ limit stops it. The directory also holds `leaf.raw`, a fixed empty file: two
 fuzzer images can only build a chain that closes on itself, which the nesting
 limit always refuses, so a chain that reads through three levels needs a third
 file, and any file is a valid raw backing.
+
+```
+scripts/generate-fuzz-seeds.sh
+cargo fuzz run disk_qcow2_chain -j `nproc` -- -max_len=4194312 \
+    -dict=fuzz/dictionaries/qcow2_chain.dict
+```
+
 #### The sandbox
 
 The backing file is named by *path*, and the engine resolves a relative name

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -104,6 +104,11 @@ Two pieces of the framework exist for these targets:
   be rejected at the door and the model would never see a byte. The executor
   snaps in range offsets down and lengths up to this value; `OpOffset::Wild`
   offsets are left alone so the bounds and overflow checks stay reachable.
+- A refused sparse op leaves the model alone. VHDX and VHD reject every
+  `punch_hole` and `write_zeroes` outright, and an op the engine refused
+  changed nothing, so marking its range unknown would let a program blank the
+  model out range by range and check nothing.
+
 A third piece is about throughput rather than correctness. An operation target
 rewrites its template every iteration, and the VHDX template is 8 MiB, so a
 plain `write_all` of it caps `disk_vhdx_ops` at 142 executions a second,

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -96,6 +96,21 @@ cargo fuzz run disk_qcow2_ops -j `nproc`
 None of them needs `-max_len` or a seed corpus: the input is an operation
 program, not an image.
 
+A third piece is about throughput rather than correctness. An operation target
+rewrites its template every iteration, and the VHDX template is 8 MiB, so a
+plain `write_all` of it caps `disk_vhdx_ops` at 142 executions a second,
+measured on a loaded 96 way host. `template_memfd` and `template_file` instead
+size the file with `set_len`, which costs nothing and reads back as zeroes,
+and write only the pages that carry data - six of 2048. That is 560
+executions a second, four times as many.
+
+The obvious form of that does not work. Scanning the buffer for zero pages on
+every iteration takes 6.1 ms for 8 MiB where writing it takes 5.9 ms, and the
+target ran at 17 executions a second. What has to go is the scan, not the
+copy: a template is the same buffer every time, so its page map is computed
+once per format and reused. `image_memfd`, which materializes fuzzer input,
+keeps writing it whole - that input is dense and different every time.
+
 Corpus entries for `disk_<format>` are ordinary disk images, so anything
 `qemu-img` can write is a usable seed. `scripts/generate-fuzz-seeds.sh` writes
 a set of them per format, covering header versions, compression, cluster sizes

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -501,6 +501,18 @@ holds images the mutator never produced.
 cargo fuzz run disk_qcow2_ops -j `nproc`
 ```
 
+#### Templates and the L2 cache
+
+A format may build more than one template image, and the program picks one by
+index, because some engine behaviour follows from the image layout rather
+than from the operations. qcow2 is the case in point: the number of L2 tables
+an image has follows from its cluster size, the engine caches 100 of them and
+writes a dirty table back when it evicts it, and with the default 64 KiB
+cluster one L2 table covers 512 MiB of the disk. No image small enough for
+the shadow model can then hold more tables than the cache does, so nothing
+ever evicted. The second qcow2 template is 4 MiB with 512 byte clusters,
+which is 128 L2 tables and still under the model's 8 MiB limit.
+
 Because that image is valid and starts out reading as zeroes, the framework
 keeps a shadow model of the disk contents and compares every read against it,
 which turns a silent offset translation bug into a crash. Both target families

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -96,6 +96,14 @@ cargo fuzz run disk_qcow2_ops -j `nproc`
 None of them needs `-max_len` or a seed corpus: the input is an operation
 program, not an image.
 
+Two pieces of the framework exist for these targets:
+
+- `DiskFormat::IO_ALIGNMENT`. The VHDX engine refuses an offset or a length
+  that is not a multiple of the logical sector size. A uniformly random `u16`
+  length is a multiple of 512 in 0.2% of cases, so an unshaped program would
+  be rejected at the door and the model would never see a byte. The executor
+  snaps in range offsets down and lengths up to this value; `OpOffset::Wild`
+  offsets are left alone so the bounds and overflow checks stay reachable.
 A third piece is about throughput rather than correctness. An operation target
 rewrites its template every iteration, and the VHDX template is 8 MiB, so a
 plain `write_all` of it caps `disk_vhdx_ops` at 142 executions a second,

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -44,6 +44,21 @@ the rest of the VMM consumes (`disk_file::AsyncFullDiskFile` and
 `async_io::AsyncIo`). Virtio request parsing sits above that boundary and is
 covered by the `block` target instead.
 
+Every format has two targets, because the two interesting input spaces do not
+mix well in a single one:
+
+| Target | Input | What it finds |
+| ------ | ----- | ------------- |
+| `disk_<format>` | the whole input is the disk image | parser bugs: headers, tables, region descriptors |
+| `disk_<format>_ops` | an operation program run against a valid image | engine bugs: offset translation, allocation, discard, resize |
+
+An operation target needs a valid image that the harness can build in process
+and that reads back as zeroes, which is what `DiskFormat::template` returns. A
+format without one gets no operation target and so no shadow model, which
+means nothing anywhere can catch it returning the *wrong bytes*: an engine
+that loses or misplaces a guest write passes every other check the framework
+makes.
+
 ### Operation targets and the shadow model
 
 Because that image is valid and starts out reading as zeroes, the framework

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -147,6 +147,19 @@ into the file needs a bigger budget than the 8 MiB default.
 The extent opener has two arms the harness has to reach on purpose, and both
 are security relevant.
 
+The first is the fallback walk. `open_extent` resolves a name with
+`openat2(2)` and `RESOLVE_BENEATH` and only walks the path component by
+component when the syscall is missing (`ENOSYS`, kernels before 5.6) or
+blocked (`EPERM`). On any kernel a fuzzer runs on the first call succeeds, so
+`open_extent_walk` and `extent_components` never run, and they are precisely
+where the fallback rejects a traversing name itself, without a kernel to do
+it. A `cfg(fuzzing)` switch in `block/src/formats/vmdk/flat.rs` lets the
+harness take the walk instead, and the VMDK adapter sets it from a hash of
+the descriptor, one input in two. Deriving it from the input rather than from
+an environment variable is what keeps a crash reproducible from its bytes
+alone; a seccomp filter could not do that, because a filter is process wide
+and cannot be lifted once installed.
+
 The second is the absolute name. An extent name may be absolute, and then the
 engine anchors resolution at the filesystem root and deliberately does not
 apply `RESOLVE_BENEATH`. A fuzzer may only open an absolute path inside its

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -72,6 +72,9 @@ The formats covered today:
 | qcow2 | `disk_qcow2` | `disk_qcow2_ops` |
 | fixed VHD | `disk_vhd` | none |
 
+The sniffer in front of them all is fuzzed by `disk_detect`, and qcow2 backing
+chains by `disk_qcow2_chain`.
+
 An operation target needs a valid image that the harness can build in process
 and that reads back as zeroes, which is what `DiskFormat::template` returns. A
 format without one gets no operation target and so no shadow model, which
@@ -138,6 +141,74 @@ cargo fuzz run disk_vmdk -j `nproc` -- -max_len=65536 \
 The same limit is why `DiskFormat::MAX_IMAGE_LEN` is a per format constant:
 the harness rejects anything larger, and a format whose metadata reaches far
 into the file needs a bigger budget than the 8 MiB default.
+
+### QCOW2 backing chains
+
+A qcow2 image may name a backing file, and `disk_qcow2` reaches none of the
+code that follows one: it opens every image with `backing_files: false`, which
+leaves `BackingFile::new`, the `Raw` versus `Qcow2` dispatch, all of
+`block/src/formats/qcow/backing.rs`, the `MAX_NESTING_DEPTH` recursion and the
+copy on write from backing arm of `deallocate_bytes` unreachable.
+`disk_qcow2_chain` covers them.
+
+Its input is two images, because a chain needs a backing image and that image
+has to be fuzzer controlled too, or the target would only ever see a valid
+backing file:
+
+```text
+[u32 LE top_len][top_len bytes: the image][the rest: the backing image]
+```
+
+The harness writes the backing half into its scratch directory, under the name
+the top image asks for and under `backing.img`, then writes the top image and
+opens it with backing files enabled. A backing image that itself names a
+backing file is what reaches the nested chain code, and one that names
+`backing.img`, the file it is itself written to, recurses until the nesting
+limit stops it. The directory also holds `leaf.raw`, a fixed empty file: two
+fuzzer images can only build a chain that closes on itself, which the nesting
+limit always refuses, so a chain that reads through three levels needs a third
+file, and any file is a valid raw backing.
+#### The sandbox
+
+The backing file is named by *path*, and the engine resolves a relative name
+against the directory of the image that stores it with a plain `Path::join`,
+which follows `..` straight out of that directory, then opens it. A corpus
+entry could therefore name any file the fuzzer can reach. That is why backing
+files were excluded from the framework until this target existed, and it is
+why the target needs two independent protections.
+
+The first is a name guard in the harness. It parses `backing_file_offset` and
+`backing_file_size` out of the raw input bytes itself, exactly as
+`QcowHeader::new` does, because the decision has to be made before the `block`
+crate opens anything, and it refuses the input unless the name is a single
+`Component::Normal`: no absolute path, no `..`, no `.`, no subdirectory, no
+embedded NUL. It is applied to *both* images, since the backing image's own
+header can name a further file. The policy is refusal rather than clamping the
+name to a safe value, for the same reason the VMDK extent guard refuses: this
+is a safety check, and a check that rewrites attacker controlled offsets in
+place is more code whose bugs fail open, while a refusal fails closed. The
+mutation budget is protected instead by materializing the backing image under
+whatever plain name the input asks for, so a mutation of the name field still
+opens something.
+
+The second is Landlock, applied once per process before the first iteration,
+allowing writes only under the scratch directory and the fuzzer's own corpus
+and artifact directories, and reads only under those, `/proc` and the system
+library directories. It fails closed: if the kernel has no Landlock, the
+target refuses every input rather than running unconfined. This second belt
+exists because, unlike the VMDK extent path, the engine takes no `openat2`
+`RESOLVE_BENEATH` precaution for a qcow2 backing file, deliberately, so the
+harness guard would otherwise be the only thing between a corpus entry and a
+
+#### Why it is a separate target
+
+`Qcow2` declares `PUNCH_HOLE_READS_ZEROES`, which is true only for an image
+without a backing file: with one, a discarded cluster reads *through* to the
+backing data, so the shadow model would report data corruption that is not
+there. `disk_qcow2_chain` therefore runs the fixed op program with the model
+off, and `OpenConfig::backing` is not fuzzer selectable, so `fuzz_program`
+cannot enable backing files under the model even for a format whose template
+changes. `disk_qcow2` and `disk_qcow2_ops` are untouched.
 
 ### Keeping the corpus openable
 
@@ -292,3 +363,8 @@ heavy, a dictionary in `fuzz/dictionaries/`. If the parser checksums part of
 the image, add a repair function next to the adapter and a `fuzz_mutator!`
 that restores the magic and calls it, as `disk_vhd` and `disk_vhdx` do.
 
+Backing files are no longer left out, but they are confined: a fuzzed image
+names its backing file by path, so `disk_qcow2_chain` parses the name out of
+the image itself, refuses anything but a plain file name in its scratch
+directory, and confines the process with Landlock on top. A format that
+resolves names out of the image needs both before it may open them.

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -124,6 +124,23 @@ copy: a template is the same buffer every time, so its page map is computed
 once per format and reused. `image_memfd`, which materializes fuzzer input,
 keeps writing it whole - that input is dense and different every time.
 
+#### The VHDX template, and why it is a table
+
+The `block` crate parses VHDX but never writes one, so the template is the
+image `qemu-img create -f vhdx -o subformat=dynamic,block_size=1M t.vhdx 4M`
+produces, stored in `fuzz/src/disk_engine/formats/vhdx.rs` as the offsets and
+bytes of its non-zero runs. The file is 8,388,608 bytes of which 333 are
+non-zero, in eleven runs, so the table is eleven lines and the harness expands
+it into the full image once per process behind a `OnceLock`.
+
+The alternatives were worse. An 8 MiB binary blob is not something upstream
+takes into the tree. Calling `qemu-img` at build time makes the harness need
+`qemu-utils` under OSS-Fuzz and makes the template depend on the qemu version,
+so a crash would stop reproducing when the build host changed. Writing the
+format by hand means two 4 KiB headers, two 64 KiB region tables, a 1 MiB BAT
+and a metadata region: some three hundred lines that would fuzz the harness
+author's reading of the specification rather than the parser under test.
+
 #### The template self test
 
 Every templated format has a `#[test]` that asserts four things about its

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -252,6 +252,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "block",
+ "crc-any",
  "devices",
  "epoll",
  "hypervisor",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -78,6 +78,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -366,6 +369,17 @@ name = "debug-helper"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80a4af69c60438a1a82af89d362f4729fd38db7b73f305a237636fad31ceb2bf"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "devices"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,7 +16,7 @@ mshv_emulator = ["hypervisor/mshv_emulator"]
 pvmemcontrol = []
 
 [dependencies]
-arbitrary = "1.4.2"
+arbitrary = { version = "1.4.2", features = ["derive"] }
 block = { path = "../block" }
 devices = { path = "../devices" }
 epoll = "4.4.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -84,6 +84,12 @@ test = false
 
 [[bin]]
 doc = false
+name = "disk_qcow2_chain"
+path = "fuzz_targets/disk_qcow2_chain.rs"
+test = false
+
+[[bin]]
+doc = false
 name = "disk_qcow2_ops"
 path = "fuzz_targets/disk_qcow2_ops.rs"
 test = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -96,6 +96,12 @@ test = false
 
 [[bin]]
 doc = false
+name = "disk_vmdk"
+path = "fuzz_targets/disk_vmdk.rs"
+test = false
+
+[[bin]]
+doc = false
 name = "http_api"
 path = "fuzz_targets/http_api.rs"
 test = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -84,6 +84,12 @@ test = false
 
 [[bin]]
 doc = false
+name = "disk_vhd"
+path = "fuzz_targets/disk_vhd.rs"
+test = false
+
+[[bin]]
+doc = false
 name = "disk_vhdx"
 path = "fuzz_targets/disk_vhdx.rs"
 test = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -72,6 +72,12 @@ test = false
 
 [[bin]]
 doc = false
+name = "disk_detect"
+path = "fuzz_targets/disk_detect.rs"
+test = false
+
+[[bin]]
+doc = false
 name = "disk_qcow2"
 path = "fuzz_targets/disk_qcow2.rs"
 test = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -113,6 +113,12 @@ test = false
 
 [[bin]]
 doc = false
+name = "disk_vhdx_ops"
+path = "fuzz_targets/disk_vhdx_ops.rs"
+test = false
+
+[[bin]]
+doc = false
 name = "disk_vmdk"
 path = "fuzz_targets/disk_vmdk.rs"
 test = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -81,6 +81,12 @@ test = false
 
 [[bin]]
 doc = false
+name = "disk_vhdx"
+path = "fuzz_targets/disk_vhdx.rs"
+test = false
+
+[[bin]]
+doc = false
 name = "http_api"
 path = "fuzz_targets/http_api.rs"
 test = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,7 +17,9 @@ pvmemcontrol = []
 
 [dependencies]
 arbitrary = { version = "1.4.2", features = ["derive"] }
-block = { path = "../block" }
+# test-utils provides the valid template images that the disk_*_ops targets
+# run their op programs against.
+block = { path = "../block", features = ["test-utils"] }
 devices = { path = "../devices" }
 epoll = "4.4.0"
 hypervisor = { path = "../hypervisor", features = ["mshv_emulator"] }
@@ -63,6 +65,18 @@ test = false
 doc = false
 name = "console"
 path = "fuzz_targets/console.rs"
+test = false
+
+[[bin]]
+doc = false
+name = "disk_qcow2"
+path = "fuzz_targets/disk_qcow2.rs"
+test = false
+
+[[bin]]
+doc = false
+name = "disk_qcow2_ops"
+path = "fuzz_targets/disk_qcow2_ops.rs"
 test = false
 
 [[bin]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -125,6 +125,12 @@ test = false
 
 [[bin]]
 doc = false
+name = "disk_vmdk_ops"
+path = "fuzz_targets/disk_vmdk_ops.rs"
+test = false
+
+[[bin]]
+doc = false
 name = "http_api"
 path = "fuzz_targets/http_api.rs"
 test = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,6 +8,11 @@ version = "0.0.0"
 [package.metadata]
 cargo-fuzz = true
 
+# `cargo fuzz` builds every crate with `--cfg fuzzing`, which the VMDK
+# adapter uses to select the extent opener's fallback walk.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+
 [features]
 default = ["mshv_emulator"]
 igvm = []

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,6 +20,9 @@ arbitrary = { version = "1.4.2", features = ["derive"] }
 # test-utils provides the valid template images that the disk_*_ops targets
 # run their op programs against.
 block = { path = "../block", features = ["test-utils"] }
+# The disk_vhdx mutator recomputes the VHDX CRC-32C checksums, and must use
+# the same implementation the parser verifies them with.
+crc-any = "3.0.0"
 devices = { path = "../devices" }
 epoll = "4.4.0"
 hypervisor = { path = "../hypervisor", features = ["mshv_emulator"] }

--- a/fuzz/dictionaries/qcow2.dict
+++ b/fuzz/dictionaries/qcow2.dict
@@ -1,0 +1,53 @@
+# Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# libFuzzer dictionary for the qcow2 image format, used by the disk_qcow2
+# target. Tokens are the magic values and field encodings that a mutated
+# image has to reproduce to reach past a header check.
+
+header_magic="QFI\xfb"
+header_version_2="\x00\x00\x00\x02"
+header_version_3="\x00\x00\x00\x03"
+
+# Header extension identifiers.
+ext_end="\x00\x00\x00\x00"
+ext_backing_format="\xe2\x79\x2a\xca"
+ext_feature_table="\x68\x03\xf8\x57"
+ext_crypto_header="\x05\x37\xbe\x77"
+ext_bitmaps="\x23\x85\x28\x75"
+ext_external_data="\x44\x41\x54\x41"
+
+# Backing file format names.
+backing_raw="raw"
+backing_qcow2="qcow2"
+
+# Encryption methods: none, AES, LUKS.
+crypt_none="\x00\x00\x00\x00"
+crypt_aes="\x00\x00\x00\x01"
+crypt_luks="\x00\x00\x00\x02"
+
+# Compatible, incompatible and autoclear feature bits.
+feature_dirty="\x00\x00\x00\x00\x00\x00\x00\x01"
+feature_corrupt="\x00\x00\x00\x00\x00\x00\x00\x02"
+feature_external_data="\x00\x00\x00\x00\x00\x00\x00\x04"
+feature_compression_type="\x00\x00\x00\x00\x00\x00\x00\x08"
+feature_extended_l2="\x00\x00\x00\x00\x00\x00\x00\x10"
+
+# Compression types: zlib and zstd.
+compression_zlib="\x00"
+compression_zstd="\x01"
+
+# Cluster and refcount sizing exponents.
+cluster_bits_9="\x00\x00\x00\x09"
+cluster_bits_12="\x00\x00\x00\x0c"
+cluster_bits_16="\x00\x00\x00\x10"
+cluster_bits_21="\x00\x00\x00\x15"
+refcount_order_0="\x00\x00\x00\x00"
+refcount_order_4="\x00\x00\x00\x04"
+refcount_order_6="\x00\x00\x00\x06"
+
+# L1, L2 and refcount entry flags.
+entry_copied="\x80\x00\x00\x00\x00\x00\x00\x00"
+entry_compressed="\x40\x00\x00\x00\x00\x00\x00\x00"
+entry_zero="\x00\x00\x00\x00\x00\x00\x00\x01"

--- a/fuzz/dictionaries/qcow2_chain.dict
+++ b/fuzz/dictionaries/qcow2_chain.dict
@@ -1,0 +1,71 @@
+# Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# libFuzzer dictionary for the qcow2 backing chain target, disk_qcow2_chain.
+# It is the qcow2 dictionary plus what this target's input adds: the backing
+# file names the harness materializes, and the header fields that point at
+# the name.
+
+# Backing file names the harness creates in its scratch directory. A name
+# that is not one of these opens nothing, and one that leaves the directory
+# is refused outright.
+backing_name_default="backing.img"
+backing_name_base="base.qcow2"
+backing_name_raw="base.raw"
+backing_name_self="image.qcow2-chain"
+backing_name_leaf="leaf.raw"
+
+# backing_file_offset and backing_file_size, the two header fields that say
+# where the name is (block/src/formats/qcow/header.rs:217). The offset has to
+# land inside the first cluster and past the header.
+backing_offset_512="\x00\x00\x00\x00\x00\x00\x02\x00"
+backing_offset_1024="\x00\x00\x00\x00\x00\x00\x04\x00"
+backing_size_10="\x00\x00\x00\x0a"
+backing_size_11="\x00\x00\x00\x0b"
+
+header_magic="QFI\xfb"
+header_version_2="\x00\x00\x00\x02"
+header_version_3="\x00\x00\x00\x03"
+
+# Header extension identifiers.
+ext_end="\x00\x00\x00\x00"
+ext_backing_format="\xe2\x79\x2a\xca"
+ext_feature_table="\x68\x03\xf8\x57"
+ext_crypto_header="\x05\x37\xbe\x77"
+ext_bitmaps="\x23\x85\x28\x75"
+ext_external_data="\x44\x41\x54\x41"
+
+# Backing file format names.
+backing_raw="raw"
+backing_qcow2="qcow2"
+
+# Encryption methods: none, AES, LUKS.
+crypt_none="\x00\x00\x00\x00"
+crypt_aes="\x00\x00\x00\x01"
+crypt_luks="\x00\x00\x00\x02"
+
+# Compatible, incompatible and autoclear feature bits.
+feature_dirty="\x00\x00\x00\x00\x00\x00\x00\x01"
+feature_corrupt="\x00\x00\x00\x00\x00\x00\x00\x02"
+feature_external_data="\x00\x00\x00\x00\x00\x00\x00\x04"
+feature_compression_type="\x00\x00\x00\x00\x00\x00\x00\x08"
+feature_extended_l2="\x00\x00\x00\x00\x00\x00\x00\x10"
+
+# Compression types: zlib and zstd.
+compression_zlib="\x00"
+compression_zstd="\x01"
+
+# Cluster and refcount sizing exponents.
+cluster_bits_9="\x00\x00\x00\x09"
+cluster_bits_12="\x00\x00\x00\x0c"
+cluster_bits_16="\x00\x00\x00\x10"
+cluster_bits_21="\x00\x00\x00\x15"
+refcount_order_0="\x00\x00\x00\x00"
+refcount_order_4="\x00\x00\x00\x04"
+refcount_order_6="\x00\x00\x00\x06"
+
+# L1, L2 and refcount entry flags.
+entry_copied="\x80\x00\x00\x00\x00\x00\x00\x00"
+entry_compressed="\x40\x00\x00\x00\x00\x00\x00\x00"
+entry_zero="\x00\x00\x00\x00\x00\x00\x00\x01"

--- a/fuzz/dictionaries/vhd.dict
+++ b/fuzz/dictionaries/vhd.dict
@@ -1,0 +1,32 @@
+# Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# libFuzzer dictionary for the VHD image format, used by the disk_vhd target.
+# The footer sits in the last 512 bytes of the file and is what decides
+# whether Cloud Hypervisor accepts an image at all.
+
+footer_cookie="conectix"
+dynamic_header_cookie="cxsparse"
+
+# A fixed VHD is the combination the parser insists on: this format version,
+# this data offset and this disk type.
+file_format_version_1_0="\x00\x01\x00\x00"
+data_offset_fixed="\xff\xff\xff\xff\xff\xff\xff\xff"
+disk_type_fixed="\x00\x00\x00\x02"
+disk_type_dynamic="\x00\x00\x00\x03"
+disk_type_differencing="\x00\x00\x00\x04"
+
+# Creator applications and host operating systems seen in real images.
+creator_qemu="qemu"
+creator_vpc="vpc "
+creator_vs="vs  "
+creator_win="win "
+host_os_windows="Wi2k"
+host_os_macintosh="Mac "
+
+# Geometry and saved state.
+geometry_cylinders_max="\xff\xff"
+geometry_heads_16="\x10"
+geometry_sectors_255="\xff"
+saved_state_set="\x01"

--- a/fuzz/dictionaries/vhdx.dict
+++ b/fuzz/dictionaries/vhdx.dict
@@ -1,0 +1,50 @@
+# Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# libFuzzer dictionary for the VHDX image format, used by the disk_vhdx
+# target. The signatures and GUIDs are the ones the parser in the block crate
+# looks for; GUIDs are in the little-endian byte order VHDX stores them in.
+
+file_identifier="vhdxfile"
+header_signature="head"
+region_signature="regi"
+metadata_signature="metadata"
+
+# Log entry signatures.
+log_entry="loge"
+log_zero="zero"
+log_descriptor="desc"
+log_data="data"
+
+# Region table entries.
+region_bat_guid="\x66\x77\xc2\x2d\x23\xf6\x00\x42\x9d\x64\x11\x5e\x9b\xfd\x4a\x08"
+region_metadata_guid="\x06\xa2\x7c\x8b\x90\x47\x9a\x4b\xb8\xfe\x57\x5f\x05\x0f\x88\x6e"
+region_required="\x01\x00\x00\x00"
+
+# Metadata table item identifiers.
+meta_file_parameters="\x37\x67\xa1\xca\x36\xfa\x43\x4d\xb3\xb6\x33\xf0\xaa\x44\xe7\x6b"
+meta_virtual_disk_size="\x24\x42\xa5\x2f\x1b\xcd\x76\x48\xb2\x11\x5d\xbe\xd8\x3b\xf4\xb8"
+meta_virtual_disk_id="\xab\x12\xca\xbe\xe6\xb2\x23\x45\x93\xef\xc3\x09\xe0\x00\xc7\x46"
+meta_logical_sector_size="\x1d\xbf\x41\x81\x6f\xa9\x09\x47\xba\x47\xf2\x33\xa8\xfa\xab\x5f"
+meta_physical_sector_size="\xc7\x48\xa3\xcd\x5d\x44\x71\x44\x9c\xc9\xe9\x88\x52\x51\xc5\x56"
+meta_parent_locator="\x2d\x5f\xd3\xa8\x0b\xb3\x4d\x45\xab\xf7\xd3\xd8\x48\x34\xab\x0c"
+
+# Metadata entry flags: is_required, and the file parameter bits.
+meta_flag_required="\x04\x00\x00\x00"
+meta_has_parent="\x02\x00\x00\x00"
+
+# Block sizes the metadata parser bounds against: 1 MiB and 256 MiB.
+block_size_min="\x00\x00\x10\x00"
+block_size_max="\x00\x00\x00\x10"
+
+# Sector sizes.
+sector_size_512="\x00\x02\x00\x00"
+sector_size_4k="\x00\x10\x00\x00"
+
+# BAT entry states: not present, undefined, zero, unmapped, fully present.
+bat_state_present="\x06"
+bat_state_partially_present="\x07"
+bat_state_undefined="\x01"
+bat_state_zero="\x02"
+bat_state_unmapped="\x03"

--- a/fuzz/dictionaries/vmdk.dict
+++ b/fuzz/dictionaries/vmdk.dict
@@ -1,0 +1,46 @@
+# Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# libFuzzer dictionary for the flat VMDK descriptor, used by the disk_vmdk
+# target. A descriptor is line oriented text, so the tokens are the section
+# comments, keywords and values the parser matches on.
+
+section_header="# Disk DescriptorFile"
+section_extent="# Extent description"
+section_ddb="# The Disk Data Base"
+section_ddb_short="#DDB"
+
+version="version=1"
+cid="CID=ffffffff"
+parent_cid="parentCID=ffffffff"
+
+create_type="createType="
+create_monolithic_flat="monolithicFlat"
+create_two_gb_flat="twoGbMaxExtentFlat"
+create_monolithic_sparse="monolithicSparse"
+create_two_gb_sparse="twoGbMaxExtentSparse"
+create_stream_optimized="streamOptimized"
+create_full_device="fullDevice"
+
+# Extent access modes and the only supported extent type.
+access_rw="RW"
+access_rdonly="RDONLY"
+access_noaccess="NOACCESS"
+extent_flat="FLAT"
+extent_sparse="SPARSE"
+extent_zero="ZERO"
+
+# A whole extent line, the shape the parser splits on.
+extent_line="RW 2048 FLAT \"image-flat.vmdk\" 0"
+
+# Disk database keys.
+ddb_hw_version="ddb.virtualHWVersion"
+ddb_cylinders="ddb.geometry.cylinders"
+ddb_heads="ddb.geometry.heads"
+ddb_sectors="ddb.geometry.sectors"
+ddb_adapter="ddb.adapterType"
+ddb_tools="ddb.toolsVersion"
+adapter_ide="ide"
+adapter_lsilogic="lsilogic"
+adapter_buslogic="buslogic"

--- a/fuzz/dictionaries/vmdk.dict
+++ b/fuzz/dictionaries/vmdk.dict
@@ -34,6 +34,13 @@ extent_zero="ZERO"
 # A whole extent line, the shape the parser splits on.
 extent_line="RW 2048 FLAT \"image-flat.vmdk\" 0"
 
+# The harness expands this placeholder into its scratch directory, which is
+# the only way a corpus entry can name an absolute extent path: the engine
+# resolves an absolute name from the filesystem root and deliberately does
+# not confine it, and that arm is unreachable with any fixed real path.
+scratch_token="/@fuzz-scratch@"
+extent_line_absolute="RW 2048 FLAT \"/@fuzz-scratch@/image-flat.vmdk\" 0"
+
 # Disk database keys.
 ddb_hw_version="ddb.virtualHWVersion"
 ddb_cylinders="ddb.geometry.cylinders"

--- a/fuzz/fuzz_targets/disk_detect.rs
+++ b/fuzz/fuzz_targets/disk_detect.rs
@@ -1,0 +1,28 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fuzzes the image type sniffer with the input as the disk image.
+//!
+//! `block::detect_image_type` runs before any format specific parser, so it
+//! sees every byte string a guest owner can point the VMM at. Its input space
+//! is every format at once, which is why it is a target of its own rather
+//! than a probe inside the per format image targets: an input that reaches a
+//! new edge in the VHD sniffer says nothing about the VHDX parser, and
+//! keeping it in the `disk_vhdx` corpus only spends that target's mutation
+//! budget on images it can never open.
+//!
+//! The seed corpus is the union of the per format seeds, so a mutation starts
+//! from a real image of one format and can drift towards another:
+//!
+//! ```text
+//! scripts/generate-fuzz-seeds.sh
+//! cargo fuzz run disk_detect -j $(nproc) -- -max_len=16777216
+//! ```
+
+#![no_main]
+
+use cloud_hypervisor_fuzz::disk_engine::fuzz_detect;
+use libfuzzer_sys::{fuzz_target, Corpus};
+
+fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_detect(bytes) });

--- a/fuzz/fuzz_targets/disk_qcow2.rs
+++ b/fuzz/fuzz_targets/disk_qcow2.rs
@@ -1,0 +1,22 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fuzzes the QCOW2 parser with the input as the disk image.
+//!
+//! Corpus entries are plain qcow2 images, so `qemu-img` output can be used
+//! as is:
+//!
+//! ```text
+//! truncate -s 16M /tmp/source
+//! qemu-img convert -O qcow2 /tmp/source fuzz/corpus/disk_qcow2/base.qcow2
+//! cargo fuzz run disk_qcow2 -j $(nproc) -- -dict=fuzz/dictionaries/qcow2.dict
+//! ```
+
+#![no_main]
+
+use cloud_hypervisor_fuzz::disk_engine::formats::qcow2::Qcow2;
+use cloud_hypervisor_fuzz::disk_engine::fuzz_image;
+use libfuzzer_sys::{fuzz_target, Corpus};
+
+fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_image::<Qcow2>(bytes) });

--- a/fuzz/fuzz_targets/disk_qcow2_chain.rs
+++ b/fuzz/fuzz_targets/disk_qcow2_chain.rs
@@ -1,0 +1,25 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fuzzes the QCOW2 backing chain code with a fuzzer built chain.
+//!
+//! The input is a length prefixed pair of images, `[u32 LE top_len][top
+//! image][backing image]`, which the harness materializes in a scratch
+//! directory before opening the top image with backing files enabled. Both
+//! halves are fuzzer controlled, so a malformed backing image is reachable,
+//! and the harness refuses any backing name that is not a plain file name in
+//! that directory:
+//!
+//! ```text
+//! scripts/generate-fuzz-seeds.sh
+//! cargo fuzz run disk_qcow2_chain -j $(nproc) -- -max_len=4194312 \
+//!     -dict=fuzz/dictionaries/qcow2.dict
+//! ```
+
+#![no_main]
+
+use cloud_hypervisor_fuzz::disk_engine::formats::qcow2_chain::fuzz_chain;
+use libfuzzer_sys::{fuzz_target, Corpus};
+
+fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_chain(bytes) });

--- a/fuzz/fuzz_targets/disk_qcow2_ops.rs
+++ b/fuzz/fuzz_targets/disk_qcow2_ops.rs
@@ -1,0 +1,20 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fuzzes the QCOW2 I/O path with op programs against a valid image.
+//!
+//! The image is a freshly created qcow2 template, so read back data is
+//! checked against a shadow model of the disk contents:
+//!
+//! ```text
+//! cargo fuzz run disk_qcow2_ops -j $(nproc)
+//! ```
+
+#![no_main]
+
+use cloud_hypervisor_fuzz::disk_engine::formats::qcow2::Qcow2;
+use cloud_hypervisor_fuzz::disk_engine::{fuzz_program, Program};
+use libfuzzer_sys::{fuzz_target, Corpus};
+
+fuzz_target!(|program: Program| -> Corpus { fuzz_program::<Qcow2>(&program) });

--- a/fuzz/fuzz_targets/disk_vhd.rs
+++ b/fuzz/fuzz_targets/disk_vhd.rs
@@ -12,11 +12,35 @@
 //! cargo fuzz run disk_vhd -j $(nproc) -- -max_len=4194304 \
 //!     -dict=fuzz/dictionaries/vhd.dict
 //! ```
+//!
+//! The fixed VHD footer is checksum protected and the parser refuses an image
+//! whose stored checksum does not match the one it computes, so a plain byte
+//! mutation of the footer is rejected before the parser looks at anything
+//! else. The custom mutator below runs the default libFuzzer mutator and then
+//! repairs that checksum, which lets structural mutations of the footer
+//! survive.
 
 #![no_main]
 
-use cloud_hypervisor_fuzz::disk_engine::formats::vhd::Vhd;
+use cloud_hypervisor_fuzz::disk_engine::formats::vhd::{repair_footer_checksum, Vhd};
 use cloud_hypervisor_fuzz::disk_engine::fuzz_image;
-use libfuzzer_sys::{fuzz_target, Corpus};
+use libfuzzer_sys::{fuzz_mutator, fuzz_target, Corpus};
 
 fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_image::<Vhd>(bytes) });
+
+// The target itself still accepts arbitrary bytes: the corpus holds images
+// this mutator never produced, and libFuzzer also feeds back inputs from the
+// seed corpus and from other mutation sources unchanged.
+//
+// One mutation in eight is left unrepaired so the parser's checksum mismatch
+// branch stays reachable.
+//
+// The footer is the last 512 bytes of the image, so it can only be located
+// once `fuzzer_mutate` has returned the new size.
+fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    let new_size = libfuzzer_sys::fuzzer_mutate(data, size, max_size);
+    if seed % 8 != 0 {
+        repair_footer_checksum(&mut data[..new_size]);
+    }
+    new_size
+});

--- a/fuzz/fuzz_targets/disk_vhd.rs
+++ b/fuzz/fuzz_targets/disk_vhd.rs
@@ -1,0 +1,22 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fuzzes the fixed VHD parser with the input as the disk image.
+//!
+//! Corpus entries are plain VHD images, so `qemu-img` output can be used
+//! as is:
+//!
+//! ```text
+//! scripts/generate-fuzz-seeds.sh
+//! cargo fuzz run disk_vhd -j $(nproc) -- -max_len=4194304 \
+//!     -dict=fuzz/dictionaries/vhd.dict
+//! ```
+
+#![no_main]
+
+use cloud_hypervisor_fuzz::disk_engine::formats::vhd::Vhd;
+use cloud_hypervisor_fuzz::disk_engine::fuzz_image;
+use libfuzzer_sys::{fuzz_target, Corpus};
+
+fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_image::<Vhd>(bytes) });

--- a/fuzz/fuzz_targets/disk_vhd.rs
+++ b/fuzz/fuzz_targets/disk_vhd.rs
@@ -13,16 +13,19 @@
 //!     -dict=fuzz/dictionaries/vhd.dict
 //! ```
 //!
-//! The fixed VHD footer is checksum protected and the parser refuses an image
-//! whose stored checksum does not match the one it computes, so a plain byte
+//! The fixed VHD footer is checksum protected and carries the `conectix`
+//! cookie, and the parser refuses an image whose cookie is wrong or whose
+//! stored checksum does not match the one it computes, so a plain byte
 //! mutation of the footer is rejected before the parser looks at anything
 //! else. The custom mutator below runs the default libFuzzer mutator and then
-//! repairs that checksum, which lets structural mutations of the footer
-//! survive.
+//! restores the cookie and repairs the checksum, which lets structural
+//! mutations of the footer survive.
 
 #![no_main]
 
-use cloud_hypervisor_fuzz::disk_engine::formats::vhd::{repair_footer_checksum, Vhd};
+use cloud_hypervisor_fuzz::disk_engine::formats::vhd::{
+    repair_footer_checksum, restore_footer_cookie, Vhd,
+};
 use cloud_hypervisor_fuzz::disk_engine::fuzz_image;
 use libfuzzer_sys::{fuzz_mutator, fuzz_target, Corpus};
 
@@ -32,14 +35,26 @@ fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_image::<Vhd>(bytes) });
 // this mutator never produced, and libFuzzer also feeds back inputs from the
 // seed corpus and from other mutation sources unchanged.
 //
-// One mutation in eight is left unrepaired so the parser's checksum mismatch
-// branch stays reachable.
+// Neither repair is unconditional, so both rejection branches stay reachable
+// and stay separable. One mutation in eight keeps a mutated cookie, with the
+// checksum repaired, which is the only way to reach the cookie branch with an
+// otherwise valid footer. A different one in eight keeps the mutated
+// checksum, with the cookie restored, which is the only way to reach the
+// checksum branch at all: the cookie is tested first, so a mutation that
+// broke both never gets that far. The remaining six in eight are fully
+// repaired and reach the parser.
+//
+// Order matters: the cookie is inside the checksummed area, so it has to be
+// written before the checksum is computed over it.
 //
 // The footer is the last 512 bytes of the image, so it can only be located
 // once `fuzzer_mutate` has returned the new size.
 fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
     let new_size = libfuzzer_sys::fuzzer_mutate(data, size, max_size);
     if seed % 8 != 0 {
+        restore_footer_cookie(&mut data[..new_size]);
+    }
+    if seed % 8 != 1 {
         repair_footer_checksum(&mut data[..new_size]);
     }
     new_size

--- a/fuzz/fuzz_targets/disk_vhdx.rs
+++ b/fuzz/fuzz_targets/disk_vhdx.rs
@@ -13,15 +13,19 @@
 //!     -dict=fuzz/dictionaries/vhdx.dict
 //! ```
 //!
-//! Both VHDX headers and both region tables are CRC-32C protected and the
-//! parser refuses an image whose checksums do not match, so a plain byte
-//! mutation of any of them is rejected before the parser looks at anything
-//! else. The custom mutator below runs the default libFuzzer mutator and then
-//! repairs those four checksums, which lets structural mutations survive.
+//! Both VHDX headers and both region tables are CRC-32C protected and are
+//! introduced by a signature, and the parser refuses an image whose
+//! signatures or checksums do not match, so a plain byte mutation of any of
+//! them is rejected before the parser looks at anything else. The custom
+//! mutator below runs the default libFuzzer mutator and then restores the
+//! four signatures and repairs the four checksums, which lets structural
+//! mutations survive.
 
 #![no_main]
 
-use cloud_hypervisor_fuzz::disk_engine::formats::vhdx::{repair_checksums, Vhdx};
+use cloud_hypervisor_fuzz::disk_engine::formats::vhdx::{
+    repair_checksums, restore_signatures, Vhdx,
+};
 use cloud_hypervisor_fuzz::disk_engine::fuzz_image;
 use libfuzzer_sys::{fuzz_mutator, fuzz_target, Corpus};
 
@@ -30,10 +34,26 @@ fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_image::<Vhdx>(bytes) });
 // The target itself still accepts arbitrary bytes: the corpus holds images
 // this mutator never produced, and libFuzzer also feeds back inputs from the
 // seed corpus and from other mutation sources unchanged.
-fuzz_mutator!(
-    |data: &mut [u8], size: usize, max_size: usize, _seed: u32| {
-        let new_size = libfuzzer_sys::fuzzer_mutate(data, size, max_size);
-        repair_checksums(&mut data[..new_size]);
-        new_size
+//
+// Neither repair is unconditional, so both rejection branches stay reachable
+// and stay separable. One mutation in eight keeps a mutated signature, with
+// the checksums repaired, which is the only way to reach the signature
+// branches with otherwise valid structures. A different one in eight keeps
+// the mutated checksums, with the signatures restored, which is the only way
+// to reach the checksum branch at all: a signature is tested before the
+// checksum of the structure it introduces, so a mutation that broke both
+// never gets that far. The remaining six in eight are fully repaired and
+// reach the parser.
+//
+// Order matters: the header and region signatures are inside the checksummed
+// areas, so they have to be written before the checksums are computed.
+fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    let new_size = libfuzzer_sys::fuzzer_mutate(data, size, max_size);
+    if seed % 8 != 0 {
+        restore_signatures(&mut data[..new_size]);
     }
-);
+    if seed % 8 != 1 {
+        repair_checksums(&mut data[..new_size]);
+    }
+    new_size
+});

--- a/fuzz/fuzz_targets/disk_vhdx.rs
+++ b/fuzz/fuzz_targets/disk_vhdx.rs
@@ -1,0 +1,22 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fuzzes the VHDX parser with the input as the disk image.
+//!
+//! Corpus entries are plain VHDX images, so `qemu-img` output can be used
+//! as is:
+//!
+//! ```text
+//! scripts/generate-fuzz-seeds.sh
+//! cargo fuzz run disk_vhdx -j $(nproc) -- -max_len=16777216 \
+//!     -dict=fuzz/dictionaries/vhdx.dict
+//! ```
+
+#![no_main]
+
+use cloud_hypervisor_fuzz::disk_engine::formats::vhdx::Vhdx;
+use cloud_hypervisor_fuzz::disk_engine::fuzz_image;
+use libfuzzer_sys::{fuzz_target, Corpus};
+
+fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_image::<Vhdx>(bytes) });

--- a/fuzz/fuzz_targets/disk_vhdx.rs
+++ b/fuzz/fuzz_targets/disk_vhdx.rs
@@ -12,11 +12,28 @@
 //! cargo fuzz run disk_vhdx -j $(nproc) -- -max_len=16777216 \
 //!     -dict=fuzz/dictionaries/vhdx.dict
 //! ```
+//!
+//! Both VHDX headers and both region tables are CRC-32C protected and the
+//! parser refuses an image whose checksums do not match, so a plain byte
+//! mutation of any of them is rejected before the parser looks at anything
+//! else. The custom mutator below runs the default libFuzzer mutator and then
+//! repairs those four checksums, which lets structural mutations survive.
 
 #![no_main]
 
-use cloud_hypervisor_fuzz::disk_engine::formats::vhdx::Vhdx;
+use cloud_hypervisor_fuzz::disk_engine::formats::vhdx::{repair_checksums, Vhdx};
 use cloud_hypervisor_fuzz::disk_engine::fuzz_image;
-use libfuzzer_sys::{fuzz_target, Corpus};
+use libfuzzer_sys::{fuzz_mutator, fuzz_target, Corpus};
 
 fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_image::<Vhdx>(bytes) });
+
+// The target itself still accepts arbitrary bytes: the corpus holds images
+// this mutator never produced, and libFuzzer also feeds back inputs from the
+// seed corpus and from other mutation sources unchanged.
+fuzz_mutator!(
+    |data: &mut [u8], size: usize, max_size: usize, _seed: u32| {
+        let new_size = libfuzzer_sys::fuzzer_mutate(data, size, max_size);
+        repair_checksums(&mut data[..new_size]);
+        new_size
+    }
+);

--- a/fuzz/fuzz_targets/disk_vhdx_ops.rs
+++ b/fuzz/fuzz_targets/disk_vhdx_ops.rs
@@ -1,0 +1,21 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fuzzes the VHDX I/O path with op programs against a valid image.
+//!
+//! The image is a blank 4 MiB dynamic VHDX built from a run table in the
+//! adapter, so read back data is checked against a shadow model of the disk
+//! contents:
+//!
+//! ```text
+//! cargo fuzz run disk_vhdx_ops -j $(nproc)
+//! ```
+
+#![no_main]
+
+use cloud_hypervisor_fuzz::disk_engine::formats::vhdx::Vhdx;
+use cloud_hypervisor_fuzz::disk_engine::{fuzz_program, Program};
+use libfuzzer_sys::{fuzz_target, Corpus};
+
+fuzz_target!(|program: Program| -> Corpus { fuzz_program::<Vhdx>(&program) });

--- a/fuzz/fuzz_targets/disk_vmdk.rs
+++ b/fuzz/fuzz_targets/disk_vmdk.rs
@@ -1,0 +1,24 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fuzzes the flat VMDK descriptor parser and extent layout.
+//!
+//! The input is the descriptor, which is what `--disk path=` points at for a
+//! VMDK image. The harness materializes it in a scratch directory holding the
+//! extent files a descriptor may name, so corpus entries are the descriptors
+//! `qemu-img` writes:
+//!
+//! ```text
+//! scripts/generate-fuzz-seeds.sh
+//! cargo fuzz run disk_vmdk -j $(nproc) -- -max_len=65536 \
+//!     -dict=fuzz/dictionaries/vmdk.dict
+//! ```
+
+#![no_main]
+
+use cloud_hypervisor_fuzz::disk_engine::formats::vmdk::Vmdk;
+use cloud_hypervisor_fuzz::disk_engine::fuzz_image;
+use libfuzzer_sys::{fuzz_target, Corpus};
+
+fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_image::<Vmdk>(bytes) });

--- a/fuzz/fuzz_targets/disk_vmdk.rs
+++ b/fuzz/fuzz_targets/disk_vmdk.rs
@@ -7,7 +7,13 @@
 //! The input is the descriptor, which is what `--disk path=` points at for a
 //! VMDK image. The harness materializes it in a scratch directory holding the
 //! extent files a descriptor may name, so corpus entries are the descriptors
-//! `qemu-img` writes:
+//! `qemu-img` writes.
+//!
+//! The process is confined to that scratch directory with Landlock before the
+//! first iteration: a descriptor may name an extent by absolute path, which
+//! the engine resolves from the filesystem root without `RESOLVE_BENEATH` and
+//! opens writable, so the harness name guard is not left as the only control.
+//! Without the confinement the target still runs, and refuses absolute names.
 //!
 //! ```text
 //! scripts/generate-fuzz-seeds.sh
@@ -17,8 +23,7 @@
 
 #![no_main]
 
-use cloud_hypervisor_fuzz::disk_engine::formats::vmdk::Vmdk;
-use cloud_hypervisor_fuzz::disk_engine::fuzz_image;
+use cloud_hypervisor_fuzz::disk_engine::formats::vmdk::fuzz_vmdk;
 use libfuzzer_sys::{fuzz_target, Corpus};
 
-fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_image::<Vmdk>(bytes) });
+fuzz_target!(|bytes: &[u8]| -> Corpus { fuzz_vmdk(bytes) });

--- a/fuzz/fuzz_targets/disk_vmdk_ops.rs
+++ b/fuzz/fuzz_targets/disk_vmdk_ops.rs
@@ -1,0 +1,23 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fuzzes the flat VMDK I/O path with op programs against a valid image.
+//!
+//! The image is a fixed two extent descriptor built by the adapter, so read
+//! back data is checked against a shadow model of the disk contents. That is
+//! what puts the extent selection, the `file_base_offset + (offset -
+//! virtual_start)` arithmetic and `spanning_io`'s per segment byte accounting
+//! under a data correctness oracle:
+//!
+//! ```text
+//! cargo fuzz run disk_vmdk_ops -j $(nproc)
+//! ```
+
+#![no_main]
+
+use cloud_hypervisor_fuzz::disk_engine::formats::vmdk::Vmdk;
+use cloud_hypervisor_fuzz::disk_engine::{fuzz_program, Program};
+use libfuzzer_sys::{fuzz_target, Corpus};
+
+fuzz_target!(|program: Program| -> Corpus { fuzz_program::<Vmdk>(&program) });

--- a/fuzz/src/disk_engine/executor.rs
+++ b/fuzz/src/disk_engine/executor.rs
@@ -11,9 +11,13 @@
 //!
 //! - an accepted op produces exactly one completion, carrying its own
 //!   `user_data`, and a rejected op produces none;
-//! - a completion never reports more bytes than were requested;
+//! - a completion never reports more bytes than were requested, and a
+//!   successfully completed read transfers all of them, for a format that
+//!   promises no short reads;
 //! - a format with a fixed capacity never reports a different size unless a
 //!   resize succeeded, and never transfers bytes beyond that size;
+//! - a format whose data lives in the image file never advertises more
+//!   capacity than the file can hold;
 //! - read back data matches the shadow model, when one is available.
 
 use std::marker::PhantomData;
@@ -64,7 +68,7 @@ impl<F: DiskFormat> Executor<F> {
         let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MAX_OP_LEN)]).ok()?;
         let model = (with_model && size <= MAX_MODEL_LEN).then(|| Model::new(size as usize));
 
-        Some(Self {
+        let executor = Self {
             disk,
             clone: None,
             io,
@@ -73,7 +77,10 @@ impl<F: DiskFormat> Executor<F> {
             model,
             user_data: 0,
             format: PhantomData,
-        })
+        };
+        executor.check_capacity_backing();
+
+        Some(executor)
     }
 
     /// Runs up to [`MAX_OPS`] ops.
@@ -117,7 +124,7 @@ impl<F: DiskFormat> Executor<F> {
         let Some(completion) = self.submit(op, user_data) else {
             return;
         };
-        let Some(done) = self.transferred(&completion, offset, len) else {
+        let Some(done) = self.read_transferred(&completion, offset, len) else {
             return;
         };
         let Some(buffer) = completion.buffer.as_ref() else {
@@ -153,7 +160,7 @@ impl<F: DiskFormat> Executor<F> {
         let Some(completion) = self.submit(op, user_data) else {
             return;
         };
-        let Some(done) = self.transferred(&completion, offset, len) else {
+        let Some(done) = self.read_transferred(&completion, offset, len) else {
             return;
         };
 
@@ -273,6 +280,7 @@ impl<F: DiskFormat> Executor<F> {
         }
 
         let _ = self.disk.physical_size();
+        self.check_capacity_backing();
         let _ = self.disk.topology();
         let _ = self.disk.supports_sparse_operations();
         let _ = self.disk.supports_zero_flag();
@@ -355,6 +363,52 @@ impl<F: DiskFormat> Executor<F> {
         }
 
         Some(done)
+    }
+
+    /// Returns how many bytes a completed read transferred.
+    ///
+    /// Only a read the engine both accepted and completed successfully
+    /// reaches the short read check: a rejected op returns before this, and a
+    /// failed one returns `None` from [`Executor::transferred`].
+    fn read_transferred(
+        &self,
+        completion: &AsyncIoCompletion,
+        offset: u64,
+        len: usize,
+    ) -> Option<usize> {
+        let done = self.transferred(completion, offset, len)?;
+
+        if F::NO_SHORT_READS {
+            assert_eq!(
+                done,
+                len,
+                "{}: read at offset {offset} transferred {done} of the {len} bytes requested",
+                F::NAME
+            );
+        }
+
+        Some(done)
+    }
+
+    /// Checks the advertised capacity against the file that holds it.
+    ///
+    /// Only a format that claims the layout is checked, and only when the
+    /// engine answers both queries: an engine that fails a size query has
+    /// made no claim to contradict.
+    fn check_capacity_backing(&self) {
+        let Some(tail) = F::CAPACITY_FILE_TAIL else {
+            return;
+        };
+        let (Ok(logical), Ok(physical)) = (self.disk.logical_size(), self.disk.physical_size())
+        else {
+            return;
+        };
+
+        assert!(
+            logical.saturating_add(tail) <= physical,
+            "{}: capacity {logical} plus a {tail} byte tail exceeds the {physical} byte image file",
+            F::NAME
+        );
     }
 
     fn guest_target(&self, len: usize) -> Option<GuestMemoryTarget> {

--- a/fuzz/src/disk_engine/executor.rs
+++ b/fuzz/src/disk_engine/executor.rs
@@ -13,7 +13,8 @@
 //!   `user_data`, and a rejected op produces none;
 //! - a completion never reports more bytes than were requested;
 //! - a format with a fixed capacity never reports a different size unless a
-//!   resize succeeded, and never transfers bytes beyond that size.
+//!   resize succeeded, and never transfers bytes beyond that size;
+//! - read back data matches the shadow model, when one is available.
 
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -25,7 +26,11 @@ use block::disk_file::{AsyncDiskFile, AsyncFullDiskFile};
 use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
 
 use crate::disk_engine::format::DiskFormat;
+use crate::disk_engine::model::Model;
 use crate::disk_engine::program::{ring_depth, Op, MAX_OPS, MAX_OP_LEN};
+
+/// Largest disk size the shadow model is kept for.
+const MAX_MODEL_LEN: u64 = 8 << 20;
 
 /// Largest size a `Resize` op may ask for.
 const MAX_RESIZE_LEN: u64 = 64 << 20;
@@ -37,6 +42,7 @@ pub struct Executor<F: DiskFormat> {
     io: Box<dyn AsyncIo>,
     mem: Arc<GuestMemoryMmap<()>>,
     size: u64,
+    model: Option<Model>,
     user_data: u64,
     format: PhantomData<F>,
 }
@@ -44,12 +50,19 @@ pub struct Executor<F: DiskFormat> {
 impl<F: DiskFormat> Executor<F> {
     /// Prepares an executor for `disk`.
     ///
-    /// Returns `None` when the engine refuses to create the I/O resources,
-    /// which is a normal outcome for a malformed image.
-    pub fn new(disk: Box<dyn AsyncFullDiskFile>, ring_depth: u32) -> Option<Self> {
+    /// `with_model` enables the shadow model, which is only sound when the
+    /// image started out valid and its contents are known. Returns `None`
+    /// when the engine refuses to create the I/O resources, which is a normal
+    /// outcome for a malformed image.
+    pub fn new(
+        disk: Box<dyn AsyncFullDiskFile>,
+        ring_depth: u32,
+        with_model: bool,
+    ) -> Option<Self> {
         let io = disk.create_async_io(ring_depth).ok()?;
         let size = disk.logical_size().ok()?;
         let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MAX_OP_LEN)]).ok()?;
+        let model = (with_model && size <= MAX_MODEL_LEN).then(|| Model::new(size as usize));
 
         Some(Self {
             disk,
@@ -57,6 +70,7 @@ impl<F: DiskFormat> Executor<F> {
             io,
             mem: Arc::new(mem),
             size,
+            model,
             user_data: 0,
             format: PhantomData,
         })
@@ -100,9 +114,17 @@ impl<F: DiskFormat> Executor<F> {
         let buffer = OwnedIoBuffer::from_vec(vec![0u8; len]);
         let op = AsyncIoOperation::read_to_vec(offset as libc::off_t, buffer, user_data);
 
-        if let Some(completion) = self.submit(op, user_data) {
-            self.transferred(&completion, offset, len);
-        }
+        let Some(completion) = self.submit(op, user_data) else {
+            return;
+        };
+        let Some(done) = self.transferred(&completion, offset, len) else {
+            return;
+        };
+        let Some(buffer) = completion.buffer.as_ref() else {
+            panic!("{}: read completion returned no buffer", F::NAME);
+        };
+
+        self.check_read(offset, &buffer.as_slice()[..done]);
     }
 
     fn write_vec(&mut self, offset: u64, len: usize, seed: u8) {
@@ -111,8 +133,13 @@ impl<F: DiskFormat> Executor<F> {
         let buffer = OwnedIoBuffer::from_vec(data.clone());
         let op = AsyncIoOperation::write_from_vec(offset as libc::off_t, buffer, user_data);
 
-        if let Some(completion) = self.submit(op, user_data) {
-            self.transferred(&completion, offset, len);
+        let Some(completion) = self.submit(op, user_data) else {
+            self.record_unknown(offset, len);
+            return;
+        };
+        match self.transferred(&completion, offset, len) {
+            Some(done) => self.record_write(offset, &data[..done], len - done),
+            None => self.record_unknown(offset, len),
         }
     }
 
@@ -123,8 +150,16 @@ impl<F: DiskFormat> Executor<F> {
         let user_data = self.next_user_data();
         let op = AsyncIoOperation::read_to_memory(offset as libc::off_t, target, user_data);
 
-        if let Some(completion) = self.submit(op, user_data) {
-            self.transferred(&completion, offset, len);
+        let Some(completion) = self.submit(op, user_data) else {
+            return;
+        };
+        let Some(done) = self.transferred(&completion, offset, len) else {
+            return;
+        };
+
+        let mut data = vec![0u8; done];
+        if self.mem.read_slice(&mut data, GuestAddress(0)).is_ok() {
+            self.check_read(offset, &data);
         }
     }
 
@@ -139,22 +174,36 @@ impl<F: DiskFormat> Executor<F> {
         let user_data = self.next_user_data();
         let op = AsyncIoOperation::write_from_memory(offset as libc::off_t, target, user_data);
 
-        if let Some(completion) = self.submit(op, user_data) {
-            self.transferred(&completion, offset, len);
+        let Some(completion) = self.submit(op, user_data) else {
+            self.record_unknown(offset, len);
+            return;
+        };
+        match self.transferred(&completion, offset, len) {
+            Some(done) => self.record_write(offset, &data[..done], len - done),
+            None => self.record_unknown(offset, len),
         }
     }
 
     fn punch_hole(&mut self, offset: u64, len: usize) {
         let user_data = self.next_user_data();
-        if self.io.punch_hole(offset, len as u64, user_data).is_ok() {
-            self.completion_succeeded(user_data);
+        let submitted = self.io.punch_hole(offset, len as u64, user_data).is_ok();
+        let succeeded = submitted && self.completion_succeeded(user_data);
+
+        if succeeded && F::PUNCH_HOLE_READS_ZEROES {
+            self.record_zeroes(offset, len);
+        } else {
+            self.record_unknown(offset, len);
         }
     }
 
     fn write_zeroes(&mut self, offset: u64, len: usize) {
         let user_data = self.next_user_data();
-        if self.io.write_zeroes(offset, len as u64, user_data).is_ok() {
-            self.completion_succeeded(user_data);
+        let submitted = self.io.write_zeroes(offset, len as u64, user_data).is_ok();
+
+        if submitted && self.completion_succeeded(user_data) {
+            self.record_zeroes(offset, len);
+        } else {
+            self.record_unknown(offset, len);
         }
     }
 
@@ -183,7 +232,17 @@ impl<F: DiskFormat> Executor<F> {
         // Trust the engine's own report rather than the requested size: a
         // format may round the capacity, and a failed resize may still have
         // changed it.
-        self.size = self.disk.logical_size().unwrap_or(self.size);
+        let reported = self.disk.logical_size().unwrap_or(self.size);
+        if reported == self.size {
+            return;
+        }
+
+        self.size = reported;
+        if reported > MAX_MODEL_LEN {
+            self.model = None;
+        } else if let Some(model) = self.model.as_mut() {
+            model.resize(reported as usize);
+        }
     }
 
     fn use_clone(&mut self, ring_depth: u32) {
@@ -194,8 +253,8 @@ impl<F: DiskFormat> Executor<F> {
             return;
         };
 
-        // The clone shares engine state with the original. It is kept alive
-        // for as long as its I/O engine is in use.
+        // The clone shares engine state with the original, so the model stays
+        // valid. It is kept alive for as long as its I/O engine is in use.
         self.io = io;
         self.clone = Some(clone);
     }
@@ -300,6 +359,37 @@ impl<F: DiskFormat> Executor<F> {
 
     fn guest_target(&self, len: usize) -> Option<GuestMemoryTarget> {
         GuestMemoryTarget::new(Arc::clone(&self.mem), &[(GuestAddress(0), len as u32)]).ok()
+    }
+
+    fn check_read(&self, offset: u64, data: &[u8]) {
+        let Some(model) = self.model.as_ref() else {
+            return;
+        };
+        if let Err(mismatch) = model.check(offset, data) {
+            panic!("{}: read back mismatch: {mismatch}", F::NAME);
+        }
+    }
+
+    fn record_write(&mut self, offset: u64, written: &[u8], missing: usize) {
+        let Some(model) = self.model.as_mut() else {
+            return;
+        };
+        model.record_write(offset, written);
+        if missing > 0 {
+            model.record_unknown(offset + written.len() as u64, missing);
+        }
+    }
+
+    fn record_zeroes(&mut self, offset: u64, len: usize) {
+        if let Some(model) = self.model.as_mut() {
+            model.record_zeroes(offset, len);
+        }
+    }
+
+    fn record_unknown(&mut self, offset: u64, len: usize) {
+        if let Some(model) = self.model.as_mut() {
+            model.record_unknown(offset, len);
+        }
     }
 
     fn next_user_data(&mut self) -> u64 {

--- a/fuzz/src/disk_engine/executor.rs
+++ b/fuzz/src/disk_engine/executor.rs
@@ -1,0 +1,322 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Executes an op program against the disk image engine.
+//!
+//! The executor owns the engine handles and turns [`Op`]s into calls on
+//! [`AsyncFullDiskFile`] and [`AsyncIo`]. Beyond crashes and panics from the
+//! engine itself, it checks the invariants that the trait contract promises
+//! to every caller:
+//!
+//! - an accepted op produces exactly one completion, carrying its own
+//!   `user_data`, and a rejected op produces none;
+//! - a completion never reports more bytes than were requested;
+//! - a format with a fixed capacity never reports a different size unless a
+//!   resize succeeded, and never transfers bytes beyond that size.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use block::async_io::{
+    AsyncIo, AsyncIoCompletion, AsyncIoOperation, GuestMemoryTarget, OwnedIoBuffer,
+};
+use block::disk_file::{AsyncDiskFile, AsyncFullDiskFile};
+use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
+
+use crate::disk_engine::format::DiskFormat;
+use crate::disk_engine::program::{ring_depth, Op, MAX_OPS, MAX_OP_LEN};
+
+/// Largest size a `Resize` op may ask for.
+const MAX_RESIZE_LEN: u64 = 64 << 20;
+
+/// Drives an op program against one opened disk image.
+pub struct Executor<F: DiskFormat> {
+    disk: Box<dyn AsyncFullDiskFile>,
+    clone: Option<Box<dyn AsyncDiskFile>>,
+    io: Box<dyn AsyncIo>,
+    mem: Arc<GuestMemoryMmap<()>>,
+    size: u64,
+    user_data: u64,
+    format: PhantomData<F>,
+}
+
+impl<F: DiskFormat> Executor<F> {
+    /// Prepares an executor for `disk`.
+    ///
+    /// Returns `None` when the engine refuses to create the I/O resources,
+    /// which is a normal outcome for a malformed image.
+    pub fn new(disk: Box<dyn AsyncFullDiskFile>, ring_depth: u32) -> Option<Self> {
+        let io = disk.create_async_io(ring_depth).ok()?;
+        let size = disk.logical_size().ok()?;
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MAX_OP_LEN)]).ok()?;
+
+        Some(Self {
+            disk,
+            clone: None,
+            io,
+            mem: Arc::new(mem),
+            size,
+            user_data: 0,
+            format: PhantomData,
+        })
+    }
+
+    /// Runs up to [`MAX_OPS`] ops.
+    pub fn run(&mut self, ops: &[Op]) {
+        for op in ops.iter().take(MAX_OPS) {
+            self.step(op);
+        }
+    }
+
+    fn step(&mut self, op: &Op) {
+        match *op {
+            Op::ReadVec { offset, len } => self.read_vec(offset.resolve(self.size), len.get()),
+            Op::WriteVec { offset, len, seed } => {
+                self.write_vec(offset.resolve(self.size), len.get(), seed)
+            }
+            Op::ReadMem { offset, len } => self.read_mem(offset.resolve(self.size), len.get()),
+            Op::WriteMem { offset, len, seed } => {
+                self.write_mem(offset.resolve(self.size), len.get(), seed)
+            }
+            Op::PunchHole { offset, len } => self.punch_hole(offset.resolve(self.size), len.get()),
+            Op::WriteZeroes { offset, len } => {
+                self.write_zeroes(offset.resolve(self.size), len.get())
+            }
+            Op::Fsync { completion } => self.fsync(completion),
+            Op::Resize { size_kib } => self.resize(u64::from(size_kib) * 1024),
+            Op::RecreateIo { ring_depth: depth } => {
+                if let Ok(io) = self.disk.create_async_io(ring_depth(depth)) {
+                    self.io = io;
+                }
+            }
+            Op::UseClone { ring_depth: depth } => self.use_clone(ring_depth(depth)),
+            Op::QueryCaps => self.query_caps(),
+        }
+    }
+
+    fn read_vec(&mut self, offset: u64, len: usize) {
+        let user_data = self.next_user_data();
+        let buffer = OwnedIoBuffer::from_vec(vec![0u8; len]);
+        let op = AsyncIoOperation::read_to_vec(offset as libc::off_t, buffer, user_data);
+
+        if let Some(completion) = self.submit(op, user_data) {
+            self.transferred(&completion, offset, len);
+        }
+    }
+
+    fn write_vec(&mut self, offset: u64, len: usize, seed: u8) {
+        let data = pattern(offset, len, seed);
+        let user_data = self.next_user_data();
+        let buffer = OwnedIoBuffer::from_vec(data.clone());
+        let op = AsyncIoOperation::write_from_vec(offset as libc::off_t, buffer, user_data);
+
+        if let Some(completion) = self.submit(op, user_data) {
+            self.transferred(&completion, offset, len);
+        }
+    }
+
+    fn read_mem(&mut self, offset: u64, len: usize) {
+        let Some(target) = self.guest_target(len) else {
+            return;
+        };
+        let user_data = self.next_user_data();
+        let op = AsyncIoOperation::read_to_memory(offset as libc::off_t, target, user_data);
+
+        if let Some(completion) = self.submit(op, user_data) {
+            self.transferred(&completion, offset, len);
+        }
+    }
+
+    fn write_mem(&mut self, offset: u64, len: usize, seed: u8) {
+        let data = pattern(offset, len, seed);
+        if self.mem.write_slice(&data, GuestAddress(0)).is_err() {
+            return;
+        }
+        let Some(target) = self.guest_target(len) else {
+            return;
+        };
+        let user_data = self.next_user_data();
+        let op = AsyncIoOperation::write_from_memory(offset as libc::off_t, target, user_data);
+
+        if let Some(completion) = self.submit(op, user_data) {
+            self.transferred(&completion, offset, len);
+        }
+    }
+
+    fn punch_hole(&mut self, offset: u64, len: usize) {
+        let user_data = self.next_user_data();
+        if self.io.punch_hole(offset, len as u64, user_data).is_ok() {
+            self.completion_succeeded(user_data);
+        }
+    }
+
+    fn write_zeroes(&mut self, offset: u64, len: usize) {
+        let user_data = self.next_user_data();
+        if self.io.write_zeroes(offset, len as u64, user_data).is_ok() {
+            self.completion_succeeded(user_data);
+        }
+    }
+
+    fn fsync(&mut self, completion: bool) {
+        let user_data = self.next_user_data();
+        let requested = completion.then_some(user_data);
+
+        if self.io.fsync(requested).is_err() {
+            return;
+        }
+        if completion {
+            self.expect_completion(user_data);
+        } else {
+            assert!(
+                self.io.next_completed_request().is_none(),
+                "{}: fsync without user data produced a completion",
+                F::NAME
+            );
+        }
+    }
+
+    fn resize(&mut self, size: u64) {
+        let size = size.min(MAX_RESIZE_LEN);
+        let _ = self.disk.resize(size);
+
+        // Trust the engine's own report rather than the requested size: a
+        // format may round the capacity, and a failed resize may still have
+        // changed it.
+        self.size = self.disk.logical_size().unwrap_or(self.size);
+    }
+
+    fn use_clone(&mut self, ring_depth: u32) {
+        let Ok(clone) = self.disk.try_clone() else {
+            return;
+        };
+        let Ok(io) = clone.create_async_io(ring_depth) else {
+            return;
+        };
+
+        // The clone shares engine state with the original. It is kept alive
+        // for as long as its I/O engine is in use.
+        self.io = io;
+        self.clone = Some(clone);
+    }
+
+    fn query_caps(&mut self) {
+        let reported = self.disk.logical_size().unwrap_or(self.size);
+        if F::FIXED_CAPACITY {
+            assert_eq!(
+                reported,
+                self.size,
+                "{}: reported size changed without a resize",
+                F::NAME
+            );
+        } else {
+            self.size = reported;
+        }
+
+        let _ = self.disk.physical_size();
+        let _ = self.disk.topology();
+        let _ = self.disk.supports_sparse_operations();
+        let _ = self.disk.supports_zero_flag();
+        let _ = self.disk.fd();
+        let _ = self.io.alignment();
+        let _ = self.io.batch_requests_enabled();
+        let _ = self.io.notifier();
+    }
+
+    /// Submits a data op and returns its completion, if it was accepted.
+    fn submit(&mut self, op: AsyncIoOperation, user_data: u64) -> Option<AsyncIoCompletion> {
+        if self.io.submit_data_operation(op).is_err() {
+            assert!(
+                self.io.next_completed_request().is_none(),
+                "{}: rejected op {user_data} produced a completion",
+                F::NAME
+            );
+            return None;
+        }
+
+        self.expect_completion(user_data)
+    }
+
+    /// Collects the single completion an accepted op owes the caller.
+    fn expect_completion(&mut self, user_data: u64) -> Option<AsyncIoCompletion> {
+        let Some(completion) = self.io.next_completed_request() else {
+            assert!(
+                !F::COMPLETES_INLINE,
+                "{}: accepted op {user_data} produced no completion",
+                F::NAME
+            );
+            return None;
+        };
+
+        assert_eq!(
+            completion.user_data,
+            user_data,
+            "{}: completion carried the wrong user data",
+            F::NAME
+        );
+        assert!(
+            self.io.next_completed_request().is_none(),
+            "{}: op {user_data} produced more than one completion",
+            F::NAME
+        );
+
+        Some(completion)
+    }
+
+    /// Returns whether the op behind `user_data` completed successfully.
+    fn completion_succeeded(&mut self, user_data: u64) -> bool {
+        self.expect_completion(user_data)
+            .is_some_and(|completion| completion.result >= 0)
+    }
+
+    /// Returns how many bytes a completed data op transferred.
+    fn transferred(
+        &self,
+        completion: &AsyncIoCompletion,
+        offset: u64,
+        len: usize,
+    ) -> Option<usize> {
+        if completion.result < 0 {
+            return None;
+        }
+
+        let done = completion.result as usize;
+        assert!(
+            done <= len,
+            "{}: op reported {done} bytes for a {len} byte request",
+            F::NAME
+        );
+        if F::FIXED_CAPACITY {
+            assert!(
+                done == 0 || offset < self.size,
+                "{}: op at offset {offset} transferred {done} bytes past the {} byte capacity",
+                F::NAME,
+                self.size
+            );
+        }
+
+        Some(done)
+    }
+
+    fn guest_target(&self, len: usize) -> Option<GuestMemoryTarget> {
+        GuestMemoryTarget::new(Arc::clone(&self.mem), &[(GuestAddress(0), len as u32)]).ok()
+    }
+
+    fn next_user_data(&mut self) -> u64 {
+        self.user_data += 1;
+        self.user_data
+    }
+}
+
+/// Builds an offset dependent byte pattern.
+///
+/// The value of every byte depends on its disk offset, so a read back that
+/// returns the right bytes from the wrong place is still caught.
+fn pattern(offset: u64, len: usize, seed: u8) -> Vec<u8> {
+    (0..len)
+        .map(|i| {
+            let at = offset.wrapping_add(i as u64);
+            seed ^ (at as u8) ^ ((at >> 8) as u8).rotate_left(3) ^ ((at >> 16) as u8).rotate_left(5)
+        })
+        .collect()
+}

--- a/fuzz/src/disk_engine/executor.rs
+++ b/fuzz/src/disk_engine/executor.rs
@@ -230,10 +230,16 @@ impl<F: DiskFormat> Executor<F> {
 
     fn punch_hole(&mut self, offset: u64, len: usize) {
         let user_data = self.next_user_data();
-        let submitted = self.io.punch_hole(offset, len as u64, user_data).is_ok();
-        let succeeded = submitted && self.completion_succeeded(user_data);
+        if self.io.punch_hole(offset, len as u64, user_data).is_err() {
+            // A request the engine refused outright owes no completion and
+            // changed nothing, so the model still describes the disk. This
+            // matters: VHDX and VHD refuse every sparse op, and marking the
+            // range unknown anyway would let a program blank the model out
+            // range by range and check nothing.
+            return;
+        }
 
-        if succeeded && F::PUNCH_HOLE_READS_ZEROES {
+        if self.completion_succeeded(user_data) && F::PUNCH_HOLE_READS_ZEROES {
             self.record_zeroes(offset, len);
         } else {
             self.record_unknown(offset, len);
@@ -242,9 +248,12 @@ impl<F: DiskFormat> Executor<F> {
 
     fn write_zeroes(&mut self, offset: u64, len: usize) {
         let user_data = self.next_user_data();
-        let submitted = self.io.write_zeroes(offset, len as u64, user_data).is_ok();
+        if self.io.write_zeroes(offset, len as u64, user_data).is_err() {
+            // As in `punch_hole`: a refused request did nothing.
+            return;
+        }
 
-        if submitted && self.completion_succeeded(user_data) {
+        if self.completion_succeeded(user_data) {
             self.record_zeroes(offset, len);
         } else {
             self.record_unknown(offset, len);

--- a/fuzz/src/disk_engine/executor.rs
+++ b/fuzz/src/disk_engine/executor.rs
@@ -31,7 +31,7 @@ use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
 
 use crate::disk_engine::format::DiskFormat;
 use crate::disk_engine::model::Model;
-use crate::disk_engine::program::{ring_depth, Op, MAX_OPS, MAX_OP_LEN};
+use crate::disk_engine::program::{ring_depth, Op, OpLen, OpOffset, MAX_OPS, MAX_OP_LEN};
 
 /// Largest disk size the shadow model is kept for.
 const MAX_MODEL_LEN: u64 = 8 << 20;
@@ -92,17 +92,29 @@ impl<F: DiskFormat> Executor<F> {
 
     fn step(&mut self, op: &Op) {
         match *op {
-            Op::ReadVec { offset, len } => self.read_vec(offset.resolve(self.size), len.get()),
+            Op::ReadVec { offset, len } => {
+                let (offset, len) = (self.offset(offset), self.len(len));
+                self.read_vec(offset, len)
+            }
             Op::WriteVec { offset, len, seed } => {
-                self.write_vec(offset.resolve(self.size), len.get(), seed)
+                let (offset, len) = (self.offset(offset), self.len(len));
+                self.write_vec(offset, len, seed)
             }
-            Op::ReadMem { offset, len } => self.read_mem(offset.resolve(self.size), len.get()),
+            Op::ReadMem { offset, len } => {
+                let (offset, len) = (self.offset(offset), self.len(len));
+                self.read_mem(offset, len)
+            }
             Op::WriteMem { offset, len, seed } => {
-                self.write_mem(offset.resolve(self.size), len.get(), seed)
+                let (offset, len) = (self.offset(offset), self.len(len));
+                self.write_mem(offset, len, seed)
             }
-            Op::PunchHole { offset, len } => self.punch_hole(offset.resolve(self.size), len.get()),
+            Op::PunchHole { offset, len } => {
+                let (offset, len) = (self.offset(offset), self.len(len));
+                self.punch_hole(offset, len)
+            }
             Op::WriteZeroes { offset, len } => {
-                self.write_zeroes(offset.resolve(self.size), len.get())
+                let (offset, len) = (self.offset(offset), self.len(len));
+                self.write_zeroes(offset, len)
             }
             Op::Fsync { completion } => self.fsync(completion),
             Op::Resize { size_kib } => self.resize(u64::from(size_kib) * 1024),
@@ -114,6 +126,31 @@ impl<F: DiskFormat> Executor<F> {
             Op::UseClone { ring_depth: depth } => self.use_clone(ring_depth(depth)),
             Op::QueryCaps => self.query_caps(),
         }
+    }
+
+    /// Resolves a program offset against the current disk size and snaps it to
+    /// [`DiskFormat::IO_ALIGNMENT`].
+    ///
+    /// A `Wild` offset is passed through unchanged: it exists to reach the
+    /// bounds and overflow checks, which run in front of any alignment test,
+    /// and aligning it would take that reach away.
+    fn offset(&self, offset: OpOffset) -> u64 {
+        let resolved = offset.resolve(self.size);
+        if matches!(offset, OpOffset::Wild(_)) {
+            return resolved;
+        }
+        resolved - resolved % F::IO_ALIGNMENT
+    }
+
+    /// Returns a byte count rounded up to [`DiskFormat::IO_ALIGNMENT`].
+    ///
+    /// Rounding up rather than down keeps a short op an op: a length below
+    /// one sector would otherwise become zero and the program would spend its
+    /// budget on requests that transfer nothing.
+    fn len(&self, len: OpLen) -> usize {
+        let alignment = F::IO_ALIGNMENT as usize;
+        debug_assert!(MAX_OP_LEN.is_multiple_of(alignment));
+        len.get().div_ceil(alignment) * alignment
     }
 
     fn read_vec(&mut self, offset: u64, len: usize) {

--- a/fuzz/src/disk_engine/executor.rs
+++ b/fuzz/src/disk_engine/executor.rs
@@ -39,6 +39,12 @@ const MAX_MODEL_LEN: u64 = 8 << 20;
 /// Largest size a `Resize` op may ask for.
 const MAX_RESIZE_LEN: u64 = 64 << 20;
 
+/// Bytes written into each L2 table by a `Sweep` op.
+///
+/// One sector is enough to allocate a cluster and dirty the table that maps
+/// it, and keeps a sweep over the whole cache cheap.
+const SWEEP_LEN: usize = 512;
+
 /// Drives an op program against one opened disk image.
 pub struct Executor<F: DiskFormat> {
     disk: Box<dyn AsyncFullDiskFile>,
@@ -48,6 +54,7 @@ pub struct Executor<F: DiskFormat> {
     size: u64,
     model: Option<Model>,
     user_data: u64,
+    sweeps: bool,
     format: PhantomData<F>,
 }
 
@@ -76,11 +83,25 @@ impl<F: DiskFormat> Executor<F> {
             size,
             model,
             user_data: 0,
+            sweeps: false,
             format: PhantomData,
         };
         executor.check_capacity_backing();
 
         Some(executor)
+    }
+
+    /// Lets a `Sweep` op walk its full run of metadata tables.
+    ///
+    /// Off by default, and only worth turning on for an image that has more
+    /// tables than the engine caches: see
+    /// [`DiskFormat::sweeps_metadata_cache`]. A sweep on any other image is
+    /// up to `MAX_SWEEP` writes and as many read backs into a single table,
+    /// which is a large part of an iteration's I/O and cannot evict
+    /// anything, so a disabled sweep still walks one table and stays a live
+    /// op rather than a dead one.
+    pub fn set_sweeps(&mut self, sweeps: bool) {
+        self.sweeps = sweeps;
     }
 
     /// Runs up to [`MAX_OPS`] ops.
@@ -125,6 +146,31 @@ impl<F: DiskFormat> Executor<F> {
             }
             Op::UseClone { ring_depth: depth } => self.use_clone(ring_depth(depth)),
             Op::QueryCaps => self.query_caps(),
+            Op::Sweep {
+                first,
+                tables,
+                seed,
+            } => self.sweep(first, tables, seed),
+        }
+    }
+
+    /// Writes one sector into each of a run of L2 tables, then reads every
+    /// one of them back.
+    ///
+    /// The read back pass is what makes the eviction path testable rather
+    /// than merely reachable: a table the engine wrote back to the wrong
+    /// place, or dropped without writing back, only shows up when the data
+    /// behind it is read again after the cache has moved on.
+    fn sweep(&mut self, first: u8, tables: u8, seed: u8) {
+        // A sweep against an image the cache cannot overflow walks one table:
+        // the write and read back still run, the 383 repeats of them do not.
+        let tables = if self.sweeps { tables } else { 0 };
+        let offsets: Vec<u64> = Op::sweep_offsets(first, tables, self.size).collect();
+        for &offset in &offsets {
+            self.write_vec(offset, SWEEP_LEN, seed);
+        }
+        for &offset in &offsets {
+            self.read_vec(offset, SWEEP_LEN);
         }
     }
 

--- a/fuzz/src/disk_engine/format.rs
+++ b/fuzz/src/disk_engine/format.rs
@@ -64,6 +64,34 @@ pub trait DiskFormat {
     /// raw images, set this to `false` and lose the capacity invariants.
     const FIXED_CAPACITY: bool = true;
 
+    /// How the image file backs the capacity the format advertises.
+    ///
+    /// `Some(tail)` says the disk data lives directly in the image file,
+    /// followed by `tail` bytes of trailing metadata, so a capacity larger
+    /// than `physical_size() - tail` is storage that does not exist: a read
+    /// inside it cannot be served and a write inside it grows the file past
+    /// what was provisioned. A fixed VHD is exactly that layout, with a 512
+    /// byte footer.
+    ///
+    /// `None`, the default, makes no claim. It is the only sound value for a
+    /// sparse format such as qcow2 or VHDX, whose file holds only the
+    /// allocated clusters, and for a multi file format such as flat VMDK,
+    /// whose data lives in extent files that the image file merely names.
+    const CAPACITY_FILE_TAIL: Option<u64> = None;
+
+    /// Whether a read the engine accepted and completed successfully always
+    /// transfers the whole requested length.
+    ///
+    /// A block backend has no way to tell its caller which bytes of a partly
+    /// filled buffer are real, so a short read that reports success leaves
+    /// the guest reading whatever its buffer held before. Formats whose read
+    /// path is all-or-error, or which fill unallocated ranges themselves, set
+    /// this and get the check. The default is off because a read served
+    /// straight from a file can legitimately stop at end of file.
+    ///
+    /// Reads only: the check says nothing about writes.
+    const NO_SHORT_READS: bool = false;
+
     /// Whether a successful `punch_hole` guarantees that the range reads back
     /// as zeroes.
     ///

--- a/fuzz/src/disk_engine/format.rs
+++ b/fuzz/src/disk_engine/format.rs
@@ -99,6 +99,26 @@ pub trait DiskFormat {
     /// shadow model instead of expecting zeroes.
     const PUNCH_HOLE_READS_ZEROES: bool = false;
 
+    /// Whether `bytes` carries the bytes that identify this format.
+    ///
+    /// This is the harness side mirror of the first check the parser makes,
+    /// and it exists so that [`fuzz_image`](super::fuzz_image) can tell
+    /// "this input is a mutation of an image of my format" from "this input
+    /// is a byte string that will never be one". An input that fails it is
+    /// still handed to [`DiskFormat::open`], because the code in front of the
+    /// magic check is worth covering, but it is only retained in the corpus
+    /// while the budget in [`fuzz_image`](super::fuzz_image) lasts.
+    ///
+    /// The default accepts everything, so a format that has no identifying
+    /// bytes keeps the old behaviour.
+    ///
+    /// Implementations must mirror the parser rather than the specification:
+    /// a check the parser does not make would drop inputs the parser would
+    /// have accepted.
+    fn magic_ok(_bytes: &[u8]) -> bool {
+        true
+    }
+
     /// Opens `file` as this format.
     ///
     /// `path` is `Some` only when [`DiskFormat::NEEDS_PATH`] is set; a memfd

--- a/fuzz/src/disk_engine/format.rs
+++ b/fuzz/src/disk_engine/format.rs
@@ -185,4 +185,18 @@ pub trait DiskFormat {
     fn template_variant(_variant: u8) -> Option<&'static [u8]> {
         Self::template()
     }
+
+    /// Whether template `variant` has more L2 style metadata tables than the
+    /// engine caches, so that an [`crate::disk_engine::Op::Sweep`] over them
+    /// can evict.
+    ///
+    /// A sweep is expensive: up to `MAX_SWEEP` sector writes and the same
+    /// number of read backs in one op. Against an image whose whole capacity
+    /// is one table it buys nothing at all - every offset lands in the same
+    /// table, nothing is ever evicted, and the op is pure cost. The default
+    /// is therefore `false`, and a format opts in for the variants whose
+    /// layout can actually reach the eviction path.
+    fn sweeps_metadata_cache(_variant: u8) -> bool {
+        false
+    }
 }

--- a/fuzz/src/disk_engine/format.rs
+++ b/fuzz/src/disk_engine/format.rs
@@ -1,0 +1,98 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Format adapter trait.
+
+use std::fs::File;
+use std::path::Path;
+
+use arbitrary::Arbitrary;
+use block::disk_file::AsyncFullDiskFile;
+use block::error::BlockResult;
+
+/// Open options handed to a format adapter.
+///
+/// Backing file support is deliberately absent: a fuzzed image names its
+/// backing file by path, so enabling it would let the corpus open arbitrary
+/// host files from inside the fuzzer. Fuzzing backing chains needs a
+/// controlled path namespace and is left to a follow-up.
+#[derive(Arbitrary, Clone, Copy, Debug, Default)]
+pub struct OpenConfig {
+    /// Open the image with the direct I/O alignment rules.
+    pub direct: bool,
+    /// Advertise sparse operations (discard, write zeroes) to the engine.
+    pub sparse: bool,
+}
+
+/// A disk image format that the framework can fuzz.
+///
+/// An adapter only has to say how to turn a `File` into an engine handle and
+/// how to produce one valid image of its own format.
+pub trait DiskFormat {
+    /// Format name, used for memfd names and assertion messages.
+    const NAME: &'static str;
+
+    /// Whether the I/O backend completes operations before
+    /// `submit_data_operation` returns.
+    ///
+    /// Synchronous backends do, so a missing completion is a lost request and
+    /// the executor treats it as a finding. Asynchronous backends may need a
+    /// notifier wakeup first, and set this to `false`.
+    const COMPLETES_INLINE: bool = true;
+
+    /// Whether the image has to exist as a real file rather than a memfd.
+    ///
+    /// A format whose image references sibling files by relative path, such as
+    /// a VMDK descriptor naming its extents, can only be opened from a
+    /// directory. The framework then materializes the image in a scratch
+    /// directory and passes its path to [`DiskFormat::open`].
+    const NEEDS_PATH: bool = false;
+
+    /// Largest image the framework will hand to this format.
+    ///
+    /// Inputs above this size are rejected instead of being fed to the
+    /// parser: they cost time without reaching new states. Formats whose
+    /// metadata reaches far into the file need a larger budget, so 8 MiB is
+    /// only a default.
+    const MAX_IMAGE_LEN: usize = 8 << 20;
+
+    /// Whether the reported capacity only ever changes through a successful
+    /// resize.
+    ///
+    /// Formats that grow their backing file on a write past the end, such as
+    /// raw images, set this to `false` and lose the capacity invariants.
+    const FIXED_CAPACITY: bool = true;
+
+    /// Whether a successful `punch_hole` guarantees that the range reads back
+    /// as zeroes.
+    ///
+    /// When `false`, the executor marks discarded ranges as unknown in the
+    /// shadow model instead of expecting zeroes.
+    const PUNCH_HOLE_READS_ZEROES: bool = false;
+
+    /// Opens `file` as this format.
+    ///
+    /// `path` is `Some` only when [`DiskFormat::NEEDS_PATH`] is set; a memfd
+    /// backed image has no meaningful path.
+    fn open(
+        file: File,
+        path: Option<&Path>,
+        config: &OpenConfig,
+    ) -> BlockResult<Box<dyn AsyncFullDiskFile>>;
+
+    /// Returns the bytes of a valid, freshly created image of this format,
+    /// for the formats that can build one in process.
+    ///
+    /// The image must read back as all zeroes so that the shadow model can
+    /// start from a known state, and it must be byte identical on every run
+    /// so that a crash reproduces from its input alone. Adapters build it
+    /// once per process.
+    ///
+    /// A format that has no in process image builder returns `None` and gets
+    /// no operation program target; its parser is still fuzzed by the image
+    /// target.
+    fn template() -> Option<&'static [u8]> {
+        None
+    }
+}

--- a/fuzz/src/disk_engine/format.rs
+++ b/fuzz/src/disk_engine/format.rs
@@ -107,6 +107,25 @@ pub trait DiskFormat {
     /// shadow model instead of expecting zeroes.
     const PUNCH_HOLE_READS_ZEROES: bool = false;
 
+    /// Granularity the engine requires data ops to be aligned to.
+    ///
+    /// A format whose engine refuses an offset or a length that is not a
+    /// multiple of its logical sector size gets almost nothing out of a
+    /// uniformly random program: a `u16` length is a multiple of 512 in 0.2%
+    /// of cases, so 99.8% of the data ops in a generated program would be
+    /// rejected before reaching any translation logic, and the shadow model
+    /// would have nothing to check. The executor therefore snaps in range
+    /// offsets down and lengths up to this value.
+    ///
+    /// Misaligned requests stay reachable: [`crate::disk_engine::OpOffset::Wild`]
+    /// offsets are passed through untouched, and the image target drives
+    /// [`crate::disk_engine::default_program`], whose 65535 byte read is not
+    /// a multiple of any sector size.
+    ///
+    /// Must divide [`crate::disk_engine::MAX_OP_LEN`], so that rounding a
+    /// length up cannot exceed the guest memory region.
+    const IO_ALIGNMENT: u64 = 1;
+
     /// Whether `bytes` carries the bytes that identify this format.
     ///
     /// This is the harness side mirror of the first check the parser makes,

--- a/fuzz/src/disk_engine/format.rs
+++ b/fuzz/src/disk_engine/format.rs
@@ -13,16 +13,24 @@ use block::error::BlockResult;
 
 /// Open options handed to a format adapter.
 ///
-/// Backing file support is deliberately absent: a fuzzed image names its
-/// backing file by path, so enabling it would let the corpus open arbitrary
-/// host files from inside the fuzzer. Fuzzing backing chains needs a
-/// controlled path namespace and is left to a follow-up.
+/// [`OpenConfig::backing`] is not fuzzer selectable: it is set by the
+/// harness, never derived from input bytes. A fuzzed image names its backing
+/// file by path, so a target that enables it has to sandbox the name space
+/// first, which only `disk_qcow2_chain` does, and enabling it under the
+/// shadow model would be unsound besides: with a backing file a discarded
+/// cluster reads through to the backing data rather than as zeroes.
 #[derive(Arbitrary, Clone, Copy, Debug, Default)]
 pub struct OpenConfig {
     /// Open the image with the direct I/O alignment rules.
     pub direct: bool,
     /// Advertise sparse operations (discard, write zeroes) to the engine.
     pub sparse: bool,
+    /// Open backing files named by the image.
+    ///
+    /// Fixed at `false` for a fuzzer generated configuration; only a target
+    /// that has confined the filesystem may set it.
+    #[arbitrary(value = false)]
+    pub backing: bool,
 }
 
 /// A disk image format that the framework can fuzz.

--- a/fuzz/src/disk_engine/format.rs
+++ b/fuzz/src/disk_engine/format.rs
@@ -170,4 +170,19 @@ pub trait DiskFormat {
     fn template() -> Option<&'static [u8]> {
         None
     }
+
+    /// Returns the template a program asked for by index.
+    ///
+    /// A format may build more than one valid image when the layouts differ
+    /// in a way the engine branches on. qcow2 does: the number of L2 tables
+    /// an image has follows from its cluster size, and the L2 cache only
+    /// evicts once more tables are live than it holds, which a single
+    /// template cannot reach at any size the shadow model can afford.
+    ///
+    /// The index comes from the input, so which image an iteration ran
+    /// against is part of what reproduces it. The default ignores it and
+    /// hands back the single template.
+    fn template_variant(_variant: u8) -> Option<&'static [u8]> {
+        Self::template()
+    }
 }

--- a/fuzz/src/disk_engine/formats/mod.rs
+++ b/fuzz/src/disk_engine/formats/mod.rs
@@ -7,3 +7,4 @@
 pub mod qcow2;
 pub mod vhd;
 pub mod vhdx;
+pub mod vmdk;

--- a/fuzz/src/disk_engine/formats/mod.rs
+++ b/fuzz/src/disk_engine/formats/mod.rs
@@ -5,4 +5,5 @@
 //! Format adapters.
 
 pub mod qcow2;
+pub mod vhd;
 pub mod vhdx;

--- a/fuzz/src/disk_engine/formats/mod.rs
+++ b/fuzz/src/disk_engine/formats/mod.rs
@@ -1,0 +1,7 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Format adapters.
+
+pub mod qcow2;

--- a/fuzz/src/disk_engine/formats/mod.rs
+++ b/fuzz/src/disk_engine/formats/mod.rs
@@ -5,6 +5,7 @@
 //! Format adapters.
 
 pub mod qcow2;
+pub mod qcow2_chain;
 pub mod vhd;
 pub mod vhdx;
 pub mod vmdk;

--- a/fuzz/src/disk_engine/formats/mod.rs
+++ b/fuzz/src/disk_engine/formats/mod.rs
@@ -5,3 +5,4 @@
 //! Format adapters.
 
 pub mod qcow2;
+pub mod vhdx;

--- a/fuzz/src/disk_engine/formats/qcow2.rs
+++ b/fuzz/src/disk_engine/formats/qcow2.rs
@@ -20,6 +20,10 @@ use crate::disk_engine::format::{DiskFormat, OpenConfig};
 /// staying small enough to keep the shadow model cheap.
 const TEMPLATE_SIZE: u64 = 1 << 20;
 
+/// The magic every qcow image starts with, from `QCOW_MAGIC`
+/// (block/src/formats/qcow/header.rs:70), big endian on disk.
+const QCOW_MAGIC: &[u8; 4] = b"QFI\xfb";
+
 /// QCOW2 images, as opened by [`QcowDisk`].
 pub struct Qcow2;
 
@@ -41,6 +45,13 @@ impl DiskFormat for Qcow2 {
     // `None`: a sparse image holds only the clusters that were written, and
     // its file is routinely far smaller than the virtual disk size.
     const NO_SHORT_READS: bool = true;
+
+    // `QcowHeader::new` rejects an image whose first four bytes are not the
+    // QCOW magic (block/src/formats/qcow/header.rs:382, QCOW_MAGIC at line
+    // 70), before it reads any other field.
+    fn magic_ok(bytes: &[u8]) -> bool {
+        bytes.len() >= QCOW_MAGIC.len() && bytes[..QCOW_MAGIC.len()] == *QCOW_MAGIC
+    }
 
     fn open(
         file: File,

--- a/fuzz/src/disk_engine/formats/qcow2.rs
+++ b/fuzz/src/disk_engine/formats/qcow2.rs
@@ -76,3 +76,17 @@ impl DiskFormat for Qcow2 {
         Some(template)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::disk_engine::selftest::assert_template_is_sound;
+
+    /// The same guard the VHDX template gets: a template that opens but is
+    /// not a blank disk of the pinned size makes `disk_qcow2_ops` an
+    /// expensive no-op. See `disk_engine::selftest`.
+    #[test]
+    fn the_template_is_a_blank_one_mib_disk() {
+        assert_template_is_sound::<Qcow2>(TEMPLATE_SIZE);
+    }
+}

--- a/fuzz/src/disk_engine/formats/qcow2.rs
+++ b/fuzz/src/disk_engine/formats/qcow2.rs
@@ -120,6 +120,14 @@ impl DiskFormat for Qcow2 {
 
         Some(template)
     }
+
+    // Only the small cluster variant can evict. The default template is 1
+    // MiB with 64 KiB clusters, so one L2 table maps 512 MiB and the whole
+    // image is a single table: a sweep over it revisits that one table up to
+    // MAX_SWEEP times and cannot reach the cache's eviction path at all.
+    fn sweeps_metadata_cache(variant: u8) -> bool {
+        !variant.is_multiple_of(2)
+    }
 }
 
 #[cfg(test)]

--- a/fuzz/src/disk_engine/formats/qcow2.rs
+++ b/fuzz/src/disk_engine/formats/qcow2.rs
@@ -1,0 +1,56 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! QCOW2 adapter.
+
+use std::fs::{self, File};
+use std::path::Path;
+use std::sync::OnceLock;
+
+use block::disk_file::AsyncFullDiskFile;
+use block::error::BlockResult;
+use block::formats::qcow::{QcowDisk, QcowTempDisk};
+
+use crate::disk_engine::format::{DiskFormat, OpenConfig};
+
+/// Virtual size of the template image.
+///
+/// Large enough to span several clusters, and so several L2 entries, while
+/// staying small enough to keep the shadow model cheap.
+const TEMPLATE_SIZE: u64 = 1 << 20;
+
+/// QCOW2 images, as opened by [`QcowDisk`].
+pub struct Qcow2;
+
+impl DiskFormat for Qcow2 {
+    const NAME: &'static str = "qcow2";
+
+    // Discarding a cluster leaves it unallocated, which reads back as zeroes
+    // only when the image has no backing file. The framework never enables
+    // backing files, so the guarantee holds.
+    const PUNCH_HOLE_READS_ZEROES: bool = true;
+
+    fn open(
+        file: File,
+        _path: Option<&Path>,
+        config: &OpenConfig,
+    ) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+        let disk = QcowDisk::new(file, config.direct, false, config.sparse, false)?;
+        Ok(Box::new(disk))
+    }
+
+    fn template() -> Option<&'static [u8]> {
+        static TEMPLATE: OnceLock<Vec<u8>> = OnceLock::new();
+
+        let template = TEMPLATE.get_or_init(|| {
+            let disk = QcowTempDisk::new(TEMPLATE_SIZE, None, false, true, false)
+                .expect("failed to create the qcow2 template image");
+            // Dropping the disk handle flushes the metadata into the file.
+            let file = disk.into_tempfile();
+            fs::read(file.as_path()).expect("failed to read the qcow2 template image")
+        });
+
+        Some(template)
+    }
+}

--- a/fuzz/src/disk_engine/formats/qcow2.rs
+++ b/fuzz/src/disk_engine/formats/qcow2.rs
@@ -14,11 +14,30 @@ use block::formats::qcow::{QcowDisk, QcowTempDisk};
 
 use crate::disk_engine::format::{DiskFormat, OpenConfig};
 
-/// Virtual size of the template image.
+/// Virtual size of the default template image.
 ///
 /// Large enough to span several clusters, and so several L2 entries, while
 /// staying small enough to keep the shadow model cheap.
 const TEMPLATE_SIZE: u64 = 1 << 20;
+
+/// Cluster size of the small cluster template, as a power of two.
+///
+/// `MIN_CLUSTER_BITS` in the parser under test
+/// (block/src/formats/qcow/header.rs:75), so 512 byte clusters.
+const SMALL_CLUSTER_BITS: u32 = 9;
+
+/// Virtual size of the small cluster template.
+///
+/// With 512 byte clusters an L2 table holds `512 / 8 = 64` entries and so
+/// covers `64 * 512 = 32 KiB` of the disk. The L2 cache holds 100 tables
+/// (block/src/formats/qcow/parser.rs:539), so its eviction path needs more
+/// than `100 * 32 KiB = 3.2 MiB` of the disk live at once. Four MiB gives
+/// 128 tables, comfortably past the cache, and still fits under the shadow
+/// model's 8 MiB limit so the eviction runs with the read back oracle on.
+const SMALL_TEMPLATE_SIZE: u64 = 4 << 20;
+
+/// Bytes covered by one L2 table of the small cluster template.
+pub const SMALL_L2_SPAN: u64 = (1 << SMALL_CLUSTER_BITS) / 8 * (1 << SMALL_CLUSTER_BITS);
 
 /// The magic every qcow image starts with, from `QCOW_MAGIC`
 /// (block/src/formats/qcow/header.rs:70), big endian on disk.
@@ -71,6 +90,32 @@ impl DiskFormat for Qcow2 {
             // Dropping the disk handle flushes the metadata into the file.
             let file = disk.into_tempfile();
             fs::read(file.as_path()).expect("failed to read the qcow2 template image")
+        });
+
+        Some(template)
+    }
+
+    // An odd index picks the small cluster image, so a program reaches
+    // either layout and neither is the only one fuzzed.
+    fn template_variant(variant: u8) -> Option<&'static [u8]> {
+        if variant.is_multiple_of(2) {
+            return Self::template();
+        }
+
+        static SMALL: OnceLock<Vec<u8>> = OnceLock::new();
+
+        let template = SMALL.get_or_init(|| {
+            let disk = QcowTempDisk::new_with_cluster_bits(
+                SMALL_TEMPLATE_SIZE,
+                None,
+                false,
+                true,
+                false,
+                SMALL_CLUSTER_BITS,
+            )
+            .expect("failed to create the small cluster qcow2 template image");
+            let file = disk.into_tempfile();
+            fs::read(file.as_path()).expect("failed to read the small cluster qcow2 template")
         });
 
         Some(template)

--- a/fuzz/src/disk_engine/formats/qcow2.rs
+++ b/fuzz/src/disk_engine/formats/qcow2.rs
@@ -31,6 +31,17 @@ impl DiskFormat for Qcow2 {
     // backing files, so the guarantee holds.
     const PUNCH_HOLE_READS_ZEROES: bool = true;
 
+    // A qcow2 read reports the whole requested length or fails:
+    // `QcowSync::read_operation` returns `total_len`
+    // (block/src/formats/qcow/engine_sync.rs:67), because an unallocated
+    // cluster is filled with zeroes by the scatter read rather than left
+    // short.
+    //
+    // The capacity is not file backed, so `CAPACITY_FILE_TAIL` stays
+    // `None`: a sparse image holds only the clusters that were written, and
+    // its file is routinely far smaller than the virtual disk size.
+    const NO_SHORT_READS: bool = true;
+
     fn open(
         file: File,
         _path: Option<&Path>,

--- a/fuzz/src/disk_engine/formats/qcow2_chain.rs
+++ b/fuzz/src/disk_engine/formats/qcow2_chain.rs
@@ -1,0 +1,591 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! QCOW2 backing chain adapter.
+//!
+//! # What this reaches that `disk_qcow2` cannot
+//!
+//! A qcow2 image may name a backing file, and everything the `block` crate
+//! does with one hangs off that name: the `Raw` versus `Qcow2` dispatch and
+//! the recursive open in `BackingFile::new`
+//! (block/src/formats/qcow/parser.rs:174), the whole of
+//! block/src/formats/qcow/backing.rs, the `MAX_NESTING_DEPTH` bound
+//! (block/src/formats/qcow/util.rs:13) and the copy on write from backing arm
+//! of `deallocate_bytes` (block/src/formats/qcow/metadata.rs:321). None of it
+//! is reachable from `disk_qcow2`, which opens every image with
+//! `backing_files: false`.
+//!
+//! # Why it needs its own target
+//!
+//! The name is a path, and the engine resolves a relative one against the
+//! directory of the image that stores it and opens it without confinement.
+//! Feeding it fuzzer bytes is only safe inside a sandbox, so the sandbox and
+//! the two image input space live here rather than in the plain image
+//! target.
+//!
+//! It also has to stay away from the shadow model. [`Qcow2`] declares
+//! `PUNCH_HOLE_READS_ZEROES`, which is true only for an image without a
+//! backing file: a discarded cluster in an image that has one reads *through*
+//! to the backing data, not as zeroes, so a model that expected zeroes would
+//! report data corruption that is not there. This target therefore runs the
+//! fixed [`default_program`] with the model off, and
+//! [`crate::disk_engine::fuzz_program`] forces backing files off, so the two
+//! never meet.
+//!
+//! # Input encoding
+//!
+//! ```text
+//! [u32 LE top_len][top_len bytes: the image][remaining bytes: the backing image]
+//! ```
+//!
+//! Both halves are fuzzer controlled, which is what makes a malformed backing
+//! image, and so `Qcow2Backing::read_clusters` over broken metadata,
+//! reachable. `top_len` is clamped to what the input holds rather than
+//! rejected: it is a harness framing field with no safety meaning, and a
+//! mutation that grows it should still run.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Component, Path};
+
+use block::disk_file::AsyncFullDiskFile;
+use block::error::{BlockError, BlockErrorKind, BlockResult};
+use block::formats::qcow::QcowDisk;
+use libfuzzer_sys::Corpus;
+
+use crate::disk_engine::executor::Executor;
+use crate::disk_engine::format::{DiskFormat, OpenConfig};
+use crate::disk_engine::formats::qcow2::Qcow2;
+use crate::disk_engine::image::{image_file, scratch_dir};
+use crate::disk_engine::program::default_program;
+use crate::disk_engine::sandbox;
+
+/// Largest image half of an input.
+///
+/// Both halves are capped well below the 8 MiB default: a backing chain is
+/// two images per iteration, and a qcow2 that `qemu-img` writes for a 1 MiB
+/// disk is a few hundred kilobytes.
+const MAX_HALF_LEN: usize = 2 << 20;
+
+/// Name the backing image is always written under.
+///
+/// A seed can name it, and a mutation that destroys the name in the header
+/// still leaves a file the engine can open under the name the other seeds
+/// use.
+const DEFAULT_BACKING_NAME: &str = "backing.img";
+
+/// Name of the fixed, empty raw file the harness also provides.
+///
+/// An input carries two images, so a chain built only out of them closes on
+/// itself: whatever the second image names is a file the harness wrote the
+/// second image to, and the engine then recurses until `MAX_NESTING_DEPTH`
+/// refuses the open, which means a three deep chain never reads anything. A
+/// fixed raw file terminates one, because any file is a valid raw backing, so
+/// a middle image that names it makes the nested `ClusterReadMapping::Backing`
+/// arm of `Qcow2Backing::read_clusters` reachable.
+const LEAF_NAME: &str = "leaf.raw";
+
+/// Size of that file.
+const LEAF_LEN: u64 = 1 << 20;
+
+/// Longest backing name the harness will materialize.
+///
+/// `MAX_BACKING_FILE_SIZE` in the parser is 1023 bytes, but a file name is
+/// bounded by `NAME_MAX`, and a longer one could only ever fail at `open`.
+const MAX_NAME_LEN: usize = 255;
+
+/// What the harness makes of the backing name in an image header.
+#[derive(Debug, Eq, PartialEq)]
+pub enum BackingName {
+    /// The image provably names no backing file, so nothing is opened.
+    Absent,
+    /// The image names a plain file, which the harness materializes in the
+    /// scratch directory.
+    Safe(String),
+    /// The image names something the harness will not resolve.
+    Escaping,
+}
+
+/// QCOW2 images opened with backing files enabled.
+pub struct Qcow2Chain;
+
+impl Qcow2Chain {
+    /// Reads the backing file name out of a qcow2 header and classifies it.
+    ///
+    /// The harness has to parse this itself, out of the raw input bytes,
+    /// because the decision has to be made *before* the `block` crate opens
+    /// anything: by the time `BackingFile::new` runs, the file is already
+    /// open. The two fields are the ones `QcowHeader::new` reads,
+    /// `backing_file_offset` as a big endian `u64` at bytes 8..16 and
+    /// `backing_file_size` as a big endian `u32` at bytes 16..20
+    /// (block/src/formats/qcow/header.rs:217), and the name is that many
+    /// bytes at that offset (block/src/formats/qcow/header.rs:467).
+    ///
+    /// The classification fails closed. [`BackingName::Absent`] is returned
+    /// only when the header provably opens nothing: a zero offset or a zero
+    /// size, either of which `QcowHeader::new` turns into an error or into no
+    /// backing file at all. Everything the harness cannot read and check as a
+    /// single plain file name, including a name that runs past the end of the
+    /// input or is not UTF-8, is [`BackingName::Escaping`] and the input is
+    /// refused, even where the parser would have rejected it anyway.
+    pub fn backing_name(bytes: &[u8]) -> BackingName {
+        // magic, version, backing_file_offset, backing_file_size.
+        if bytes.len() < 20 {
+            return BackingName::Absent;
+        }
+        let offset = u64::from_be_bytes(bytes[8..16].try_into().expect("8 bytes"));
+        let size = u32::from_be_bytes(bytes[16..20].try_into().expect("4 bytes"));
+        if offset == 0 || size == 0 {
+            return BackingName::Absent;
+        }
+
+        let Ok(start) = usize::try_from(offset) else {
+            return BackingName::Escaping;
+        };
+        let Some(end) = start.checked_add(size as usize) else {
+            return BackingName::Escaping;
+        };
+        if end > bytes.len() || size as usize > MAX_NAME_LEN {
+            return BackingName::Escaping;
+        }
+        let Ok(name) = std::str::from_utf8(&bytes[start..end]) else {
+            return BackingName::Escaping;
+        };
+
+        if Self::is_plain_name(name) {
+            BackingName::Safe(name.to_string())
+        } else {
+            BackingName::Escaping
+        }
+    }
+
+    /// Whether `name` is a single plain file name inside the scratch
+    /// directory.
+    ///
+    /// The engine joins a relative backing name onto the directory of the
+    /// image that stores it (block/src/formats/qcow/parser.rs:317) with
+    /// `Path::join` and no normalisation, so `..` walks straight out of the
+    /// scratch directory and an absolute name replaces it outright. Only a
+    /// name that is exactly one [`Component::Normal`] is allowed: that turns
+    /// away absolute paths, root and prefix components, `..`, `.`, the empty
+    /// name and, unlike the VMDK guard, subdirectories too, since the harness
+    /// creates none. An embedded NUL is refused as well, so that what the
+    /// harness checked and what the engine passes to `open` cannot differ.
+    fn is_plain_name(name: &str) -> bool {
+        if name.is_empty() || name.len() > MAX_NAME_LEN || name.contains('\0') {
+            return false;
+        }
+        let path = Path::new(name);
+        if path.is_absolute() {
+            return false;
+        }
+        let mut components = path.components();
+        matches!(components.next(), Some(Component::Normal(c)) if c == name)
+            && components.next().is_none()
+    }
+
+    /// Removes every file left in the scratch directory.
+    ///
+    /// An iteration may create a file under any plain name the input asks
+    /// for, so without this the directory grows without bound and, worse, an
+    /// input could open a backing image a previous input created, which would
+    /// make a crash depend on the run rather than on the input.
+    fn reset_scratch(dir: &Path) -> std::io::Result<()> {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            if entry.file_type()?.is_file() {
+                fs::remove_file(entry.path())?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Writes `bytes` into the scratch directory under `name`.
+    fn write_backing(dir: &Path, name: &str, bytes: &[u8]) -> std::io::Result<()> {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(dir.join(name))?;
+        file.write_all(bytes)
+    }
+
+    /// Creates the fixed raw file that terminates a chain, see [`LEAF_NAME`].
+    fn write_leaf(dir: &Path) -> std::io::Result<()> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(dir.join(LEAF_NAME))?;
+        file.set_len(LEAF_LEN)
+    }
+}
+
+impl DiskFormat for Qcow2Chain {
+    const NAME: &'static str = "qcow2-chain";
+
+    // The backing name is resolved against the directory of the image that
+    // stores it, through /proc/self/fd (block/src/formats/qcow/parser.rs:319),
+    // so the image cannot be a memfd: that readlink names a deleted
+    // /memfd:... path and the name would be resolved against the working
+    // directory instead.
+    const NEEDS_PATH: bool = true;
+
+    const MAX_IMAGE_LEN: usize = MAX_HALF_LEN;
+
+    // Inherited from the plain qcow2 adapter, which documents both.
+    const NO_SHORT_READS: bool = Qcow2::NO_SHORT_READS;
+
+    // Deliberately *not* inherited: with a backing file a discarded cluster
+    // reads through to the backing data rather than as zeroes. The default of
+    // false is the only sound value here, and this target runs without a
+    // shadow model anyway.
+    const PUNCH_HOLE_READS_ZEROES: bool = false;
+
+    fn magic_ok(bytes: &[u8]) -> bool {
+        Qcow2::magic_ok(bytes)
+    }
+
+    fn open(
+        file: File,
+        path: Option<&Path>,
+        config: &OpenConfig,
+    ) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+        // The guard is repeated at the open, not only where the input is
+        // split, so that no future caller can reach `QcowDisk::new` with
+        // backing files enabled and an unchecked name.
+        if config.backing {
+            let path = path.expect("a backing chain image is path backed");
+            let bytes = fs::read(path).map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
+            if Self::backing_name(&bytes) == BackingName::Escaping {
+                return Err(BlockError::from_kind(BlockErrorKind::UnsupportedFeature));
+            }
+        }
+
+        let disk = QcowDisk::new(file, config.direct, config.backing, config.sparse, false)?;
+        Ok(Box::new(disk))
+    }
+}
+
+/// Splits an input into the image and its backing image.
+///
+/// Returns `None` only for an input too short to carry the length prefix.
+fn split(bytes: &[u8]) -> Option<(&[u8], &[u8])> {
+    let (len, rest) = bytes.split_at_checked(4)?;
+    let top_len = u32::from_le_bytes(len.try_into().expect("4 bytes")) as usize;
+    Some(rest.split_at(top_len.min(rest.len())))
+}
+
+/// Fuzzes the qcow2 backing chain code with a fuzzer built chain.
+///
+/// The sandbox comes first: the harness name guard is the only thing between
+/// a corpus entry and an arbitrary host path, so the target refuses to run at
+/// all when the process cannot be confined as well.
+pub fn fuzz_chain(bytes: &[u8]) -> Corpus {
+    let Ok(dir) = scratch_dir(Qcow2Chain::NAME) else {
+        return Corpus::Reject;
+    };
+    if !sandbox::confine(dir) {
+        return Corpus::Reject;
+    }
+
+    let Some((top, backing)) = split(bytes) else {
+        return Corpus::Reject;
+    };
+    if top.len() > MAX_HALF_LEN || backing.len() > MAX_HALF_LEN {
+        return Corpus::Reject;
+    }
+    // The rejection paths in front of the backing code are `disk_qcow2`'s
+    // job; an input that cannot open is worth nothing here.
+    if !Qcow2Chain::magic_ok(top) {
+        return Corpus::Reject;
+    }
+
+    // Both images are checked: the backing image's own header can name a
+    // further backing file, and that is exactly the nested chain this target
+    // is here to reach, so its name is as untrusted as the top one's.
+    let names = [
+        Qcow2Chain::backing_name(top),
+        Qcow2Chain::backing_name(backing),
+    ];
+    if names.contains(&BackingName::Escaping) {
+        return Corpus::Reject;
+    }
+
+    if Qcow2Chain::reset_scratch(dir).is_err() {
+        return Corpus::Reject;
+    }
+    // The backing bytes are written under every name the chain asks for, so
+    // a mutation of the name field still opens something, and a chain that
+    // names itself recurses until `MAX_NESTING_DEPTH` stops it. The top image
+    // is written last, so a name that collides with it still ends up holding
+    // the top image and the chain closes on itself rather than on stale
+    // bytes.
+    if Qcow2Chain::write_backing(dir, DEFAULT_BACKING_NAME, backing).is_err() {
+        return Corpus::Reject;
+    }
+    if Qcow2Chain::write_leaf(dir).is_err() {
+        return Corpus::Reject;
+    }
+    for name in &names {
+        if let BackingName::Safe(name) = name {
+            if Qcow2Chain::write_backing(dir, name, backing).is_err() {
+                return Corpus::Reject;
+            }
+        }
+    }
+
+    let Ok((file, path)) = image_file(Qcow2Chain::NAME, top) else {
+        return Corpus::Reject;
+    };
+
+    let config = OpenConfig {
+        backing: true,
+        // Sparse ops are what reach the copy on write from backing arm of
+        // `deallocate_bytes` (block/src/formats/qcow/metadata.rs:321).
+        sparse: true,
+        ..OpenConfig::default()
+    };
+    let Ok(disk) = Qcow2Chain::open(file, Some(&path), &config) else {
+        return Corpus::Keep;
+    };
+
+    // No shadow model: the image contents are unknown, and punch hole over a
+    // backing file does not read back as zeroes.
+    if let Some(mut executor) = Executor::<Qcow2Chain>::new(disk, 1, false) {
+        executor.run(&default_program());
+    }
+
+    Corpus::Keep
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use block::async_io::{AsyncIoOperation, OwnedIoBuffer};
+
+    use super::*;
+
+    /// Byte the backing image is filled with.
+    const PATTERN: u8 = 0xa5;
+
+    /// Builds a real two image chain with `qemu-img`, the top image naming
+    /// the base by a plain relative name, and returns their bytes.
+    ///
+    /// The base holds a known pattern so that a read served through the
+    /// chain can be told from a read of a hole.
+    fn qemu_chain() -> Option<(Vec<u8>, Vec<u8>)> {
+        let dir = std::env::temp_dir().join("qcow2-chain-check");
+        let _ = fs::create_dir_all(&dir);
+        for name in ["source.raw", "base.qcow2", "top.qcow2"] {
+            let _ = fs::remove_file(dir.join(name));
+        }
+
+        fs::write(dir.join("source.raw"), vec![PATTERN; 1 << 20]).ok()?;
+        let qemu = |args: &[&str]| -> Option<bool> {
+            Some(
+                Command::new("qemu-img")
+                    .current_dir(&dir)
+                    .args(args)
+                    .status()
+                    .ok()?
+                    .success(),
+            )
+        };
+        if !qemu(&["convert", "-O", "qcow2", "source.raw", "base.qcow2"])?
+            || !qemu(&[
+                "create",
+                "-f",
+                "qcow2",
+                "-F",
+                "qcow2",
+                "-b",
+                "base.qcow2",
+                "top.qcow2",
+                "1M",
+            ])?
+        {
+            return None;
+        }
+
+        Some((
+            fs::read(dir.join("top.qcow2")).ok()?,
+            fs::read(dir.join("base.qcow2")).ok()?,
+        ))
+    }
+
+    /// Builds a minimal v3 header carrying `name` as its backing file name.
+    ///
+    /// Only the fields the guard reads have to be right; the rest is what
+    /// `QcowHeader::new` needs to get that far.
+    fn image_with_backing(name: &str) -> Vec<u8> {
+        let mut image = vec![0u8; 1 << 16];
+        image[0..4].copy_from_slice(b"QFI\xfb");
+        image[4..8].copy_from_slice(&3u32.to_be_bytes());
+        let offset: u64 = 512;
+        image[8..16].copy_from_slice(&offset.to_be_bytes());
+        image[16..20].copy_from_slice(&(name.len() as u32).to_be_bytes());
+        // cluster_bits = 16, so the name stays inside the first cluster.
+        image[20..24].copy_from_slice(&16u32.to_be_bytes());
+        image[24..32].copy_from_slice(&(1u64 << 20).to_be_bytes());
+        let at = offset as usize;
+        image[at..at + name.len()].copy_from_slice(name.as_bytes());
+        image
+    }
+
+    // The engine joins a relative name onto the image's own directory with
+    // no normalisation and then opens it, so a name that escapes must never
+    // get that far.
+    #[test]
+    fn traversing_backing_names_are_refused() {
+        for name in [
+            "../../../../tmp/victim",
+            "..",
+            "./backing.img",
+            "sub/../../tmp/victim",
+            "sub/backing.img",
+            "/tmp/victim",
+            "/etc/passwd",
+            "back\0ing.img",
+        ] {
+            assert_eq!(
+                Qcow2Chain::backing_name(&image_with_backing(name)),
+                BackingName::Escaping,
+                "{name:?} must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn plain_backing_names_are_accepted() {
+        for name in ["backing.img", "base.qcow2", "image.qcow2-chain"] {
+            assert_eq!(
+                Qcow2Chain::backing_name(&image_with_backing(name)),
+                BackingName::Safe(name.to_string()),
+                "{name} must be accepted"
+            );
+        }
+    }
+
+    // A header that opens no backing file at all must not be confused with
+    // one that names something unreadable: the first is normal, the second
+    // is refused.
+    #[test]
+    fn a_header_without_a_backing_file_is_absent() {
+        let mut image = image_with_backing("backing.img");
+        image[8..16].copy_from_slice(&0u64.to_be_bytes());
+        assert_eq!(Qcow2Chain::backing_name(&image), BackingName::Absent);
+
+        let mut image = image_with_backing("backing.img");
+        image[16..20].copy_from_slice(&0u32.to_be_bytes());
+        assert_eq!(Qcow2Chain::backing_name(&image), BackingName::Absent);
+
+        assert_eq!(Qcow2Chain::backing_name(b"QFI\xfb"), BackingName::Absent);
+    }
+
+    // Fail closed: a name the harness cannot read out of the input is
+    // refused rather than assumed harmless.
+    #[test]
+    fn an_unreadable_name_is_refused() {
+        let mut image = image_with_backing("backing.img");
+        image[8..16].copy_from_slice(&u64::MAX.to_be_bytes());
+        assert_eq!(Qcow2Chain::backing_name(&image), BackingName::Escaping);
+
+        let mut image = image_with_backing("backing.img");
+        // Past the end of the input.
+        image[16..20].copy_from_slice(&(1u32 << 20).to_be_bytes());
+        assert_eq!(Qcow2Chain::backing_name(&image), BackingName::Escaping);
+
+        let mut image = image_with_backing("backing.img");
+        image[512] = 0xff;
+        assert_eq!(Qcow2Chain::backing_name(&image), BackingName::Escaping);
+    }
+
+    // The framing field is clamped, not refused: it carries no safety
+    // meaning and a mutation that grows it should still run.
+    #[test]
+    fn the_length_prefix_is_clamped() {
+        let mut input = 4u32.to_le_bytes().to_vec();
+        input.extend_from_slice(b"topsbacking");
+        let (top, backing) = split(&input).expect("split");
+        assert_eq!(top, b"tops");
+        assert_eq!(backing, b"backing");
+
+        let mut input = u32::MAX.to_le_bytes().to_vec();
+        input.extend_from_slice(b"tops");
+        let (top, backing) = split(&input).expect("split");
+        assert_eq!(top, b"tops");
+        assert!(backing.is_empty());
+
+        assert!(split(b"abc").is_none());
+    }
+
+    // The guard has to hold at the entry point the engine is reached
+    // through, not only in isolation.
+    #[test]
+    fn open_refuses_a_traversing_backing_name() {
+        let victim = Path::new("/tmp/ch-fuzz-victim-qcow2-chain");
+        let _ = fs::remove_file(victim);
+
+        let bytes = image_with_backing("../../../../tmp/ch-fuzz-victim-qcow2-chain");
+        let (file, path) = image_file(Qcow2Chain::NAME, &bytes).expect("scratch image");
+        let config = OpenConfig {
+            backing: true,
+            ..OpenConfig::default()
+        };
+        let err = Qcow2Chain::open(file, Some(&path), &config)
+            .err()
+            .expect("a backing name escaping the scratch directory must be refused");
+        assert_eq!(err.kind(), BlockErrorKind::UnsupportedFeature);
+        assert!(
+            !victim.exists(),
+            "the harness must not have created the victim file"
+        );
+    }
+
+    // The other half of the guard: a legitimate relative name must still
+    // open, and the data must actually come from the backing image, or the
+    // target would only be proving that it can refuse things.
+    #[test]
+    fn open_accepts_a_plain_backing_name_and_reads_through_it() {
+        let Some((top, backing)) = qemu_chain() else {
+            eprintln!("skipping: qemu-img unavailable");
+            return;
+        };
+        assert_eq!(
+            Qcow2Chain::backing_name(&top),
+            BackingName::Safe("base.qcow2".to_string()),
+            "qemu-img writes the backing name as a plain relative name"
+        );
+
+        let dir = scratch_dir(Qcow2Chain::NAME).expect("scratch directory");
+        Qcow2Chain::write_backing(dir, "base.qcow2", &backing).expect("backing image");
+        let (file, path) = image_file(Qcow2Chain::NAME, &top).expect("scratch image");
+        let config = OpenConfig {
+            backing: true,
+            sparse: true,
+            ..OpenConfig::default()
+        };
+        let disk =
+            Qcow2Chain::open(file, Some(&path), &config).expect("a plain backing name must open");
+
+        // An unallocated cluster of the top image has to come back as the
+        // backing pattern rather than as zeroes, or the chain was not
+        // followed and the target would only be proving that it can refuse
+        // things.
+        let mut io = disk.create_async_io(1).expect("async io");
+        let buffer = OwnedIoBuffer::from_vec(vec![0u8; 4096]);
+        io.submit_data_operation(AsyncIoOperation::read_to_vec(0, buffer, 1))
+            .expect("read submitted");
+        let completion = io.next_completed_request().expect("read completed");
+        assert_eq!(completion.result, 4096, "the read must succeed in full");
+        assert_eq!(
+            completion.buffer.as_ref().expect("buffer").as_slice(),
+            vec![PATTERN; 4096]
+        );
+    }
+}

--- a/fuzz/src/disk_engine/formats/qcow2_chain.rs
+++ b/fuzz/src/disk_engine/formats/qcow2_chain.rs
@@ -288,7 +288,7 @@ pub fn fuzz_chain(bytes: &[u8]) -> Corpus {
     let Ok(dir) = scratch_dir(Qcow2Chain::NAME) else {
         return Corpus::Reject;
     };
-    if !sandbox::confine(dir) {
+    if !sandbox::confine(dir, sandbox::Directories::ScratchOnly) {
         return Corpus::Reject;
     }
 

--- a/fuzz/src/disk_engine/formats/vhd.rs
+++ b/fuzz/src/disk_engine/formats/vhd.rs
@@ -1,0 +1,39 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fixed VHD adapter.
+
+use std::fs::File;
+use std::path::Path;
+
+use block::disk_file::AsyncFullDiskFile;
+use block::error::BlockResult;
+use block::formats::vhd::VhdDisk;
+
+use crate::disk_engine::format::{DiskFormat, OpenConfig};
+
+/// Fixed VHD images, as opened by [`VhdDisk`].
+///
+/// The io_uring backend is not selected: the `block` crate only builds it
+/// with its `io_uring` feature, which the fuzz crate does not enable, and a
+/// kernel ring per iteration would dominate the run time anyway.
+///
+/// There is no template image because the `block` crate parses a VHD footer
+/// but never writes one, and a footer built inside the fuzzer would encode
+/// the harness author's reading of the format rather than the code under
+/// test. The parser is fuzzed through the image target instead.
+pub struct Vhd;
+
+impl DiskFormat for Vhd {
+    const NAME: &'static str = "vhd";
+
+    fn open(
+        file: File,
+        _path: Option<&Path>,
+        config: &OpenConfig,
+    ) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+        let disk = VhdDisk::new(file, false, config.direct)?;
+        Ok(Box::new(disk))
+    }
+}

--- a/fuzz/src/disk_engine/formats/vhd.rs
+++ b/fuzz/src/disk_engine/formats/vhd.rs
@@ -113,6 +113,30 @@ pub fn repair_footer_checksum(image: &mut [u8]) {
         .copy_from_slice(&checksum.to_be_bytes());
 }
 
+/// Restores the cookie that identifies a fixed VHD footer in `image`.
+///
+/// A byte mutation anywhere in the last 512 bytes can land on the cookie, and
+/// `VhdFooter::validate_fixed` tests it first
+/// (block/src/formats/vhd/footer.rs:162), so such a mutation is refused
+/// before the checksum, the disk type or anything else is looked at. The
+/// measured effect on a campaign corpus is severe: 634 of the 666 rejections
+/// were this cookie alone. Writing it back after mutating keeps the mutation
+/// pointed at the fields the parser actually interprets.
+///
+/// Call this *before* [`repair_footer_checksum`]: the cookie is inside the
+/// checksummed area, so restoring it afterwards would invalidate the checksum
+/// that was just computed.
+///
+/// The footer is the *last* 512 bytes of the image, so callers must pass the
+/// buffer already trimmed to its post mutation length. A buffer shorter than
+/// a footer is left alone.
+pub fn restore_footer_cookie(image: &mut [u8]) {
+    let Some(start) = image.len().checked_sub(FOOTER_LEN) else {
+        return;
+    };
+    image[start..start + COOKIE.len()].copy_from_slice(COOKIE);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,7 +260,65 @@ mod tests {
         for len in [0usize, 1, 511, 512, 4096] {
             let mut buf = vec![0x5au8; len];
             repair_footer_checksum(&mut buf);
+            restore_footer_cookie(&mut buf);
         }
+    }
+
+    // The mutator writes the cookie back before recomputing the checksum, so
+    // a mutation that landed on the cookie still reaches the parser.
+    #[test]
+    fn restoring_the_cookie_rescues_a_mutated_footer() {
+        let seed = seed_vhd();
+
+        for offset in 0..COOKIE.len() {
+            let mut mutated = seed.clone();
+            mutated[512 + offset] ^= 0xff;
+            repair_footer_checksum(&mut mutated);
+            assert!(!Vhd::magic_ok(&mutated), "the cookie is broken");
+            assert!(open_result(&mutated).is_err());
+
+            // The mutator's order: cookie first, checksum over it after.
+            restore_footer_cookie(&mut mutated);
+            repair_footer_checksum(&mut mutated);
+            assert!(Vhd::magic_ok(&mutated), "the cookie is back");
+            assert!(
+                open_result(&mutated).is_ok(),
+                "a restored footer must open again"
+            );
+        }
+    }
+
+    // Both rejection branches the mutator deliberately leaves reachable have
+    // to be reachable *separately*: the cookie is tested before the checksum,
+    // so only an input with a valid cookie can reach the checksum branch.
+    #[test]
+    fn the_unrepaired_fractions_reach_distinct_rejections() {
+        let seed = seed_vhd();
+
+        // seed % 8 == 0: cookie left mutated, checksum recomputed. The
+        // cookie is what the parser tests first, so this is the only
+        // combination that reaches its cookie branch with a footer that is
+        // otherwise valid.
+        let mut cookie_branch = seed.clone();
+        cookie_branch[512] ^= 0xff;
+        repair_footer_checksum(&mut cookie_branch);
+        assert!(!Vhd::magic_ok(&cookie_branch));
+        assert!(open_result(&cookie_branch).is_err());
+
+        // seed % 8 == 1: cookie restored, checksum left mutated. The image
+        // still carries the magic, which is what lets the parser get as far
+        // as the checksum test.
+        let mut checksum_branch = seed.clone();
+        checksum_branch[512] ^= 0xff;
+        checksum_branch[512 + CHECKSUM_OFFSET] ^= 0xff;
+        restore_footer_cookie(&mut checksum_branch);
+        assert!(Vhd::magic_ok(&checksum_branch));
+        assert!(open_result(&checksum_branch).is_err());
+
+        // The repaired form of that same image opens, so the checksum was
+        // the only thing standing in its way.
+        repair_footer_checksum(&mut checksum_branch);
+        assert!(open_result(&checksum_branch).is_ok());
     }
 
     // The empirical claim the mutator rests on: byte mutations of the footer

--- a/fuzz/src/disk_engine/formats/vhd.rs
+++ b/fuzz/src/disk_engine/formats/vhd.rs
@@ -28,6 +28,21 @@ pub struct Vhd;
 impl DiskFormat for Vhd {
     const NAME: &'static str = "vhd";
 
+    // A fixed VHD is the disk data followed by the 512 byte hard disk
+    // footer, so the capacity the footer states cannot exceed the file
+    // length less that footer. `FixedVhd::new` rejects an image where it
+    // does (block/src/formats/vhd/fixed.rs:27), and this is the harness
+    // side guard on that check.
+    const CAPACITY_FILE_TAIL: Option<u64> = Some(512);
+
+    // Reads go through `RawSync`, which serves them with a single `preadv`
+    // on the image file (block/src/formats/raw/engine_sync.rs:55), after
+    // `FixedVhdSync` has bounded the request by the capacity
+    // (block/src/formats/vhd/engine_sync.rs:35). A `preadv` only comes up
+    // short at end of file, and the capacity check above keeps every byte
+    // below the capacity inside the file, so it cannot.
+    const NO_SHORT_READS: bool = true;
+
     fn open(
         file: File,
         _path: Option<&Path>,

--- a/fuzz/src/disk_engine/formats/vhd.rs
+++ b/fuzz/src/disk_engine/formats/vhd.rs
@@ -43,6 +43,17 @@ impl DiskFormat for Vhd {
     // below the capacity inside the file, so it cannot.
     const NO_SHORT_READS: bool = true;
 
+    // `VhdFooter::validate_fixed` rejects an image whose footer does not
+    // begin with "conectix" (block/src/formats/vhd/footer.rs:162), and the
+    // footer is the last 512 bytes of the file. Measured on a campaign
+    // corpus, 634 of the 666 rejections were this cookie alone.
+    fn magic_ok(bytes: &[u8]) -> bool {
+        let Some(footer) = bytes.len().checked_sub(FOOTER_LEN) else {
+            return false;
+        };
+        bytes[footer..footer + COOKIE.len()] == *COOKIE
+    }
+
     fn open(
         file: File,
         _path: Option<&Path>,
@@ -56,6 +67,10 @@ impl DiskFormat for Vhd {
 /// Length of the hard disk footer, from `VHD_FOOTER_LEN` in the parser under
 /// test (block/src/formats/vhd/footer.rs:13).
 const FOOTER_LEN: usize = 512;
+
+/// The cookie every hard disk footer begins with, from `VHD_COOKIE`
+/// (block/src/formats/vhd/footer.rs:16).
+const COOKIE: &[u8; 8] = b"conectix";
 
 /// Byte range of the `checksum` field inside the footer, from
 /// `VHD_CHECKSUM_RANGE` (block/src/formats/vhd/footer.rs:29).
@@ -186,6 +201,32 @@ mod tests {
                 open_result(&mutated).is_err(),
                 "{label}: a repaired checksum must not rescue an invalid field"
             );
+        }
+    }
+
+    // `magic_ok` decides whether a corpus entry is a VHD at all, so it has to
+    // agree with the cookie test the parser makes and with nothing else.
+    #[test]
+    fn magic_ok_tracks_the_cookie() {
+        let seed = seed_vhd();
+        assert!(Vhd::magic_ok(&seed), "the seed carries the cookie");
+
+        let mut broken = seed.clone();
+        broken[512] ^= 0xff;
+        repair_footer_checksum(&mut broken);
+        assert!(!Vhd::magic_ok(&broken), "a broken cookie is not VHD magic");
+        assert!(open_result(&broken).is_err());
+
+        // A field the cookie test says nothing about stays magic, even though
+        // the parser refuses the image: `magic_ok` is not an open oracle.
+        let mut wrong_type = seed.clone();
+        wrong_type[512 + 63] ^= 0xff;
+        repair_footer_checksum(&mut wrong_type);
+        assert!(Vhd::magic_ok(&wrong_type));
+        assert!(open_result(&wrong_type).is_err());
+
+        for len in [0usize, 1, 7, 511] {
+            assert!(!Vhd::magic_ok(&vec![0u8; len]));
         }
     }
 

--- a/fuzz/src/disk_engine/formats/vhd.rs
+++ b/fuzz/src/disk_engine/formats/vhd.rs
@@ -37,3 +37,193 @@ impl DiskFormat for Vhd {
         Ok(Box::new(disk))
     }
 }
+
+/// Length of the hard disk footer, from `VHD_FOOTER_LEN` in the parser under
+/// test (block/src/formats/vhd/footer.rs:13).
+const FOOTER_LEN: usize = 512;
+
+/// Byte range of the `checksum` field inside the footer, from
+/// `VHD_CHECKSUM_RANGE` (block/src/formats/vhd/footer.rs:29).
+const CHECKSUM_OFFSET: usize = 64;
+const CHECKSUM_LEN: usize = 4;
+
+/// Recomputes the footer checksum [`VhdDisk`] verifies while opening `image`.
+///
+/// `VhdFooter::validate_fixed` rejects an image whose stored checksum differs
+/// from the one it computes over the footer
+/// (block/src/formats/vhd/footer.rs:186-191), so every value changing byte
+/// mutation of the footer is refused at open and the fuzzer never reaches the
+/// code behind it. Rewriting the checksum after mutating keeps structural
+/// mutations of the footer alive.
+///
+/// The algorithm mirrors `footer_checksum`
+/// (block/src/formats/vhd/footer.rs:33-41): sum all 512 footer bytes as a
+/// wrapping `u32` with the checksum field taken as zero, and store the
+/// bitwise NOT of that sum in the field. Unlike VHDX, the field is **big
+/// endian**.
+///
+/// The footer is the *last* 512 bytes of the image, not the first, so callers
+/// must pass the buffer already trimmed to its post mutation length.
+/// A buffer shorter than a footer is left alone, so this is safe to call on
+/// arbitrary, short or non VHD buffers.
+pub fn repair_footer_checksum(image: &mut [u8]) {
+    let Some(start) = image.len().checked_sub(FOOTER_LEN) else {
+        // Too short to hold a footer; the parser rejects it before it looks
+        // at any checksum, so there is nothing to repair.
+        return;
+    };
+    let footer = &mut image[start..];
+
+    footer[CHECKSUM_OFFSET..CHECKSUM_OFFSET + CHECKSUM_LEN].fill(0);
+    let sum = footer
+        .iter()
+        .fold(0u32, |acc, b| acc.wrapping_add(u32::from(*b)));
+    let checksum = !sum;
+    footer[CHECKSUM_OFFSET..CHECKSUM_OFFSET + CHECKSUM_LEN]
+        .copy_from_slice(&checksum.to_be_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::disk_engine::image::image_memfd;
+
+    /// A minimal fixed VHD: one sector of data plus a footer the parser
+    /// accepts. The field layout is the one `VhdFooter::new` reads
+    /// (block/src/formats/vhd/footer.rs:88-105); everything it does not
+    /// validate is left zero.
+    fn seed_vhd() -> Vec<u8> {
+        let mut image = vec![0u8; 512 + FOOTER_LEN];
+        {
+            let footer = &mut image[512..];
+            footer[0..8].copy_from_slice(b"conectix");
+            // file_format_version 1.0
+            footer[12..16].copy_from_slice(&0x0001_0000u32.to_be_bytes());
+            // data_offset: all ones, as a fixed image requires
+            footer[16..24].copy_from_slice(&u64::MAX.to_be_bytes());
+            // current_size: the 512 data bytes ahead of the footer
+            footer[48..56].copy_from_slice(&512u64.to_be_bytes());
+            // disk_type 2, fixed hard disk
+            footer[60..64].copy_from_slice(&2u32.to_be_bytes());
+        }
+        repair_footer_checksum(&mut image);
+        image
+    }
+
+    fn open_result(bytes: &[u8]) -> Result<(), String> {
+        let file = image_memfd("vhd", bytes).map_err(|e| e.to_string())?;
+        block::formats::vhd::VhdDisk::new(file, false, false)
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    // The mutator is only useful if the checksum it writes is the one the
+    // parser verifies: a repaired mutation must get past the checksum test.
+    //
+    // Repair is necessary, not sufficient. The footer also carries a cookie,
+    // a format version, a data offset and a disk type the parser validates,
+    // so a mutation of one of those is still rejected for a reason that has
+    // nothing to do with the checksum. The offsets below are chosen to
+    // separate the two: they are checksum protected but otherwise
+    // unconstrained.
+    #[test]
+    fn repair_makes_a_mutated_footer_open_again() {
+        let seed = seed_vhd();
+        assert!(open_result(&seed).is_ok(), "the unmodified seed must open");
+
+        for (label, offset) in [
+            ("features", 512 + 8),
+            ("time_stamp", 512 + 24),
+            ("creator_application", 512 + 28),
+            ("unique_id", 512 + 68),
+            ("reserved padding", 512 + 400),
+        ] {
+            let mut mutated = seed.clone();
+            mutated[offset] ^= 0xff;
+            let raw = open_result(&mutated);
+            repair_footer_checksum(&mut mutated);
+            let repaired = open_result(&mutated);
+            println!(
+                "{label:24} raw={:<28} repaired={}",
+                raw.as_ref().err().map(String::as_str).unwrap_or("ok"),
+                repaired.as_ref().err().map(String::as_str).unwrap_or("ok")
+            );
+            assert!(raw.is_err(), "{label}: a raw mutation must be rejected");
+            assert!(repaired.is_ok(), "{label}: the repaired mutation must open");
+        }
+    }
+
+    // Repair is not sufficient: a mutation of a field the parser constrains
+    // stays rejected even with a correct checksum, which is the branch the
+    // unrepaired fraction of mutations is meant to keep reachable.
+    #[test]
+    fn repair_does_not_rescue_a_constrained_field() {
+        for (label, offset) in [
+            ("cookie", 512),
+            ("file_format_version", 512 + 13),
+            ("data_offset", 512 + 16),
+            ("disk_type", 512 + 63),
+        ] {
+            let mut mutated = seed_vhd();
+            mutated[offset] ^= 0xff;
+            repair_footer_checksum(&mut mutated);
+            assert!(
+                open_result(&mutated).is_err(),
+                "{label}: a repaired checksum must not rescue an invalid field"
+            );
+        }
+    }
+
+    // Short and non-VHD buffers must not panic.
+    #[test]
+    fn repair_tolerates_junk() {
+        for len in [0usize, 1, 511, 512, 4096] {
+            let mut buf = vec![0x5au8; len];
+            repair_footer_checksum(&mut buf);
+        }
+    }
+
+    // The empirical claim the mutator rests on: byte mutations of the footer
+    // are essentially all rejected without repair, and essentially all
+    // accepted with it.
+    #[test]
+    fn repair_restores_the_open_rate() {
+        let seed = seed_vhd();
+        // Offsets the parser does not constrain, so the checksum is the only
+        // thing standing between a mutation and a successful open.
+        let free: Vec<usize> = (8..12)
+            .chain(24..48)
+            .chain(56..60)
+            .chain(68..FOOTER_LEN)
+            .filter(|o| !(CHECKSUM_OFFSET..CHECKSUM_OFFSET + CHECKSUM_LEN).contains(o))
+            .collect();
+
+        let mut raw_ok = 0usize;
+        let mut repaired_ok = 0usize;
+        let mut total = 0usize;
+        // A cheap deterministic value source; no rand dependency needed.
+        let mut state = 0x1234_5678u32;
+        for _ in 0..2000 {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            let offset = 512 + free[(state >> 8) as usize % free.len()];
+            let delta = ((state >> 24) as u8) | 1;
+
+            let mut mutated = seed.clone();
+            mutated[offset] ^= delta;
+            total += 1;
+            if open_result(&mutated).is_ok() {
+                raw_ok += 1;
+            }
+            repair_footer_checksum(&mut mutated);
+            if open_result(&mutated).is_ok() {
+                repaired_ok += 1;
+            }
+        }
+        println!("raw {raw_ok}/{total} open, repaired {repaired_ok}/{total} open");
+        assert_eq!(raw_ok, 0, "unrepaired footer mutations must not open");
+        assert!(
+            repaired_ok * 100 >= total * 90,
+            "repaired footer mutations must open at least 90% of the time, got {repaired_ok}/{total}"
+        );
+    }
+}

--- a/fuzz/src/disk_engine/formats/vhdx.rs
+++ b/fuzz/src/disk_engine/formats/vhdx.rs
@@ -30,6 +30,25 @@ impl DiskFormat for Vhdx {
     // default budget would reject those.
     const MAX_IMAGE_LEN: usize = 16 << 20;
 
+    // A VHDX read is all or error. `io::read` loops until every requested
+    // sector is accounted for and returns early with an error on any entry
+    // it cannot serve, so the `Ok(read_count)` it reaches
+    // (block/src/formats/vhdx/io.rs:141) always covers the whole request; an
+    // unallocated block is left as the zeroes the buffer already holds. A
+    // length that is not a multiple of the sector size is rejected up front
+    // (block/src/formats/vhdx/parser.rs:102), which is a rejection rather
+    // than a short read.
+    //
+    // The check is on reads only, but the write path is built the same way:
+    // it serves each sector run with `write_all_at` and propagates any
+    // failure with `?` (block/src/formats/vhdx/io.rs:202 and 213), so it too
+    // returns either the full count or an error.
+    //
+    // The capacity is not file backed, so `CAPACITY_FILE_TAIL` stays
+    // `None`: a dynamic VHDX allocates payload blocks on demand, so its file
+    // is routinely smaller than the virtual disk size.
+    const NO_SHORT_READS: bool = true;
+
     fn open(
         file: File,
         _path: Option<&Path>,

--- a/fuzz/src/disk_engine/formats/vhdx.rs
+++ b/fuzz/src/disk_engine/formats/vhdx.rs
@@ -39,3 +39,151 @@ impl DiskFormat for Vhdx {
         Ok(Box::new(disk))
     }
 }
+
+/// Offsets and sizes of the checksummed VHDX structures, taken from the
+/// parser under test in `block/src/formats/vhdx/header.rs`:
+///
+/// - `HEADER_1_START` = 64 KiB and `HEADER_2_START` = 128 KiB (lines 22-23),
+/// - `REGION_TABLE_1_START` = 192 KiB and `REGION_TABLE_2_START` = 256 KiB
+///   (lines 24-25),
+/// - `HEADER_SIZE` = 4 KiB and `REGION_SIZE` = 64 KiB (lines 27-28).
+const HEADER_1_START: usize = 64 * 1024;
+const HEADER_2_START: usize = 128 * 1024;
+const REGION_TABLE_1_START: usize = 192 * 1024;
+const REGION_TABLE_2_START: usize = 256 * 1024;
+const HEADER_SIZE: usize = 4 * 1024;
+const REGION_SIZE: usize = 64 * 1024;
+
+/// Byte offset of the `checksum` field inside both `Header` and
+/// `RegionTableHeader`. Both structures start with a `u32` signature followed
+/// by the `u32` checksum (header.rs lines 111-113 and 193-195), and the parser
+/// passes `size_of::<u32>()` as the checksum offset when it verifies them
+/// (header.rs lines 138 and 214).
+const CHECKSUM_OFFSET: usize = 4;
+
+/// The structures the parser checksums, as `(start, length)` pairs.
+const CHECKSUMMED: [(usize, usize); 4] = [
+    (HEADER_1_START, HEADER_SIZE),
+    (HEADER_2_START, HEADER_SIZE),
+    (REGION_TABLE_1_START, REGION_SIZE),
+    (REGION_TABLE_2_START, REGION_SIZE),
+];
+
+/// Recomputes every checksum [`VhdxDisk`] verifies while opening `image`.
+///
+/// `VhdxHeader::new` rejects an image unless both headers and both region
+/// tables carry a correct CRC-32C (block/src/formats/vhdx/header.rs lines
+/// 348-355), so a byte level mutation of any of those four structures makes
+/// the image unopenable and the fuzzer never reaches the code behind the
+/// header. Rewriting the checksums after mutating keeps structural mutations
+/// alive.
+///
+/// The algorithm mirrors `calculate_checksum` (header.rs lines 434-448):
+/// zero the 32 bit checksum field, run CRC-32C over the whole structure, and
+/// store the result little endian in that field.
+///
+/// Structures that do not fit in `image` are skipped, so this is safe to call
+/// on arbitrary, short or non VHDX buffers.
+pub fn repair_checksums(image: &mut [u8]) {
+    for (start, len) in CHECKSUMMED {
+        let Some(buffer) = image.get_mut(start..start.wrapping_add(len)) else {
+            // The structure is past the end of the image; the parser would
+            // fail its read_exact_at anyway, so there is nothing to repair.
+            continue;
+        };
+
+        buffer[CHECKSUM_OFFSET..CHECKSUM_OFFSET + 4].fill(0);
+        let mut crc = crc_any::CRC::crc32c();
+        crc.digest(&*buffer);
+        let checksum = crc.get_crc() as u32;
+        buffer[CHECKSUM_OFFSET..CHECKSUM_OFFSET + 4].copy_from_slice(&checksum.to_le_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::Write;
+    use std::process::Command;
+
+    use super::*;
+    use crate::disk_engine::image::image_memfd;
+
+    fn qemu_vhdx() -> Option<Vec<u8>> {
+        let dir = std::env::temp_dir().join("vhdx-mutator-check");
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join("seed.vhdx");
+        let _ = fs::remove_file(&path);
+        let status = Command::new("qemu-img")
+            .args([
+                "create",
+                "-f",
+                "vhdx",
+                "-o",
+                "subformat=dynamic,block_size=1M",
+            ])
+            .arg(&path)
+            .arg("16M")
+            .status()
+            .ok()?;
+        status.success().then(|| fs::read(&path).ok())?
+    }
+
+    fn open_result(bytes: &[u8]) -> Result<(), String> {
+        let file = image_memfd("vhdx", bytes).map_err(|e| e.to_string())?;
+        block::formats::vhdx::VhdxDisk::new(file, false)
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    // The mutator is only useful if the checksum it writes is the one the
+    // parser verifies: a repaired mutation must get past the checksum test.
+    //
+    // Repair is necessary, not sufficient. A region table entry also carries
+    // a GUID naming the region and an offset and length the parser validates,
+    // so a mutation there can still be rejected for a reason that has nothing
+    // to do with the checksum. The offsets below are chosen to separate the
+    // two: bytes inside the header structures, and padding past the region
+    // table entries, are checksum protected but otherwise unconstrained.
+    #[test]
+    fn repair_makes_a_mutated_structure_open_again() {
+        let Some(seed) = qemu_vhdx() else {
+            eprintln!("skipping: qemu-img unavailable");
+            return;
+        };
+        assert!(open_result(&seed).is_ok(), "the unmodified seed must open");
+
+        for (label, offset) in [
+            ("header 1 reserved", 0x1_0100),
+            ("header 2 reserved", 0x2_0100),
+            ("region table 1 padding", 0x3_8000),
+            ("region table 2 padding", 0x4_8000),
+        ] {
+            let offset = offset as usize;
+            if offset >= seed.len() {
+                continue;
+            }
+            let mut mutated = seed.clone();
+            mutated[offset] ^= 0xff;
+            let raw = open_result(&mutated);
+            repair_checksums(&mut mutated);
+            let repaired = open_result(&mutated);
+            println!(
+                "{label:24} raw={:<28} repaired={}",
+                raw.as_ref().err().map(String::as_str).unwrap_or("ok"),
+                repaired.as_ref().err().map(String::as_str).unwrap_or("ok")
+            );
+            assert!(raw.is_err(), "{label}: a raw mutation must be rejected");
+            assert!(repaired.is_ok(), "{label}: the repaired mutation must open");
+        }
+    }
+
+    // Short and non-VHDX buffers must not panic.
+    #[test]
+    fn repair_tolerates_junk() {
+        for len in [0usize, 1, 4096, 100_000] {
+            let mut buf = vec![0x5au8; len];
+            repair_checksums(&mut buf);
+        }
+    }
+}

--- a/fuzz/src/disk_engine/formats/vhdx.rs
+++ b/fuzz/src/disk_engine/formats/vhdx.rs
@@ -93,6 +93,14 @@ const REGION_SIZE: usize = 64 * 1024;
 /// (header.rs lines 138 and 214).
 const CHECKSUM_OFFSET: usize = 4;
 
+/// Signature of a VHDX `Header` structure, from `HEADER_SIGN`
+/// (block/src/formats/vhdx/header.rs:18).
+const HEADER_SIGNATURE: &[u8; 4] = b"head";
+
+/// Signature of a VHDX `RegionTableHeader`, from `REGION_SIGN`
+/// (block/src/formats/vhdx/header.rs:19).
+const REGION_SIGNATURE: &[u8; 4] = b"regi";
+
 /// The structures the parser checksums, as `(start, length)` pairs.
 const CHECKSUMMED: [(usize, usize); 4] = [
     (HEADER_1_START, HEADER_SIZE),
@@ -132,6 +140,40 @@ pub fn repair_checksums(image: &mut [u8]) {
     }
 }
 
+/// Restores the signatures that identify a VHDX file and its structures.
+///
+/// `VhdxHeader::new` tests four signatures before it verifies any checksum:
+/// the eight byte `vhdxfile` file type identifier at offset 0
+/// (block/src/formats/vhdx/header.rs:101), and the `head` and `regi`
+/// signatures at the start of each header and each region table
+/// (lines 134 and 210). A mutation that lands on one of them makes the image
+/// unopenable for a reason that has nothing to do with the structure it
+/// changed, and repairing the checksums does not help: the signature is
+/// checked first. Measured on a campaign corpus, 717 of 872 disk_vhdx entries
+/// failed the file type identifier alone.
+///
+/// Call this *before* [`repair_checksums`]: the header and region signatures
+/// are inside the checksummed areas.
+///
+/// Structures that do not fit in `image` are skipped, so this is safe to call
+/// on arbitrary, short or non VHDX buffers.
+pub fn restore_signatures(image: &mut [u8]) {
+    if let Some(sign) = image.get_mut(..FILE_SIGNATURE.len()) {
+        sign.copy_from_slice(FILE_SIGNATURE);
+    }
+
+    for (start, signature) in [
+        (HEADER_1_START, HEADER_SIGNATURE),
+        (HEADER_2_START, HEADER_SIGNATURE),
+        (REGION_TABLE_1_START, REGION_SIGNATURE),
+        (REGION_TABLE_2_START, REGION_SIGNATURE),
+    ] {
+        if let Some(sign) = image.get_mut(start..start + signature.len()) {
+            sign.copy_from_slice(signature);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -141,10 +183,12 @@ mod tests {
     use super::*;
     use crate::disk_engine::image::image_memfd;
 
-    fn qemu_vhdx() -> Option<Vec<u8>> {
+    // `name` keeps concurrently running tests off each other's image:
+    // qemu-img takes a lock on the file it creates.
+    fn qemu_vhdx(name: &str) -> Option<Vec<u8>> {
         let dir = std::env::temp_dir().join("vhdx-mutator-check");
         let _ = fs::create_dir_all(&dir);
-        let path = dir.join("seed.vhdx");
+        let path = dir.join(format!("{name}.vhdx"));
         let _ = fs::remove_file(&path);
         let status = Command::new("qemu-img")
             .args([
@@ -179,7 +223,7 @@ mod tests {
     // table entries, are checksum protected but otherwise unconstrained.
     #[test]
     fn repair_makes_a_mutated_structure_open_again() {
-        let Some(seed) = qemu_vhdx() else {
+        let Some(seed) = qemu_vhdx("checksum-repair") else {
             eprintln!("skipping: qemu-img unavailable");
             return;
         };
@@ -216,6 +260,82 @@ mod tests {
         for len in [0usize, 1, 4096, 100_000] {
             let mut buf = vec![0x5au8; len];
             repair_checksums(&mut buf);
+            restore_signatures(&mut buf);
         }
+    }
+
+    // The mutator writes the signatures back before recomputing the
+    // checksums, so a mutation that landed on one still reaches the parser.
+    //
+    // The headers and the region tables come in pairs and the parser accepts
+    // an image as long as one of each pair is valid, so a case that has to be
+    // rejected breaks both copies.
+    #[test]
+    fn restoring_the_signatures_rescues_a_mutated_image() {
+        let Some(seed) = qemu_vhdx("signature-restore") else {
+            eprintln!("skipping: qemu-img unavailable");
+            return;
+        };
+
+        for (label, offsets) in [
+            ("file type identifier", vec![0]),
+            ("header signatures", vec![HEADER_1_START, HEADER_2_START]),
+            (
+                "region table signatures",
+                vec![REGION_TABLE_1_START, REGION_TABLE_2_START],
+            ),
+        ] {
+            if offsets.iter().any(|o| *o >= seed.len()) {
+                continue;
+            }
+            let mut mutated = seed.clone();
+            for offset in &offsets {
+                mutated[*offset] ^= 0xff;
+            }
+            repair_checksums(&mut mutated);
+            assert!(
+                open_result(&mutated).is_err(),
+                "{label}: a broken signature must be rejected"
+            );
+
+            // The mutator's order: signatures first, checksums over them
+            // after.
+            restore_signatures(&mut mutated);
+            repair_checksums(&mut mutated);
+            assert!(
+                open_result(&mutated).is_ok(),
+                "{label}: a restored image must open again"
+            );
+        }
+    }
+
+    // Both rejection branches the mutator leaves reachable have to be
+    // reachable separately: a signature is tested before the checksum of the
+    // structure it introduces.
+    #[test]
+    fn the_unrepaired_fractions_reach_distinct_rejections() {
+        let Some(seed) = qemu_vhdx("rejection-branches") else {
+            eprintln!("skipping: qemu-img unavailable");
+            return;
+        };
+
+        // seed % 8 == 0: signatures left mutated, checksums recomputed.
+        let mut signature_branch = seed.clone();
+        signature_branch[HEADER_1_START] ^= 0xff;
+        signature_branch[HEADER_2_START] ^= 0xff;
+        repair_checksums(&mut signature_branch);
+        assert!(open_result(&signature_branch).is_err());
+
+        // seed % 8 == 1: signatures restored, checksums left mutated. The
+        // image is still identifiably a VHDX, which is what lets the parser
+        // get as far as the checksum test.
+        let mut checksum_branch = seed.clone();
+        checksum_branch[HEADER_1_START] ^= 0xff;
+        checksum_branch[HEADER_1_START + CHECKSUM_OFFSET] ^= 0xff;
+        checksum_branch[HEADER_2_START + CHECKSUM_OFFSET] ^= 0xff;
+        restore_signatures(&mut checksum_branch);
+        let err = open_result(&checksum_branch).expect_err("must be rejected");
+        println!("checksum branch: {err}");
+        assert!(Vhdx::magic_ok(&checksum_branch));
     }
 }

--- a/fuzz/src/disk_engine/formats/vhdx.rs
+++ b/fuzz/src/disk_engine/formats/vhdx.rs
@@ -1,0 +1,41 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! VHDX adapter.
+
+use std::fs::File;
+use std::path::Path;
+
+use block::disk_file::AsyncFullDiskFile;
+use block::error::BlockResult;
+use block::formats::vhdx::VhdxDisk;
+
+use crate::disk_engine::format::{DiskFormat, OpenConfig};
+
+/// Dynamic VHDX images, as opened by [`VhdxDisk`].
+///
+/// There is no template image: building a valid VHDX means writing the file
+/// identifier, both headers with their checksums, the region table, the BAT
+/// and a metadata region, and the `block` crate has no writer for any of
+/// that. The parser is fuzzed through the image target instead.
+pub struct Vhdx;
+
+impl DiskFormat for Vhdx {
+    const NAME: &'static str = "vhdx";
+
+    // VHDX places its BAT region at 2 MiB and its metadata region at 3 MiB,
+    // so a parseable image is several MiB before it holds any data: an empty
+    // one is exactly 8 MiB and a populated one runs to 9 or 10 MiB. The
+    // default budget would reject those.
+    const MAX_IMAGE_LEN: usize = 16 << 20;
+
+    fn open(
+        file: File,
+        _path: Option<&Path>,
+        config: &OpenConfig,
+    ) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+        let disk = VhdxDisk::new(file, config.direct)?;
+        Ok(Box::new(disk))
+    }
+}

--- a/fuzz/src/disk_engine/formats/vhdx.rs
+++ b/fuzz/src/disk_engine/formats/vhdx.rs
@@ -49,6 +49,14 @@ impl DiskFormat for Vhdx {
     // is routinely smaller than the virtual disk size.
     const NO_SHORT_READS: bool = true;
 
+    // `FileTypeIdentifier::new` rejects an image whose first eight bytes are
+    // not "vhdxfile" (block/src/formats/vhdx/header.rs:101), before anything
+    // else in the file is looked at. Measured on a campaign corpus, 717 of
+    // 872 entries failed exactly this.
+    fn magic_ok(bytes: &[u8]) -> bool {
+        bytes.len() >= FILE_SIGNATURE.len() && bytes[..FILE_SIGNATURE.len()] == *FILE_SIGNATURE
+    }
+
     fn open(
         file: File,
         _path: Option<&Path>,
@@ -58,6 +66,11 @@ impl DiskFormat for Vhdx {
         Ok(Box::new(disk))
     }
 }
+
+/// The file type identifier, from `VHDX_SIGN` in the parser under test
+/// (block/src/formats/vhdx/header.rs:17). It is the first eight bytes of the
+/// file and the first thing `VhdxHeader::new` checks.
+const FILE_SIGNATURE: &[u8; 8] = b"vhdxfile";
 
 /// Offsets and sizes of the checksummed VHDX structures, taken from the
 /// parser under test in `block/src/formats/vhdx/header.rs`:

--- a/fuzz/src/disk_engine/formats/vhdx.rs
+++ b/fuzz/src/disk_engine/formats/vhdx.rs
@@ -30,6 +30,14 @@ impl DiskFormat for Vhdx {
     // default budget would reject those.
     const MAX_IMAGE_LEN: usize = 16 << 20;
 
+    // The engine refuses an offset or a length that is not a multiple of the
+    // logical sector size before it does anything else
+    // (block/src/formats/vhdx/parser.rs:100 and 111 for reads, 149 and 160
+    // for writes), so an unshaped program would be rejected at the door and
+    // the shadow model would never see a byte. 512 is the
+    // `LogicalSectorSize` metadata item of the template.
+    const IO_ALIGNMENT: u64 = 512;
+
     // A VHDX read is all or error. `io::read` loops until every requested
     // sector is accounted for and returns early with an error on any entry
     // it cannot serve, so the `Ok(read_count)` it reaches

--- a/fuzz/src/disk_engine/formats/vhdx.rs
+++ b/fuzz/src/disk_engine/formats/vhdx.rs
@@ -6,6 +6,7 @@
 
 use std::fs::File;
 use std::path::Path;
+use std::sync::OnceLock;
 
 use block::disk_file::AsyncFullDiskFile;
 use block::error::BlockResult;
@@ -13,12 +14,94 @@ use block::formats::vhdx::VhdxDisk;
 
 use crate::disk_engine::format::{DiskFormat, OpenConfig};
 
-/// Dynamic VHDX images, as opened by [`VhdxDisk`].
+/// Virtual disk size the template advertises, in bytes.
 ///
-/// There is no template image: building a valid VHDX means writing the file
-/// identifier, both headers with their checksums, the region table, the BAT
-/// and a metadata region, and the `block` crate has no writer for any of
-/// that. The parser is fuzzed through the image target instead.
+/// This is the `VirtualDiskSize` metadata item of [`TEMPLATE_RUNS`], pinned
+/// here so that the self test can prove the template is the image it is
+/// supposed to be rather than merely an image that opens.
+pub const TEMPLATE_LOGICAL_SIZE: u64 = 4 << 20;
+
+/// Byte length of the template image file.
+///
+/// A dynamic VHDX is 8 MiB before it holds any data: the BAT region sits at
+/// 2 MiB, the metadata region at 3 MiB, and a 1 MiB log follows.
+const TEMPLATE_LEN: usize = 8 << 20;
+
+/// The non-zero bytes of the template image, as `(offset, hex)` runs.
+///
+/// The image is `qemu-img create -f vhdx -o subformat=dynamic,block_size=1M
+/// t.vhdx 4M`: 8,388,608 bytes of which 333 are non-zero, spanning 520 bytes
+/// in the eleven runs below (runs are coalesced across gaps of up to eight
+/// zero bytes, which is what turns 70 bare runs into 11 lines). Expanding a
+/// table is not the obvious way to get a template, so the
+/// alternatives are worth recording:
+///
+/// - committing the 8 MiB image as a binary blob works, but upstream does not
+///   take blobs into the tree and OSS-Fuzz would have to carry it;
+/// - shelling out to `qemu-img` at build or run time makes the harness depend
+///   on `qemu-utils` and makes the template depend on the qemu version, so a
+///   crash would stop reproducing when the build host changed;
+/// - writing the format by hand means two 4 KiB headers, two 64 KiB region
+///   tables, a 1 MiB BAT and a metadata region, some three hundred lines of
+///   specification interpretation. That would fuzz the harness author's
+///   reading of the VHDX specification rather than the parser under test.
+///
+/// The table is none of those: it is byte for byte the image `qemu-img`
+/// wrote, it is in the source where it can be reviewed, and it is fixed
+/// forever so an input reproduces on any host.
+///
+/// For orientation, the runs are, in order: the `vhdxfile` file type
+/// identifier and its UTF-16 creator string; header 1 at 0x010000 and header
+/// 2 at 0x020000 (`head`, CRC-32C at +4, sequence number at +8, a zero
+/// `log_guid` at +48 so that no log replay is needed); the two region tables
+/// at 0x030000 and 0x040000 (`regi`, CRC-32C at +4, entry count at +8, then
+/// 32 byte entries of GUID, file offset, length and a required flag) naming
+/// the BAT at 0x200000 and the metadata region at 0x300000; four BAT entries
+/// in state 2, `PAYLOAD_BLOCK_ZERO`, one per 1 MiB block of the 4 MiB disk;
+/// and the metadata region, whose items are `FileParameters` with a 1 MiB
+/// block size, `VirtualDiskSize` 0x400000 and `LogicalSectorSize` 512.
+///
+/// The CRC-32C checksums are qemu's and are already correct, so
+/// [`repair_checksums`] plays no part here: it exists for the image target's
+/// mutator.
+const TEMPLATE_RUNS: [(usize, &str); 11] = [
+    (0x000000, "7668647866696c65510045004d00550020007600310030002e0032002e0031"),
+    (0x010000, "68656164763f022f40a3b97400000000968d9ca5c1574f418f461232fa33ff932bc1289d3cd44c73b882f83d656353e5"),
+    (0x010042, "010000001000000010"),
+    (0x020000, "6865616401a3faad41a3b97400000000968d9ca5c1574f418f461232fa33ff932bc1289d3cd44c73b882f83d656353e5"),
+    (0x020042, "010000001000000010"),
+    (0x030000, "7265676983ce6f2c02000000000000006677c22d23f600429d64115e9bfd4a080000200000000000000010000000000006a27c8b90479a4bb8fe575f050f886e0000300000000000000010"),
+    (0x040000, "7265676983ce6f2c02000000000000006677c22d23f600429d64115e9bfd4a080000200000000000000010000000000006a27c8b90479a4bb8fe575f050f886e0000300000000000000010"),
+    (0x200000, "02000000000000000200000000000000020000000000000002"),
+    (0x300000, "6d65746164617461000005"),
+    (0x300020, "3767a1ca36fa434db3b633f0aa44e76b000001000800000004000000000000002442a52f1bcd7648b2115dbed83bf4b808000100080000000600000000000000ab12cabee6b2234593efc309e000c746100001001000000006000000000000001dbf41816fa90947ba47f233a8faab5f20000100040000000600000000000000c748a3cd5d4471449cc9e9885251c556240001000400000006"),
+    (0x310002, "1000000000000000400000000000dd83c75228904fd484ece3b363199ea3000200000002"),
+];
+
+/// Expands [`TEMPLATE_RUNS`] into the full image.
+fn build_template() -> Vec<u8> {
+    let mut image = vec![0u8; TEMPLATE_LEN];
+
+    for (offset, hex) in TEMPLATE_RUNS {
+        assert!(
+            hex.len().is_multiple_of(2),
+            "run at {offset:#x} is half a byte"
+        );
+        let bytes: Vec<u8> = hex
+            .as_bytes()
+            .chunks(2)
+            .map(|pair| {
+                let text = std::str::from_utf8(pair).expect("the run table is ASCII");
+                u8::from_str_radix(text, 16).expect("the run table is hexadecimal")
+            })
+            .collect();
+        image[offset..offset + bytes.len()].copy_from_slice(&bytes);
+    }
+
+    image
+}
+
+/// Dynamic VHDX images, as opened by [`VhdxDisk`].
 pub struct Vhdx;
 
 impl DiskFormat for Vhdx {
@@ -72,6 +155,12 @@ impl DiskFormat for Vhdx {
     ) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
         let disk = VhdxDisk::new(file, config.direct)?;
         Ok(Box::new(disk))
+    }
+
+    fn template() -> Option<&'static [u8]> {
+        static TEMPLATE: OnceLock<Vec<u8>> = OnceLock::new();
+
+        Some(TEMPLATE.get_or_init(build_template))
     }
 }
 
@@ -189,7 +278,72 @@ mod tests {
     use std::process::Command;
 
     use super::*;
-    use crate::disk_engine::image::image_memfd;
+    use crate::disk_engine::image::{image_memfd, template_memfd};
+    use crate::disk_engine::selftest::assert_template_is_sound;
+    use crate::disk_engine::{Executor, Op, OpLen, OpOffset};
+
+    /// The template is what the whole operation target rests on, and a
+    /// template that is subtly wrong makes that target an expensive no-op
+    /// that passes forever. See `disk_engine::selftest`.
+    #[test]
+    fn the_template_is_a_blank_four_mib_disk() {
+        assert_template_is_sound::<Vhdx>(TEMPLATE_LOGICAL_SIZE);
+    }
+
+    /// The shadow model has to be armed against the write path this target
+    /// exists for.
+    ///
+    /// The block allocating arm of `vhdx::io::write` used to write the
+    /// payload at the *block base* rather than at the sector's offset within
+    /// the block, so a guest write to any sector but the first of an
+    /// unallocated block was silently misplaced and lost. That is exactly the
+    /// class of bug nothing but a data correctness oracle can see: every
+    /// operation reports success and the right byte count.
+    ///
+    /// The fixed program in `default_program` does write at a non-zero offset
+    /// inside an unallocated block, but it never reads that range back, so it
+    /// would not notice. This program does both, and it is the smallest one
+    /// that can: allocate a block by writing to its second sector, then read
+    /// that sector back.
+    #[test]
+    fn the_model_catches_a_misplaced_block_allocating_write() {
+        // Sector 1 of block 1: a byte offset inside a block that no BAT entry
+        // has allocated yet, and not the block's first sector.
+        let offset = (1 << 20) + 512;
+        let program = vec![
+            Op::WriteVec {
+                offset: OpOffset::Byte(offset),
+                len: OpLen(512),
+                seed: 0x11,
+            },
+            Op::ReadVec {
+                offset: OpOffset::Byte(offset),
+                len: OpLen(512),
+            },
+        ];
+
+        let template = Vhdx::template().expect("vhdx has a template");
+        let file = template_memfd(Vhdx::NAME, template).expect("memfd");
+        let disk = Vhdx::open(file, None, &OpenConfig::default()).expect("the template opens");
+        let mut executor = Executor::<Vhdx>::new(disk, 1, true).expect("executor");
+        // Panics on a read back mismatch, which is the point.
+        executor.run(&program);
+    }
+
+    /// The run table has to expand to exactly the image `qemu-img` wrote, so
+    /// its shape is pinned too: a table edit that adds or drops bytes is
+    /// caught here rather than showing up as a mysterious parse failure.
+    #[test]
+    fn the_run_table_expands_to_the_qemu_image() {
+        let template = Vhdx::template().expect("vhdx has a template");
+        assert_eq!(template.len(), TEMPLATE_LEN);
+        assert_eq!(
+            template.iter().filter(|byte| **byte != 0).count(),
+            333,
+            "the number of non-zero bytes in the template changed"
+        );
+        assert!(Vhdx::magic_ok(template));
+    }
 
     // `name` keeps concurrently running tests off each other's image:
     // qemu-img takes a lock on the file it creates.

--- a/fuzz/src/disk_engine/formats/vmdk.rs
+++ b/fuzz/src/disk_engine/formats/vmdk.rs
@@ -100,6 +100,20 @@ impl DiskFormat for Vmdk {
     // A descriptor is a small text file; the data lives in the extents.
     const MAX_IMAGE_LEN: usize = 64 << 10;
 
+    // Neither new invariant holds for a flat VMDK, so both keep their
+    // conservative default.
+    //
+    // The capacity is the sum of the extent sizes the descriptor declares,
+    // and the data lives in those separate files rather than in the image
+    // file, so `physical_size` says nothing about it.
+    //
+    // A read can legitimately come up short: an extent declared longer than
+    // the file behind it makes the buffered path stop at end of file
+    // (block/src/formats/vmdk/engine_sync.rs:100) and the spanning path
+    // break out of its loop (block/src/formats/vmdk/engine_sync.rs:180),
+    // both reporting the partial count as a success. A fuzzed descriptor
+    // declares extent sizes freely, so this is reachable by construction.
+
     fn open(
         file: File,
         path: Option<&Path>,

--- a/fuzz/src/disk_engine/formats/vmdk.rs
+++ b/fuzz/src/disk_engine/formats/vmdk.rs
@@ -134,6 +134,40 @@ impl Vmdk {
         Ok(())
     }
 
+    /// Decides from the input whether this iteration resolves its extents
+    /// with the `openat2` fallback walk.
+    ///
+    /// One input in two, by a hash of the descriptor, so both resolution
+    /// paths keep a share of the corpus and neither depends on anything
+    /// outside the input.
+    ///
+    /// A descriptor naming an absolute extent is the exception: it is the
+    /// only thing that reaches the `openat2` arm which deliberately leaves
+    /// `RESOLVE_BENEATH` off, so sending it down the walk would spend the
+    /// one input that can cover it.
+    #[cfg_attr(not(fuzzing), allow(dead_code))]
+    fn force_walk(bytes: &[u8]) -> bool {
+        if bytes
+            .windows(SCRATCH_TOKEN.len())
+            .any(|window| window == SCRATCH_TOKEN.as_bytes())
+        {
+            return false;
+        }
+
+        // FNV-1a rather than `DefaultHasher`: std explicitly disclaims
+        // stability of its default hasher across releases, and this hash
+        // decides which of the two resolution paths an input takes. The
+        // whole point of deriving it from the input is that a crash
+        // reproduces from its bytes alone, and OSS-Fuzz re-runs regression
+        // testcases on newer toolchains: a reshuffle would send one down the
+        // other arm and silently close a live bug as fixed. A fixed
+        // algorithm costs no dependency and one line.
+        let mixed = bytes.iter().fold(0xcbf2_9ce4_8422_2325u64, |h, &b| {
+            (h ^ u64::from(b)).wrapping_mul(0x0000_0100_0000_01b3)
+        });
+        !mixed.is_multiple_of(2)
+    }
+
     /// Expands [`SCRATCH_TOKEN`] in `descriptor` into the scratch directory.
     ///
     /// Returns `None` when there is nothing to expand, so the common case
@@ -268,6 +302,14 @@ impl DiskFormat for Vmdk {
 
         Self::reset_extents(dir)?;
 
+        // Which resolution path the engine takes is derived from the input
+        // rather than from the environment, so a crash found on the fallback
+        // walk reproduces from its bytes alone. Without this the walk is
+        // dead code on every kernel a fuzzer runs on, because `openat2`
+        // always succeeds there.
+        #[cfg(fuzzing)]
+        block::formats::vmdk::set_force_extent_walk(Self::force_walk(&raw[..len]));
+
         // The fuzzer drives the writable path, so it asks for a writable
         // open and lets the descriptor's own access field decide per extent.
         let disk = VmdkDisk::new(file, path, false, config.direct)?;
@@ -364,6 +406,39 @@ mod tests {
         assert!(expanded.contains(&dir.display().to_string()));
         assert!(!Vmdk::names_escaping_extent(&expanded, dir, true));
         assert!(Vmdk::expand_scratch_token("no token here", dir).is_none());
+    }
+
+    // The resolution path must depend on the input alone, and both paths
+    // have to keep a share of it.
+    #[test]
+    fn the_walk_choice_is_a_function_of_the_input() {
+        let a = descriptor("image-flat.vmdk");
+        assert_eq!(
+            Vmdk::force_walk(a.as_bytes()),
+            Vmdk::force_walk(a.as_bytes())
+        );
+
+        // Pinned, not merely reproducible in this process: the split has to
+        // survive a toolchain upgrade, or a regression testcase re-run on a
+        // newer compiler would take the other arm and close a live bug.
+        assert!(Vmdk::force_walk(b""), "the FNV-1a basis is odd");
+        assert!(!Vmdk::force_walk(b"a"));
+        assert!(Vmdk::force_walk(b"b"));
+        assert!(!Vmdk::force_walk(b"# Disk DescriptorFile\n"));
+
+        let mixed = (0..64u8)
+            .map(|i| Vmdk::force_walk(format!("{a}{i}").as_bytes()))
+            .filter(|walk| *walk)
+            .count();
+        assert!(
+            (8..56).contains(&mixed),
+            "{mixed} of 64 inputs took the walk, expected a rough split"
+        );
+
+        // An absolute name has to reach openat2, which is the only arm that
+        // can cover the unconfined resolve.
+        let absolute = descriptor(&format!("{SCRATCH_TOKEN}/image-flat.vmdk"));
+        assert!(!Vmdk::force_walk(absolute.as_bytes()));
     }
 
     // A name that is lexically inside the scratch directory but traverses a

--- a/fuzz/src/disk_engine/formats/vmdk.rs
+++ b/fuzz/src/disk_engine/formats/vmdk.rs
@@ -7,13 +7,16 @@
 use std::fs::{File, OpenOptions};
 use std::os::unix::fs::FileExt;
 use std::path::{Component, Path};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use block::disk_file::AsyncFullDiskFile;
 use block::error::{BlockError, BlockErrorKind, BlockResult};
 use block::formats::vmdk::VmdkDisk;
+use libfuzzer_sys::Corpus;
 
 use crate::disk_engine::format::{DiskFormat, OpenConfig};
 use crate::disk_engine::image::scratch_dir;
+use crate::disk_engine::{fuzz_image, sandbox};
 
 /// Size of each extent file the harness provides.
 const EXTENT_LEN: u64 = 1 << 20;
@@ -37,6 +40,69 @@ const EXTENTS: [&str; 6] = [
     "two-f001.vmdk",
     "two-f002.vmdk",
 ];
+
+/// Placeholder a descriptor uses to name the scratch directory.
+///
+/// An extent name may be absolute, and the engine treats an absolute name
+/// very differently from a relative one: it anchors resolution at the
+/// filesystem root and deliberately does not apply `RESOLVE_BENEATH`
+/// (block/src/formats/vmdk/flat.rs:141 and :190). That arm cannot be fuzzed
+/// by naming a real absolute path, because the only absolute path that is
+/// safe to open here is one inside the scratch directory, and the scratch
+/// directory carries the process id so no fixed corpus entry can name it.
+///
+/// A descriptor therefore writes the placeholder, and the harness expands it
+/// into the scratch directory before the parser reads the file. The
+/// expansion is a pure function of the input, so an input still reproduces
+/// on its own: what varies between processes is the directory the harness
+/// itself creates, exactly as it already does for relative names.
+const SCRATCH_TOKEN: &str = "/@fuzz-scratch@";
+
+/// Whether this process is confined to its scratch directory, and therefore
+/// whether an absolute extent name may be admitted at all.
+///
+/// An absolute name is the one arm the kernel does not confine: resolution
+/// is anchored at the filesystem root without `RESOLVE_BENEATH`, so a
+/// symlink planted anywhere along the name is followed out of the scratch
+/// directory and the extent behind it is opened *writable*. The lexical
+/// guard cannot see that: every component of
+/// `<scratch>/link/victim` is a [`Component::Normal`], and `O_NOFOLLOW`
+/// only ever guards the final one.
+///
+/// So the arm is only fuzzed when the process itself is confined, and the
+/// default is `false`: a harness that never called [`confine`] - a unit
+/// test, or a future caller of [`Vmdk::open`] - refuses absolute names
+/// outright and keeps the `RESOLVE_BENEATH` backstop the relative arm has.
+static CONFINED: AtomicBool = AtomicBool::new(false);
+
+/// Confines the process to `dir` and records whether it worked.
+///
+/// Called once, before the first iteration. The result gates the absolute
+/// extent arm rather than the whole target: without confinement the relative
+/// arm is still fuzzed, and it is still covered by `RESOLVE_BENEATH`.
+fn confine(dir: &Path) -> bool {
+    // The extent opener anchors an absolute name by opening `/`, so the
+    // ruleset has to allow a directory open outside the scratch directory.
+    // It allows nothing beneath one: opening the extent *file* behind the
+    // symlink is what stays denied.
+    let confined = sandbox::confine(dir, sandbox::Directories::ListAnywhere);
+    CONFINED.store(confined, Ordering::Relaxed);
+    confined
+}
+
+/// Fuzzes the flat VMDK descriptor parser and extent layout.
+///
+/// The confinement comes first, for the reason [`CONFINED`] gives: the
+/// harness name guard is lexical, and the engine's absolute extent arm opens
+/// files writable with no kernel confinement behind it.
+pub fn fuzz_vmdk(bytes: &[u8]) -> Corpus {
+    let Ok(dir) = scratch_dir(Vmdk::NAME) else {
+        return Corpus::Reject;
+    };
+    confine(dir);
+
+    fuzz_image::<Vmdk>(bytes)
+}
 
 /// Flat VMDK images, as opened by [`VmdkDisk`].
 ///
@@ -68,29 +134,60 @@ impl Vmdk {
         Ok(())
     }
 
+    /// Expands [`SCRATCH_TOKEN`] in `descriptor` into the scratch directory.
+    ///
+    /// Returns `None` when there is nothing to expand, so the common case
+    /// pays nothing.
+    fn expand_scratch_token(descriptor: &str, dir: &Path) -> Option<String> {
+        if !descriptor.contains(SCRATCH_TOKEN) {
+            return None;
+        }
+        Some(descriptor.replace(SCRATCH_TOKEN, &dir.to_string_lossy()))
+    }
+
     /// Rejects a descriptor that names an extent outside the scratch
     /// directory.
     ///
     /// The engine resolves an extent name against the descriptor's directory
-    /// with `openat2` and `resolve: 0`, which anchors an absolute name at the
-    /// filesystem root and follows `..` out of the directory, and it opens
-    /// the extent writable. A corpus entry could therefore reach and
-    /// overwrite any file on the host. That is unacceptable in a fuzzer, and
-    /// it is the same reason backing files are not enabled for qcow2.
-    /// Fuzzing that branch safely needs a filesystem sandbox rather than a
-    /// scratch directory.
+    /// with `openat2`, and for an absolute name it anchors at the filesystem
+    /// root without `RESOLVE_BENEATH`, and it opens the extent writable. A
+    /// corpus entry could therefore reach and overwrite any file on the
+    /// host, which is unacceptable in a fuzzer.
     ///
-    /// Only names made entirely of [`Component::Normal`] components are
-    /// allowed: that rejects absolute paths, root and prefix components, `..`
-    /// and `.` alike.
-    fn names_escaping_extent(descriptor: &str) -> bool {
+    /// A relative name is accepted when every component is
+    /// [`Component::Normal`]: that rejects root and prefix components, `..`
+    /// and `.` alike. An absolute name is accepted only when the process is
+    /// confined (`absolute_allowed`), and then only when it starts with the
+    /// scratch directory and every component after it is `Normal`.
+    ///
+    /// The lexical test alone is *not* enough for an absolute name, which is
+    /// why it is gated: `<scratch>/link/victim` is all `Normal` components
+    /// and still leaves the directory when `link` is a symlink, because the
+    /// absolute arm drops `RESOLVE_BENEATH` and `O_NOFOLLOW` only guards the
+    /// final component. Landlock is what refuses that open; without it the
+    /// name is refused here instead.
+    fn names_escaping_extent(descriptor: &str, dir: &Path, absolute_allowed: bool) -> bool {
         descriptor.lines().any(|line| {
             let parts: Vec<&str> = line.split_whitespace().collect();
             if !matches!(parts.len(), 4 | 5) {
                 return false;
             }
             let name = Path::new(parts[3].trim_matches('"'));
-            name.is_absolute() || !name.components().all(|c| matches!(c, Component::Normal(_)))
+            let rest = if name.is_absolute() {
+                if !absolute_allowed {
+                    return true;
+                }
+                match name.strip_prefix(dir) {
+                    Ok(rest) => rest,
+                    Err(_) => return true,
+                }
+            } else {
+                name
+            };
+            // An empty remainder is the scratch directory itself, which is
+            // not an extent.
+            rest.components().next().is_none()
+                || !rest.components().all(|c| matches!(c, Component::Normal(_)))
         })
     }
 }
@@ -152,9 +249,20 @@ impl DiskFormat for Vmdk {
         let len = file
             .read_at(&mut raw, 0)
             .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
-        let descriptor = String::from_utf8_lossy(&raw[..len]);
+        let mut descriptor = String::from_utf8_lossy(&raw[..len]).into_owned();
 
-        if Self::names_escaping_extent(&descriptor) {
+        // The placeholder is expanded in the file itself, because the parser
+        // reads the descriptor from there and the expanded name has to be
+        // the one it resolves.
+        if let Some(expanded) = Self::expand_scratch_token(&descriptor, dir) {
+            file.write_all_at(expanded.as_bytes(), 0)
+                .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
+            file.set_len(expanded.len() as u64)
+                .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
+            descriptor = expanded;
+        }
+
+        if Self::names_escaping_extent(&descriptor, dir, CONFINED.load(Ordering::Relaxed)) {
             return Err(BlockError::from_kind(BlockErrorKind::UnsupportedFeature));
         }
 
@@ -170,30 +278,181 @@ impl DiskFormat for Vmdk {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::disk_engine::image::image_file;
+    use crate::disk_engine::image::{image_file, scratch_dir};
 
     fn descriptor(name: &str) -> String {
         format!("# Disk DescriptorFile\nversion=1\ncreateType=\"monolithicFlat\"\nRW 2048 FLAT \"{name}\" 0\n")
     }
 
-    // The engine opens extents writable through openat2 with resolve: 0,
-    // which follows `..` out of the scratch directory, so a descriptor that
-    // escapes must never reach it.
+    /// A descriptor the parser accepts in full, so that an open reaches the
+    /// extent opener rather than stopping at the layout.
+    fn openable_descriptor(name: &str) -> String {
+        format!(
+            "# Disk DescriptorFile\nversion=1\nCID=fffffffe\nparentCID=ffffffff\n\
+             createType=\"monolithicFlat\"\n\n# Extent description\n\
+             RW 2048 FLAT \"{name}\" 0\n\n# The Disk Data Base\n\
+             ddb.virtualHWVersion = \"4\"\n"
+        )
+    }
+
+    fn scratch() -> &'static Path {
+        scratch_dir(Vmdk::NAME).expect("scratch directory")
+    }
+
+    // The engine opens extents writable, and for an absolute name it
+    // resolves from the filesystem root without RESOLVE_BENEATH, so a
+    // descriptor that escapes the scratch directory must never reach it.
     #[test]
     fn traversing_extent_names_are_rejected() {
+        let dir = scratch();
         for name in [
-            "../../../../tmp/victim",
-            "..",
-            "./image-flat.vmdk",
-            "sub/../../tmp/victim",
-            "/tmp/victim",
-            "/etc/passwd",
+            "../../../../tmp/victim".to_string(),
+            "..".to_string(),
+            "./image-flat.vmdk".to_string(),
+            "sub/../../tmp/victim".to_string(),
+            "/tmp/victim".to_string(),
+            "/etc/passwd".to_string(),
+            // Absolute, and inside the scratch directory only until the
+            // components after it are followed.
+            format!("{}/../../tmp/victim", dir.display()),
+            // The scratch directory itself is not an extent.
+            dir.display().to_string(),
+            // A directory whose name merely starts with the scratch path.
+            format!("{}-evil/image-flat.vmdk", dir.display()),
         ] {
             assert!(
-                Vmdk::names_escaping_extent(&descriptor(name)),
+                Vmdk::names_escaping_extent(&descriptor(&name), dir, true),
                 "{name} must be rejected"
             );
         }
+    }
+
+    // The absolute arm of the engine's extent opener is only reachable with
+    // an absolute name, and the only absolute name that is safe to give it
+    // is one inside the scratch directory the harness owns.
+    #[test]
+    fn absolute_names_inside_the_scratch_directory_are_accepted() {
+        let dir = scratch();
+        for name in [
+            format!("{}/image-flat.vmdk", dir.display()),
+            format!("{}/extents/s001.vmdk", dir.display()),
+        ] {
+            assert!(
+                !Vmdk::names_escaping_extent(&descriptor(&name), dir, true),
+                "{name} must be accepted"
+            );
+            assert!(
+                Vmdk::names_escaping_extent(&descriptor(&name), dir, false),
+                "{name} must be refused without confinement"
+            );
+        }
+    }
+
+    // A corpus entry cannot know the scratch path, so it writes the
+    // placeholder and the harness expands it. The expansion has to produce a
+    // name the guard then accepts, or the arm stays unreachable.
+    #[test]
+    fn the_scratch_token_expands_to_an_accepted_absolute_name() {
+        let dir = scratch();
+        let raw = descriptor(&format!("{SCRATCH_TOKEN}/image-flat.vmdk"));
+        assert!(
+            Vmdk::names_escaping_extent(&raw, dir, true),
+            "the unexpanded placeholder is not a valid name"
+        );
+
+        let expanded = Vmdk::expand_scratch_token(&raw, dir).expect("the token must expand");
+        assert!(expanded.contains(&dir.display().to_string()));
+        assert!(!Vmdk::names_escaping_extent(&expanded, dir, true));
+        assert!(Vmdk::expand_scratch_token("no token here", dir).is_none());
+    }
+
+    // A name that is lexically inside the scratch directory but traverses a
+    // symlink out of it is exactly what the guard cannot see, so it must be
+    // refused for as long as nothing else can refuse it: an unconfined
+    // process admits no absolute name at all.
+    #[test]
+    fn absolute_names_need_the_confinement() {
+        let dir = scratch();
+        for name in [
+            format!("{}/image-flat.vmdk", dir.display()),
+            format!("{}/link/victim", dir.display()),
+        ] {
+            assert!(
+                Vmdk::names_escaping_extent(&descriptor(&name), dir, false),
+                "{name} must be refused while the process is not confined"
+            );
+        }
+        // The default is unconfined, so a caller that never confined the
+        // process gets the refusing policy without asking for it.
+        assert!(!CONFINED.load(Ordering::Relaxed));
+    }
+
+    // What the confinement is for. The absolute arm resolves from the
+    // filesystem root without RESOLVE_BENEATH and opens the extent writable,
+    // and O_NOFOLLOW only guards the final component, so a symlink planted
+    // inside the scratch directory reaches a file outside it with every
+    // component of the name a plain `Component::Normal`. The lexical guard
+    // admits that name by construction; Landlock is what refuses the open.
+    //
+    // Ignored by default because it confines the whole test process, and a
+    // test that ran after it would lose its own scratch directory. Run it on
+    // its own:
+    //
+    //     cargo test --lib -- --ignored --exact \
+    //         disk_engine::formats::vmdk::tests::a_symlink_out_of_the_scratch_directory_is_denied
+    #[test]
+    #[ignore = "confines the whole test process"]
+    fn a_symlink_out_of_the_scratch_directory_is_denied() {
+        let dir = scratch();
+        std::fs::create_dir_all(dir).expect("scratch directory");
+
+        // The victim lives outside the scratch directory, and the symlink to
+        // it lives inside: every component of the extent name below is a
+        // plain name.
+        let outside =
+            std::env::temp_dir().join(format!("ch-fuzz-vmdk-outside-{}", std::process::id()));
+        std::fs::create_dir_all(&outside).expect("victim directory");
+        let victim = outside.join("victim");
+        std::fs::write(&victim, b"UNTOUCHED").expect("victim file");
+        let link = dir.join("link");
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink(&outside, &link).expect("symlink into the scratch directory");
+        // Opened before the confinement, because afterwards not even this
+        // test may open a path outside the scratch directory - which is the
+        // point. An already open descriptor keeps working.
+        let handle = File::open(&victim).expect("victim handle");
+
+        assert!(confine(dir), "the process must be confined");
+
+        let escaping = openable_descriptor(&format!("{}/link/victim", dir.display()));
+        let (file, path) = image_file("vmdk", escaping.as_bytes()).expect("scratch image");
+        let err = Vmdk::open(file, Some(&path), &OpenConfig::default())
+            .err()
+            .expect("an extent name traversing a symlink out of the scratch directory");
+        // Not merely an error: the open has to be denied by the kernel, or
+        // the test would pass on a descriptor that never reached the opener.
+        let denied = format!("{err:?}").contains("PermissionDenied");
+        eprintln!("escaping extent name refused: {err:?}");
+        assert!(denied, "the open must be denied, got {err:?}");
+        let mut seen = [0u8; 9];
+        handle.read_at(&mut seen, 0).expect("victim contents");
+        assert_eq!(
+            &seen, b"UNTOUCHED",
+            "the victim file must not have been written"
+        );
+        assert_eq!(
+            handle.metadata().expect("victim metadata").len(),
+            9,
+            "the victim file must not have been resized"
+        );
+
+        // And the arm the absolute name exists to cover still works, so the
+        // confinement bought the refusal and not the coverage.
+        let legitimate = openable_descriptor(&format!("{}/image-flat.vmdk", dir.display()));
+        let (file, path) = image_file("vmdk", legitimate.as_bytes()).expect("scratch image");
+        Vmdk::open(file, Some(&path), &OpenConfig::default())
+            .expect("an absolute extent name inside the scratch directory must still open");
+        eprintln!("absolute extent name inside the scratch directory: opened");
     }
 
     // `magic_ok` decides whether a corpus entry is a descriptor at all, so it
@@ -213,7 +472,7 @@ mod tests {
     fn plain_extent_names_are_accepted() {
         for name in ["image-flat.vmdk", "two-f001.vmdk"] {
             assert!(
-                !Vmdk::names_escaping_extent(&descriptor(name)),
+                !Vmdk::names_escaping_extent(&descriptor(name), scratch(), true),
                 "{name} must be accepted"
             );
         }

--- a/fuzz/src/disk_engine/formats/vmdk.rs
+++ b/fuzz/src/disk_engine/formats/vmdk.rs
@@ -18,6 +18,10 @@ use crate::disk_engine::image::scratch_dir;
 /// Size of each extent file the harness provides.
 const EXTENT_LEN: u64 = 1 << 20;
 
+/// The first line of every descriptor, from `VMDK_DESCRIPTOR_HEADER` in the
+/// parser under test (block/src/formats/vmdk/descriptor.rs:19).
+const DESCRIPTOR_HEADER: &str = "# Disk DescriptorFile";
+
 /// Extent names the harness creates in the scratch directory.
 ///
 /// A descriptor referring to one of these opens successfully and reaches the
@@ -100,6 +104,23 @@ impl DiskFormat for Vmdk {
     // A descriptor is a small text file; the data lives in the extents.
     const MAX_IMAGE_LEN: usize = 64 << 10;
 
+    // `parse_header` rejects a descriptor whose first line is not exactly
+    // "# Disk DescriptorFile" (block/src/formats/vmdk/descriptor.rs:133,
+    // VMDK_DESCRIPTOR_HEADER at line 19), and `read_descriptor` rejects one
+    // that is not UTF-8 (line 118). Both run before anything else is parsed.
+    //
+    // The parser compares the line with its trailing whitespace stripped, so
+    // this does too: a check the parser does not make would drop inputs it
+    // would have accepted.
+    fn magic_ok(bytes: &[u8]) -> bool {
+        let Ok(text) = std::str::from_utf8(bytes) else {
+            return false;
+        };
+        text.lines()
+            .next()
+            .is_some_and(|line| line.trim_end() == DESCRIPTOR_HEADER)
+    }
+
     // Neither new invariant holds for a flat VMDK, so both keep their
     // conservative default.
     //
@@ -173,6 +194,19 @@ mod tests {
                 "{name} must be rejected"
             );
         }
+    }
+
+    // `magic_ok` decides whether a corpus entry is a descriptor at all, so it
+    // has to agree with the header line test the parser makes.
+    #[test]
+    fn magic_ok_tracks_the_descriptor_header() {
+        assert!(Vmdk::magic_ok(descriptor("image-flat.vmdk").as_bytes()));
+        // The parser trims trailing whitespace off the header line.
+        assert!(Vmdk::magic_ok(b"# Disk DescriptorFile \nversion=1\n"));
+        assert!(!Vmdk::magic_ok(b"# Disk Descriptor\n"));
+        assert!(!Vmdk::magic_ok(b"version=1\n# Disk DescriptorFile\n"));
+        assert!(!Vmdk::magic_ok(b""));
+        assert!(!Vmdk::magic_ok(&[0xff, 0xfe, 0xfd]));
     }
 
     #[test]

--- a/fuzz/src/disk_engine/formats/vmdk.rs
+++ b/fuzz/src/disk_engine/formats/vmdk.rs
@@ -1,0 +1,190 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Flat VMDK adapter.
+
+use std::fs::{File, OpenOptions};
+use std::os::unix::fs::FileExt;
+use std::path::{Component, Path};
+
+use block::disk_file::AsyncFullDiskFile;
+use block::error::{BlockError, BlockErrorKind, BlockResult};
+use block::formats::vmdk::VmdkDisk;
+
+use crate::disk_engine::format::{DiskFormat, OpenConfig};
+use crate::disk_engine::image::scratch_dir;
+
+/// Size of each extent file the harness provides.
+const EXTENT_LEN: u64 = 1 << 20;
+
+/// Extent names the harness creates in the scratch directory.
+///
+/// A descriptor referring to one of these opens successfully and reaches the
+/// extent aware I/O engine; any other name fails at open, which is the same
+/// path a missing extent takes in production. The names are the ones
+/// `qemu-img` derives from an image called `image.vmdk`, plus the ones the
+/// generated seeds use.
+const EXTENTS: [&str; 6] = [
+    "image-flat.vmdk",
+    "image-f001.vmdk",
+    "image-f002.vmdk",
+    "flat-flat.vmdk",
+    "two-f001.vmdk",
+    "two-f002.vmdk",
+];
+
+/// Flat VMDK images, as opened by [`VmdkDisk`].
+///
+/// A VMDK image is a text descriptor that names its data extents as separate
+/// files, so unlike every other format here it cannot be fuzzed from a memfd:
+/// the engine resolves extent names against the descriptor's directory. The
+/// harness therefore materializes the descriptor in a scratch directory that
+/// already holds the extent files.
+///
+/// There is no template image: the `block` crate parses descriptors but never
+/// writes one.
+pub struct Vmdk;
+
+impl Vmdk {
+    /// Creates the extent files a descriptor may refer to, and resets them so
+    /// that one iteration cannot observe what an earlier one wrote.
+    fn reset_extents(dir: &Path) -> BlockResult<()> {
+        for name in EXTENTS {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(dir.join(name))
+                .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
+            file.set_len(EXTENT_LEN)
+                .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
+        }
+        Ok(())
+    }
+
+    /// Rejects a descriptor that names an extent outside the scratch
+    /// directory.
+    ///
+    /// The engine resolves an extent name against the descriptor's directory
+    /// with `openat2` and `resolve: 0`, which anchors an absolute name at the
+    /// filesystem root and follows `..` out of the directory, and it opens
+    /// the extent writable. A corpus entry could therefore reach and
+    /// overwrite any file on the host. That is unacceptable in a fuzzer, and
+    /// it is the same reason backing files are not enabled for qcow2.
+    /// Fuzzing that branch safely needs a filesystem sandbox rather than a
+    /// scratch directory.
+    ///
+    /// Only names made entirely of [`Component::Normal`] components are
+    /// allowed: that rejects absolute paths, root and prefix components, `..`
+    /// and `.` alike.
+    fn names_escaping_extent(descriptor: &str) -> bool {
+        descriptor.lines().any(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if !matches!(parts.len(), 4 | 5) {
+                return false;
+            }
+            let name = Path::new(parts[3].trim_matches('"'));
+            name.is_absolute() || !name.components().all(|c| matches!(c, Component::Normal(_)))
+        })
+    }
+}
+
+impl DiskFormat for Vmdk {
+    const NAME: &'static str = "vmdk";
+
+    // The descriptor names its extents relative to its own directory.
+    const NEEDS_PATH: bool = true;
+
+    // A descriptor is a small text file; the data lives in the extents.
+    const MAX_IMAGE_LEN: usize = 64 << 10;
+
+    fn open(
+        file: File,
+        path: Option<&Path>,
+        config: &OpenConfig,
+    ) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+        let path = path.expect("vmdk images are path backed");
+        let dir = path
+            .parent()
+            .unwrap_or_else(|| scratch_dir(Self::NAME).expect("scratch directory"));
+
+        // Read positionally: `try_clone` is dup(2) and shares the file
+        // cursor with the engine, so a probe that moved it would leave the
+        // guard and the parser looking at different bytes.
+        let mut raw = vec![0u8; Self::MAX_IMAGE_LEN];
+        let len = file
+            .read_at(&mut raw, 0)
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
+        let descriptor = String::from_utf8_lossy(&raw[..len]);
+
+        if Self::names_escaping_extent(&descriptor) {
+            return Err(BlockError::from_kind(BlockErrorKind::UnsupportedFeature));
+        }
+
+        Self::reset_extents(dir)?;
+
+        // The fuzzer drives the writable path, so it asks for a writable
+        // open and lets the descriptor's own access field decide per extent.
+        let disk = VmdkDisk::new(file, path, false, config.direct)?;
+        Ok(Box::new(disk))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::disk_engine::image::image_file;
+
+    fn descriptor(name: &str) -> String {
+        format!("# Disk DescriptorFile\nversion=1\ncreateType=\"monolithicFlat\"\nRW 2048 FLAT \"{name}\" 0\n")
+    }
+
+    // The engine opens extents writable through openat2 with resolve: 0,
+    // which follows `..` out of the scratch directory, so a descriptor that
+    // escapes must never reach it.
+    #[test]
+    fn traversing_extent_names_are_rejected() {
+        for name in [
+            "../../../../tmp/victim",
+            "..",
+            "./image-flat.vmdk",
+            "sub/../../tmp/victim",
+            "/tmp/victim",
+            "/etc/passwd",
+        ] {
+            assert!(
+                Vmdk::names_escaping_extent(&descriptor(name)),
+                "{name} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn plain_extent_names_are_accepted() {
+        for name in ["image-flat.vmdk", "two-f001.vmdk"] {
+            assert!(
+                !Vmdk::names_escaping_extent(&descriptor(name)),
+                "{name} must be accepted"
+            );
+        }
+    }
+
+    // The guard has to hold at the harness entry point, not just in
+    // isolation: `open` reads the descriptor positionally, so it sees the
+    // same bytes the engine parses.
+    #[test]
+    fn open_refuses_a_traversing_descriptor() {
+        let bytes = descriptor("../../../../tmp/victim");
+        let (file, path) = image_file("vmdk", bytes.as_bytes()).expect("scratch image");
+        let err = Vmdk::open(file, Some(&path), &OpenConfig::default())
+            .err()
+            .expect("a descriptor escaping the scratch directory must be refused");
+        assert_eq!(err.kind(), BlockErrorKind::UnsupportedFeature);
+        assert!(
+            !Path::new("/tmp/victim").exists(),
+            "the harness must not have created /tmp/victim"
+        );
+    }
+}

--- a/fuzz/src/disk_engine/formats/vmdk.rs
+++ b/fuzz/src/disk_engine/formats/vmdk.rs
@@ -41,6 +41,74 @@ const EXTENTS: [&str; 6] = [
     "two-f002.vmdk",
 ];
 
+/// The template descriptor `disk_vmdk_ops` runs its programs against.
+///
+/// For a flat VMDK the image file *is* the descriptor: the data lives in the
+/// extent files the harness already creates and resets, so the template is
+/// two hundred bytes of ASCII rather than a binary run table. There is
+/// nothing to expand and nothing to checksum.
+///
+/// The layout is chosen so that the engine's translation logic is under the
+/// shadow model rather than merely reachable:
+///
+/// - **Two extents**, so a request can straddle the boundary at virtual
+///   offset 1,048,576 and take `spanning_io`
+///   (block/src/formats/vmdk/engine_sync.rs:154) with its per segment byte
+///   accounting, instead of always taking `single_extent_io`. A one extent
+///   descriptor would leave the spanning path, which is where the byte
+///   counting can go wrong, completely unexercised.
+/// - **A non-zero base offset on the second extent**, 512 bytes, one sector.
+///   `file_base_offset + (offset - virtual_start)` is the whole of the
+///   format's offset arithmetic, and with a zero base offset the term
+///   vanishes and an error in it cannot be observed. One sector is enough:
+///   an off-by-one in either operand moves every byte of the second extent.
+/// - **Different extent lengths**, 2048 and 1024 sectors, so that a bug
+///   using the wrong extent's length or start is not masked by the two being
+///   interchangeable.
+/// - **Both extents `RW`**, because the model's precondition is that the
+///   whole disk is readable and writable. `RDONLY` and `NOACCESS` extents
+///   drive `check_access`, but a `NOACCESS` extent cannot be read at all, so
+///   a template containing one could not satisfy assertion (c) of
+///   [`crate::disk_engine::selftest`]. Those arms stay with `disk_vmdk`,
+///   whose descriptors are fuzzer generated.
+///
+/// Both extent names must be in [`EXTENTS`], which is what makes them exist
+/// and be reset to zeroes before every open, and both are relative, so the
+/// template is unaffected by whatever policy absolute extent names end up
+/// with.
+///
+/// The `# Extent description` line is mandatory: `parse_extents` rejects a
+/// descriptor without it (block/src/formats/vmdk/descriptor.rs:170,
+/// "Expected the extents section comment line").
+const TEMPLATE: &str = "\
+# Disk DescriptorFile
+version=1
+CID=fffffffe
+parentCID=ffffffff
+createType=\"twoGbMaxExtentFlat\"
+
+# Extent description
+RW 2048 FLAT \"image-f001.vmdk\" 0
+RW 1024 FLAT \"image-f002.vmdk\" 1
+
+# The Disk Data Base
+ddb.virtualHWVersion = \"4\"
+";
+
+/// Virtual disk size [`TEMPLATE`] advertises, in bytes.
+///
+/// The capacity of a flat VMDK is the sum of its extent sector counts
+/// (block/src/formats/vmdk/flat.rs:400), so this is (2048 + 1024) * 512 =
+/// 1,572,864. Pinned here so that the self test proves the template is the
+/// disk it is supposed to be rather than merely a descriptor that parses.
+pub const TEMPLATE_LOGICAL_SIZE: u64 = (2048 + 1024) * 512;
+
+/// Virtual offset at which [`TEMPLATE`]'s first extent ends.
+///
+/// A request that starts below this and ends above it is the one that takes
+/// `spanning_io`.
+pub const TEMPLATE_EXTENT_BOUNDARY: u64 = 2048 * 512;
+
 /// Placeholder a descriptor uses to name the scratch directory.
 ///
 /// An extent name may be absolute, and the engine treats an absolute name
@@ -315,12 +383,32 @@ impl DiskFormat for Vmdk {
         let disk = VmdkDisk::new(file, path, false, config.direct)?;
         Ok(Box::new(disk))
     }
+
+    fn template() -> Option<&'static [u8]> {
+        Some(TEMPLATE.as_bytes())
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
     use crate::disk_engine::image::{image_file, scratch_dir};
+    use crate::disk_engine::selftest::assert_template_is_sound;
+    use crate::disk_engine::{Executor, Op, OpLen, OpOffset};
+
+    /// Serializes the tests that drive I/O against the template.
+    ///
+    /// Unlike every other format's, a VMDK template is not a memfd: the
+    /// descriptor and its extents are real files in the one scratch
+    /// directory the process owns, and opening the template truncates and
+    /// zero fills the extents (`reset_extents`). Two such tests running on
+    /// the harness's own threads therefore share a disk, and the second
+    /// one's open blanks the first one's data underneath it. That is a
+    /// property of the test harness, not of the target: a fuzz process runs
+    /// exactly one iteration at a time.
+    static TEMPLATE_IO: Mutex<()> = Mutex::new(());
 
     fn descriptor(name: &str) -> String {
         format!("# Disk DescriptorFile\nversion=1\ncreateType=\"monolithicFlat\"\nRW 2048 FLAT \"{name}\" 0\n")
@@ -568,5 +656,145 @@ mod tests {
             !Path::new("/tmp/victim").exists(),
             "the harness must not have created /tmp/victim"
         );
+    }
+
+    /// The template is what the whole operation target rests on, and a
+    /// template that is subtly wrong makes that target an expensive no-op
+    /// that passes forever. See `disk_engine::selftest`.
+    #[test]
+    fn the_template_is_a_blank_one_and_a_half_mib_disk() {
+        let _guard = TEMPLATE_IO.lock().unwrap_or_else(|e| e.into_inner());
+        assert_template_is_sound::<Vmdk>(TEMPLATE_LOGICAL_SIZE);
+    }
+
+    /// The layout the template exists for is pinned, not merely described.
+    ///
+    /// Every property below is one the operation target's value depends on,
+    /// and each is one edit away from being lost silently: an extent name
+    /// that is not in [`EXTENTS`] is never created or zeroed, a zero base
+    /// offset takes the offset arithmetic out of the oracle's reach, and a
+    /// single extent takes `spanning_io` out of it.
+    #[test]
+    fn the_template_descriptor_is_the_pinned_layout() {
+        let text = std::str::from_utf8(Vmdk::template().expect("vmdk has a template"))
+            .expect("the template is ASCII");
+        assert!(Vmdk::magic_ok(text.as_bytes()));
+        assert!(text.lines().any(|line| line == "# Extent description"));
+
+        let extents: Vec<Vec<&str>> = text
+            .lines()
+            .filter(|line| line.starts_with("RW ") || line.starts_with("RDONLY "))
+            .map(|line| line.split_whitespace().collect())
+            .collect();
+        assert_eq!(extents.len(), 2, "a single extent never spans");
+
+        let mut virtual_start = 0u64;
+        for (index, parts) in extents.iter().enumerate() {
+            assert_eq!(parts.len(), 5, "an extent line without a base offset");
+            assert_eq!(parts[2], "FLAT");
+            let name = parts[3].trim_matches('"');
+            assert!(
+                !Path::new(name).is_absolute(),
+                "{name}: the template must use relative extent names only"
+            );
+            assert!(
+                EXTENTS.contains(&name),
+                "{name} is not created and reset by the harness"
+            );
+            let sectors: u64 = parts[1].parse().expect("a sector count");
+            let base: u64 = parts[4].parse().expect("a base offset");
+            assert!(
+                base * 512 + sectors * 512 <= EXTENT_LEN,
+                "{name} does not fit the {EXTENT_LEN} byte extent files"
+            );
+            if index == 1 {
+                assert!(base > 0, "a zero base offset hides the offset arithmetic");
+            }
+            virtual_start += sectors * 512;
+            if index == 0 {
+                assert_eq!(virtual_start, TEMPLATE_EXTENT_BOUNDARY);
+            }
+        }
+        assert_eq!(virtual_start, TEMPLATE_LOGICAL_SIZE);
+    }
+
+    /// The shadow model has to be armed against the arithmetic this target
+    /// exists for.
+    ///
+    /// There is no known VMDK data corruption bug to reproduce here, so this
+    /// is the shape a future one would take rather than a regression test for
+    /// a past one: a write that straddles the extent boundary, so every byte
+    /// past it goes through `file_base_offset + (cur - virtual_start)` in
+    /// `spanning_io`, read back *through the other path*.
+    ///
+    /// Reading it back the same way it was written is not enough, and this is
+    /// the trap worth spelling out: an offset error that both the write and
+    /// the read make cancels out, and the data comes back exactly where the
+    /// oracle expects it. What catches a misplaced byte is a read whose
+    /// translation does not share the mistake, so each write below is read
+    /// back both ways - once spanning, once as a plain single extent read of
+    /// each side of the boundary.
+    ///
+    /// Both cache modes, because the direct arm goes through
+    /// `AlignedFile::{read,write}_unaligned` and its bounce buffer instead of
+    /// straight `pread`/`pwrite`.
+    #[test]
+    fn the_model_catches_a_misplaced_spanning_write() {
+        let _guard = TEMPLATE_IO.lock().unwrap_or_else(|e| e.into_inner());
+        let straddle = TEMPLATE_EXTENT_BOUNDARY - 512;
+        let tail = TEMPLATE_LOGICAL_SIZE - 4096;
+        let program = vec![
+            // Spanning write: 512 bytes into the first extent, 1536 into the
+            // second at its non-zero base offset.
+            Op::WriteVec {
+                offset: OpOffset::Byte(straddle as u32),
+                len: OpLen(2048),
+                seed: 0x27,
+            },
+            // Read the far side back on its own, which takes
+            // `single_extent_io`. A spanning write that landed at the wrong
+            // file offset shows up here even though a spanning read of the
+            // same range would have hidden it.
+            Op::ReadVec {
+                offset: OpOffset::Byte(TEMPLATE_EXTENT_BOUNDARY as u32),
+                len: OpLen(1536),
+            },
+            // And the near side, still inside the first extent.
+            Op::ReadVec {
+                offset: OpOffset::Byte(straddle as u32),
+                len: OpLen(512),
+            },
+            // The same range spanning, so the spanning read path is checked
+            // against data the model already agrees on.
+            Op::ReadVec {
+                offset: OpOffset::Byte(straddle as u32),
+                len: OpLen(2048),
+            },
+            // A single extent write at the tail, read back spanning the
+            // boundary, which is the mirror of the first pair.
+            Op::WriteVec {
+                offset: OpOffset::Byte(tail as u32),
+                len: OpLen(4096),
+                seed: 0x93,
+            },
+            Op::ReadVec {
+                offset: OpOffset::Byte(straddle as u32),
+                len: OpLen(65535),
+            },
+        ];
+
+        let template = Vmdk::template().expect("vmdk has a template");
+        for direct in [false, true] {
+            let (file, path) =
+                crate::disk_engine::materialize_template::<Vmdk>(template).expect("template");
+            let config = OpenConfig {
+                direct,
+                ..OpenConfig::default()
+            };
+            let disk = Vmdk::open(file, path.as_deref(), &config).expect("the template opens");
+            let mut executor = Executor::<Vmdk>::new(disk, 1, true).expect("executor");
+            // Panics on a read back mismatch, which is the point.
+            executor.run(&program);
+        }
     }
 }

--- a/fuzz/src/disk_engine/image.rs
+++ b/fuzz/src/disk_engine/image.rs
@@ -1,0 +1,64 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backing storage for fuzzed disk images.
+
+use std::ffi::CString;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Seek, SeekFrom, Write};
+use std::os::unix::io::{FromRawFd, RawFd};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Materializes `bytes` as an anonymous file.
+///
+/// A memfd keeps the image in tmpfs so a fuzz iteration never touches the
+/// filesystem, and the descriptor is closed when the returned `File` drops.
+pub fn image_memfd(name: &str, bytes: &[u8]) -> io::Result<File> {
+    let name = CString::new(name).map_err(io::Error::other)?;
+    // SAFETY: FFI call with a valid NUL terminated name and no flags.
+    let fd = unsafe { libc::syscall(libc::SYS_memfd_create, name.as_ptr(), 0) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // SAFETY: memfd_create returned a fresh descriptor owned by nobody else.
+    let mut file: File = unsafe { File::from_raw_fd(fd as RawFd) };
+    file.write_all(bytes)?;
+    file.seek(SeekFrom::Start(0))?;
+    Ok(file)
+}
+
+/// Returns the per process scratch directory for path backed images.
+///
+/// Formats that resolve sibling files relative to the image need a real
+/// directory. One is created per process and reused, so an iteration only
+/// rewrites the image itself.
+pub fn scratch_dir(name: &str) -> io::Result<&'static Path> {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+
+    let dir = DIR.get_or_init(|| {
+        let dir = std::env::temp_dir().join(format!("ch-fuzz-{name}-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        dir
+    });
+    Ok(dir.as_path())
+}
+
+/// Materializes `bytes` as a real file inside the scratch directory.
+///
+/// The path is stable across iterations so that a format resolving siblings
+/// relative to it sees the same directory every time.
+pub fn image_file(name: &str, bytes: &[u8]) -> io::Result<(File, PathBuf)> {
+    let path = scratch_dir(name)?.join(format!("image.{name}"));
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path)?;
+    file.write_all(bytes)?;
+    file.seek(SeekFrom::Start(0))?;
+    Ok((file, path))
+}

--- a/fuzz/src/disk_engine/image.rs
+++ b/fuzz/src/disk_engine/image.rs
@@ -4,18 +4,17 @@
 
 //! Backing storage for fuzzed disk images.
 
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Seek, SeekFrom, Write};
+use std::os::unix::fs::FileExt;
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Arc, Mutex, OnceLock};
 
-/// Materializes `bytes` as an anonymous file.
-///
-/// A memfd keeps the image in tmpfs so a fuzz iteration never touches the
-/// filesystem, and the descriptor is closed when the returned `File` drops.
-pub fn image_memfd(name: &str, bytes: &[u8]) -> io::Result<File> {
+/// Creates an empty anonymous file.
+fn memfd(name: &str) -> io::Result<File> {
     let name = CString::new(name).map_err(io::Error::other)?;
     // SAFETY: FFI call with a valid NUL terminated name and no flags.
     let fd = unsafe { libc::syscall(libc::SYS_memfd_create, name.as_ptr(), 0) };
@@ -24,8 +23,104 @@ pub fn image_memfd(name: &str, bytes: &[u8]) -> io::Result<File> {
     }
 
     // SAFETY: memfd_create returned a fresh descriptor owned by nobody else.
-    let mut file: File = unsafe { File::from_raw_fd(fd as RawFd) };
+    Ok(unsafe { File::from_raw_fd(fd as RawFd) })
+}
+
+/// Materializes `bytes` as an anonymous file.
+///
+/// A memfd keeps the image in tmpfs so a fuzz iteration never touches the
+/// filesystem, and the descriptor is closed when the returned `File` drops.
+///
+/// The whole buffer is written. `bytes` here is fuzzer input, which is dense,
+/// and looking for the zero pages in it would cost as much as writing them:
+/// measured on a loaded 96 way host, scanning 8 MiB took 6.1 ms and writing
+/// it took 5.9 ms. Only a *fixed* image can skip the scan, which is what
+/// [`template_memfd`] does.
+pub fn image_memfd(name: &str, bytes: &[u8]) -> io::Result<File> {
+    let mut file = memfd(name)?;
     file.write_all(bytes)?;
+    file.seek(SeekFrom::Start(0))?;
+    Ok(file)
+}
+
+/// Page granularity at which a template's zero regions are skipped.
+///
+/// One page is the smallest unit tmpfs allocates, so a page of zeroes that is
+/// never written costs neither memory nor a copy.
+const SPARSE_PAGE: usize = 4096;
+
+/// Returns the indices of the pages of `bytes` that are not entirely zero,
+/// computing them once per template buffer.
+///
+/// A template is the same buffer on every iteration, so its layout is a
+/// constant and finding it again each time is pure overhead - and it is the
+/// dominant overhead. Measured for the VHDX template, 8 MiB of file holding
+/// 333 non-zero bytes: scanning it took 6.1 ms of a 7.7 ms iteration and
+/// capped the target at 17 executions a second. Writing it densely instead
+/// costs the same 5.9 ms, so skipping the zero pages only pays once the scan
+/// is not repeated. Cached, materialization is a `set_len` and six page
+/// writes, about 5 us.
+///
+/// The cache is keyed by the identity of the buffer - its address and its
+/// length - and not by the format name. A format has as many templates as
+/// [`crate::disk_engine::format::DiskFormat::template_variant`] hands out,
+/// and qcow2 has two of different sizes, so a name is not the name of one
+/// buffer: keying by it returned the first materialized variant's page map
+/// for the other one, and indexing a 1 MiB image's map into the 2560 byte
+/// file of the small cluster image panicked. Length alone is no better,
+/// because two variants may coincidentally match.
+///
+/// A template lives in a `OnceLock` static for the life of the process,
+/// which is what `&'static [u8]` here demands: an address that is never
+/// freed and so never reused, and two distinct live slices cannot share
+/// both an address and a length. Empty slices may share the dangling
+/// address every allocator hands out for a zero sized read, but their page
+/// map is empty either way.
+fn template_pages(bytes: &'static [u8]) -> Arc<Vec<usize>> {
+    /// Cached page maps, one per template buffer, keyed by address and
+    /// length.
+    type PageMaps = HashMap<(usize, usize), Arc<Vec<usize>>>;
+
+    static CACHE: Mutex<Option<PageMaps>> = Mutex::new(None);
+
+    let key = (bytes.as_ptr() as usize, bytes.len());
+    let mut guard = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    let cache = guard.get_or_insert_with(PageMaps::new);
+    Arc::clone(cache.entry(key).or_insert_with(|| {
+        Arc::new(
+            bytes
+                .chunks(SPARSE_PAGE)
+                .enumerate()
+                .filter(|(_, page)| page.iter().any(|byte| *byte != 0))
+                .map(|(index, _)| index)
+                .collect(),
+        )
+    }))
+}
+
+/// Writes the pages of `bytes` named by `pages` into an emptied `file`.
+///
+/// The file is first sized to the whole length, so the pages that are skipped
+/// stay holes and read back as zeroes. `file` must be empty or freshly
+/// truncated.
+fn write_template(file: &File, bytes: &[u8], pages: &[usize]) -> io::Result<()> {
+    file.set_len(bytes.len() as u64)?;
+    for index in pages {
+        let start = index * SPARSE_PAGE;
+        let end = (start + SPARSE_PAGE).min(bytes.len());
+        file.write_all_at(&bytes[start..end], start as u64)?;
+    }
+    Ok(())
+}
+
+/// Materializes a fixed template image as an anonymous file.
+///
+/// Unlike [`image_memfd`] this writes only the pages that carry data, using
+/// the page map cached by [`template_pages`].
+pub fn template_memfd(name: &str, bytes: &'static [u8]) -> io::Result<File> {
+    let pages = template_pages(bytes);
+    let mut file = memfd(name)?;
+    write_template(&file, bytes, &pages)?;
     file.seek(SeekFrom::Start(0))?;
     Ok(file)
 }
@@ -46,19 +141,141 @@ pub fn scratch_dir(name: &str) -> io::Result<&'static Path> {
     Ok(dir.as_path())
 }
 
-/// Materializes `bytes` as a real file inside the scratch directory.
-///
-/// The path is stable across iterations so that a format resolving siblings
-/// relative to it sees the same directory every time.
-pub fn image_file(name: &str, bytes: &[u8]) -> io::Result<(File, PathBuf)> {
+/// Opens the scratch image for `name`, emptied.
+fn scratch_image(name: &str) -> io::Result<(File, PathBuf)> {
     let path = scratch_dir(name)?.join(format!("image.{name}"));
-    let mut file = OpenOptions::new()
+    let file = OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(true)
         .open(&path)?;
+    Ok((file, path))
+}
+
+/// Materializes `bytes` as a real file inside the scratch directory.
+///
+/// The path is stable across iterations so that a format resolving siblings
+/// relative to it sees the same directory every time.
+pub fn image_file(name: &str, bytes: &[u8]) -> io::Result<(File, PathBuf)> {
+    let (mut file, path) = scratch_image(name)?;
     file.write_all(bytes)?;
     file.seek(SeekFrom::Start(0))?;
     Ok((file, path))
+}
+
+/// Materializes a fixed template image inside the scratch directory.
+///
+/// The path backed counterpart of [`template_memfd`].
+pub fn template_file(name: &str, bytes: &'static [u8]) -> io::Result<(File, PathBuf)> {
+    let pages = template_pages(bytes);
+    let (mut file, path) = scratch_image(name)?;
+    // `truncate(true)` freed every block, so the skipped pages read as zeroes.
+    write_template(&file, bytes, &pages)?;
+    file.seek(SeekFrom::Start(0))?;
+    Ok((file, path))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use super::*;
+
+    // A sparsely written template has to be byte identical to the buffer it
+    // was built from: the framework, and the shadow model in particular,
+    // assumes the engine sees exactly the bytes the harness handed it.
+    #[test]
+    fn template_materialization_reproduces_the_buffer() {
+        let mut bytes = vec![0u8; 3 * SPARSE_PAGE + 17];
+        bytes[0] = 0xff;
+        bytes[SPARSE_PAGE - 1] = 0x01;
+        // The second page stays all zero, so it is never written.
+        bytes[2 * SPARSE_PAGE + 5] = 0xaa;
+        bytes[3 * SPARSE_PAGE + 16] = 0x5a;
+        // A template is `'static` in the harness because it lives in a
+        // `OnceLock`; leaking gives the test the same lifetime.
+        let bytes: &'static [u8] = Box::leak(bytes.into_boxed_slice());
+
+        // Twice, because the second round runs off the cached page map.
+        for round in 0..2 {
+            let mut file = template_memfd("sparse-test", bytes).expect("memfd");
+            let mut read_back = Vec::new();
+            file.read_to_end(&mut read_back).expect("read back");
+            assert_eq!(read_back, bytes, "round {round}");
+        }
+        assert_eq!(*template_pages(bytes), vec![0, 2, 3]);
+
+        // An empty buffer and a wholly zero buffer are degenerate cases of
+        // the same loop, and each needs its own cache key.
+        for len in [0usize, 1, SPARSE_PAGE, SPARSE_PAGE + 1] {
+            let zeroes: &'static [u8] = Box::leak(vec![0u8; len].into_boxed_slice());
+            let mut file = template_memfd("zero-test", zeroes).expect("memfd");
+            let mut read_back = Vec::new();
+            file.read_to_end(&mut read_back).expect("read back");
+            assert_eq!(read_back, zeroes, "{len} zero bytes");
+        }
+    }
+
+    // Two templates of the same format, materialized in one process, must
+    // each get their own page map.
+    //
+    // The cache used to be keyed by format name, on the assumption that a
+    // format had one template. `DiskFormat::template_variant` broke that:
+    // qcow2 has a 1 MiB default image and a 4 MiB small cluster one whose
+    // file is only a couple of kilobytes. Whichever was materialized first
+    // owned the entry, and applying its page map to the other panicked with
+    // an out of range slice index the moment a fuzz target replayed a
+    // corpus that reached both. The shapes here are the same: a long buffer
+    // whose pages are spread out, and a short one that a page index of the
+    // long map runs past.
+    #[test]
+    fn two_templates_of_one_format_do_not_share_a_page_map() {
+        let mut large = vec![0u8; 32 * SPARSE_PAGE];
+        large[0] = 0x1;
+        large[31 * SPARSE_PAGE] = 0x2;
+        let large: &'static [u8] = Box::leak(large.into_boxed_slice());
+
+        let mut small = vec![0u8; 2560];
+        small[7] = 0x3;
+        let small: &'static [u8] = Box::leak(small.into_boxed_slice());
+
+        // Both orders, and twice each, so that neither the first nor the
+        // cached path can be the one that is right by accident.
+        for round in 0..2 {
+            for (which, bytes) in [("large", large), ("small", small)] {
+                let mut file = template_memfd("variant-test", bytes).expect("memfd");
+                let mut read_back = Vec::new();
+                file.read_to_end(&mut read_back).expect("read back");
+                assert_eq!(read_back.len(), bytes.len(), "{which}, round {round}");
+                assert_eq!(read_back, bytes, "{which}, round {round}");
+            }
+        }
+
+        // And the maps themselves are the two different maps, not one -
+        // and each is still cached, which is the whole point of keying
+        // them at all: a second call hands back the same allocation
+        // rather than scanning the buffer again.
+        assert_eq!(*template_pages(large), vec![0, 31]);
+        assert_eq!(*template_pages(small), vec![0]);
+        assert!(Arc::ptr_eq(&template_pages(large), &template_pages(large)));
+        assert!(Arc::ptr_eq(&template_pages(small), &template_pages(small)));
+        assert!(!Arc::ptr_eq(&template_pages(large), &template_pages(small)));
+    }
+
+    // A path backed template is rewritten in place every iteration, so a
+    // shorter image must not leave the tail of a longer one behind.
+    #[test]
+    fn a_rewritten_scratch_image_keeps_no_tail() {
+        let long = vec![0xa5u8; 2 * SPARSE_PAGE];
+        let (_file, path) = image_file("sparse-file-test", &long).expect("scratch image");
+        assert_eq!(
+            fs::metadata(&path).expect("metadata").len(),
+            long.len() as u64
+        );
+
+        let short = vec![0u8; 8];
+        let (_file, path) = image_file("sparse-file-test", &short).expect("scratch image");
+        assert_eq!(fs::read(&path).expect("read back"), short);
+    }
 }

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -211,9 +211,19 @@ pub fn fuzz_program<F: DiskFormat>(program: &Program) -> Corpus {
         return Corpus::Reject;
     };
 
+    // A template image names no backing file, but the switch is forced off
+    // regardless: the shadow model this target runs with assumes that a
+    // discarded cluster reads back as zeroes, which stops being true the
+    // moment an image has a backing file. Backing chains are fuzzed by
+    // `disk_qcow2_chain`, which runs without the model.
+    let open = OpenConfig {
+        backing: false,
+        ..program.open
+    };
+
     // A template that does not open means the adapter is broken, which is a
     // harness bug rather than a finding, so fail loudly.
-    let disk = F::open(file, path.as_deref(), &program.open)
+    let disk = F::open(file, path.as_deref(), &open)
         .unwrap_or_else(|e| panic!("{}: template image failed to open: {e}", F::NAME));
 
     let Some(mut executor) = Executor::<F>::new(disk, program.ring_depth(), true) else {

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -61,7 +61,9 @@ use libfuzzer_sys::Corpus;
 
 pub use crate::disk_engine::executor::Executor;
 pub use crate::disk_engine::format::{DiskFormat, OpenConfig};
-pub use crate::disk_engine::image::{image_file, image_memfd, scratch_dir};
+pub use crate::disk_engine::image::{
+    image_file, image_memfd, scratch_dir, template_file, template_memfd,
+};
 pub use crate::disk_engine::model::Model;
 pub use crate::disk_engine::program::{
     default_program, Op, OpLen, OpOffset, Program, MAX_OPS, MAX_OP_LEN,
@@ -213,7 +215,7 @@ pub fn fuzz_detect(bytes: &[u8]) -> Corpus {
 pub fn fuzz_program<F: DiskFormat>(program: &Program) -> Corpus {
     let template =
         F::template().unwrap_or_else(|| panic!("{}: format has no template image", F::NAME));
-    let Ok((file, path)) = materialize::<F>(template) else {
+    let Ok((file, path)) = materialize_template::<F>(template) else {
         return Corpus::Reject;
     };
 
@@ -251,6 +253,27 @@ fn materialize<F: DiskFormat>(bytes: &[u8]) -> std::io::Result<(std::fs::File, O
         Ok((file, Some(path)))
     } else {
         Ok((image_memfd(F::NAME, bytes)?, None))
+    }
+}
+
+/// Materializes the format's fixed template image.
+///
+/// Same placement as [`materialize`], but the buffer is known to be the same
+/// on every iteration, so only its non-zero pages are written. That is what
+/// makes an operation target over a multi megabyte image affordable: see
+/// [`crate::disk_engine::image::template_memfd`].
+///
+/// The buffer is `'static` because the page map cache holds onto its
+/// identity: see [`crate::disk_engine::image::template_memfd`]. Every
+/// template comes out of a `OnceLock`, so this costs nothing.
+fn materialize_template<F: DiskFormat>(
+    bytes: &'static [u8],
+) -> std::io::Result<(std::fs::File, Option<PathBuf>)> {
+    if F::NEEDS_PATH {
+        let (file, path) = template_file(F::NAME, bytes)?;
+        Ok((file, Some(path)))
+    } else {
+        Ok((template_memfd(F::NAME, bytes)?, None))
     }
 }
 

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -36,6 +36,7 @@
 
 mod executor;
 mod format;
+pub mod formats;
 mod image;
 mod model;
 mod program;

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -15,4 +15,7 @@
 //!
 
 mod format;
+mod image;
+
 pub use crate::disk_engine::format::{DiskFormat, OpenConfig};
+pub use crate::disk_engine::image::{image_file, image_memfd, scratch_dir};

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -45,6 +45,7 @@ pub mod formats;
 mod image;
 mod model;
 mod program;
+pub mod sandbox;
 
 use std::collections::{HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -33,6 +33,11 @@
 //! format can open. It gets its own target, [`fuzz_detect`], whose input
 //! space is "any image of any format".
 //!
+//! Backing chains are not part of either family either. A qcow2 image names
+//! its backing file by path, so the harness has to sandbox the filesystem
+//! before the engine sees it, and the input is two images rather than one.
+//! That lives in [`formats::qcow2_chain`], behind `disk_qcow2_chain`.
+//!
 //! # Adding a format
 //!
 //! Implement [`DiskFormat`] for the new format, then add two targets that call

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -51,6 +51,8 @@ mod image;
 mod model;
 mod program;
 pub mod sandbox;
+#[cfg(test)]
+mod selftest;
 
 use std::collections::{HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -1,0 +1,18 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Format agnostic fuzzing framework for the disk image engine.
+//!
+//! # Fuzzed boundary
+//!
+//! The disk image engine is everything between the point where untrusted
+//! image bytes are parsed ([`block::factory::open_disk`] and the per format
+//! constructors) and the trait contract the rest of the VMM consumes
+//! ([`block::disk_file::AsyncFullDiskFile`] and [`block::async_io::AsyncIo`]).
+//! Virtio request parsing sits above that line and is fuzzed by the `block`
+//! target instead.
+//!
+
+mod format;
+pub use crate::disk_engine::format::{DiskFormat, OpenConfig};

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -17,11 +17,13 @@
 mod executor;
 mod format;
 mod image;
+mod model;
 mod program;
 
 pub use crate::disk_engine::executor::Executor;
 pub use crate::disk_engine::format::{DiskFormat, OpenConfig};
 pub use crate::disk_engine::image::{image_file, image_memfd, scratch_dir};
+pub use crate::disk_engine::model::Model;
 pub use crate::disk_engine::program::{
     default_program, Op, OpLen, OpOffset, Program, MAX_OPS, MAX_OP_LEN,
 };

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -41,7 +41,10 @@ mod image;
 mod model;
 mod program;
 
+use std::collections::{HashMap, HashSet};
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::PathBuf;
+use std::sync::Mutex;
 
 use libfuzzer_sys::Corpus;
 
@@ -53,6 +56,63 @@ pub use crate::disk_engine::program::{
     default_program, Op, OpLen, OpOffset, Program, MAX_OPS, MAX_OP_LEN,
 };
 
+/// How many distinct inputs that fail [`DiskFormat::magic_ok`] a process
+/// keeps per length class.
+///
+/// Rejecting all of them would be wrong: a parser does real work before it
+/// looks at the magic. `VhdFooter::new` queries the device size, does the
+/// length arithmetic that finds the footer and computes the footer checksum,
+/// and `VhdxHeader::new` reads and checksums both headers, all before the
+/// signature test, and those paths are reached only by inputs that then fail
+/// it. Measured per region on the campaign corpora, dropping every non magic
+/// input loses 7 regions in `block` for `disk_vhd`, 3 for `disk_vhdx`, 9 for
+/// `disk_vmdk` and 2 for `disk_qcow2`, so the budget is what keeps those
+/// paths alive.
+const NON_MAGIC_BUDGET: usize = 8;
+
+/// Length class of an input, used to spread [`NON_MAGIC_BUDGET`] over input
+/// sizes rather than over arrival order.
+///
+/// A flat budget is not enough. What the code in front of a magic check
+/// branches on is the length: `FileTypeIdentifier::new` fails its eight byte
+/// read (block/src/formats/vhdx/header.rs:99) and the VMDK descriptor reader
+/// refuses a file shorter than four bytes
+/// (block/src/formats/vmdk/descriptor.rs:83) only for inputs far smaller than
+/// anything else in the corpus. A first come first served budget fills up
+/// with megabyte sized rejects and those regions go uncovered, which is
+/// measurable: a flat budget of 64 still lost exactly those two regions on
+/// the campaign corpora. Bucketing by binary magnitude keeps one of every
+/// size.
+fn length_class(len: usize) -> u32 {
+    usize::BITS - len.leading_zeros()
+}
+
+/// Decides whether an input that failed the magic check is worth keeping.
+///
+/// The budget is per process, per target and per length class, which is all
+/// libFuzzer needs: the point is to stop an unbounded number of near
+/// identical rejects from accumulating, not to pick the best ones.
+fn keep_non_magic(bytes: &[u8]) -> Corpus {
+    static SEEN: Mutex<Option<HashMap<u32, HashSet<u64>>>> = Mutex::new(None);
+
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    let digest = hasher.finish();
+
+    let Ok(mut guard) = SEEN.lock() else {
+        return Corpus::Reject;
+    };
+    let seen = guard
+        .get_or_insert_with(HashMap::new)
+        .entry(length_class(bytes.len()))
+        .or_default();
+    if seen.len() < NON_MAGIC_BUDGET && seen.insert(digest) {
+        Corpus::Keep
+    } else {
+        Corpus::Reject
+    }
+}
+
 /// Fuzzes the format parsers with `bytes` as the complete disk image.
 ///
 /// The image is materialized in a memfd, opened through the format adapter,
@@ -60,6 +120,13 @@ pub use crate::disk_engine::program::{
 /// executor runs without the shadow model and only checks the invariants that
 /// hold for any image (completion accounting, reported byte counts, stable
 /// reported size).
+///
+/// An input that does not carry the format's identifying bytes is still
+/// opened, so the code in front of the magic check stays covered, but it is
+/// only retained while the [`NON_MAGIC_BUDGET`] for its length class lasts. Without that, the corpus
+/// drowns in inputs that can never reach the parser: measured on a campaign
+/// corpus, 634 of the 666 disk_vhd rejections were the `conectix` cookie
+/// alone, and only 6 of 764 entries, 0.8%, opened at all.
 pub fn fuzz_image<F: DiskFormat>(bytes: &[u8]) -> Corpus {
     if bytes.len() > F::MAX_IMAGE_LEN {
         return Corpus::Reject;
@@ -76,15 +143,23 @@ pub fn fuzz_image<F: DiskFormat>(bytes: &[u8]) -> Corpus {
         let _ = block::detect_image_type(&mut probe);
     }
 
+    // The magic check is on the harness side, but the open is not: the
+    // parser's own rejection path is part of what this target fuzzes.
+    let verdict = if F::magic_ok(bytes) {
+        Corpus::Keep
+    } else {
+        keep_non_magic(bytes)
+    };
+
     let Ok(disk) = F::open(file, path.as_deref(), &OpenConfig::default()) else {
-        return Corpus::Keep;
+        return verdict;
     };
 
     if let Some(mut executor) = Executor::<F>::new(disk, 1, false) {
         executor.run(&default_program());
     }
 
-    Corpus::Keep
+    verdict
 }
 
 /// Fuzzes the engine op handling with an arbitrary program.
@@ -125,5 +200,38 @@ fn materialize<F: DiskFormat>(bytes: &[u8]) -> std::io::Result<(std::fs::File, O
         Ok((file, Some(path)))
     } else {
         Ok((image_memfd(F::NAME, bytes)?, None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn length_classes_separate_magnitudes() {
+        assert_eq!(length_class(0), 0);
+        assert_eq!(length_class(1), 1);
+        assert_eq!(length_class(511), length_class(300));
+        assert_ne!(length_class(511), length_class(512));
+    }
+
+    // The budget has to be per length class: a run that sees a megabyte of
+    // rejects first must still keep the tiny inputs that reach the length
+    // checks in front of a magic check.
+    #[test]
+    fn the_non_magic_budget_is_per_length_class() {
+        let kept = |bytes: &[u8]| matches!(keep_non_magic(bytes), Corpus::Keep);
+
+        // Fill one class.
+        for i in 0..NON_MAGIC_BUDGET {
+            assert!(kept(&[i as u8; 4096]), "input {i} of the budget");
+        }
+        assert!(!kept(&[0xaa; 4096]), "the class budget is spent");
+        // A repeat of an input already seen is not kept either.
+        assert!(!kept(&[0u8; 4096]));
+
+        // A different magnitude has its own budget.
+        assert!(kept(b"1"), "a one byte input is a different class");
+        assert!(kept(b"12"));
     }
 }

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -243,6 +243,10 @@ pub fn fuzz_program<F: DiskFormat>(program: &Program) -> Corpus {
     let Some(mut executor) = Executor::<F>::new(disk, program.ring_depth(), true) else {
         return Corpus::Reject;
     };
+    // A sweep is only worth its I/O against a template with more metadata
+    // tables than the engine caches; against any other it is up to 384 I/Os
+    // that revisit one table.
+    executor.set_sweeps(F::sweeps_metadata_cache(program.template));
     executor.run(program.ops());
 
     Corpus::Keep

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -215,8 +215,12 @@ pub fn fuzz_detect(bytes: &[u8]) -> Corpus {
 /// Only formats that build a template in process can be fuzzed this way, so
 /// a missing template is a harness error rather than a finding.
 pub fn fuzz_program<F: DiskFormat>(program: &Program) -> Corpus {
-    let template =
-        F::template().unwrap_or_else(|| panic!("{}: format has no template image", F::NAME));
+    // Both halves of the merge matter: the variant picks WHICH template (the
+    // small-cluster one is the only one whose L2 cache can overflow), and the
+    // template materializer skips the zero pages so an 8 MiB image does not
+    // cost a full copy per iteration.
+    let template = F::template_variant(program.template)
+        .unwrap_or_else(|| panic!("{}: format has no template image", F::NAME));
     let Ok((file, path)) = materialize_template::<F>(template) else {
         return Corpus::Reject;
     };

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -28,6 +28,11 @@
 //!   model of the disk contents and check read back data. This targets the
 //!   offset translation, allocation and sparse handling logic.
 //!
+//! Format sniffing is not part of either family: it accepts every byte
+//! string, so a corpus driven by it fills up with inputs that no single
+//! format can open. It gets its own target, [`fuzz_detect`], whose input
+//! space is "any image of any format".
+//!
 //! # Adding a format
 //!
 //! Implement [`DiskFormat`] for the new format, then add two targets that call
@@ -136,13 +141,6 @@ pub fn fuzz_image<F: DiskFormat>(bytes: &[u8]) -> Corpus {
         return Corpus::Reject;
     };
 
-    // Cover the format sniffing path with the same bytes. The result is not
-    // asserted: the target forces its own format so that malformed images
-    // still reach the parser under test.
-    if let Ok(mut probe) = file.try_clone() {
-        let _ = block::detect_image_type(&mut probe);
-    }
-
     // The magic check is on the harness side, but the open is not: the
     // parser's own rejection path is part of what this target fuzzes.
     let verdict = if F::magic_ok(bytes) {
@@ -160,6 +158,43 @@ pub fn fuzz_image<F: DiskFormat>(bytes: &[u8]) -> Corpus {
     }
 
     verdict
+}
+
+/// Largest input [`fuzz_detect`] hands to the sniffer.
+///
+/// The sniffer only ever reads the first alignment sized block and, for the
+/// VHD and VMDK probes, the tail of the file, so a large input costs the
+/// materialization and buys nothing. The cap is the largest
+/// [`DiskFormat::MAX_IMAGE_LEN`] in the tree so that a real image of any
+/// supported format still fits.
+const MAX_DETECT_LEN: usize = 16 << 20;
+
+/// Fuzzes the image type sniffer with `bytes` as the complete image.
+///
+/// [`block::detect_image_type`] is what `factory::open_disk` runs before any
+/// format specific parser, so it sees every byte string a guest owner can
+/// point the VMM at, and it is the one piece of the engine whose input space
+/// really is "anything". It used to be probed from [`fuzz_image`] with the
+/// same bytes, which made every `disk_<format>` corpus pay for it: an input
+/// that can never open as VHDX still found new edges in the qcow2, VHD and
+/// VMDK sniffers and was kept in the `disk_vhdx` corpus forever. Measured on
+/// a campaign corpus, 717 of 872 `disk_vhdx` entries failed the eight byte
+/// `vhdxfile` signature yet persisted. Sniffing therefore gets its own
+/// target, seeded with images of every format.
+pub fn fuzz_detect(bytes: &[u8]) -> Corpus {
+    if bytes.len() > MAX_DETECT_LEN {
+        return Corpus::Reject;
+    }
+
+    let Ok(mut file) = image_memfd("detect", bytes) else {
+        return Corpus::Reject;
+    };
+
+    // The result is not asserted: a sniffer answer is only a guess, and every
+    // answer including `Raw` is a legitimate one for arbitrary bytes.
+    let _ = block::detect_image_type(&mut file);
+
+    Corpus::Keep
 }
 
 /// Fuzzes the engine op handling with an arbitrary program.

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -16,6 +16,10 @@
 
 mod format;
 mod image;
+mod program;
 
 pub use crate::disk_engine::format::{DiskFormat, OpenConfig};
 pub use crate::disk_engine::image::{image_file, image_memfd, scratch_dir};
+pub use crate::disk_engine::program::{
+    default_program, Op, OpLen, OpOffset, Program, MAX_OPS, MAX_OP_LEN,
+};

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -13,12 +13,36 @@
 //! Virtio request parsing sits above that line and is fuzzed by the `block`
 //! target instead.
 //!
+//! # Target families
+//!
+//! Each format gets two targets so that every target has one coherent,
+//! mutation friendly input space:
+//!
+//! - `disk_<format>` calls [`fuzz_image`]: the whole input is the image, and
+//!   a fixed op program runs against whatever the engine made of it. Corpus
+//!   entries are real disk images, so `qemu-img` output can be dropped in
+//!   unmodified. This targets the parsers.
+//! - `disk_<format>_ops` calls [`fuzz_program`]: the image is a valid
+//!   template built by the format adapter and the input is an arbitrary op
+//!   program. Because the image is well formed, the executor can run a shadow
+//!   model of the disk contents and check read back data. This targets the
+//!   offset translation, allocation and sparse handling logic.
+//!
+//! # Adding a format
+//!
+//! Implement [`DiskFormat`] for the new format, then add two targets that call
+//! [`fuzz_image`] and [`fuzz_program`] with the new adapter. Nothing else in
+//! the framework is format specific.
 
 mod executor;
 mod format;
 mod image;
 mod model;
 mod program;
+
+use std::path::PathBuf;
+
+use libfuzzer_sys::Corpus;
 
 pub use crate::disk_engine::executor::Executor;
 pub use crate::disk_engine::format::{DiskFormat, OpenConfig};
@@ -27,3 +51,78 @@ pub use crate::disk_engine::model::Model;
 pub use crate::disk_engine::program::{
     default_program, Op, OpLen, OpOffset, Program, MAX_OPS, MAX_OP_LEN,
 };
+
+/// Fuzzes the format parsers with `bytes` as the complete disk image.
+///
+/// The image is materialized in a memfd, opened through the format adapter,
+/// and driven with [`default_program`]. Contents are unknown, so the
+/// executor runs without the shadow model and only checks the invariants that
+/// hold for any image (completion accounting, reported byte counts, stable
+/// reported size).
+pub fn fuzz_image<F: DiskFormat>(bytes: &[u8]) -> Corpus {
+    if bytes.len() > F::MAX_IMAGE_LEN {
+        return Corpus::Reject;
+    }
+
+    let Ok((file, path)) = materialize::<F>(bytes) else {
+        return Corpus::Reject;
+    };
+
+    // Cover the format sniffing path with the same bytes. The result is not
+    // asserted: the target forces its own format so that malformed images
+    // still reach the parser under test.
+    if let Ok(mut probe) = file.try_clone() {
+        let _ = block::detect_image_type(&mut probe);
+    }
+
+    let Ok(disk) = F::open(file, path.as_deref(), &OpenConfig::default()) else {
+        return Corpus::Keep;
+    };
+
+    if let Some(mut executor) = Executor::<F>::new(disk, 1, false) {
+        executor.run(&default_program());
+    }
+
+    Corpus::Keep
+}
+
+/// Fuzzes the engine op handling with an arbitrary program.
+///
+/// The image is the format adapter's valid template, so the executor runs
+/// with the shadow model enabled and read back data is checked against it.
+///
+/// Only formats that build a template in process can be fuzzed this way, so
+/// a missing template is a harness error rather than a finding.
+pub fn fuzz_program<F: DiskFormat>(program: &Program) -> Corpus {
+    let template =
+        F::template().unwrap_or_else(|| panic!("{}: format has no template image", F::NAME));
+    let Ok((file, path)) = materialize::<F>(template) else {
+        return Corpus::Reject;
+    };
+
+    // A template that does not open means the adapter is broken, which is a
+    // harness bug rather than a finding, so fail loudly.
+    let disk = F::open(file, path.as_deref(), &program.open)
+        .unwrap_or_else(|e| panic!("{}: template image failed to open: {e}", F::NAME));
+
+    let Some(mut executor) = Executor::<F>::new(disk, program.ring_depth(), true) else {
+        return Corpus::Reject;
+    };
+    executor.run(program.ops());
+
+    Corpus::Keep
+}
+
+/// Materializes an image the way the format needs it.
+///
+/// Most formats get a memfd, which keeps an iteration off the filesystem. A
+/// format that resolves sibling files relative to the image gets a real file
+/// in a scratch directory instead.
+fn materialize<F: DiskFormat>(bytes: &[u8]) -> std::io::Result<(std::fs::File, Option<PathBuf>)> {
+    if F::NEEDS_PATH {
+        let (file, path) = image_file(F::NAME, bytes)?;
+        Ok((file, Some(path)))
+    } else {
+        Ok((image_memfd(F::NAME, bytes)?, None))
+    }
+}

--- a/fuzz/src/disk_engine/mod.rs
+++ b/fuzz/src/disk_engine/mod.rs
@@ -14,10 +14,12 @@
 //! target instead.
 //!
 
+mod executor;
 mod format;
 mod image;
 mod program;
 
+pub use crate::disk_engine::executor::Executor;
 pub use crate::disk_engine::format::{DiskFormat, OpenConfig};
 pub use crate::disk_engine::image::{image_file, image_memfd, scratch_dir};
 pub use crate::disk_engine::program::{

--- a/fuzz/src/disk_engine/model.rs
+++ b/fuzz/src/disk_engine/model.rs
@@ -1,0 +1,106 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shadow model of the disk contents.
+//!
+//! The model tracks what the guest visible contents of the disk must be after
+//! the ops the executor has run so far. It is only usable when the fuzzer
+//! starts from a valid template image whose contents are known, so the image
+//! parsing targets run without it.
+//!
+//! Every byte is either known, and then the model holds its value, or
+//! unknown, and then it is skipped when read back data is checked. Ops that
+//! only partially succeed, or whose effect on the contents is not guaranteed
+//! by the format, mark their range unknown rather than guessing.
+
+/// Known contents of a disk, byte by byte.
+pub struct Model {
+    data: Vec<u8>,
+    unknown: Vec<bool>,
+}
+
+impl Model {
+    /// Creates a model of a freshly created image of `size` bytes, which
+    /// reads back as all zeroes.
+    pub fn new(size: usize) -> Self {
+        Self {
+            data: vec![0; size],
+            unknown: vec![false; size],
+        }
+    }
+
+    /// Returns the modelled disk size in bytes.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Records a write of `bytes` at `offset`.
+    pub fn record_write(&mut self, offset: u64, bytes: &[u8]) {
+        let Some(range) = self.range(offset, bytes.len()) else {
+            return;
+        };
+        let written = range.end - range.start;
+        self.data[range.clone()].copy_from_slice(&bytes[..written]);
+        self.unknown[range].fill(false);
+    }
+
+    /// Records that `len` bytes at `offset` now read back as zeroes.
+    pub fn record_zeroes(&mut self, offset: u64, len: usize) {
+        let Some(range) = self.range(offset, len) else {
+            return;
+        };
+        self.data[range.clone()].fill(0);
+        self.unknown[range].fill(false);
+    }
+
+    /// Records that the contents of `len` bytes at `offset` are no longer
+    /// predictable.
+    pub fn record_unknown(&mut self, offset: u64, len: usize) {
+        let Some(range) = self.range(offset, len) else {
+            return;
+        };
+        self.unknown[range].fill(true);
+    }
+
+    /// Checks read back `bytes` from `offset` against the model.
+    ///
+    /// Returns a description of the first mismatch, if any.
+    pub fn check(&self, offset: u64, bytes: &[u8]) -> Result<(), String> {
+        let Some(range) = self.range(offset, bytes.len()) else {
+            return Ok(());
+        };
+
+        for (i, index) in range.enumerate() {
+            if self.unknown[index] {
+                continue;
+            }
+            if bytes[i] != self.data[index] {
+                return Err(format!(
+                    "offset {} byte {i}: read {:#04x}, model {:#04x}",
+                    offset, bytes[i], self.data[index]
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Resizes the model, dropping all knowledge of the contents.
+    pub fn resize(&mut self, size: usize) {
+        self.data.clear();
+        self.data.resize(size, 0);
+        self.unknown.clear();
+        self.unknown.resize(size, true);
+    }
+
+    /// Clips `offset` and `len` to the modelled range.
+    fn range(&self, offset: u64, len: usize) -> Option<std::ops::Range<usize>> {
+        let start = usize::try_from(offset).ok()?;
+        if start >= self.data.len() || len == 0 {
+            return None;
+        }
+        let end = start.saturating_add(len).min(self.data.len());
+        Some(start..end)
+    }
+}

--- a/fuzz/src/disk_engine/program.rs
+++ b/fuzz/src/disk_engine/program.rs
@@ -98,6 +98,8 @@ pub enum Op {
 pub struct Program {
     /// How the image is opened.
     pub open: OpenConfig,
+    /// Which of the format's template images to run against.
+    pub template: u8,
     /// Ring depth for the first I/O engine.
     pub ring_depth: u8,
     /// Ops to execute, truncated to [`MAX_OPS`].

--- a/fuzz/src/disk_engine/program.rs
+++ b/fuzz/src/disk_engine/program.rs
@@ -11,6 +11,31 @@ use crate::disk_engine::format::OpenConfig;
 /// Largest number of ops executed from one program.
 pub const MAX_OPS: usize = 64;
 
+/// Bytes covered by one L2 table of the small cluster qcow2 template.
+///
+/// A program that means to press on the L2 cache has to touch tables, not
+/// clusters, so the stride it walks with is the span of a table.
+const L2_SPAN: u64 = crate::disk_engine::formats::qcow2::SMALL_L2_SPAN;
+
+/// Largest number of L2 tables one [`Op::Sweep`] walks.
+///
+/// The qcow2 L2 cache holds 100 tables, so a sweep has to be able to touch
+/// more than that in a single op: with [`MAX_OPS`] at 64, no program made of
+/// ordinary ops can reach 101 distinct tables however its offsets are
+/// chosen.
+///
+/// It stays at 192 even though the small cluster template has only 128 L2
+/// tables, so a longer sweep wraps onto tables it has already walked.
+/// Lowering it to 128 to remove those repeats was measured and made the
+/// target *slower*: 20 000 executions of `disk_qcow2_ops` fell from 307 to
+/// 273 exec/s, and a replay of a fixed 1080 entry corpus rose from 11.1s to
+/// 13.5s. A repeat is cheap - the table is already cached and the cluster
+/// already allocated - while a *distinct* table costs an allocation and an
+/// eviction, and `tables % MAX_SWEEP` maps a whole range of inputs onto
+/// short sweeps only while the modulus exceeds the table count. Wrapping is
+/// therefore where the cheap inputs come from, not waste.
+const MAX_SWEEP: u64 = 192;
+
 /// Largest byte count for a single data op.
 ///
 /// This also sizes the guest memory region shared by all guest memory ops.
@@ -91,6 +116,25 @@ pub enum Op {
     UseClone { ring_depth: u8 },
     /// Query every capability trait.
     QueryCaps,
+    /// Write one sector into each of a run of consecutive L2 tables.
+    ///
+    /// The engine caches 100 L2 tables and writes a dirty one back when it
+    /// evicts it, so nothing evicts until a program has more tables live
+    /// than the cache holds. One op that strides table by table is what
+    /// reaches that, and because every write is recorded in the shadow
+    /// model, a table written back to the wrong place, or not written back
+    /// at all, turns into a read back mismatch rather than silence.
+    Sweep { first: u8, tables: u8, seed: u8 },
+}
+
+impl Op {
+    /// Returns the offsets and byte count one [`Op::Sweep`] writes.
+    pub fn sweep_offsets(first: u8, tables: u8, size: u64) -> impl Iterator<Item = u64> {
+        let size = size.max(1);
+        let count = u64::from(tables) % MAX_SWEEP + 1;
+        let first = u64::from(first);
+        (0..count).map(move |i| (first + i) * L2_SPAN % size)
+    }
 }
 
 /// An open configuration plus the ops to run against it.
@@ -196,4 +240,42 @@ pub fn default_program() -> Vec<Op> {
         Op::Fsync { completion: false },
         Op::QueryCaps,
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The qcow2 L2 cache holds 100 tables, so a sweep is only worth having
+    // if one op can touch more than that; and every offset it names has to
+    // be the start of a distinct table, or it presses on the cache far less
+    // than it appears to.
+    #[test]
+    fn a_sweep_can_outrun_the_l2_cache() {
+        let size = 4 << 20;
+        let offsets: Vec<u64> = Op::sweep_offsets(0, 191, size).collect();
+        assert_eq!(offsets.len(), 192);
+
+        let distinct: std::collections::BTreeSet<u64> = offsets.iter().copied().collect();
+        assert!(
+            distinct.len() > 100,
+            "{} distinct tables, the cache holds 100",
+            distinct.len()
+        );
+        for offset in offsets {
+            assert!(offset < size, "offset {offset} is outside the disk");
+            assert_eq!(offset % L2_SPAN, 0, "offset {offset} is not table aligned");
+        }
+    }
+
+    // A sweep must stay inside the disk whatever the fuzzer names, including
+    // a disk far smaller than one table.
+    #[test]
+    fn a_sweep_stays_inside_the_disk() {
+        for size in [1, 512, 4096, L2_SPAN, 1 << 20] {
+            for offset in Op::sweep_offsets(u8::MAX, u8::MAX, size) {
+                assert!(offset < size.max(1), "size {size}, offset {offset}");
+            }
+        }
+    }
 }

--- a/fuzz/src/disk_engine/program.rs
+++ b/fuzz/src/disk_engine/program.rs
@@ -1,0 +1,197 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Op program driven against the disk image engine.
+
+use arbitrary::Arbitrary;
+
+use crate::disk_engine::format::OpenConfig;
+
+/// Largest number of ops executed from one program.
+pub const MAX_OPS: usize = 64;
+
+/// Largest byte count for a single data op.
+///
+/// This also sizes the guest memory region shared by all guest memory ops.
+pub const MAX_OP_LEN: usize = 64 << 10;
+
+/// A disk offset selected by the fuzzer.
+///
+/// The in range variants keep offsets inside the disk, where the interesting
+/// translation logic lives, while [`OpOffset::Wild`] reaches the overflow and
+/// out of bounds checks.
+#[derive(Arbitrary, Clone, Copy, Debug)]
+pub enum OpOffset {
+    /// Sector index, wrapped into the reported size.
+    Sector(u16),
+    /// Byte offset, wrapped into the reported size.
+    Byte(u32),
+    /// Position at `size * n / 256`, so a program can name the middle or the
+    /// tail of a disk of any size.
+    Fraction(u8),
+    /// Offset used unmodified, including values that do not fit an `off_t`.
+    Wild(u64),
+}
+
+impl OpOffset {
+    /// Resolves the offset against a disk of `size` bytes.
+    pub fn resolve(self, size: u64) -> u64 {
+        let size = size.max(1);
+        match self {
+            OpOffset::Sector(sector) => (u64::from(sector) * 512) % size,
+            OpOffset::Byte(offset) => u64::from(offset) % size,
+            OpOffset::Fraction(n) => size / 256 * u64::from(n),
+            OpOffset::Wild(offset) => offset,
+        }
+    }
+}
+
+/// A byte count for a data op, capped at [`MAX_OP_LEN`].
+#[derive(Arbitrary, Clone, Copy, Debug)]
+pub struct OpLen(pub u16);
+
+impl OpLen {
+    /// Returns the capped byte count.
+    pub fn get(self) -> usize {
+        usize::from(self.0).min(MAX_OP_LEN)
+    }
+}
+
+/// One operation on the engine.
+#[derive(Arbitrary, Clone, Debug)]
+pub enum Op {
+    /// Read into an owned host buffer.
+    ReadVec { offset: OpOffset, len: OpLen },
+    /// Write from an owned host buffer.
+    WriteVec {
+        offset: OpOffset,
+        len: OpLen,
+        seed: u8,
+    },
+    /// Read into guest memory.
+    ReadMem { offset: OpOffset, len: OpLen },
+    /// Write from guest memory.
+    WriteMem {
+        offset: OpOffset,
+        len: OpLen,
+        seed: u8,
+    },
+    /// Discard a range, dropping its allocation.
+    PunchHole { offset: OpOffset, len: OpLen },
+    /// Zero a range, possibly through a metadata flag.
+    WriteZeroes { offset: OpOffset, len: OpLen },
+    /// Flush, with or without asking for a completion.
+    Fsync { completion: bool },
+    /// Resize the disk, in KiB, capped by the executor.
+    Resize { size_kib: u16 },
+    /// Replace the I/O engine with a freshly created one.
+    RecreateIo { ring_depth: u8 },
+    /// Continue on an I/O engine created from a cloned disk handle.
+    UseClone { ring_depth: u8 },
+    /// Query every capability trait.
+    QueryCaps,
+}
+
+/// An open configuration plus the ops to run against it.
+#[derive(Arbitrary, Debug)]
+pub struct Program {
+    /// How the image is opened.
+    pub open: OpenConfig,
+    /// Ring depth for the first I/O engine.
+    pub ring_depth: u8,
+    /// Ops to execute, truncated to [`MAX_OPS`].
+    pub ops: Vec<Op>,
+}
+
+impl Program {
+    /// Returns the ops to execute.
+    pub fn ops(&self) -> &[Op] {
+        let len = self.ops.len().min(MAX_OPS);
+        &self.ops[..len]
+    }
+
+    /// Returns a usable ring depth.
+    pub fn ring_depth(&self) -> u32 {
+        ring_depth(self.ring_depth)
+    }
+}
+
+/// Maps a fuzzer byte to a ring depth accepted by the engine.
+pub fn ring_depth(raw: u8) -> u32 {
+    u32::from(raw) % 64 + 1
+}
+
+/// The fixed program run by the image parsing targets.
+///
+/// It walks the whole capability surface once with a bounded amount of I/O:
+/// reads at the start, middle and tail, writes and read backs, both sparse
+/// ops, a flush, a clone, a resize, and finally offsets that no image can
+/// satisfy.
+pub fn default_program() -> Vec<Op> {
+    vec![
+        Op::QueryCaps,
+        Op::ReadVec {
+            offset: OpOffset::Byte(0),
+            len: OpLen(4096),
+        },
+        Op::ReadVec {
+            offset: OpOffset::Fraction(128),
+            len: OpLen(65535),
+        },
+        Op::ReadMem {
+            offset: OpOffset::Fraction(255),
+            len: OpLen(512),
+        },
+        Op::WriteVec {
+            offset: OpOffset::Byte(0),
+            len: OpLen(4096),
+            seed: 0xa5,
+        },
+        Op::WriteMem {
+            offset: OpOffset::Fraction(128),
+            len: OpLen(8192),
+            seed: 0x5a,
+        },
+        Op::Fsync { completion: true },
+        Op::ReadVec {
+            offset: OpOffset::Byte(0),
+            len: OpLen(4096),
+        },
+        Op::WriteZeroes {
+            offset: OpOffset::Fraction(128),
+            len: OpLen(8192),
+        },
+        Op::PunchHole {
+            offset: OpOffset::Fraction(64),
+            len: OpLen(8192),
+        },
+        Op::ReadVec {
+            offset: OpOffset::Fraction(64),
+            len: OpLen(8192),
+        },
+        Op::UseClone { ring_depth: 16 },
+        Op::ReadVec {
+            offset: OpOffset::Sector(1),
+            len: OpLen(512),
+        },
+        Op::Resize { size_kib: 4096 },
+        Op::WriteVec {
+            offset: OpOffset::Fraction(255),
+            len: OpLen(512),
+            seed: 0x3c,
+        },
+        Op::RecreateIo { ring_depth: 1 },
+        Op::ReadVec {
+            offset: OpOffset::Wild(u64::MAX - 511),
+            len: OpLen(512),
+        },
+        Op::WriteVec {
+            offset: OpOffset::Wild(1 << 63),
+            len: OpLen(512),
+            seed: 0xff,
+        },
+        Op::Fsync { completion: false },
+        Op::QueryCaps,
+    ]
+}

--- a/fuzz/src/disk_engine/sandbox.rs
+++ b/fuzz/src/disk_engine/sandbox.rs
@@ -1,0 +1,368 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Process level filesystem confinement for the backing chain target.
+//!
+//! # Why a second belt
+//!
+//! A qcow2 image names its backing file by path, and the engine resolves a
+//! relative name against the directory of the image that stores it
+//! (block/src/formats/qcow/parser.rs:317) with a plain `Path::join`, which
+//! follows `..` straight out of that directory, and then opens it with
+//! `OpenOptions::read` (block/src/formats/qcow/parser.rs:192). Unlike the
+//! VMDK extent path, the engine takes no `openat2` `RESOLVE_BENEATH`
+//! precaution: qcow2 backing files are opt in and `docs/threat-model.md`
+//! declares them trusted, and qemu does not confine them either. The harness
+//! side name guard in
+//! [`crate::disk_engine::formats::qcow2_chain::Qcow2Chain`] is therefore the
+//! only thing standing between a corpus entry and an arbitrary host path,
+//! with no kernel backstop behind it.
+//!
+//! One guard for a whole class of file disclosure is one too few, so the
+//! target also confines the process itself with Landlock before the first
+//! iteration. A bug in the name guard then costs a denied `open` rather than
+//! the contents of a host file.
+//!
+//! # Why not a namespace
+//!
+//! `unshare` plus `pivot_root` would be a tighter jail, but it breaks the
+//! ASan symbolizer and the OSS-Fuzz runner, both of which need the paths
+//! they were started with. Landlock restricts the existing mount namespace
+//! in place, survives `execve`, and needs no privilege.
+//!
+//! # Fail closed
+//!
+//! Every step is checked, and the whole target refuses to run with backing
+//! files enabled when any of them fails, including the `ENOSYS` and
+//! `EOPNOTSUPP` of a kernel built without Landlock. Raw syscalls rather than
+//! a crate, so that the fuzzer gains no dependency for 150 lines of ABI.
+
+use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// `LANDLOCK_CREATE_RULESET_VERSION`, which asks for the supported ABI
+/// version instead of creating a ruleset.
+const CREATE_RULESET_VERSION: u32 = 1;
+
+/// `LANDLOCK_RULE_PATH_BENEATH`.
+const RULE_PATH_BENEATH: libc::c_int = 1;
+
+const ACCESS_EXECUTE: u64 = 1 << 0;
+const ACCESS_WRITE_FILE: u64 = 1 << 1;
+const ACCESS_READ_FILE: u64 = 1 << 2;
+const ACCESS_READ_DIR: u64 = 1 << 3;
+const ACCESS_REMOVE_DIR: u64 = 1 << 4;
+const ACCESS_REMOVE_FILE: u64 = 1 << 5;
+const ACCESS_MAKE_DIR: u64 = 1 << 7;
+const ACCESS_MAKE_REG: u64 = 1 << 8;
+const ACCESS_MAKE_SYM: u64 = 1 << 12;
+const ACCESS_REFER: u64 = 1 << 13;
+const ACCESS_TRUNCATE: u64 = 1 << 14;
+
+/// Every filesystem access the first Landlock ABI knows about, bits 0 to 12.
+///
+/// An access the ruleset does not handle is allowed everywhere, so the
+/// handled set has to be as wide as the ABI allows for the rules to mean
+/// anything.
+const ACCESS_ABI1: u64 = (1 << 13) - 1;
+
+/// Accesses that apply to a regular file rather than to a directory.
+const ACCESS_FILE: u64 = ACCESS_EXECUTE | ACCESS_WRITE_FILE | ACCESS_READ_FILE | ACCESS_TRUNCATE;
+
+/// What the target may do inside a directory it owns.
+const ACCESS_READ: u64 = ACCESS_EXECUTE | ACCESS_READ_FILE | ACCESS_READ_DIR;
+const ACCESS_WRITE: u64 = ACCESS_READ
+    | ACCESS_WRITE_FILE
+    | ACCESS_REMOVE_DIR
+    | ACCESS_REMOVE_FILE
+    | ACCESS_MAKE_DIR
+    | ACCESS_MAKE_REG
+    | ACCESS_MAKE_SYM
+    | ACCESS_REFER
+    | ACCESS_TRUNCATE;
+
+/// `struct landlock_ruleset_attr`, ABI 1 layout.
+///
+/// Later ABIs append fields; the size is passed to the kernel, so the older
+/// layout stays valid and only asks for less.
+#[repr(C)]
+struct RulesetAttr {
+    handled_access_fs: u64,
+}
+
+/// `struct landlock_path_beneath_attr`, which the kernel header declares
+/// packed.
+#[repr(C, packed)]
+struct PathBeneathAttr {
+    allowed_access: u64,
+    parent_fd: i32,
+}
+
+/// Returns the Landlock ABI version, or `None` when the kernel has no
+/// Landlock at all.
+fn abi_version() -> Option<i32> {
+    // SAFETY: FFI call. A NULL attribute with the VERSION flag is the
+    // documented way to query the ABI and writes nothing.
+    let abi = unsafe {
+        libc::syscall(
+            libc::SYS_landlock_create_ruleset,
+            std::ptr::null::<RulesetAttr>(),
+            0usize,
+            CREATE_RULESET_VERSION,
+        )
+    };
+    (abi > 0).then_some(abi as i32)
+}
+
+/// The accesses an ABI of `version` can handle.
+fn handled_access(version: i32) -> u64 {
+    let mut handled = ACCESS_ABI1;
+    if version >= 2 {
+        handled |= ACCESS_REFER;
+    }
+    if version >= 3 {
+        handled |= ACCESS_TRUNCATE;
+    }
+    // ABI 5 adds LANDLOCK_ACCESS_FS_IOCTL_DEV, which is deliberately left
+    // unhandled: libFuzzer's terminal detection ioctls a tty, and denying
+    // those would change how the fuzzer reports rather than what the target
+    // can reach.
+    handled
+}
+
+/// Adds a `path beneath` rule granting `access` under `path`.
+///
+/// A path that does not exist is not an error: the rule list covers several
+/// distributions' library directories, and the fuzzer's own corpus and
+/// artifact directories, only some of which exist on any one host.
+///
+/// A rule on a file may only grant the accesses that apply to a file, so
+/// `access` is masked for one: asking for `READ_DIR` on /dev/null, or on a
+/// corpus entry named on the command line, is `EINVAL` rather than a wider
+/// rule, and a failed rule would take the whole confinement, and with it the
+/// target, down.
+fn add_rule(ruleset_fd: libc::c_int, path: &Path, access: u64) -> Result<(), ()> {
+    let Ok(cpath) = CString::new(path.as_os_str().as_bytes()) else {
+        return Ok(());
+    };
+    let access = if path.is_dir() {
+        access
+    } else {
+        access & ACCESS_FILE
+    };
+    // SAFETY: FFI call with a NUL terminated path. O_PATH opens the name
+    // without granting any access to its contents.
+    let fd = unsafe { libc::open(cpath.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
+    if fd < 0 {
+        return Ok(());
+    }
+
+    let attr = PathBeneathAttr {
+        allowed_access: access,
+        parent_fd: fd,
+    };
+    // SAFETY: FFI call with a correctly sized rule attribute for the
+    // PATH_BENEATH rule type and a live descriptor.
+    let rc = unsafe {
+        libc::syscall(
+            libc::SYS_landlock_add_rule,
+            ruleset_fd,
+            RULE_PATH_BENEATH,
+            &attr as *const PathBeneathAttr,
+            0u32,
+        )
+    };
+    // SAFETY: FFI call closing a descriptor this function owns.
+    unsafe { libc::close(fd) };
+
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
+/// Directories the fuzzer itself needs, beyond the scratch directory.
+///
+/// libFuzzer reads a corpus entry from disk between iterations and writes a
+/// crash artifact after one, so the confinement has to survive its own
+/// bookkeeping or the target reports nothing. The corpus and artifact
+/// directories are named on the command line, so they are read off there,
+/// together with the working directory `cargo fuzz` passes them relative to.
+fn fuzzer_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        paths.push(cwd);
+    }
+    for arg in std::env::args().skip(1) {
+        // -artifact_prefix=<path> and friends carry the path after '='.
+        let value = arg.split_once('=').map_or(arg.as_str(), |(_, v)| v);
+        let path = Path::new(value);
+        if path.is_absolute() && path.exists() {
+            paths.push(path.to_path_buf());
+        }
+    }
+    paths
+}
+
+/// Confines this process to `scratch` plus what the runtime needs.
+fn restrict(scratch: &Path) -> Result<(), ()> {
+    // Landlock needs no privilege, but it does need no_new_privs.
+    // SAFETY: FFI call with the documented argument count.
+    if unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } != 0 {
+        return Err(());
+    }
+
+    let version = abi_version().ok_or(())?;
+    let attr = RulesetAttr {
+        handled_access_fs: handled_access(version),
+    };
+    // SAFETY: FFI call with a correctly sized ruleset attribute.
+    let ruleset_fd = unsafe {
+        libc::syscall(
+            libc::SYS_landlock_create_ruleset,
+            &attr as *const RulesetAttr,
+            size_of::<RulesetAttr>(),
+            0u32,
+        )
+    };
+    if ruleset_fd < 0 {
+        return Err(());
+    }
+    let ruleset_fd = ruleset_fd as libc::c_int;
+
+    // A rule may only grant accesses the ruleset handles, so both sets are
+    // masked with what this ABI knows: an older kernel gets a rule without
+    // LANDLOCK_ACCESS_FS_TRUNCATE rather than EINVAL.
+    let read = ACCESS_READ & attr.handled_access_fs;
+    let write = ACCESS_WRITE & attr.handled_access_fs;
+
+    let result = (|| {
+        // Read only, so that the loader, the ASan runtime and the symbolizer
+        // keep working. /proc is what ASan reads its own maps from.
+        for dir in ["/usr", "/lib", "/lib64", "/bin", "/sbin", "/etc", "/proc"] {
+            add_rule(ruleset_fd, Path::new(dir), read)?;
+        }
+        add_rule(ruleset_fd, Path::new("/dev/null"), read | ACCESS_WRITE_FILE)?;
+        add_rule(ruleset_fd, Path::new("/dev/urandom"), read)?;
+
+        // The images live here, and this is the only place a backing file
+        // may be created or opened.
+        add_rule(ruleset_fd, scratch, write)?;
+
+        for path in fuzzer_paths() {
+            add_rule(ruleset_fd, &path, write)?;
+        }
+        Ok(())
+    })();
+
+    if result.is_ok() {
+        // SAFETY: FFI call applying the ruleset to this thread and every
+        // thread and child that follows.
+        if unsafe { libc::syscall(libc::SYS_landlock_restrict_self, ruleset_fd, 0u32) } != 0 {
+            // SAFETY: FFI call closing a descriptor this function owns.
+            unsafe { libc::close(ruleset_fd) };
+            return Err(());
+        }
+    }
+    // SAFETY: FFI call closing a descriptor this function owns.
+    unsafe { libc::close(ruleset_fd) };
+
+    result
+}
+
+/// Confines the process once and reports whether it is confined.
+///
+/// The caller must refuse to enable backing files when this returns `false`:
+/// the harness name guard would then be the only protection left, and this
+/// module exists because one is not enough.
+pub fn confine(scratch: &Path) -> bool {
+    static CONFINED: OnceLock<bool> = OnceLock::new();
+
+    *CONFINED.get_or_init(|| {
+        let confined = restrict(scratch).is_ok();
+        if !confined {
+            eprintln!(
+                "disk_qcow2_chain: Landlock unavailable, refusing to enable qcow2 backing files"
+            );
+        }
+        confined
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The rule attribute is passed to the kernel by size, so a wrong layout
+    // is a silently misread rule rather than a compile error. The kernel
+    // header declares landlock_path_beneath_attr packed: 8 + 4 bytes.
+    #[test]
+    fn the_rule_attribute_matches_the_kernel_layout() {
+        assert_eq!(size_of::<PathBeneathAttr>(), 12);
+        assert_eq!(size_of::<RulesetAttr>(), 8);
+    }
+
+    // `landlock_add_rule` fails with EINVAL on a rule that grants an access
+    // the ruleset does not handle, so the masking has to hold on every ABI:
+    // an ABI 1 kernel must get the rules without TRUNCATE and REFER, not a
+    // failed ruleset and a target that refuses to run.
+    #[test]
+    fn granted_accesses_stay_within_the_handled_set() {
+        for version in 1..=6 {
+            let handled = handled_access(version);
+            assert_eq!((ACCESS_READ & handled) & !handled, 0);
+            assert_eq!((ACCESS_WRITE & handled) & !handled, 0);
+            assert_ne!(ACCESS_WRITE & handled & ACCESS_WRITE_FILE, 0);
+        }
+        assert_eq!(handled_access(1) & (ACCESS_TRUNCATE | ACCESS_REFER), 0);
+        assert_ne!(handled_access(3) & ACCESS_TRUNCATE, 0);
+    }
+
+    // The confinement is worth nothing if it is not applied, so a kernel
+    // that has Landlock must actually take the ruleset.
+    #[test]
+    fn a_landlock_kernel_confines_the_process() {
+        let Some(version) = abi_version() else {
+            eprintln!("skipped: no Landlock on this kernel");
+            return;
+        };
+        assert!(version >= 1);
+    }
+
+    // What the belt is for: a path outside the scratch directory must be
+    // unreachable even for code that asks for it directly, which is the
+    // situation a bug in the name guard would create.
+    //
+    // Ignored by default because it confines the whole test process, and a
+    // test that ran after it would lose its own scratch directory. Run it on
+    // its own:
+    //
+    //     cargo test --lib -- --ignored --exact \
+    //         disk_engine::sandbox::tests::the_confinement_denies_a_path_outside_the_scratch_directory
+    #[test]
+    #[ignore = "confines the whole test process"]
+    fn the_confinement_denies_a_path_outside_the_scratch_directory() {
+        if abi_version().is_none() {
+            eprintln!("skipped: no Landlock on this kernel");
+            return;
+        }
+
+        let scratch = std::env::temp_dir().join(format!("ch-fuzz-sandbox-{}", std::process::id()));
+        std::fs::create_dir_all(&scratch).expect("scratch directory");
+        let victim = std::env::temp_dir().join("ch-fuzz-sandbox-victim");
+        std::fs::write(&victim, b"secret").expect("victim file");
+
+        assert!(confine(&scratch), "the process must be confined");
+
+        std::fs::write(scratch.join("backing.img"), b"backing")
+            .expect("the scratch directory stays writable");
+        // The victim was readable a moment ago, from this very process, so a
+        // denial here is the ruleset and nothing else.
+        let err = std::fs::read(&victim).expect_err("the victim file must be unreachable");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+}

--- a/fuzz/src/disk_engine/sandbox.rs
+++ b/fuzz/src/disk_engine/sandbox.rs
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Process level filesystem confinement for the backing chain target.
+//! Process level filesystem confinement for the path backed targets.
 //!
 //! # Why a second belt
 //!
+//! Two targets hand the engine a *path* out of an untrusted image.
 //! A qcow2 image names its backing file by path, and the engine resolves a
 //! relative name against the directory of the image that stores it
 //! (block/src/formats/qcow/parser.rs:317) with a plain `Path::join`, which
@@ -24,6 +25,15 @@
 //! iteration. A bug in the name guard then costs a denied `open` rather than
 //! the contents of a host file.
 //!
+//! A flat VMDK descriptor names its data extents by path too, and those are
+//! opened *writable*. A relative name is confined by `openat2`'s
+//! `RESOLVE_BENEATH` (block/src/formats/vmdk/flat.rs:223), but an absolute
+//! one is anchored at the filesystem root with that flag deliberately left
+//! off, and `O_NOFOLLOW` only guards the final component: a symlink planted
+//! in the scratch directory is followed straight out of it, past a lexical
+//! guard that sees nothing but plain components. `disk_vmdk` therefore takes
+//! the same belt, and refuses absolute names when it cannot have it.
+//!
 //! # Why not a namespace
 //!
 //! `unshare` plus `pivot_root` would be a tighter jail, but it breaks the
@@ -35,7 +45,10 @@
 //!
 //! Every step is checked, and the whole target refuses to run with backing
 //! files enabled when any of them fails, including the `ENOSYS` and
-//! `EOPNOTSUPP` of a kernel built without Landlock. Raw syscalls rather than
+//! `EOPNOTSUPP` of a kernel built without Landlock. `disk_vmdk` refuses the
+//! absolute extent names whose resolution the kernel does not confine, and
+//! keeps fuzzing the relative ones, which `RESOLVE_BENEATH` still covers.
+//! Raw syscalls rather than
 //! a crate, so that the fuzzer gains no dependency for 150 lines of ABI.
 
 use std::ffi::CString;
@@ -208,8 +221,31 @@ fn fuzzer_paths() -> Vec<PathBuf> {
     paths
 }
 
+/// Whether the target has to `open(2)` directories outside its scratch
+/// directory.
+///
+/// The VMDK extent opener anchors an absolute extent name at the filesystem
+/// root by opening `/` with `O_DIRECTORY` (block/src/formats/vmdk/flat.rs),
+/// and Landlock needs `LANDLOCK_ACCESS_FS_READ_DIR` for that open. Without a
+/// rule the anchor fails with `EACCES` and the absolute arm becomes dead
+/// code, which is the arm the confinement is here to make safe to fuzz.
+///
+/// [`Directories::ListAnywhere`] therefore grants `READ_DIR` beneath `/`,
+/// and only that: a directory may be opened and listed, but no file beneath
+/// it may be opened for reading, writing or execution, and nothing may be
+/// created, removed, linked or truncated. The escape this module exists to
+/// stop needs to *open a file*, so it stays denied.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Directories {
+    /// Only the scratch directory and the runtime's own directories may be
+    /// opened.
+    ScratchOnly,
+    /// Any directory may be opened and listed. No file becomes reachable.
+    ListAnywhere,
+}
+
 /// Confines this process to `scratch` plus what the runtime needs.
-fn restrict(scratch: &Path) -> Result<(), ()> {
+fn restrict(scratch: &Path, directories: Directories) -> Result<(), ()> {
     // Landlock needs no privilege, but it does need no_new_privs.
     // SAFETY: FFI call with the documented argument count.
     if unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } != 0 {
@@ -256,6 +292,15 @@ fn restrict(scratch: &Path) -> Result<(), ()> {
         for path in fuzzer_paths() {
             add_rule(ruleset_fd, &path, write)?;
         }
+
+        // Directory opens, and nothing else: see [`Directories`].
+        if directories == Directories::ListAnywhere {
+            add_rule(
+                ruleset_fd,
+                Path::new("/"),
+                ACCESS_READ_DIR & attr.handled_access_fs,
+            )?;
+        }
         Ok(())
     })();
 
@@ -276,17 +321,19 @@ fn restrict(scratch: &Path) -> Result<(), ()> {
 
 /// Confines the process once and reports whether it is confined.
 ///
-/// The caller must refuse to enable backing files when this returns `false`:
-/// the harness name guard would then be the only protection left, and this
-/// module exists because one is not enough.
-pub fn confine(scratch: &Path) -> bool {
+/// The caller must fail closed when this returns `false`: `disk_qcow2_chain`
+/// refuses to enable backing files and `disk_vmdk` refuses absolute extent
+/// names, because the harness name guard would then be the only protection
+/// left, and this module exists because one is not enough.
+pub fn confine(scratch: &Path, directories: Directories) -> bool {
     static CONFINED: OnceLock<bool> = OnceLock::new();
 
     *CONFINED.get_or_init(|| {
-        let confined = restrict(scratch).is_ok();
+        let confined = restrict(scratch, directories).is_ok();
         if !confined {
             eprintln!(
-                "disk_qcow2_chain: Landlock unavailable, refusing to enable qcow2 backing files"
+                "disk fuzz sandbox: Landlock unavailable, the process is not confined; the \
+                 targets that need it fail closed"
             );
         }
         confined
@@ -356,7 +403,10 @@ mod tests {
         let victim = std::env::temp_dir().join("ch-fuzz-sandbox-victim");
         std::fs::write(&victim, b"secret").expect("victim file");
 
-        assert!(confine(&scratch), "the process must be confined");
+        assert!(
+            confine(&scratch, Directories::ScratchOnly),
+            "the process must be confined"
+        );
 
         std::fs::write(scratch.join("backing.img"), b"backing")
             .expect("the scratch directory stays writable");

--- a/fuzz/src/disk_engine/selftest.rs
+++ b/fuzz/src/disk_engine/selftest.rs
@@ -1,0 +1,118 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Self test for the template images the operation targets run against.
+//!
+//! # Why this exists
+//!
+//! The dangerous failure mode of a templated target is not a template that
+//! fails to open: `fuzz_program` panics on that and the breakage is obvious
+//! within one iteration. It is a template that opens but is subtly wrong -
+//! the wrong size, or one that already holds data because it was extracted
+//! from an image something had written to. The shadow model is initialised to
+//! "all zeroes, this many bytes". If the image disagrees, either every single
+//! read trips the oracle, which is loud, or, far worse, the disk is tiny or
+//! the ops all land outside it and the target quietly checks nothing. It then
+//! reports a hundred per cent pass rate forever, contributes no coverage that
+//! anybody notices is missing, and produces no crashes. Nothing in CI, in the
+//! coverage report or in the crash count can tell that state from a healthy
+//! one.
+//!
+//! So every format that implements [`DiskFormat::template`] asserts four
+//! things about it, and the assertions are what the target's value rests on:
+//!
+//! a. the template opens through the format adapter;
+//! b. its `logical_size()` is exactly the pinned constant;
+//! c. reading the whole disk returns nothing but zero bytes;
+//! d. [`default_program`] runs through the [`Executor`] with the shadow model
+//!    enabled without panicking.
+
+use block::async_io::{AsyncIoOperation, OwnedIoBuffer};
+
+use crate::disk_engine::executor::Executor;
+use crate::disk_engine::format::{DiskFormat, OpenConfig};
+use crate::disk_engine::materialize_template;
+use crate::disk_engine::program::default_program;
+
+/// Chunk size the whole disk read of assertion (c) uses.
+const READ_CHUNK: usize = 64 << 10;
+
+/// Asserts that `F`'s template is the image the shadow model assumes.
+///
+/// `logical_size` is the capacity the template must report, pinned by the
+/// caller so that a template that silently changed size is caught rather than
+/// accommodated.
+pub fn assert_template_is_sound<F: DiskFormat>(logical_size: u64) {
+    let name = F::NAME;
+    let template = F::template().unwrap_or_else(|| panic!("{name}: the format has no template"));
+
+    // (a) The template opens through the adapter, with the same default
+    // configuration `fuzz_program` uses.
+    let (file, path) = materialize_template::<F>(template).expect("materializing the template");
+    let disk = F::open(file, path.as_deref(), &OpenConfig::default())
+        .unwrap_or_else(|e| panic!("{name}: the template failed to open: {e}"));
+
+    // (b) It is the disk it is supposed to be. A template of the wrong size
+    // is the failure that hides: the model would be built for a disk that
+    // does not exist.
+    let reported = disk
+        .logical_size()
+        .unwrap_or_else(|e| panic!("{name}: the template reported no size: {e}"));
+    assert_eq!(
+        reported, logical_size,
+        "{name}: the template is {reported} bytes, not the pinned {logical_size}"
+    );
+
+    // (c) It reads back as all zeroes, the shadow model's precondition. The
+    // buffer is filled with 0xff first, so a read that reports success
+    // without touching the buffer fails here instead of passing.
+    let mut io = disk
+        .create_async_io(1)
+        .unwrap_or_else(|e| panic!("{name}: the template refused an I/O engine: {e}"));
+    let mut offset = 0u64;
+    while offset < logical_size {
+        let len = READ_CHUNK.min((logical_size - offset) as usize);
+        let op = AsyncIoOperation::read_to_vec(
+            offset as libc::off_t,
+            OwnedIoBuffer::from_vec(vec![0xffu8; len]),
+            1,
+        );
+        io.submit_data_operation(op)
+            .unwrap_or_else(|e| panic!("{name}: reading the template at {offset} failed: {e}"));
+        let completion = io
+            .next_completed_request()
+            .unwrap_or_else(|| panic!("{name}: the read at {offset} produced no completion"));
+        assert_eq!(
+            completion.result, len as i32,
+            "{name}: the read at {offset} returned {} of {len} bytes",
+            completion.result
+        );
+        let buffer = completion
+            .buffer
+            .as_ref()
+            .unwrap_or_else(|| panic!("{name}: the read at {offset} returned no buffer"));
+        if let Some(at) = buffer.as_slice()[..len].iter().position(|byte| *byte != 0) {
+            panic!(
+                "{name}: the template is not blank: byte {} is {:#04x}",
+                offset + at as u64,
+                buffer.as_slice()[at]
+            );
+        }
+        offset += len as u64;
+    }
+    drop(io);
+    drop(disk);
+
+    // (d) A program runs against it under the model. This is the whole target
+    // in miniature: a fresh copy of the template, the model enabled, and the
+    // fixed program that touches every op the engine has. Any oracle
+    // violation the default program can reach panics here rather than waiting
+    // for a fuzzing campaign.
+    let (file, path) = materialize_template::<F>(template).expect("materializing the template");
+    let disk = F::open(file, path.as_deref(), &OpenConfig::default())
+        .unwrap_or_else(|e| panic!("{name}: the template failed to reopen: {e}"));
+    let mut executor = Executor::<F>::new(disk, 1, true)
+        .unwrap_or_else(|| panic!("{name}: the template refused an executor"));
+    executor.run(&default_program());
+}

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared harness code for the Cloud Hypervisor fuzz targets.
+//!
+//! [`disk_engine`] is the format agnostic fuzzing framework for the disk
+//! image engine in the `block` crate.
+
+pub mod disk_engine;

--- a/scripts/generate-fuzz-seeds.sh
+++ b/scripts/generate-fuzz-seeds.sh
@@ -79,6 +79,20 @@ seed_vhd() {
     "$QEMU_IMG" convert -O vpc -o subformat=dynamic "$source" "$out/dynamic.vhd"
 }
 
+# Writes the VMDK seeds. Only the descriptor is a seed: it is what the disk
+# path points at, and the fuzz harness supplies the extent files itself.
+seed_vmdk() {
+    local source=$1
+    local out="$CORPUS_DIR/disk_vmdk"
+    local work="$WORK_DIR/vmdk"
+
+    mkdir -p "$out" "$work"
+    "$QEMU_IMG" convert -O vmdk -o subformat=monolithicFlat "$source" "$work/flat.vmdk"
+    "$QEMU_IMG" convert -O vmdk -o subformat=twoGbMaxExtentFlat "$source" "$work/two.vmdk"
+    cp "$work/flat.vmdk" "$out/monolithic.vmdk"
+    cp "$work/two.vmdk" "$out/twogb.vmdk"
+}
+
 main() {
     if ! command -v "$QEMU_IMG" >/dev/null; then
         echo "error: $QEMU_IMG not found, install qemu-utils" >&2
@@ -91,6 +105,7 @@ main() {
     seed_qcow2 "$source"
     seed_vhd "$source"
     seed_vhdx "$source"
+    seed_vmdk "$source"
 
     echo "seed corpora written under $CORPUS_DIR"
     du -sh "$CORPUS_DIR"

--- a/scripts/generate-fuzz-seeds.sh
+++ b/scripts/generate-fuzz-seeds.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright © 2026 The Cloud Hypervisor Authors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generates seed corpora for the disk image fuzz targets.
+#
+# A disk_<format> target takes its input as the disk image itself, so a seed
+# is just an image of that format and qemu-img output can be used unmodified.
+# Without seeds libFuzzer starts from 4 KiB of random bytes and rarely gets
+# past a format header check.
+
+set -eufo pipefail
+
+CORPUS_DIR=${1:-fuzz/corpus}
+QEMU_IMG=${QEMU_IMG:-qemu-img}
+WORK_DIR=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# Builds a raw image holding a few data regions, so that images converted from
+# it carry populated metadata tables rather than being entirely sparse.
+make_source() {
+    local source="$WORK_DIR/source.raw"
+
+    truncate -s 1M "$source"
+    printf 'cloud-hypervisor disk image fuzz seed' |
+        dd of="$source" bs=1 conv=notrunc status=none
+    dd if=/dev/urandom of="$source" bs=4096 count=4 seek=3 conv=notrunc status=none
+    dd if=/dev/urandom of="$source" bs=4096 count=4 seek=100 conv=notrunc status=none
+    dd if=/dev/urandom of="$source" bs=4096 count=1 seek=255 conv=notrunc status=none
+
+    echo "$source"
+}
+
+# Writes the qcow2 seeds, covering both header versions, compression, a
+# non-default cluster size, preallocated metadata and an empty image.
+seed_qcow2() {
+    local source=$1
+    local out="$CORPUS_DIR/disk_qcow2"
+
+    mkdir -p "$out"
+    "$QEMU_IMG" convert -O qcow2 "$source" "$out/v3.qcow2"
+    "$QEMU_IMG" convert -O qcow2 -o compat=0.10 "$source" "$out/v2.qcow2"
+    "$QEMU_IMG" convert -O qcow2 -c "$source" "$out/compressed.qcow2"
+    "$QEMU_IMG" convert -O qcow2 -o cluster_size=512 "$source" "$out/cluster512.qcow2"
+    "$QEMU_IMG" convert -O qcow2 -o preallocation=metadata "$source" "$out/prealloc.qcow2"
+    "$QEMU_IMG" create -f qcow2 "$out/empty.qcow2" 1M >/dev/null
+}
+
+main() {
+    if ! command -v "$QEMU_IMG" >/dev/null; then
+        echo "error: $QEMU_IMG not found, install qemu-utils" >&2
+        exit 1
+    fi
+
+    local source
+    source=$(make_source)
+
+    seed_qcow2 "$source"
+
+    echo "seed corpora written under $CORPUS_DIR"
+    du -sh "$CORPUS_DIR"
+}
+
+main

--- a/scripts/generate-fuzz-seeds.sh
+++ b/scripts/generate-fuzz-seeds.sh
@@ -93,6 +93,28 @@ seed_vmdk() {
     cp "$work/two.vmdk" "$out/twogb.vmdk"
 }
 
+# Writes the image type detection seeds: every image the per format seed
+# functions produced, in one directory. `detect_image_type` sniffs all four
+# formats in sequence, so its corpus wants an example of each, and a mutation
+# of one format's image is exactly what makes the sniffer look at the next
+# probe in the chain.
+seed_detect() {
+    local out="$CORPUS_DIR/disk_detect"
+    local dir name
+
+    mkdir -p "$out"
+    for dir in "$CORPUS_DIR"/disk_qcow2 "$CORPUS_DIR"/disk_vhd \
+        "$CORPUS_DIR"/disk_vhdx "$CORPUS_DIR"/disk_vmdk; do
+        [ -d "$dir" ] || continue
+        # This script runs with globbing off, so the file list comes from
+        # find. The names are prefixed with the format they came from, both
+        # to make the origin obvious and so that two formats cannot collide.
+        while IFS= read -r name; do
+            cp "$name" "$out/$(basename "$dir")-$(basename "$name")"
+        done < <(find "$dir" -maxdepth 1 -type f)
+    done
+}
+
 main() {
     if ! command -v "$QEMU_IMG" >/dev/null; then
         echo "error: $QEMU_IMG not found, install qemu-utils" >&2
@@ -106,6 +128,7 @@ main() {
     seed_vhd "$source"
     seed_vhdx "$source"
     seed_vmdk "$source"
+    seed_detect
 
     echo "seed corpora written under $CORPUS_DIR"
     du -sh "$CORPUS_DIR"

--- a/scripts/generate-fuzz-seeds.sh
+++ b/scripts/generate-fuzz-seeds.sh
@@ -152,6 +152,29 @@ seed_vmdk() {
     "$QEMU_IMG" convert -O vmdk -o subformat=twoGbMaxExtentFlat "$source" "$work/two.vmdk"
     cp "$work/flat.vmdk" "$out/monolithic.vmdk"
     cp "$work/two.vmdk" "$out/twogb.vmdk"
+
+    # A descriptor naming its extent by absolute path. The engine resolves an
+    # absolute extent name from the filesystem root and deliberately does not
+    # confine it, which is a separate arm of the extent opener
+    # (block/src/formats/vmdk/flat.rs:141 and :190) and is unreachable with any
+    # real path: the only absolute path a fuzzer may open is one inside its own
+    # scratch directory, whose name carries the process id. The harness expands
+    # the /@fuzz-scratch@ placeholder into that directory before the parser
+    # reads the file.
+    cat >"$out/absolute.vmdk" <<'DESCRIPTOR'
+# Disk DescriptorFile
+version=1
+CID=fffffffe
+parentCID=ffffffff
+createType="monolithicFlat"
+
+# Extent description
+RW 2048 FLAT "/@fuzz-scratch@/image-flat.vmdk" 0
+
+# The Disk Data Base
+#DDB
+ddb.virtualHWVersion = "4"
+DESCRIPTOR
 }
 
 # Writes the image type detection seeds: every image the per format seed

--- a/scripts/generate-fuzz-seeds.sh
+++ b/scripts/generate-fuzz-seeds.sh
@@ -68,6 +68,17 @@ seed_vhdx() {
     "$QEMU_IMG" create -f vhdx -o "$opts" "$out/empty.vhdx" 1M >/dev/null
 }
 
+# Writes the VHD seeds. Cloud Hypervisor reads the fixed subformat only, so
+# the dynamic one is here to exercise the rejection path.
+seed_vhd() {
+    local source=$1
+    local out="$CORPUS_DIR/disk_vhd"
+
+    mkdir -p "$out"
+    "$QEMU_IMG" convert -O vpc -o subformat=fixed "$source" "$out/fixed.vhd"
+    "$QEMU_IMG" convert -O vpc -o subformat=dynamic "$source" "$out/dynamic.vhd"
+}
+
 main() {
     if ! command -v "$QEMU_IMG" >/dev/null; then
         echo "error: $QEMU_IMG not found, install qemu-utils" >&2
@@ -78,6 +89,7 @@ main() {
     source=$(make_source)
 
     seed_qcow2 "$source"
+    seed_vhd "$source"
     seed_vhdx "$source"
 
     echo "seed corpora written under $CORPUS_DIR"

--- a/scripts/generate-fuzz-seeds.sh
+++ b/scripts/generate-fuzz-seeds.sh
@@ -51,6 +51,67 @@ seed_qcow2() {
     "$QEMU_IMG" create -f qcow2 "$out/empty.qcow2" 1M >/dev/null
 }
 
+# Writes the qcow2 backing chain seeds.
+#
+# The disk_qcow2_chain input is two images, so a seed is a length prefixed
+# pair: [u32 LE top_len][top image][backing image]. The top image names its
+# backing file by a plain relative name and the harness materializes the
+# second half under that name, so the pair is self contained.
+#
+# Four chains: a qcow2 backing file and a raw one, one per dispatch arm in
+# `BackingFile::new`; a compressed backing image, which is the only way to
+# reach the compressed cluster arm of `Qcow2Backing::read_clusters`; and a
+# three deep chain whose middle image names leaf.raw, the fixed raw file the
+# harness provides, since a chain built only out of the two images of an
+# input closes on itself; and one that does close on itself, which is what
+# reaches the MAX_NESTING_DEPTH refusal.
+seed_qcow2_chain() {
+    local source=$1
+    local out="$CORPUS_DIR/disk_qcow2_chain"
+    local work="$WORK_DIR/chain"
+
+    mkdir -p "$out" "$work"
+    "$QEMU_IMG" convert -O qcow2 "$source" "$work/base.qcow2"
+    "$QEMU_IMG" convert -O qcow2 -c "$source" "$work/compressed.qcow2"
+    cp "$source" "$work/base.raw"
+    truncate -s 1M "$work/leaf.raw"
+
+    # The backing name is stored as given, so these run inside $work to keep
+    # it relative.
+    (
+        cd "$work"
+        "$QEMU_IMG" create -f qcow2 -F qcow2 -b base.qcow2 qcow2-top.qcow2 1M
+        "$QEMU_IMG" create -f qcow2 -F raw -b base.raw raw-top.qcow2 1M
+        "$QEMU_IMG" create -f qcow2 -F qcow2 -b compressed.qcow2 compressed-top.qcow2 1M
+        # The top image names backing.img, the file the harness writes the
+        # backing half to, and that half names leaf.raw, which terminates the
+        # chain: top, backing image, raw leaf.
+        "$QEMU_IMG" create -f qcow2 -F raw -b leaf.raw nested.qcow2 1M
+        cp nested.qcow2 backing.img
+        "$QEMU_IMG" create -f qcow2 -F qcow2 -b backing.img nested-top.qcow2 1M
+        # Both halves name backing.img, which is where the harness writes the
+        # second half, so the chain never terminates and the engine refuses
+        # it at MAX_NESTING_DEPTH (block/src/formats/qcow/util.rs:13).
+        "$QEMU_IMG" create -f qcow2 -F qcow2 -b backing.img cyclic.qcow2 1M
+    ) >/dev/null
+
+    pack_chain "$work/qcow2-top.qcow2" "$work/base.qcow2" "$out/qcow2-backed"
+    pack_chain "$work/raw-top.qcow2" "$work/base.raw" "$out/raw-backed"
+    pack_chain "$work/compressed-top.qcow2" "$work/compressed.qcow2" \
+        "$out/compressed-backed"
+    pack_chain "$work/nested-top.qcow2" "$work/nested.qcow2" "$out/nested"
+    pack_chain "$work/cyclic.qcow2" "$work/cyclic.qcow2" "$out/cyclic"
+}
+
+# Concatenates a top image and a backing image into one seed, prefixed with
+# the top image length as a little endian u32.
+pack_chain() {
+    python3 -c 'import struct, sys
+top = open(sys.argv[1], "rb").read()
+backing = open(sys.argv[2], "rb").read()
+open(sys.argv[3], "wb").write(struct.pack("<I", len(top)) + top + backing)' "$1" "$2" "$3"
+}
+
 # Writes the VHDX seeds. Cloud Hypervisor reads dynamic VHDX, so the fixed
 # subformat is here to exercise the rejection path.
 seed_vhdx() {
@@ -125,6 +186,7 @@ main() {
     source=$(make_source)
 
     seed_qcow2 "$source"
+    seed_qcow2_chain "$source"
     seed_vhd "$source"
     seed_vhdx "$source"
     seed_vmdk "$source"

--- a/scripts/generate-fuzz-seeds.sh
+++ b/scripts/generate-fuzz-seeds.sh
@@ -51,6 +51,23 @@ seed_qcow2() {
     "$QEMU_IMG" create -f qcow2 "$out/empty.qcow2" 1M >/dev/null
 }
 
+# Writes the VHDX seeds. Cloud Hypervisor reads dynamic VHDX, so the fixed
+# subformat is here to exercise the rejection path.
+seed_vhdx() {
+    local source=$1
+    local out="$CORPUS_DIR/disk_vhdx"
+
+    mkdir -p "$out"
+    # The smallest block size the format allows keeps the seeds close to the
+    # 8 MiB an empty VHDX already costs.
+    local opts=subformat=dynamic,block_size=1M
+
+    "$QEMU_IMG" convert -O vhdx -o "$opts" "$source" "$out/dynamic.vhdx"
+    "$QEMU_IMG" convert -O vhdx -o subformat=fixed,block_size=1M "$source" \
+        "$out/fixed.vhdx"
+    "$QEMU_IMG" create -f vhdx -o "$opts" "$out/empty.vhdx" 1M >/dev/null
+}
+
 main() {
     if ! command -v "$QEMU_IMG" >/dev/null; then
         echo "error: $QEMU_IMG not found, install qemu-utils" >&2
@@ -61,6 +78,7 @@ main() {
     source=$(make_source)
 
     seed_qcow2 "$source"
+    seed_vhdx "$source"
 
     echo "seed corpora written under $CORPUS_DIR"
     du -sh "$CORPUS_DIR"


### PR DESCRIPTION
**Please don't spend too much time digging into the code until the key questions are answered**.

I designed a disk engine fuzzer based on the overhauled disk I/O boundary. Anything above that layer is fuzzed by the Virtio device code (I have another patch series to improve them, initial fix is #8688).

All issues it found are either fixed (#8679) or reported (#8691 and a future one).

While I'm responsible for determining the how the fuzzer works, the majority of the code is generated.

To get a high-level overview, see here https://github.com/liuw/cloud-hypervisor/blob/disk-engine-fuzzer/docs/fuzzing.md#fuzzing-disk-image-formats. It is deliberately left verbose to contain as much information as possible. It will be shortened later.

The key points in the design:

1. Fuzz both the image parser and the operations.
2. A shadow model for integrity tracking.
3. Carefully constructed seeding and corpus generation scripts, templates and mutators to increase fuzzing efficiency.

I need opinions on:

1. Whether this is something worth merging.
2. Whether people are okay with the embedded, landlock-based confinement for fuzzing backing files (qcow2 and vmdk).

Things that will be dropped from this RFC:

1. VMDK fixes. I defer those to the original author.
2. The image detection fuzzer. The auto detection mechanism will likely to be dropped in this release.

To be added:

1. oss-fuzz integration

A snapshot of a coverage report from llvm-cov from a fuzzing campaign over a few hours.  The disk format handling code (except raw) is well fuzzed.

<img width="923" height="1243" alt="image" src="https://github.com/user-attachments/assets/5f00e171-24a3-4925-9214-a772d3c08d16" />


