### PR TITLE
net_util: Drop TX frames on tap EIO instead of failing the VM

### DIFF
--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -138,6 +138,9 @@ impl TxVirtio {
                     if e.raw_os_error() == Some(libc::EINVAL) {
                         error!("net: tx: dropping malformed packet: {e}");
                         0
+                    } else if e.raw_os_error() == Some(libc::EIO) {
+                        error!("net: tx: dropping frame, tap I/O error: {e}");
+                        0
                     } else {
                         error!("net: tx: failed writing to tap: {e}");
                         return Err(NetQueuePairError::WriteTap(e));


### PR DESCRIPTION
Fixes #8722.

A `writev` to the tap failing with `EIO` (device down, or carrier not up yet) kills the net worker thread and the VM exits. A tap in that state is a transient, recoverable host-side condition — snapshot-resumed guests hit it routinely by transmitting within a few hundred milliseconds of resume, racing host tap (re)wiring — but one refused frame becomes guest death.

Physical NICs drop the frame when the link is down and let the guest stack retransmit. This change does the same for `EIO`: log and drop the frame with used length 0, exactly like the `EINVAL` malformed-packet case introduced by #8142, keeping the queue and worker alive. `EAGAIN` keeps its existing retry behaviour; all other errnos remain fatal.

One deliberate difference from the `EAGAIN` path: on `EIO` we keep draining the ring rather than breaking out. A down tap stays "writable" from epoll's perspective (writes fail immediately instead of blocking), so there is no `EPOLLOUT` edge to re-arm the worker, and breaking early would strand the already-available descriptors. Each kick drains at most one ring's worth of drops, bounded by ring depth and the TX rate limiter's ops budget when configured.

## Testing

- `cargo +nightly fmt --all -- --check`, `cargo check -p net_util --all-targets`, `cargo clippy -p net_util --all-targets`, `cargo test -p net_util`: clean.
- Live repro: with a tap set down while the guest transmits, the VM previously exited on the first frame; with this patch it survives, frames are dropped, and traffic resumes when the tap comes back up.
- The drop path calls `libc::writev` on a real tap fd and is not meaningfully unit-testable without a full mock stack (same situation as #8142's drop paths).

## Notes

Analysis and patch preparation assisted by AI; reviewed and understood by the submitter.

Assisted-by: Claude:Fable-5
