### PR TITLE
performance-metrics: Fix hardcoded raw image type

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -1847,7 +1847,8 @@ fn main() {
                     "Override the image format used for block tests, supported values: qcow2, raw, vhd, vhdx. \
                      Default is 'raw'.",
                 )
-                .num_args(1),
+                .num_args(1)
+                .value_parser(["raw", "qcow2", "vhd", "vhdx"]),
         )
         .arg(
             Arg::new("vm-type")

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -221,6 +221,7 @@ pub struct PerformanceTestControl {
     num_boot_vcpus: Option<u8>,
     num_ops: Option<u32>, // Workload size for micro benchmarks
     vm_type: GuestVmType,
+    test_image_format: ImageFormat,
 }
 
 impl fmt::Display for PerformanceTestControl {
@@ -268,6 +269,7 @@ impl PerformanceTestControl {
             num_boot_vcpus: Some(1),
             num_ops: None,
             vm_type: GuestVmType::Regular,
+            test_image_format: ImageFormat::Raw,
         }
     }
 }
@@ -297,6 +299,9 @@ impl PerformanceTest {
                 control.test_timeout = test_timeout;
             }
             control.vm_type = overrides.vm_type;
+            if let Some(test_image_format) = overrides.test_image_format {
+                control.test_image_format = test_image_format;
+            }
             control
         };
 

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -411,7 +411,7 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
             test_disk_arg.push_str(",backing_files=on");
         }
     } else if test_file == BLK_IO_TEST_IMG {
-        test_disk_arg.push_str(",image_type=raw");
+        test_disk_arg.push_str(&format!(",image_type={}", control.test_image_format));
     }
     guest.num_cpu = num_queues;
     let mut child = GuestCommand::new(&guest)


### PR DESCRIPTION
--image-format was broken and always used a raw image rather than the
desired type

Signed-off-by: Rob Bradford <rbradford@meta.com>
