### PR TITLE
vmm: Propagate clean shutdown on ARM64

### DIFF
--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -626,7 +626,7 @@ impl cpu::Vcpu for MshvVcpu {
                 }
                 hv_message_type_HVMSG_UNRECOVERABLE_EXCEPTION => {
                     warn!("TRIPLE FAULT");
-                    Ok(cpu::VmExit::Shutdown)
+                    Ok(cpu::VmExit::Reset)
                 }
                 #[cfg(target_arch = "x86_64")]
                 hv_message_type_HVMSG_X64_IO_PORT_INTERCEPT => {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -237,6 +237,9 @@ pub enum Error {
 
     #[error("Error generating MSR configuration update")]
     MsrConfigurationUpdate(#[source] arch::Error),
+
+    #[error("Cannot clone EventFd")]
+    EventFdClone(#[source] io::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -1196,13 +1199,13 @@ impl CpuManager {
         vcpu_thread_barrier: Arc<Barrier>,
         inserting: bool,
     ) -> Result<()> {
-        let reset_evt = self.reset_evt.try_clone().unwrap();
-        let exit_evt = self.exit_evt.try_clone().unwrap();
+        let reset_evt = self.reset_evt.try_clone().map_err(Error::EventFdClone)?;
+        let exit_evt = self.exit_evt.try_clone().map_err(Error::EventFdClone)?;
         #[cfg(feature = "kvm")]
         let hypervisor_type = self.hypervisor.hypervisor_type();
         #[cfg(feature = "guest_debug")]
-        let vm_debug_evt = self.vm_debug_evt.try_clone().unwrap();
-        let panic_exit_evt = self.exit_evt.try_clone().unwrap();
+        let vm_debug_evt = self.vm_debug_evt.try_clone().map_err(Error::EventFdClone)?;
+        let panic_exit_evt = self.exit_evt.try_clone().map_err(Error::EventFdClone)?;
         let vcpus_kill_signalled = self.vcpus_kill_signalled.clone();
         let vcpus_pause_signalled = self.vcpus_pause_signalled.clone();
         let vcpus_kick_signalled = self.vcpus_kick_signalled.clone();

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -723,6 +723,7 @@ pub struct CpuManager {
     vcpus_pause_signalled: Arc<AtomicBool>,
     vcpus_kick_signalled: Arc<AtomicBool>,
     exit_evt: EventFd,
+    guest_exit_evt: EventFd,
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     reset_evt: EventFd,
     #[cfg(feature = "guest_debug")]
@@ -865,6 +866,7 @@ impl CpuManager {
         config: &CpusConfig,
         vm: Arc<dyn hypervisor::Vm>,
         exit_evt: EventFd,
+        guest_exit_evt: EventFd,
         reset_evt: EventFd,
         #[cfg(feature = "guest_debug")] vm_debug_evt: EventFd,
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
@@ -962,6 +964,7 @@ impl CpuManager {
             vcpus_kick_signalled: Arc::new(AtomicBool::new(false)),
             vcpu_states,
             exit_evt,
+            guest_exit_evt,
             reset_evt,
             #[cfg(feature = "guest_debug")]
             vm_debug_evt,
@@ -1201,6 +1204,11 @@ impl CpuManager {
     ) -> Result<()> {
         let reset_evt = self.reset_evt.try_clone().map_err(Error::EventFdClone)?;
         let exit_evt = self.exit_evt.try_clone().map_err(Error::EventFdClone)?;
+        let guest_exit_evt = self
+            .guest_exit_evt
+            .try_clone()
+            .map_err(Error::EventFdClone)?;
+
         #[cfg(feature = "kvm")]
         let hypervisor_type = self.hypervisor.hypervisor_type();
         #[cfg(feature = "guest_debug")]
@@ -1458,7 +1466,7 @@ impl CpuManager {
                                     VmExit::Shutdown => {
                                         info!("VmExit::Shutdown");
                                         vcpu_run_interrupted.store(true, Ordering::SeqCst);
-                                        exit_evt.write(1).unwrap();
+                                        guest_exit_evt.write(1).unwrap();
                                         break;
                                     }
                                     #[cfg(feature = "tdx")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -634,6 +634,7 @@ impl Vm {
             &config,
             vm.clone(),
             exit_evt.try_clone().map_err(Error::EventFdClone)?,
+            guest_exit_evt.try_clone().map_err(Error::EventFdClone)?,
             reset_evt.try_clone().map_err(Error::EventFdClone)?,
             #[cfg(feature = "guest_debug")]
             vm_debug_evt,
@@ -778,6 +779,7 @@ impl Vm {
         config: &Arc<Mutex<VmConfig>>,
         vm: Arc<dyn hypervisor::Vm>,
         exit_evt: EventFd,
+        guest_exit_evt: EventFd,
         reset_evt: EventFd,
         #[cfg(feature = "guest_debug")] vm_debug_evt: EventFd,
         hypervisor: &Arc<dyn hypervisor::Hypervisor>,
@@ -803,6 +805,7 @@ impl Vm {
             &cpus_config,
             vm,
             exit_evt,
+            guest_exit_evt,
             reset_evt,
             #[cfg(feature = "guest_debug")]
             vm_debug_evt,


### PR DESCRIPTION
Treat a clean shutdown on ARM64 the same as x86-64. On ARM64 there is a KVM
exit that represents this which is mapped to the VmExit::Shutdown exit. That
exit was being mapped to a write to the exit_evt vs the guest_exit_evt EventFd.
One effect of this change is to make `--no-shutdown` work on ARM64.

- **hypervisor: mshv: Map triple-fault to VmExit::Reset**
- **vmm: cpu: Introduce error enum value for EventFd cloning**
- **vmm: Map VmExit::Shutdown to guest poweroff**
