### PR TITLE
ci: Update virtio-villain to v0.9.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -854,7 +854,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VILLAIN_REPO: https://github.com/weltling/virtio-villain.git
-      VILLAIN_REF: v0.6.4
+      VILLAIN_REF: v0.9.0
     steps:
       - name: Code checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
The new version expands split, packed, and indirect ring coverage with descriptor address overflow, queue memory overlap, device config overlap, and reset during active requests.

It adds malformed descriptor tests for network transmit and receive queues plus indirect table tests for rng and console devices. It also fixes network expectations for offload, announce, and ack handling.