### PR TITLE
tests: re-enable test_live_migration_tcp_timeout_cancel() + make more robust

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7367,6 +7367,7 @@ mod common_parallel {
                 Some(status) => status.success(),
                 None => {
                     let _ = send_migration.kill();
+                    let _ = send_migration.wait();
                     false
                 }
             };
@@ -7383,6 +7384,7 @@ mod common_parallel {
             // Clean up receive-migration if it gets stuck for some reason.
             if receive_status.is_none() {
                 let _ = receive_migration.kill();
+                let _ = receive_migration.wait();
             }
 
             // Kill the stressor now that migration has completed or aborted,
@@ -7443,12 +7445,11 @@ mod common_parallel {
                         &src_event_path
                     ));
 
-                    thread::sleep(Duration::from_secs(3));
                     assert!(
                         wait_until(Duration::from_secs(30), || {
                             matches!(src_child.try_wait(), Ok(Some(_)))
                         }),
-                        "Source VM should have terminated after a forced migration"
+                        "Source VMM should have terminated after a forced migration"
                     );
 
                     // Confirm the VM is still responsive over SSH on the new host
@@ -7458,8 +7459,10 @@ mod common_parallel {
         }));
 
         let _ = src_child.kill();
+        let _ = src_child.wait();
         let src_output = src_child.wait_with_output().unwrap();
         let _ = dest_child.kill();
+        let _ = dest_child.wait();
         let _dest_output = dest_child.wait_with_output().unwrap();
 
         handle_child_output(r, &src_output);

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7360,14 +7360,9 @@ mod common_parallel {
                 .stdout(Stdio::piped())
                 .spawn()
                 .unwrap();
-
             let send_status = send_migration
                 .wait_timeout(Duration::from_secs(60))
                 .unwrap();
-            let receive_status = receive_migration
-                .wait_timeout(Duration::from_secs(60))
-                .unwrap();
-
             let send_dispatched = match send_status {
                 Some(status) => status.success(),
                 None => {
@@ -7380,7 +7375,12 @@ mod common_parallel {
                 "send-migration should have dispatched successfully"
             );
 
-            // Clean up receive-migration regardless of its outcome
+            let receive_status = receive_migration
+                .wait_timeout(Duration::from_secs(60))
+                .unwrap()
+                .map(|status| status.success());
+
+            // Clean up receive-migration if it gets stuck for some reason.
             if receive_status.is_none() {
                 let _ = receive_migration.kill();
             }
@@ -7391,6 +7391,11 @@ mod common_parallel {
 
             match timeout_strategy {
                 TimeoutStrategy::Cancel => {
+                    assert!(
+                        receive_status == Some(false),
+                        "receive-migration should have failed because the migration was aborted: is {receive_status:?}"
+                    );
+
                     let expected_events = [
                         &MetaEvent {
                             event: "migration-started".to_string(),
@@ -7417,6 +7422,11 @@ mod common_parallel {
                     assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
                 }
                 TimeoutStrategy::Ignore => {
+                    assert!(
+                        receive_status == Some(true),
+                        "receive-migration should have succeeded because the migration succeeded: is {receive_status:?}"
+                    );
+
                     let expected_events = [
                         &MetaEvent {
                             event: "migration-started".to_string(),

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7269,8 +7269,9 @@ mod common_parallel {
             "id={},tap=,mac={},ip={},mask=255.255.255.128",
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
-        let memory_param: &[&str] = &["--memory", "size=1500M,shared=on"];
-        let boot_vcpus = 2;
+        let memory_size_mb = 1600;
+        let memory_param: &[&str] = &["--memory", &format!("size={memory_size_mb}M,shared=on")];
+        let boot_vcpus = 4;
 
         let src_vm_path = clh_command("cloud-hypervisor");
         let src_api_socket = temp_api_path(&guest.tmp_dir);
@@ -7307,13 +7308,17 @@ mod common_parallel {
 
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
 
+            let stress_worker = boot_vcpus - 1;
+            let stress_mem_per_worker =
+                (memory_size_mb as f64 * 0.75 / stress_worker as f64) as u64;
             // Start a memory stressor in the background to keep pages dirty,
             // ensuring the precopy loop cannot converge within the 1s timeout.
-            guest
-                .ssh_command("nohup stress --vm 2 --vm-bytes 220M --vm-keep &>/dev/null &")
-                .unwrap();
+            let stress_cmd = format!(
+                "nohup stress --vm {stress_worker} --vm-bytes {stress_mem_per_worker}M --vm-keep &>/dev/null &"
+            );
+            guest.ssh_command(&stress_cmd).unwrap();
             // Give stress a moment to actually start dirtying memory
-            thread::sleep(Duration::from_secs(3));
+            thread::sleep(Duration::from_secs(4));
 
             let migration_port = get_available_port();
             let host_ip = "127.0.0.1";
@@ -7402,13 +7407,13 @@ mod common_parallel {
                         &src_event_path
                     ));
 
+                    // Check that even after a few seconds, the VMM is still
+                    // running and the VM responsive over SSH.
                     thread::sleep(Duration::from_secs(2));
                     assert!(
                         src_child.try_wait().unwrap().is_none(),
-                        "Source VM should still be running after a cancelled migration"
+                        "VM should still be running on the source after a cancelled migration"
                     );
-
-                    // Confirm the source VM is still responsive over SSH
                     assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
                 }
                 TimeoutStrategy::Ignore => {
@@ -7487,7 +7492,6 @@ mod common_parallel {
     }
 
     #[test]
-    #[ignore = "See #8651"]
     fn test_live_migration_tcp_timeout_cancel() {
         _test_live_migration_tcp_timeout(TimeoutStrategy::Cancel);
     }


### PR DESCRIPTION
Closes #8492 and #8651, both affecting the integration test `test_live_migration_tcp_timeout_cancel()`.