### PR TITLE
virtio-devices: pci: Skip ring index restore for unused queues

### DIFF
--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -578,18 +578,14 @@ impl VirtioPciDevice {
                 queue
                     .try_set_used_ring_address(GuestAddress(state.queues[i].used_ring))
                     .unwrap();
-                queue.set_next_avail(
-                    queue
+                if queue.ready() && queue.is_valid(memory.memory().deref()) {
+                    let used_idx = queue
                         .used_idx(memory.memory().deref(), Ordering::Acquire)
                         .unwrap()
-                        .0,
-                );
-                queue.set_next_used(
-                    queue
-                        .used_idx(memory.memory().deref(), Ordering::Acquire)
-                        .unwrap()
-                        .0,
-                );
+                        .0;
+                    queue.set_next_avail(used_idx);
+                    queue.set_next_used(used_idx);
+                }
             }
 
             (


### PR DESCRIPTION
Restoring a snapshot read the used index of every virtqueue. A queue the guest never set up has zeroed ring addresses, so the read targeted guest address 0x2 and the `unwrap()` on the failed read panicked the vmm thread. 

Only read the index for queues that have a used ring address, and read it once for both indexes.


Fixes: #8693

Assisted-by: Claude:Opus-5