### PR TITLE
tests: Add explicit image_type to integration tests

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -900,15 +900,8 @@ pub(crate) fn test_boot_from_vhost_user_blk(
         .args(["--memory", "size=512M,shared=on"])
         .args(["--kernel", kernel_path.to_str().unwrap()])
         .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-        .args([
-            "--disk",
-            blk_boot_params.as_str(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
-        ])
+        .args(["--disk", blk_boot_params.as_str()])
+        .default_cloudinit_disk()
         .default_net()
         .capture_output()
         .spawn()
@@ -2037,11 +2030,10 @@ pub(crate) fn _test_virtio_block(
                 if backing_files { "on" } else { "off" },
             )
             .as_str(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
+        ])
+        .default_cloudinit_disk()
+        .args([
+            "--disk",
             format!(
                 "path={},readonly=on,direct=on,num_queues=4,_disable_io_uring={},_disable_aio={}",
                 blk_file_path.to_str().unwrap(),
@@ -2205,12 +2197,8 @@ pub(crate) fn _test_virtio_block_vmdk(guest: &Guest, subformat: &str) {
             // Force the flat VMDK backend explicitly instead of relying on
             // image-format auto-detection.
             format!("path={vmdk_path_str},image_type=vmdk").as_str(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
         ])
+        .default_cloudinit_disk()
         .default_net()
         .capture_output()
         .spawn()

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -2125,7 +2125,10 @@ pub fn _test_virtio_block_dynamic_vhdx_expand(guest: &Guest) {
         .default_memory()
         .default_kernel_cmdline()
         .default_disks()
-        .args(["--disk", format!("path={vhdx_path}").as_str()])
+        .args([
+            "--disk",
+            format!("path={vhdx_path},image_type=vhdx").as_str(),
+        ])
         .default_net()
         .capture_output()
         .spawn()

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -2031,7 +2031,8 @@ pub(crate) fn _test_virtio_block(
         .args([
             "--disk",
             format!(
-                "path={},readonly=on,direct=on,num_queues=4,_disable_io_uring={},_disable_aio={}",
+                "path={},readonly=on,direct=on,num_queues=4,image_type=raw,\
+                 _disable_io_uring={},_disable_aio={}",
                 blk_file_path.to_str().unwrap(),
                 disable_io_uring,
                 disable_aio,
@@ -2977,7 +2978,7 @@ pub(crate) fn _test_landlock(guest: &Guest) {
             "add-disk",
             Some(
                 format!(
-                    "path={},id=test0,readonly=true",
+                    "path={},id=test0,readonly=true,image_type=raw",
                     blk_file_path.to_str().unwrap()
                 )
                 .as_str()
@@ -3036,7 +3037,7 @@ pub(crate) fn _test_disk_hotplug(guest: &Guest, landlock_enabled: bool) {
             "add-disk",
             Some(
                 format!(
-                    "path={},id=test0,readonly=true",
+                    "path={},id=test0,readonly=true,image_type=raw",
                     blk_file_path.to_str().unwrap()
                 )
                 .as_str(),
@@ -3072,7 +3073,7 @@ pub(crate) fn _test_disk_hotplug(guest: &Guest, landlock_enabled: bool) {
             "add-disk",
             Some(
                 format!(
-                    "path={},id=test0,readonly=true",
+                    "path={},id=test0,readonly=true,image_type=raw",
                     blk_file_path.to_str().unwrap()
                 )
                 .as_str(),
@@ -3142,7 +3143,7 @@ pub(crate) fn _test_virtio_block_topology(guest: &Guest, loop_dev: &str) {
         .default_memory()
         .default_kernel_cmdline()
         .default_disks()
-        .args(["--disk", format!("path={loop_dev}").as_str()])
+        .args(["--disk", format!("path={loop_dev},image_type=raw").as_str()])
         .default_net()
         .capture_output()
         .spawn()

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -1408,7 +1408,7 @@ pub(crate) fn _test_virtio_iommu(_acpi: bool /* not needed on x86_64 */) {
             )
             .as_str(),
             format!(
-                "path={},iommu=on",
+                "path={},iommu=on,image_type=raw",
                 guest.disk_config.disk(DiskType::CloudInit).unwrap()
             )
             .as_str(),

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -764,20 +764,8 @@ pub(crate) fn test_vhost_user_blk(
         .args(["--memory", "size=512M,hotplug_size=2048M,shared=on"])
         .args(["--kernel", kernel_path.to_str().unwrap()])
         .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-        .args([
-            "--disk",
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-            )
-            .as_str(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
-            blk_params.as_str(),
-        ])
+        .default_disks()
+        .args(["--disk", blk_params.as_str()])
         .default_net()
         .args(["--api-socket", &api_socket])
         .capture_output()
@@ -1911,18 +1899,9 @@ pub(crate) fn _test_pci_multiple_segments(
         .default_kernel_cmdline_with_platform(Some(&format!(
             "num_pci_segments={max_num_pci_segments}"
         )))
+        .default_disks()
         .args([
             "--disk",
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-            )
-            .as_str(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
             format!("path={test_disk_path},pci_segment={pci_segments_for_disk},image_type=raw")
                 .as_str(),
         ])
@@ -2157,20 +2136,8 @@ pub fn _test_virtio_block_dynamic_vhdx_expand(guest: &Guest) {
         .default_cpus()
         .default_memory()
         .default_kernel_cmdline()
-        .args([
-            "--disk",
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-            )
-            .as_str(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
-            format!("path={vhdx_path}").as_str(),
-        ])
+        .default_disks()
+        .args(["--disk", format!("path={vhdx_path}").as_str()])
         .default_net()
         .capture_output()
         .spawn()
@@ -2303,18 +2270,9 @@ pub(crate) fn _test_virtio_block_vmdk_enospc(guest: &Guest, subformat: &str) {
         .default_cpus()
         .default_memory()
         .default_kernel_cmdline()
+        .default_disks()
         .args([
             "--disk",
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-            )
-            .as_str(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
             // Force the flat VMDK backend explicitly.
             format!("path={vmdk_path_str},image_type=vmdk").as_str(),
         ])
@@ -2450,20 +2408,8 @@ pub(crate) fn _test_virtio_block_vmdk_extent_spanning(guest: &Guest, direct: boo
         .default_cpus()
         .default_memory()
         .default_kernel_cmdline()
-        .args([
-            "--disk",
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-            )
-            .as_str(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
-            data_disk.as_str(),
-        ])
+        .default_disks()
+        .args(["--disk", data_disk.as_str()])
         .default_net()
         .capture_output()
         .spawn()
@@ -3208,20 +3154,8 @@ pub(crate) fn _test_virtio_block_topology(guest: &Guest, loop_dev: &str) {
         .default_cpus()
         .default_memory()
         .default_kernel_cmdline()
-        .args([
-            "--disk",
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-            )
-            .as_str(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
-            format!("path={loop_dev}").as_str(),
-        ])
+        .default_disks()
+        .args(["--disk", format!("path={loop_dev}").as_str()])
         .default_net()
         .capture_output()
         .spawn()

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -1403,7 +1403,7 @@ pub(crate) fn _test_virtio_iommu(_acpi: bool /* not needed on x86_64 */) {
         .args([
             "--disk",
             format!(
-                "path={},iommu=on",
+                "path={},iommu=on,image_type=raw",
                 guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
             )
             .as_str(),
@@ -1758,7 +1758,7 @@ pub(crate) fn _test_virtio_queue_affinity(guest: &Guest) {
         .args([
             "--disk",
             format!(
-                "path={},num_queues=4,queue_affinity=[0@[0,2],1@[1,3],2@[1],3@[3]]",
+                "path={},num_queues=4,queue_affinity=[0@[0,2],1@[1,3],2@[1],3@[3]],image_type=raw",
                 guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
             )
             .as_str(),

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -1758,16 +1758,12 @@ pub(crate) fn _test_virtio_queue_affinity(guest: &Guest) {
         .args([
             "--disk",
             format!(
-                "path={}",
+                "path={},num_queues=4,queue_affinity=[0@[0,2],1@[1,3],2@[1],3@[3]]",
                 guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
             )
             .as_str(),
-            format!(
-                "path={},num_queues=4,queue_affinity=[0@[0,2],1@[1,3],2@[1],3@[3]]",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
         ])
+        .default_cloudinit_disk()
         .default_net()
         .capture_output()
         .spawn()
@@ -1776,13 +1772,13 @@ pub(crate) fn _test_virtio_queue_affinity(guest: &Guest) {
     let r = panic::catch_unwind(|| {
         guest.wait_vm_boot().unwrap();
         let pid = child.id();
-        let taskset_q0 = exec_host_command_output(format!("taskset -pc $(ps -T -p {pid} | grep disk1_q0 | xargs | cut -f 2 -d \" \") | cut -f 6 -d \" \"").as_str());
+        let taskset_q0 = exec_host_command_output(format!("taskset -pc $(ps -T -p {pid} | grep disk0_q0 | xargs | cut -f 2 -d \" \") | cut -f 6 -d \" \"").as_str());
         assert_eq!(String::from_utf8_lossy(&taskset_q0.stdout).trim(), "0,2");
-        let taskset_q1 = exec_host_command_output(format!("taskset -pc $(ps -T -p {pid} | grep disk1_q1 | xargs | cut -f 2 -d \" \") | cut -f 6 -d \" \"").as_str());
+        let taskset_q1 = exec_host_command_output(format!("taskset -pc $(ps -T -p {pid} | grep disk0_q1 | xargs | cut -f 2 -d \" \") | cut -f 6 -d \" \"").as_str());
         assert_eq!(String::from_utf8_lossy(&taskset_q1.stdout).trim(), "1,3");
-        let taskset_q2 = exec_host_command_output(format!("taskset -pc $(ps -T -p {pid} | grep disk1_q2 | xargs | cut -f 2 -d \" \") | cut -f 6 -d \" \"").as_str());
+        let taskset_q2 = exec_host_command_output(format!("taskset -pc $(ps -T -p {pid} | grep disk0_q2 | xargs | cut -f 2 -d \" \") | cut -f 6 -d \" \"").as_str());
         assert_eq!(String::from_utf8_lossy(&taskset_q2.stdout).trim(), "1");
-        let taskset_q3 = exec_host_command_output(format!("taskset -pc $(ps -T -p {pid} | grep disk1_q3 | xargs | cut -f 2 -d \" \") | cut -f 6 -d \" \"").as_str());
+        let taskset_q3 = exec_host_command_output(format!("taskset -pc $(ps -T -p {pid} | grep disk0_q3 | xargs | cut -f 2 -d \" \") | cut -f 6 -d \" \"").as_str());
         assert_eq!(String::from_utf8_lossy(&taskset_q3.stdout).trim(), "3");
     });
 

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -383,8 +383,8 @@ pub(crate) fn setup_ovs_dpdk_guests(
         clh_command("cloud-hypervisor")
     };
 
-    let mut child1 = GuestCommand::new_with_binary_path(guest1, &clh_path)
-        .args(["--cpus", "boot=2"])
+    let mut cmd1 = GuestCommand::new_with_binary_path(guest1, &clh_path);
+    cmd1.args(["--cpus", "boot=2"])
         .args(["--memory", "size=0,shared=on"])
         .args([
             "--memory-zone",
@@ -392,11 +392,14 @@ pub(crate) fn setup_ovs_dpdk_guests(
         ])
         .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
         .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-        .default_disks()
         .args(["--net", guest1.default_net_string().as_str(), OVS_DPDK_NET1])
-        .capture_output()
-        .spawn()
-        .unwrap();
+        .capture_output();
+    if release_binary {
+        cmd1.legacy_default_disks();
+    } else {
+        cmd1.default_disks();
+    }
+    let mut child1 = cmd1.spawn().unwrap();
 
     #[cfg(target_arch = "x86_64")]
     let guest_net_iface = "ens5";
@@ -435,8 +438,8 @@ pub(crate) fn setup_ovs_dpdk_guests(
         panic!("Test should already be failed/panicked"); // To explicitly mark this block never return
     }
 
-    let mut child2 = GuestCommand::new_with_binary_path(guest2, &clh_path)
-        .args(["--api-socket", api_socket])
+    let mut cmd2 = GuestCommand::new_with_binary_path(guest2, &clh_path);
+    cmd2.args(["--api-socket", api_socket])
         .args(["--cpus", "boot=2"])
         .args(["--memory", "size=0,shared=on"])
         .args([
@@ -445,11 +448,14 @@ pub(crate) fn setup_ovs_dpdk_guests(
         ])
         .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
         .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-        .default_disks()
         .args(["--net", guest2.default_net_string().as_str(), OVS_DPDK_NET2])
-        .capture_output()
-        .spawn()
-        .unwrap();
+        .capture_output();
+    if release_binary {
+        cmd2.legacy_default_disks();
+    } else {
+        cmd2.default_disks();
+    }
+    let mut child2 = cmd2.spawn().unwrap();
 
     let r = panic::catch_unwind(|| {
         guest2.wait_vm_boot().unwrap();

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -363,6 +363,11 @@ pub(crate) fn cleanup_ovs_dpdk() {
     exec_host_command_status("rm -f ovs-vsctl /tmp/dpdkvhostclient1 /tmp/dpdkvhostclient2");
 }
 
+const OVS_DPDK_NET1: &str =
+    "vhost_user=true,socket=/tmp/dpdkvhostclient1,num_queues=2,queue_size=256,vhost_mode=server";
+const OVS_DPDK_NET2: &str =
+    "vhost_user=true,socket=/tmp/dpdkvhostclient2,num_queues=2,queue_size=256,vhost_mode=server";
+
 // Setup two guests and ensure they are connected through ovs-dpdk
 pub(crate) fn setup_ovs_dpdk_guests(
     guest1: &Guest,
@@ -379,16 +384,19 @@ pub(crate) fn setup_ovs_dpdk_guests(
     };
 
     let mut child1 = GuestCommand::new_with_binary_path(guest1, &clh_path)
-                    .args(["--cpus", "boot=2"])
-                    .args(["--memory", "size=0,shared=on"])
-                    .args(["--memory-zone", "id=mem0,size=1G,shared=on,host_numa_node=0"])
-                    .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
-                    .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-                    .default_disks()
-                    .args(["--net", guest1.default_net_string().as_str(), "vhost_user=true,socket=/tmp/dpdkvhostclient1,num_queues=2,queue_size=256,vhost_mode=server"])
-                    .capture_output()
-                    .spawn()
-                    .unwrap();
+        .args(["--cpus", "boot=2"])
+        .args(["--memory", "size=0,shared=on"])
+        .args([
+            "--memory-zone",
+            "id=mem0,size=1G,shared=on,host_numa_node=0",
+        ])
+        .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
+        .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+        .default_disks()
+        .args(["--net", guest1.default_net_string().as_str(), OVS_DPDK_NET1])
+        .capture_output()
+        .spawn()
+        .unwrap();
 
     #[cfg(target_arch = "x86_64")]
     let guest_net_iface = "ens5";
@@ -428,17 +436,20 @@ pub(crate) fn setup_ovs_dpdk_guests(
     }
 
     let mut child2 = GuestCommand::new_with_binary_path(guest2, &clh_path)
-                    .args(["--api-socket", api_socket])
-                    .args(["--cpus", "boot=2"])
-                    .args(["--memory", "size=0,shared=on"])
-                    .args(["--memory-zone", "id=mem0,size=1G,shared=on,host_numa_node=0"])
-                    .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
-                    .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-                    .default_disks()
-                    .args(["--net", guest2.default_net_string().as_str(), "vhost_user=true,socket=/tmp/dpdkvhostclient2,num_queues=2,queue_size=256,vhost_mode=server"])
-                    .capture_output()
-                    .spawn()
-                    .unwrap();
+        .args(["--api-socket", api_socket])
+        .args(["--cpus", "boot=2"])
+        .args(["--memory", "size=0,shared=on"])
+        .args([
+            "--memory-zone",
+            "id=mem0,size=1G,shared=on,host_numa_node=0",
+        ])
+        .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
+        .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+        .default_disks()
+        .args(["--net", guest2.default_net_string().as_str(), OVS_DPDK_NET2])
+        .capture_output()
+        .spawn()
+        .unwrap();
 
     let r = panic::catch_unwind(|| {
         guest2.wait_vm_boot().unwrap();

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8551,7 +8551,7 @@ mod snapshot_restore_common {
         }
 
         let cloudinit_params = format!(
-            "path={},iommu=on",
+            "path={},iommu=on,image_type=raw",
             guest.disk_config.disk(DiskType::CloudInit).unwrap()
         );
 
@@ -9710,7 +9710,7 @@ mod common_sequential {
         );
 
         let cloudinit_params = format!(
-            "path={},iommu=on",
+            "path={},iommu=on,image_type=raw",
             guest.disk_config.disk(DiskType::CloudInit).unwrap()
         );
 

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -475,18 +475,9 @@ mod common_parallel {
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .args(["--api-socket", &api_socket])
             .capture_output()
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!("path={test_disk_path},pci_segment={TEST_DISK_NODE}").as_str(),
             ])
             .default_net()
@@ -656,18 +647,9 @@ mod common_parallel {
             .args(["--memory", "size=512M"])
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!(
                     "path={},image_type=raw,num_queues=2,\
                      _disable_io_uring={},_disable_aio={}",
@@ -1652,18 +1634,9 @@ mod common_parallel {
             .args(["--memory", "size=512M"])
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!(
                     "path={},direct=on,image_type={image_type_str}",
                     test_disk.to_str().unwrap()
@@ -2911,18 +2884,9 @@ mod common_parallel {
             .args(["--cpus", "boot=4"])
             .args(["--memory", "size=2G,hugepages=on,shared=on"])
             .args(["--kernel", kernel_path.to_str().unwrap()])
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!("path={},image_type=raw", vfio_disk_path.to_str().unwrap()).as_str(),
                 format!("path={},iommu=on,readonly=true", blk_file_path.to_str().unwrap()).as_str(),
             ])
@@ -4031,18 +3995,9 @@ mod common_parallel {
             .args(["--memory", "size=512M"])
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!("path={loop_dev},direct=on,image_type=raw").as_str(),
             ])
             .default_net()
@@ -4143,18 +4098,9 @@ mod common_parallel {
             .args(["--memory", "size=512M"])
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!(
                     "path={},direct=on,image_type=raw",
                     test_disk_path.to_str().unwrap()
@@ -4357,18 +4303,9 @@ mod common_parallel {
             .default_memory()
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!(
                     "path={},num_queues=4,image_type={}{}",
                     test_disk_path.to_str().unwrap(),
@@ -4570,18 +4507,9 @@ mod common_parallel {
             .default_cpus()
             .default_memory()
             .default_kernel_cmdline()
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!("path={},image_type=raw", test_disk_path.to_str().unwrap()).as_str(),
             ])
             .default_net()
@@ -4672,20 +4600,8 @@ mod common_parallel {
             .args(["--memory", "size=512M"])
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-            .args([
-                "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
-                format!("path={loop_dev},image_type=raw").as_str(),
-            ])
+            .default_disks()
+            .args(["--disk", format!("path={loop_dev},image_type=raw").as_str()])
             .default_net()
             .capture_output()
             .spawn()
@@ -4848,20 +4764,8 @@ mod common_parallel {
             .args(["--memory", "size=512M"])
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-            .args([
-                "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
-                format!("path={dm_dev},image_type=raw").as_str(),
-            ])
+            .default_disks()
+            .args(["--disk", format!("path={dm_dev},image_type=raw").as_str()])
             .default_net()
             .capture_output()
             .spawn()
@@ -4992,18 +4896,9 @@ mod common_parallel {
             .default_memory()
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!(
                     "path={},num_queues=4,image_type={}{}",
                     test_disk_path.to_str().unwrap(),
@@ -5196,18 +5091,9 @@ mod common_parallel {
             .default_memory()
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!("path={test_disk_path},sparse=off").as_str(),
             ])
             .default_net()
@@ -5303,18 +5189,9 @@ mod common_parallel {
             .default_memory()
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
             .args([
                 "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
                 format!("path={test_disk_path},sparse=off,num_queues=4").as_str(),
             ])
             .default_net()
@@ -9648,20 +9525,8 @@ mod snapshot_restore_common {
             .args(["--memory", "size=512M,shared=on"])
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-            .args([
-                "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
-                blk_params.as_str(),
-            ])
+            .default_disks()
+            .args(["--disk", blk_params.as_str()])
             .default_net()
             .capture_output()
             .spawn()
@@ -13254,20 +13119,8 @@ mod rate_limiter {
             .args(["--memory", "size=1G"])
             .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-            .args([
-                "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-                )
-                .as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
-                test_blk_params.as_str(),
-            ])
+            .default_disks()
+            .args(["--disk", test_blk_params.as_str()])
             .default_net()
             .args(["--api-socket", &api_socket])
             .capture_output()
@@ -13325,17 +13178,7 @@ mod rate_limiter {
             )
         };
 
-        let mut disk_args = vec![
-            "--disk".to_string(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-            ),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            ),
-        ];
+        let mut test_disks = vec!["--disk".to_string()];
 
         for i in 0..num_disks {
             let test_img_path = String::from(
@@ -13354,7 +13197,7 @@ mod rate_limiter {
                 .success()
             );
 
-            disk_args.push(format!(
+            test_disks.push(format!(
                 "path={test_img_path},num_queues={num_queues},rate_limit_group=group0,image_type=raw"
             ));
         }
@@ -13365,7 +13208,8 @@ mod rate_limiter {
             .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .args(["--rate-limit-group", &rate_limit_group_arg])
-            .args(disk_args)
+            .default_disks()
+            .args(test_disks)
             .default_net()
             .args(["--api-socket", &api_socket])
             .capture_output()

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -943,10 +943,10 @@ mod common_parallel {
                     "path={},num_queues=8",
                     guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
                 ),
-                &format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                ),
+            ])
+            .default_cloudinit_disk()
+            .args([
+                "--disk",
                 &format!(
                     "path={},num_queues=8,backing_files={},image_type=qcow2",
                     test_image_path.to_str().unwrap(),
@@ -1549,11 +1549,8 @@ mod common_parallel {
                     "path={},direct=on,image_type=qcow2",
                     dest_qcow2.to_str().unwrap()
                 ),
-                &format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                ),
             ])
+            .default_cloudinit_disk()
             .default_net()
             .capture_output()
             .spawn()
@@ -1737,11 +1734,8 @@ mod common_parallel {
             .args([
                 "--disk",
                 &format!("path={}", test_image_path.to_str().unwrap()),
-                &format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                ),
             ])
+            .default_cloudinit_disk()
             .default_net()
             .capture_output()
             .spawn()
@@ -1800,11 +1794,8 @@ mod common_parallel {
             .args([
                 "--disk",
                 &format!("path={}", test_image_path.to_str().unwrap()),
-                &format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                ),
             ])
+            .default_cloudinit_disk()
             .default_net()
             .capture_output()
             .spawn()
@@ -1867,11 +1858,8 @@ mod common_parallel {
             .args([
                 "--disk",
                 &format!("path={}", test_image_path.to_str().unwrap()),
-                &format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                ),
             ])
+            .default_cloudinit_disk()
             .default_net()
             .capture_output()
             .spawn()
@@ -1917,11 +1905,8 @@ mod common_parallel {
             .args([
                 "--disk",
                 &format!("path={},readonly=on", test_image_path.to_str().unwrap()),
-                &format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                ),
             ])
+            .default_cloudinit_disk()
             .default_net()
             .capture_output()
             .spawn()
@@ -2084,12 +2069,8 @@ mod common_parallel {
             .args([
                 "--disk",
                 format!("path={},direct=on", os_path.as_path().to_str().unwrap()).as_str(),
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
             ])
+            .default_cloudinit_disk()
             .default_net()
             .capture_output()
             .spawn()
@@ -2419,14 +2400,7 @@ mod common_parallel {
             .default_cpus()
             .default_memory()
             .args(["--kernel", kernel_path.to_str().unwrap()])
-            .args([
-                "--disk",
-                format!(
-                    "path={}",
-                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
-                )
-                .as_str(),
-            ])
+            .default_cloudinit_disk()
             .default_net()
             .args([
                 "--pmem",

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6654,13 +6654,17 @@ mod common_parallel {
             .args(memory_param)
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-            .default_disks()
             .args(["--net", net_params.as_str()])
             .args(["--api-socket", &src_api_socket])
             .args([
                 "--pmem",
                 format!("file={}", pmem_temp_file.as_path().to_str().unwrap(),).as_str(),
             ]);
+        if upgrade_test {
+            src_vm_cmd.legacy_default_disks();
+        } else {
+            src_vm_cmd.default_disks();
+        }
         let mut src_child = src_vm_cmd.capture_output().spawn().unwrap();
 
         // Start the destination VM
@@ -10156,13 +10160,17 @@ mod common_sequential {
             .args(memory_param)
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-            .default_disks()
             .args(["--net", net_params.as_str()])
             .args(["--api-socket", &src_api_socket])
             .args([
                 "--pmem",
                 format!("file={}", pmem_temp_file.as_path().to_str().unwrap(),).as_str(),
             ]);
+        if upgrade_test {
+            src_vm_cmd.legacy_default_disks();
+        } else {
+            src_vm_cmd.default_disks();
+        }
         let mut src_child = src_vm_cmd.capture_output().spawn().unwrap();
 
         // Start the destination VM
@@ -10372,13 +10380,17 @@ mod common_sequential {
             .args(memory_param)
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-            .default_disks()
             .args(["--net", net_params.as_str()])
             .args(["--api-socket", &src_api_socket])
             .args([
                 "--pmem",
                 format!("file={}", pmem_temp_file.as_path().to_str().unwrap(),).as_str(),
             ]);
+        if upgrade_test {
+            src_vm_cmd.legacy_default_disks();
+        } else {
+            src_vm_cmd.default_disks();
+        }
         let mut src_child = src_vm_cmd.capture_output().spawn().unwrap();
 
         // Start the destination VM
@@ -10796,7 +10808,6 @@ mod common_sequential {
             .args(memory_param)
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-            .default_disks()
             .args(["--net", net_params.as_str()])
             .args(["--api-socket", &src_api_socket])
             .args([
@@ -10804,6 +10815,11 @@ mod common_sequential {
                 format!("file={}", pmem_temp_file.as_path().to_str().unwrap(),).as_str(),
             ])
             .args(["--watchdog"]);
+        if upgrade_test {
+            src_vm_cmd.legacy_default_disks();
+        } else {
+            src_vm_cmd.default_disks();
+        }
         let mut src_child = src_vm_cmd.capture_output().spawn().unwrap();
 
         // Start the destination VM

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -940,7 +940,7 @@ mod common_parallel {
             .args([
                 "--disk",
                 &format!(
-                    "path={},num_queues=8",
+                    "path={},num_queues=8,image_type=qcow2",
                     guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
                 ),
             ])
@@ -1733,7 +1733,10 @@ mod common_parallel {
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .args([
                 "--disk",
-                &format!("path={}", test_image_path.to_str().unwrap()),
+                &format!(
+                    "path={},image_type=qcow2",
+                    test_image_path.to_str().unwrap()
+                ),
             ])
             .default_cloudinit_disk()
             .default_net()
@@ -1793,7 +1796,10 @@ mod common_parallel {
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .args([
                 "--disk",
-                &format!("path={}", test_image_path.to_str().unwrap()),
+                &format!(
+                    "path={},image_type=qcow2",
+                    test_image_path.to_str().unwrap()
+                ),
             ])
             .default_cloudinit_disk()
             .default_net()
@@ -1857,7 +1863,10 @@ mod common_parallel {
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .args([
                 "--disk",
-                &format!("path={}", test_image_path.to_str().unwrap()),
+                &format!(
+                    "path={},image_type=qcow2",
+                    test_image_path.to_str().unwrap()
+                ),
             ])
             .default_cloudinit_disk()
             .default_net()
@@ -1904,7 +1913,10 @@ mod common_parallel {
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .args([
                 "--disk",
-                &format!("path={},readonly=on", test_image_path.to_str().unwrap()),
+                &format!(
+                    "path={},readonly=on,image_type=qcow2",
+                    test_image_path.to_str().unwrap()
+                ),
             ])
             .default_cloudinit_disk()
             .default_net()
@@ -3702,7 +3714,7 @@ mod common_parallel {
                 &api_socket,
                 "add-disk",
                 Some(&format!(
-                    "path={},id=test0",
+                    "path={},id=test0,image_type=qcow2",
                     test_disk_path.to_str().unwrap()
                 )),
             );
@@ -5166,7 +5178,7 @@ mod common_parallel {
             .default_disks()
             .args([
                 "--disk",
-                format!("path={test_disk_path},sparse=off,num_queues=4").as_str(),
+                format!("path={test_disk_path},sparse=off,num_queues=4,image_type=qcow2").as_str(),
             ])
             .default_net()
             .capture_output()

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -386,7 +386,7 @@ mod common_parallel {
                 "add-disk",
                 Some(
                     format!(
-                        "path={},id=test0,pci_segment=1,iommu=on",
+                        "path={},id=test0,pci_segment=1,iommu=on,image_type=raw",
                         test_disk_path.as_str()
                     )
                     .as_str(),
@@ -478,7 +478,8 @@ mod common_parallel {
             .default_disks()
             .args([
                 "--disk",
-                format!("path={test_disk_path},pci_segment={TEST_DISK_NODE}").as_str(),
+                format!("path={test_disk_path},pci_segment={TEST_DISK_NODE},image_type=raw")
+                    .as_str(),
             ])
             .default_net()
             .spawn()
@@ -2878,7 +2879,11 @@ mod common_parallel {
             .args([
                 "--disk",
                 format!("path={},image_type=raw", vfio_disk_path.to_str().unwrap()).as_str(),
-                format!("path={},iommu=on,readonly=true", blk_file_path.to_str().unwrap()).as_str(),
+                format!(
+                    "path={},iommu=on,readonly=true,image_type=raw",
+                    blk_file_path.to_str().unwrap()
+                )
+                .as_str(),
             ])
             .args([
                 "--cmdline",
@@ -3602,7 +3607,7 @@ mod common_parallel {
             let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
-                Some("path=/tmp/resize.img,id=test0"),
+                Some("path=/tmp/resize.img,id=test0,image_type=raw"),
             );
 
             assert!(cmd_success);
@@ -5084,7 +5089,7 @@ mod common_parallel {
             .default_disks()
             .args([
                 "--disk",
-                format!("path={test_disk_path},sparse=off").as_str(),
+                format!("path={test_disk_path},sparse=off,image_type=raw").as_str(),
             ])
             .default_net()
             .capture_output()
@@ -6840,7 +6845,13 @@ mod common_parallel {
             assert!(!remote_command(
                 &src_api_socket,
                 "add-disk",
-                Some(format!("path={},id=test0", blk_file_path.to_str().unwrap()).as_str()),
+                Some(
+                    format!(
+                        "path={},id=test0,image_type=raw",
+                        blk_file_path.to_str().unwrap()
+                    )
+                    .as_str()
+                ),
             ));
 
             // Start the live-migration
@@ -6898,7 +6909,13 @@ mod common_parallel {
         assert!(!remote_command(
             &dest_api_socket,
             "add-disk",
-            Some(format!("path={},id=test0", blk_file_path.to_str().unwrap()).as_str()),
+            Some(
+                format!(
+                    "path={},id=test0,image_type=raw",
+                    blk_file_path.to_str().unwrap()
+                )
+                .as_str()
+            ),
         ));
 
         // Clean-up the destination VM and make sure it terminated correctly
@@ -11950,7 +11967,7 @@ mod windows {
             let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
-                Some(format!("path={disk},readonly=off").as_str()),
+                Some(format!("path={disk},readonly=off,image_type=raw").as_str()),
             );
             assert!(cmd_success);
             assert!(String::from_utf8_lossy(&cmd_output).contains("\"id\":\"_disk2\""));
@@ -11988,7 +12005,7 @@ mod windows {
             let (cmd_success, _cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
-                Some(format!("path={disk},readonly=off").as_str()),
+                Some(format!("path={disk},readonly=off,image_type=raw").as_str()),
             );
             assert!(cmd_success);
             // Wait for Windows to mount the re-added disk again.
@@ -12079,7 +12096,7 @@ mod windows {
                 let (cmd_success, cmd_output, _) = remote_command_w_output(
                     &api_socket,
                     "add-disk",
-                    Some(format!("path={disk},readonly=off").as_str()),
+                    Some(format!("path={disk},readonly=off,image_type=raw").as_str()),
                 );
                 assert!(cmd_success);
                 assert!(
@@ -12132,7 +12149,7 @@ mod windows {
                 let (cmd_success, _cmd_output, _) = remote_command_w_output(
                     &api_socket,
                     "add-disk",
-                    Some(format!("path={disk},readonly=off").as_str()),
+                    Some(format!("path={disk},readonly=off,image_type=raw").as_str()),
                 );
                 assert!(cmd_success);
             }

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -2080,7 +2080,11 @@ mod common_parallel {
             .args(["--kernel", fw_path(FwType::RustHypervisorFirmware).as_str()])
             .args([
                 "--disk",
-                format!("path={},direct=on", os_path.as_path().to_str().unwrap()).as_str(),
+                format!(
+                    "path={},direct=on,image_type=raw",
+                    os_path.as_path().to_str().unwrap()
+                )
+                .as_str(),
             ])
             .default_cloudinit_disk()
             .default_net()
@@ -8589,7 +8593,7 @@ mod snapshot_restore_common {
             .args([
                 "--disk",
                 format!(
-                    "path={}",
+                    "path={},image_type=raw",
                     guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
                 )
                 .as_str(),
@@ -9738,7 +9742,7 @@ mod common_sequential {
             .args([
                 "--disk",
                 format!(
-                    "path={}",
+                    "path={},image_type=raw",
                     guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
                 )
                 .as_str(),
@@ -11517,7 +11521,7 @@ mod windows {
             .args([
                 "--disk",
                 format!(
-                    "path={},num_queues=4",
+                    "path={},num_queues=4,image_type=raw",
                     windows_guest
                         .guest()
                         .disk_config

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -350,7 +350,6 @@ pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
         let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = performance_test_new_guest(Box::new(jammy), control);
         let mut cmd = GuestCommand::new(&guest);
-        let cloud_init = guest.disk_config.disk(DiskType::CloudInit).unwrap();
         let c = cmd
             .default_cpus()
             .args(["--memory", "size=1G,hugepages=on"])
@@ -358,7 +357,7 @@ pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
             .args(["--cmdline", "root=/dev/pmem0p1 console=ttyS0 quiet rw"])
             .args(["--console", "off"])
             .default_net()
-            .args(["--disk", format!("path={cloud_init}").as_str()])
+            .default_cloudinit_disk()
             .args([
                 "--pmem",
                 format!(

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -418,20 +418,8 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
         .default_cpus()
         .args(["--memory", "size=4G"])
         .default_kernel_cmdline()
-        .args([
-            "--disk",
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
-            )
-            .as_str(),
-            format!(
-                "path={}",
-                guest.disk_config.disk(DiskType::CloudInit).unwrap()
-            )
-            .as_str(),
-            test_disk_arg.as_str(),
-        ])
+        .default_disks()
+        .args(["--disk", test_disk_arg.as_str()])
         .default_net()
         .args(["--api-socket", &api_socket])
         .capture_output()

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2027,22 +2027,12 @@ impl<'a> GuestCommand<'a> {
     }
 
     pub fn default_disks(&mut self) -> &mut Self {
-        self.default_disks_inner(true)
-    }
-
-    pub fn default_disks_sparse_off(&mut self) -> &mut Self {
-        self.default_disks_inner(false)
-    }
-
-    fn default_disks_inner(&mut self, sparse: bool) -> &mut Self {
-        let sparse_opt = if sparse { "" } else { ",sparse=off" };
         let os_disk = format!(
-            "path={}{}",
+            "path={}",
             self.guest
                 .disk_config
                 .disk(DiskType::OperatingSystem)
                 .unwrap(),
-            sparse_opt
         );
         if let Some(cloud_init) = self.guest.disk_config.disk(DiskType::CloudInit) {
             self.args([

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1427,9 +1427,11 @@ impl Guest {
             "disks": [
             {
                 "path": self.disk_config.disk(DiskType::OperatingSystem).unwrap(),
+                "image_type": "Raw",
             },
             {
                 "path": self.disk_config.disk(DiskType::CloudInit).unwrap(),
+                "image_type": "Raw",
             }
             ]
         });
@@ -2028,7 +2030,7 @@ impl<'a> GuestCommand<'a> {
 
     pub fn default_disks(&mut self) -> &mut Self {
         let os_disk = format!(
-            "path={}",
+            "path={},image_type=raw",
             self.guest
                 .disk_config
                 .disk(DiskType::OperatingSystem)

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2040,6 +2040,24 @@ impl<'a> GuestCommand<'a> {
         self.default_cloudinit_disk()
     }
 
+    // Needed for when running old version as part of live upgrade
+    pub fn legacy_default_disks(&mut self) -> &mut Self {
+        let mut disks = vec![
+            "--disk".to_string(),
+            format!(
+                "path={}",
+                self.guest
+                    .disk_config
+                    .disk(DiskType::OperatingSystem)
+                    .unwrap(),
+            ),
+        ];
+        if let Some(cloud_init) = self.guest.disk_config.disk(DiskType::CloudInit) {
+            disks.push(format!("path={cloud_init}"));
+        }
+        self.args(disks)
+    }
+
     pub fn default_cloudinit_disk(&mut self) -> &mut Self {
         if let Some(cloud_init) = self.guest.disk_config.disk(DiskType::CloudInit) {
             self.args([

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2040,7 +2040,10 @@ impl<'a> GuestCommand<'a> {
 
     pub fn default_cloudinit_disk(&mut self) -> &mut Self {
         if let Some(cloud_init) = self.guest.disk_config.disk(DiskType::CloudInit) {
-            self.args(["--disk", format!("path={cloud_init}").as_str()]);
+            self.args([
+                "--disk",
+                format!("path={cloud_init},image_type=raw").as_str(),
+            ]);
         }
         self
     }

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2034,15 +2034,15 @@ impl<'a> GuestCommand<'a> {
                 .disk(DiskType::OperatingSystem)
                 .unwrap(),
         );
+        self.args(["--disk", os_disk.as_str()]);
+        self.default_cloudinit_disk()
+    }
+
+    pub fn default_cloudinit_disk(&mut self) -> &mut Self {
         if let Some(cloud_init) = self.guest.disk_config.disk(DiskType::CloudInit) {
-            self.args([
-                "--disk",
-                os_disk.as_str(),
-                format!("path={cloud_init}").as_str(),
-            ])
-        } else {
-            self.args(["--disk", os_disk.as_str()])
+            self.args(["--disk", format!("path={cloud_init}").as_str()]);
         }
+        self
     }
 
     pub fn default_net(&mut self) -> &mut Self {


### PR DESCRIPTION
Many tests still relied on image type autodetection. Add explicit image_type to
the disk configuration.

- **tests: Use Guest::default_disks() where possible**
- **test_infra: Remove unused default_disks_sparse_off()**
- **tests: Add a Guest::default_cloudinit_disk() and use it**
- **tests: Apply the queue affinity to the boot disk**
- **tests: Set image_type=raw for cloud-init file**
- **tests: Add missing image_type parameters for non-raw files**
- **test_infra: Specify image_type for API based boots**
- **tests: Add image_type=raw on OS disks where missing**
- **tests: Mark raw test disks with image_type=raw**
