### PR TITLE
tests: Verify receive-migration returns error on timeout cancel

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7592,6 +7592,15 @@ mod common_parallel {
             // to reduce system load during post-migration checks.
             let _ = guest.ssh_command("pkill -f 'stress --vm'");
 
+            // Wait for the receive migration process to exit after the
+            // source-side migration has completed (either failed or finished).
+            let receive_exit_status = if let Some(status) = receive_status {
+                status
+            } else {
+                let _ = receive_migration.wait();
+                panic!("receive-migration process did not exit within timeout")
+            };
+
             match timeout_strategy {
                 TimeoutStrategy::Cancel => {
                     let expected_events = [
@@ -7618,6 +7627,14 @@ mod common_parallel {
 
                     // Confirm the source VM is still responsive over SSH
                     assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
+
+                    // Verify that the receive-migration call on the destination
+                    // side returns an error, since the migration was cancelled
+                    // by the source.
+                    assert!(
+                        !receive_exit_status.success(),
+                        "receive-migration should have returned an error when the source cancelled the migration"
+                    );
                 }
                 TimeoutStrategy::Ignore => {
                     let expected_events = [


### PR DESCRIPTION
This PR addresses [issue #8492](https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8492).

   When the source-side live migration times out with `TimeoutStrategy::Cancel`,
   the source VM aborts the migration and emits a `migration-failed` event. The
   existing test `test_live_migration_tcp_timeout_cancel` verified this
   source-side behavior, but did **not** check that the destination's
   `ch-remote receive-migration` call also returned an error.

   This change adds an assertion that `receive-migration` exits with a
   non-success status code when the source cancels, confirming the error
   propagates correctly from the VMM API layer through the CLI to the user.

   ## Changes

   - Extract `receive_exit_status` from the `receive_migration` child process
     before entering the strategy match block
   - In the `TimeoutStrategy::Cancel` branch, assert that
     `receive_exit_status.success()` is `false`

   ## Checklist

   - [x] Code compiles (`cargo check --all-targets --tests`)
   - [x] Clippy clean (`cargo clippy --all-targets --tests`)
   - [x] Formatting clean (`cargo +nightly fmt --all -- --check`)
   - [x] Commit message passes `gitlint`
   - [x] Commit signed-off-by

   ## Related

   Fixes #8492