### PR TITLE
Align tdx support with linux v6.16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -448,6 +448,14 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           args: --locked --all --all-targets --no-default-features --tests --examples --features "mshv,igvm" -- -D warnings
+      - name: Clippy (kvm + tdx)
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        uses: houseabsolute/actions-rust-cross@v1
+        with:
+          command: clippy
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          args: --locked --all --all-targets --no-default-features --tests --examples --features "tdx,kvm" -- -D warnings
       - name: Clippy (kvm + igvm + sev_snp + fw_cfg)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: houseabsolute/actions-rust-cross@v1
@@ -500,6 +508,8 @@ jobs:
         run: cargo build --locked --bin cloud-hypervisor
       - name: Build (kvm)
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "kvm"
+      - name: Build (default features + tdx)
+        run: cargo build --locked --bin cloud-hypervisor --features "tdx"
       - name: Build (default features + dbus_api)
         run: cargo build --locked --bin cloud-hypervisor --features "dbus_api"
       - name: Build (default features + guest_debug)

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1055,6 +1055,7 @@ pub fn configure_vcpu(
     topology: (u16, u16, u16, u16),
     nested: bool,
     setup_registers: bool,
+    tdx_enabled: bool,
 ) -> super::Result<()> {
     let x2apic_id = get_x2apic_id(id, Some(topology));
 
@@ -1124,7 +1125,12 @@ pub fn configure_vcpu(
         vcpu.enable_hyperv_synic().unwrap();
     }
 
-    regs::setup_msrs(vcpu).map_err(Error::MsrsConfiguration)?;
+    // For TDX, the vCPU's MSR state is owned by the TDX module and cannot be
+    // programmed through KVM_SET_MSRS (the vCPU is guest-state protected), so
+    // skip the boot MSR setup for TDs.
+    if !tdx_enabled {
+        regs::setup_msrs(vcpu).map_err(Error::MsrsConfiguration)?;
+    }
     if let Some((kernel_entry_point, guest_memory)) = boot_setup {
         if setup_registers {
             regs::setup_regs(vcpu, kernel_entry_point).map_err(Error::RegsConfiguration)?;
@@ -1140,7 +1146,12 @@ pub fn configure_vcpu(
         }
         regs::setup_fpu(vcpu).map_err(Error::FpuConfiguration)?;
     }
-    interrupts::set_lint(vcpu).map_err(|e| Error::LocalIntConfiguration(e.into()))?;
+    // For TDX, the vCPU's local APIC state is owned by the TDX module and is not
+    // accessible via KVM_GET_LAPIC/KVM_SET_LAPIC (the vCPU is guest-state
+    // protected), so skip the LINT setup that those ioctls back.
+    if !tdx_enabled {
+        interrupts::set_lint(vcpu).map_err(|e| Error::LocalIntConfiguration(e.into()))?;
+    }
     Ok(())
 }
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -907,9 +907,23 @@ fn required_common_cpuid_updates(
             }
             // Set CPU physical bits and guest physical bits
             0x8000_0008 => {
-                entry.eax = (entry.eax & 0xff00_ff00)
-                    | (config.phys_bits as u32 & 0xff)
-                    | ((config.phys_bits as u32 & 0xff) << 16);
+                // For TDX the guest physical address width (GPAW) is fixed at 48
+                // (GPAW-48, 4-level EPT), and the shared/private bit lives at bit
+                // GPAW-1 (bit 47). KVM derives the vCPU's reserved GPA bits from the
+                // CPUID maxphyaddr (EAX[7:0]); it must be at least the GPAW so that a
+                // guest MapGPA carrying the shared bit is not rejected as an illegal
+                // GPA. Report both the maxphyaddr and the guest physical bits as 48,
+                // independent of the (host-derived) memory-layout phys_bits.
+                #[cfg(feature = "tdx")]
+                let phys_bits = if config.tdx {
+                    48u32
+                } else {
+                    config.phys_bits as u32
+                };
+                #[cfg(not(feature = "tdx"))]
+                let phys_bits = config.phys_bits as u32;
+                entry.eax =
+                    (entry.eax & 0xff00_ff00) | (phys_bits & 0xff) | ((phys_bits & 0xff) << 16);
             }
             0x4000_0001 => {
                 // Enable KVM_FEATURE_MSI_EXT_DEST_ID. This allows the guest to target

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1009,16 +1009,16 @@ fn common_cpuid_tdx_configuration(
     for entry in cpuid.iter_mut().filter(|entry| entry.function == 0xd) {
         let xcr0_mask: u64 = 0x82ff;
         let xss_mask: u64 = !xcr0_mask;
+        // Upstream Linux 6.16 reports a single `supported_xfam` mask of the
+        // XSAVE state components the TDX module can virtualize, replacing the
+        // old fixed0/fixed1 pair. Mask the guest CPUID.0xD leaf down to the
+        // supported components.
         if entry.index == 0 {
-            entry.eax &= (caps.xfam_fixed0 as u32) & (xcr0_mask as u32);
-            entry.eax |= (caps.xfam_fixed1 as u32) & (xcr0_mask as u32);
-            entry.edx &= ((caps.xfam_fixed0 & xcr0_mask) >> 32) as u32;
-            entry.edx |= ((caps.xfam_fixed1 & xcr0_mask) >> 32) as u32;
+            entry.eax &= (caps.supported_xfam as u32) & (xcr0_mask as u32);
+            entry.edx &= ((caps.supported_xfam & xcr0_mask) >> 32) as u32;
         } else if entry.index == 1 {
-            entry.ecx &= (caps.xfam_fixed0 as u32) & (xss_mask as u32);
-            entry.ecx |= (caps.xfam_fixed1 as u32) & (xss_mask as u32);
-            entry.edx &= ((caps.xfam_fixed0 & xss_mask) >> 32) as u32;
-            entry.edx |= ((caps.xfam_fixed1 & xss_mask) >> 32) as u32;
+            entry.ecx &= (caps.supported_xfam as u32) & (xss_mask as u32);
+            entry.edx &= ((caps.supported_xfam & xss_mask) >> 32) as u32;
         }
     }
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -207,6 +207,11 @@ pub enum Error {
     #[error("Error retrieving TDX capabilities through the hypervisor API")]
     TdxCapabilities(#[source] HypervisorError),
 
+    /// No VM handle was available to query TDX capabilities
+    #[cfg(feature = "tdx")]
+    #[error("No VM handle available to query TDX capabilities")]
+    TdxCapabilitiesNoVm,
+
     /// Failed to configure E820 map for bzImage
     #[error("Failed to configure E820 map for bzImage")]
     E820Configuration,
@@ -649,6 +654,7 @@ impl CpuidFeatureEntry {
 /// to apply the selected CPU profile.
 pub fn generate_common_cpuid(
     hypervisor: &dyn hypervisor::Hypervisor,
+    #[cfg(feature = "tdx")] vm: Option<&dyn hypervisor::Vm>,
     config: &CpuidConfig,
 ) -> super::Result<Vec<CpuIdEntry>> {
     #[allow(unused_unsafe)]
@@ -685,7 +691,8 @@ pub fn generate_common_cpuid(
             // TDX is not supported by CPU profiles other than host for the time being.
             return Err(Error::CpuProfileTdxIncompatibility.into());
         }
-        common_cpuid_tdx_configuration(&mut cpuid, hypervisor)?;
+        let vm = vm.ok_or(Error::TdxCapabilitiesNoVm)?;
+        common_cpuid_tdx_configuration(&mut cpuid, vm)?;
     }
 
     // Copy CPU identification string
@@ -1013,11 +1020,9 @@ fn required_common_cpuid_updates(
 #[cfg(feature = "tdx")]
 fn common_cpuid_tdx_configuration(
     cpuid: &mut [CpuIdEntry],
-    hypervisor: &dyn hypervisor::Hypervisor,
+    vm: &dyn hypervisor::Vm,
 ) -> super::Result<()> {
-    let caps = hypervisor
-        .tdx_capabilities()
-        .map_err(Error::TdxCapabilities)?;
+    let caps = vm.tdx_capabilities().map_err(Error::TdxCapabilities)?;
     info!("TDX capabilities {caps:#?}");
 
     for entry in cpuid.iter_mut().filter(|entry| entry.function == 0xd) {

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1026,7 +1026,12 @@ fn common_cpuid_tdx_configuration(
     info!("TDX capabilities {caps:#?}");
 
     for entry in cpuid.iter_mut().filter(|entry| entry.function == 0xd) {
-        let xcr0_mask: u64 = 0x82ff;
+        // XCR0-managed (user) XSAVE state components. Must include the AMX
+        // tile state components (XTILECFG bit 17, XTILEDATA bit 18); otherwise
+        // AMX is stripped from CPUID.0xD.0 and never makes it into the TD XFAM.
+        // Bits: x87(0) SSE(1) AVX(2) BNDREG(3) BNDCSR(4) OPMASK(5) ZMM_Hi256(6)
+        //       Hi16_ZMM(7) PKRU(9) XTILECFG(17) XTILEDATA(18).
+        let xcr0_mask: u64 = 0x602ff;
         let xss_mask: u64 = !xcr0_mask;
         // Upstream Linux 6.16 reports a single `supported_xfam` mask of the
         // XSAVE state components the TDX module can virtualize, replacing the

--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -264,10 +264,16 @@ pub enum PayloadImageType {
     RawVmLinux,
 }
 
+// Layout of the HOB_PAYLOAD_INFO_TABLE as defined by the TD-Shim
+// specification (doc/tdshim_spec.md, "TD Payload Info GUID Extension HOB").
+// The `reserved` field between `image_type` and `entry_point` is mandated by
+// the spec to 8-byte align the entry point; omitting it makes the HOB one
+// UINT32 too short and TD-Shim fails to parse it.
 #[repr(C, packed)]
 #[derive(Copy, Clone, Default, Debug)]
 pub struct PayloadInfo {
     pub image_type: PayloadImageType,
+    pub reserved: u32,
     pub entry_point: u64,
 }
 

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -944,8 +944,6 @@ fn expand_fdtable() -> Result<(), FdTableError> {
 }
 
 fn main() {
-    #[cfg(feature = "tdx")]
-    compile_error!("Feature 'tdx' is broken.");
     #[cfg(all(feature = "tdx", feature = "sev_snp"))]
     compile_error!("Feature 'tdx' and 'sev_snp' are mutually exclusive.");
     #[cfg(all(feature = "sev_snp", not(target_arch = "x86_64")))]

--- a/docs/intel_tdx.md
+++ b/docs/intel_tdx.md
@@ -7,38 +7,43 @@ host platform. Here are some useful links:
 - [TDX Homepage](https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html):
   more information about TDX technical aspects, design and specification
 
-- [KVM TDX tree](https://github.com/intel/tdx/tree/kvm): the required
-  Linux kernel changes for the host side
+- [KVM TDX documentation](https://docs.kernel.org/virt/kvm/x86/intel-tdx.html):
+  the host-side KVM ABI for TDX, which is part of the upstream Linux kernel
+  (v6.16 and later)
 
-- [Guest TDX tree](https://github.com/intel/tdx/tree/guest): the Linux
-  kernel changes for the guest side
+- [TDX kernel documentation](https://docs.kernel.org/arch/x86/tdx.html): the
+  host and guest kernel support for TDX, which is part of the upstream Linux
+  kernel
 
 - [EDK2 project](https://github.com/tianocore/edk2): the TDVF firmware
 
 - [Confidential Containers project](https://github.com/confidential-containers/td-shim):
   the TDShim firmware
 
-- [TDX Linux](https://github.com/intel/tdx-linux): a collection of tools
-  and scripts to setup TDX environment for testing purpose (such as
-  installing required packages on the host, creating guest images, and
-  building the custom Linux kernel for TDX host and guest)
+- [Intel TDX Enabling Guide](https://cc-enabling.trustedservices.intel.com/intel-tdx-enabling-guide/01/introduction/):
+  Intel's official guide for enabling TDX, covering host and guest setup,
+  building images, and running TDX guests
 
 ## Cloud Hypervisor support
 
-It is required to use a machine with TDX enabled in hardware and
-with the host OS compiled from the [KVM TDX tree](https://github.com/intel/tdx/tree/kvm).
-The host environment can also be setup with the [TDX Linux](https://github.com/intel/tdx-linux).
+It is required to use a machine with TDX enabled in hardware, running a host
+kernel with TDX support. Host-side TDX support is part of the upstream Linux
+kernel (v6.16 and later), so a recent distribution kernel or an upstream kernel
+built with `CONFIG_INTEL_TDX_HOST=y` can be used. The host environment can also
+be setup by following the [Intel TDX Enabling Guide](https://cc-enabling.trustedservices.intel.com/intel-tdx-enabling-guide/01/introduction/).
 
-Cloud Hypervisor can run TDX VM (Trust Domain) by loading a TD firmware ([TDVF](https://github.com/tianocore/edk2)),
-which will then load the guest kernel from the image. The image must be custom
-as it must include a kernel built from the [Guest TDX tree](https://github.com/intel/tdx/tree/guest).
-Cloud Hypervisor can also boot a TDX VM with direct kernel boot using [TDshim](https://github.com/confidential-containers/td-shim).
-The custom Linux kernel for the guest can be built with the [TDX Linux](https://github.com/intel/tdx-linux).
+Cloud Hypervisor can run a TDX VM (Trust Domain) by loading a TD firmware ([TDVF](https://github.com/tianocore/edk2)),
+which then loads the guest kernel from the image. The guest kernel must have
+TDX guest support, which is also part of the upstream Linux kernel; recent
+distributions ship such kernels, so a custom guest kernel is no longer required.
+Cloud Hypervisor can also boot a TDX VM with direct kernel boot using [TDShim](https://github.com/confidential-containers/td-shim).
 
 ### TDVF
 
 > **Note**
-> The latest version of TDVF being tested is [_13b9773_](https://github.com/tianocore/edk2/commit/13b97736c876919b9786055829caaa4fa46984b7).
+> TDVF (`OvmfPkg/IntelTdx`) is maintained in upstream edk2, so any recent edk2
+> [stable release](https://github.com/tianocore/edk2/releases) can be used. The
+> commands below use `edk2-stable202605` as an example.
 
 The firmware can be built as follows:
 
@@ -48,7 +53,7 @@ sudo apt-get install uuid-dev nasm iasl build-essential python3-distutils git
 
 git clone https://github.com/tianocore/edk2.git
 cd edk2
-git checkout 13b97736c876919b9786055829caaa4fa46984b7
+git checkout edk2-stable202605
 source ./edksetup.sh
 git submodule update --init --recursive
 make -C BaseTools -j `nproc`
@@ -68,10 +73,11 @@ On the Cloud Hypervisor side, all you need is to build the project with the
 cargo build --features tdx
 ```
 
-And run a TDX VM by providing the firmware previously built, along with the
-guest image containing the TDX enlightened kernel. The latest image
-`td-guest-rhel8.5.raw` contains `console=hvc0` on the kernel boot parameters,
-meaning it will be printing guest kernel logs to the `virtio-console` device.
+And run a TDX VM by providing the firmware previously built, along with a guest
+image whose kernel has TDX guest support. Recent distribution cloud images
+(such as RHEL 9/10, Ubuntu, or Fedora) already ship such kernels. If the guest
+kernel is booted with `console=hvc0` in its boot parameters, it will print
+guest kernel logs to the `virtio-console` device.
 
 ```bash
 ./cloud-hypervisor \
@@ -102,10 +108,10 @@ firmware:
 > The latest version of TDShim being tested is [_v0.8.0_](https://github.com/confidential-containers/td-shim/releases/tag/v0.8.0).
 
 This is a lightweight version of the TDVF, written in Rust and designed for
-direct kernel boot, which is useful for containers use cases.
+direct kernel boot, which is useful for container use cases.
 
 To build TDShim from source, it is required to install `Rust`, `NASM`,
-and `LLVM` first. The TDshim can be built as follows:
+and `LLVM` first. The TDShim can be built as follows:
 
 ```bash
 git clone https://github.com/confidential-containers/td-shim
@@ -121,16 +127,16 @@ git submodule update --init --recursive
 cargo image --release
 ```
 
-If debug logs from the TDShim is needed, here are the alternative
-commands:
+If debug logs from the TDShim are needed, here is the alternative
+command:
 
 ```bash
 cargo image
 ```
 
 And run a TDX VM by providing the firmware previously built, along with a guest
-kernel built from the [Guest TDX tree](https://github.com/intel/tdx/tree/guest)
-or the [TDX Linux](https://github.com/intel/tdx-linux).
+kernel that has upstream TDX guest support (shipped by recent distributions, or
+built by following the [Intel TDX Enabling Guide](https://cc-enabling.trustedservices.intel.com/intel-tdx-enabling-guide/01/introduction/)).
 The appropriate kernel boot options must be provided through the `--cmdline`
 option as well.
 
@@ -158,22 +164,6 @@ TDShim:
     --memory size=1G \
     --disk path=tdx_guest_img
 ```
-
-### Guest kernel limitations
-
-#### Serial ports disabled
-
-The latest guest kernel that can be found in the latest image
-`td-guest-rhel8.5.raw` disabled the support for serial ports. This means adding
-`console=ttyS0` will have no effect and will not print any log from the guest.
-
-#### PCI hotplug through ACPI
-
-Unless you run the guest kernel with the parameter `tdx_disable_filter`, ACPI
-devices responsible for handling PCI hotplug (PCI hotplug controller, PCI
-Express Bus and Generic Event Device) will not be allowed, therefore the
-corresponding drivers will not be loaded and the PCI hotplug feature will not
-be supported.
 
 ### Remote attestation (GetQuote)
 

--- a/docs/intel_tdx.md
+++ b/docs/intel_tdx.md
@@ -175,6 +175,32 @@ Express Bus and Generic Event Device) will not be allowed, therefore the
 corresponding drivers will not be loaded and the PCI hotplug feature will not
 be supported.
 
+### Remote attestation (GetQuote)
+
+When a TD guest asks for a quote it issues the
+`TDG.VP.VMCALL<GetQuote>` GHCI call, which traps out to Cloud Hypervisor. The
+VMM forwards the embedded TD report to a Quote Generation Service (QGS) and
+writes the returned quote back into the guest's shared buffer.
+
+The QGS endpoint is a host Unix socket configured through the
+`quote_generation_socket` platform option:
+
+```bash
+./cloud-hypervisor \
+    --platform tdx=on,quote_generation_socket=/var/run/tdx-qgs/qgs.socket \
+    --firmware td-shim/target/release/final.bin \
+    --kernel bzImage \
+    --cmdline "root=/dev/vda3 console=hvc0 rw" \
+    --cpus boot=1 \
+    --memory size=1G \
+    --disk path=tdx_guest_img
+```
+
+If `quote_generation_socket` is not set, GetQuote requests complete with the
+GHCI `QGS_UNAVAILABLE` status. The transaction is handled synchronously on the
+vCPU thread; TDs that rely on the asynchronous `SetupEventNotifyInterrupt`
+completion interrupt are not yet supported.
+
 ## Measurement configuration registers
 
 A TD carries three owner/configuration measurement registers that are baked

--- a/docs/intel_tdx.md
+++ b/docs/intel_tdx.md
@@ -182,8 +182,13 @@ When a TD guest asks for a quote it issues the
 VMM forwards the embedded TD report to a Quote Generation Service (QGS) and
 writes the returned quote back into the guest's shared buffer.
 
-The QGS endpoint is a host Unix socket configured through the
-`quote_generation_socket` platform option:
+The QGS endpoint is configured through the `quote_generation_socket` platform
+option. Mirroring QEMU's `SocketAddress`-typed `quote-generation-socket`, it
+accepts a host Unix, `AF_VSOCK` or TCP socket using the following string forms:
+
+- `<path>` or `unix:<path>` — host Unix socket (default when no scheme is given)
+- `vsock:<cid>:<port>` — host `AF_VSOCK` socket
+- `tcp:<host>:<port>` (or `inet:<host>:<port>`) — host TCP socket
 
 ```bash
 ./cloud-hypervisor \
@@ -195,6 +200,9 @@ The QGS endpoint is a host Unix socket configured through the
     --memory size=1G \
     --disk path=tdx_guest_img
 ```
+
+For example, a QGS reachable over vsock on the host would be configured with
+`quote_generation_socket=vsock:2:4050`.
 
 If `quote_generation_socket` is not set, GetQuote requests complete with the
 GHCI `QGS_UNAVAILABLE` status. The transaction is handled synchronously on the

--- a/docs/intel_tdx.md
+++ b/docs/intel_tdx.md
@@ -174,3 +174,27 @@ devices responsible for handling PCI hotplug (PCI hotplug controller, PCI
 Express Bus and Generic Event Device) will not be allowed, therefore the
 corresponding drivers will not be loaded and the PCI hotplug feature will not
 be supported.
+
+## Measurement configuration registers
+
+A TD carries three owner/configuration measurement registers that are baked
+into its attestation report: `MRCONFIGID`, `MROWNER` and `MROWNERCONFIG`. Each
+is a 384-bit (48-byte) SHA384 digest chosen by the tenant or platform owner.
+
+They can be supplied through the matching `--platform` options as hex strings
+of exactly 96 characters (48 bytes):
+
+```bash
+./cloud-hypervisor \
+    --platform tdx=on,mrconfigid=<96-hex-chars>,mrowner=<96-hex-chars>,mrownerconfig=<96-hex-chars> \
+    --firmware td-shim/target/release/final.bin \
+    --kernel bzImage \
+    --cmdline "root=/dev/vda3 console=hvc0 rw" \
+    --cpus boot=1 \
+    --memory size=1G \
+    --disk path=tdx_guest_img
+```
+
+Any register left unset defaults to all zeros, preserving the previous
+behavior.
+

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -300,6 +300,12 @@ pub enum HypervisorCpuError {
     #[error("Failed to initialize TDX")]
     InitializeTdx(#[source] io::Error),
     ///
+    /// Failed to initialize a TDX memory region
+    ///
+    #[cfg(feature = "tdx")]
+    #[error("Failed to initialize TDX memory region")]
+    InitializeTdxMemoryRegion(#[source] io::Error),
+    ///
     /// Unknown TDX VM call
     ///
     #[cfg(feature = "tdx")]
@@ -605,6 +611,26 @@ pub trait Vcpu: Send + Sync {
     ///
     #[cfg(feature = "tdx")]
     fn tdx_get_cpuid(&self) -> Result<Vec<CpuIdEntry>> {
+        unimplemented!()
+    }
+    ///
+    /// Add a TDX memory region to the TD's initial (measured) image.
+    ///
+    /// With the KVM TDX ABI, `KVM_TDX_INIT_MEM_REGION` is a vCPU-scoped ioctl:
+    /// the TDX module maps the private page through this vCPU's Secure-EPT and
+    /// copies the contents from `_host_address`.
+    ///
+    /// # Safety
+    ///
+    /// `_host_address` must be valid for `_size` bytes.
+    #[cfg(feature = "tdx")]
+    unsafe fn tdx_init_memory_region(
+        &self,
+        _host_address: *const u8,
+        _guest_address: u64,
+        _size: usize,
+        _measure: bool,
+    ) -> Result<()> {
         unimplemented!()
     }
     ///

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -598,6 +598,16 @@ pub trait Vcpu: Send + Sync {
         unimplemented!()
     }
     ///
+    /// Retrieve the CPUID the TDX module virtualizes for this TD vCPU
+    /// (KVM_TDX_GET_CPUID). This reflects the final values the guest observes,
+    /// with the module's fixed bits applied, and is used to cross-check the
+    /// CPUID programmed via `set_cpuid2`.
+    ///
+    #[cfg(feature = "tdx")]
+    fn tdx_get_cpuid(&self) -> Result<Vec<CpuIdEntry>> {
+        unimplemented!()
+    }
+    ///
     /// Set the "immediate_exit" state
     ///
     fn set_immediate_exit(&mut self, _exit: bool) {}

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -20,8 +20,6 @@ use crate::arch::x86::{
 };
 #[cfg(target_arch = "x86_64")]
 use crate::cpu::CpuVendor;
-#[cfg(feature = "tdx")]
-use crate::kvm::TdxCapabilities;
 use crate::vm::Vm;
 use crate::{HypervisorType, HypervisorVmConfig};
 
@@ -162,13 +160,6 @@ pub trait Hypervisor: Send + Sync {
     /// Retrieve AArch64 host maximum IPA size supported by KVM
     ///
     fn get_host_ipa_limit(&self) -> i32;
-    ///
-    /// Retrieve TDX capabilities
-    ///
-    #[cfg(feature = "tdx")]
-    fn tdx_capabilities(&self) -> Result<TdxCapabilities> {
-        unimplemented!()
-    }
     ///
     /// Get the number of supported hardware breakpoints
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -276,6 +276,8 @@ const TDG_VP_VMCALL_SETUP_EVENT_NOTIFY_INTERRUPT: u64 = 0x10004;
 const TDG_VP_VMCALL_SUCCESS: u64 = 0;
 #[cfg(feature = "tdx")]
 const TDG_VP_VMCALL_INVALID_OPERAND: u64 = 0x8000000000000000;
+#[cfg(feature = "tdx")]
+const TDG_VP_VMCALL_ALIGN_ERROR: u64 = 0x8000000000000002;
 
 #[cfg(feature = "tdx")]
 ioctl_iowr_nr!(KVM_MEMORY_ENCRYPT_OP, KVMIO, 0xba, raw::c_ulong);
@@ -296,7 +298,13 @@ enum TdxCommand {
 
 #[cfg(feature = "tdx")]
 pub enum TdxExitDetails {
-    GetQuote,
+    /// `TDG.VP.VMCALL<GetQuote>`. `shared_gpa` points to the shared-memory
+    /// GetQuote buffer (GHCI header followed by the TD report) and `buf_len`
+    /// is its total length in bytes.
+    GetQuote {
+        shared_gpa: u64,
+        buf_len: u64,
+    },
     SetupEventNotifyInterrupt,
 }
 
@@ -304,6 +312,7 @@ pub enum TdxExitDetails {
 pub enum TdxExitStatus {
     Success,
     InvalidOperand,
+    AlignError,
 }
 
 // `struct kvm_tdx_capabilities` as defined by the upstream Linux 6.16 UAPI.
@@ -3889,7 +3898,10 @@ impl cpu::Vcpu for KvmVcpu {
         }
 
         match tdx_vmcall.subfunction {
-            TDG_VP_VMCALL_GET_QUOTE => Ok(TdxExitDetails::GetQuote),
+            TDG_VP_VMCALL_GET_QUOTE => Ok(TdxExitDetails::GetQuote {
+                shared_gpa: tdx_vmcall.in_r12,
+                buf_len: tdx_vmcall.in_r13,
+            }),
             TDG_VP_VMCALL_SETUP_EVENT_NOTIFY_INTERRUPT => {
                 Ok(TdxExitDetails::SetupEventNotifyInterrupt)
             }
@@ -3913,6 +3925,7 @@ impl cpu::Vcpu for KvmVcpu {
         tdx_vmcall.status_code = match status {
             TdxExitStatus::Success => TDG_VP_VMCALL_SUCCESS,
             TdxExitStatus::InvalidOperand => TDG_VP_VMCALL_INVALID_OPERAND,
+            TdxExitStatus::AlignError => TDG_VP_VMCALL_ALIGN_ERROR,
         };
     }
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -279,6 +279,8 @@ const TDG_VP_VMCALL_INVALID_OPERAND: u64 = 0x8000000000000000;
 #[cfg(feature = "tdx")]
 ioctl_iowr_nr!(KVM_MEMORY_ENCRYPT_OP, KVMIO, 0xba, raw::c_ulong);
 
+// Trust Domain eXtension sub-ioctl() commands, matching `enum kvm_tdx_cmd_id`
+// in the upstream Linux 6.16 UAPI (arch/x86/include/uapi/asm/kvm.h).
 #[cfg(feature = "tdx")]
 #[repr(u32)]
 enum TdxCommand {
@@ -287,6 +289,8 @@ enum TdxCommand {
     InitVcpu,
     InitMemRegion,
     Finalize,
+    #[allow(dead_code)] // Used once KVM_TDX_GET_CPUID support is added
+    GetCpuid,
 }
 
 #[cfg(feature = "tdx")]
@@ -301,32 +305,24 @@ pub enum TdxExitStatus {
     InvalidOperand,
 }
 
-#[cfg(feature = "tdx")]
-const TDX_MAX_NR_CPUID_CONFIGS: usize = 6;
-
-#[cfg(feature = "tdx")]
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct TdxCpuidConfig {
-    pub leaf: u32,
-    pub sub_leaf: u32,
-    pub eax: u32,
-    pub ebx: u32,
-    pub ecx: u32,
-    pub edx: u32,
-}
-
+// `struct kvm_tdx_capabilities` as defined by the upstream Linux 6.16 UAPI.
+// `Default` cannot be derived because of the 256-entry CPUID array, so the
+// struct is built explicitly in `tdx_capabilities()`.
 #[cfg(feature = "tdx")]
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct TdxCapabilities {
-    pub attrs_fixed0: u64,
-    pub attrs_fixed1: u64,
-    pub xfam_fixed0: u64,
-    pub xfam_fixed1: u64,
-    pub nr_cpuid_configs: u32,
-    pub padding: u32,
-    pub cpuid_configs: [TdxCpuidConfig; TDX_MAX_NR_CPUID_CONFIGS],
+    pub supported_attrs: u64,
+    pub supported_xfam: u64,
+    pub kernel_tdvmcallinfo_1_r11: u64,
+    pub user_tdvmcallinfo_1_r11: u64,
+    pub kernel_tdvmcallinfo_1_r12: u64,
+    pub user_tdvmcallinfo_1_r12: u64,
+    pub reserved: [u64; 250],
+    // Trailing `struct kvm_cpuid2`: nent + padding + flexible entries[].
+    pub cpuid_nent: u32,
+    pub cpuid_padding: u32,
+    pub cpuid_entries: [kvm_bindings::kvm_cpuid_entry2; 256],
 }
 
 #[cfg(feature = "tdx")]
@@ -1501,25 +1497,35 @@ impl vm::Vm for KvmVm {
             cpuid.iter().map(|e| (*e).into()).collect();
         cpuid.resize(256, kvm_bindings::kvm_cpuid_entry2::default());
 
+        // The upstream Linux 6.16 `struct kvm_tdx_init_vm` no longer carries
+        // `max_vcpus`; it must be configured via KVM_CAP_MAX_VCPUS before vCPU
+        // creation. Wiring that up belongs with the guest_memfd memory-model
+        // rework, so the argument is intentionally unused here for now.
+        let _ = max_vcpus;
+
+        // `struct kvm_tdx_init_vm`: the space before the trailing CPUIDs is a
+        // fixed 256 bytes (attributes + xfam + 3 sha384 digests + reserved).
         #[repr(C)]
         struct TdxInitVm {
             attributes: u64,
-            max_vcpus: u32,
-            padding: u32,
+            xfam: u64,
             mrconfigid: [u64; 6],
             mrowner: [u64; 6],
             mrownerconfig: [u64; 6],
+            reserved: [u64; 12],
+            // Trailing `struct kvm_cpuid2`: nent + padding + entries[].
             cpuid_nent: u32,
             cpuid_padding: u32,
             cpuid_entries: [kvm_bindings::kvm_cpuid_entry2; 256],
         }
         let data = TdxInitVm {
             attributes: 1 << TDX_ATTR_SEPT_VE_DISABLE,
-            max_vcpus,
-            padding: 0,
+            // TODO: derive XFAM from the guest's enabled XCR0/XSS state.
+            xfam: 0,
             mrconfigid: [0; 6],
             mrowner: [0; 6],
             mrownerconfig: [0; 6],
+            reserved: [0; 12],
             cpuid_nent: cpuid.len() as u32,
             cpuid_padding: 0,
             cpuid_entries: cpuid.as_slice().try_into().unwrap(),
@@ -1590,20 +1596,19 @@ fn tdx_command(
     flags: u32,
     data: *const libc::c_void,
 ) -> io::Result<()> {
+    // `struct kvm_tdx_cmd` from the upstream Linux 6.16 UAPI.
     #[repr(C)]
     struct TdxIoctlCmd {
         command: TdxCommand,
         flags: u32,
         data: u64,
-        error: u64,
-        unused: u64,
+        hw_error: u64,
     }
     let cmd = TdxIoctlCmd {
         command,
         flags,
         data: data as _,
-        error: 0,
-        unused: 0,
+        hw_error: 0,
     };
     // SAFETY: FFI call. All input parameters are valid.
     let ret =
@@ -1736,6 +1741,10 @@ impl hypervisor::Hypervisor for KvmHypervisor {
 
             #[cfg(feature = "tdx")]
             if _config.tdx_enabled {
+                // TODO: Align with upstream Linux 6.16 by switching to
+                // KVM_X86_TDX_VM (type 5). That requires guest_memfd-backed
+                // private memory plus KVM_SET_MEMORY_ATTRIBUTES, so it is
+                // deferred together with the TDX memory-model rework.
                 vm_type = KVM_X86_SW_PROTECTED_VM.into();
             }
         }
@@ -1898,8 +1907,16 @@ impl hypervisor::Hypervisor for KvmHypervisor {
     #[cfg(feature = "tdx")]
     fn tdx_capabilities(&self) -> hypervisor::Result<TdxCapabilities> {
         let data = TdxCapabilities {
-            nr_cpuid_configs: TDX_MAX_NR_CPUID_CONFIGS as u32,
-            ..Default::default()
+            supported_attrs: 0,
+            supported_xfam: 0,
+            kernel_tdvmcallinfo_1_r11: 0,
+            user_tdvmcallinfo_1_r11: 0,
+            kernel_tdvmcallinfo_1_r12: 0,
+            user_tdvmcallinfo_1_r12: 0,
+            reserved: [0; 250],
+            cpuid_nent: 256,
+            cpuid_padding: 0,
+            cpuid_entries: [kvm_bindings::kvm_cpuid_entry2::default(); 256],
         };
 
         tdx_command(

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -290,7 +290,6 @@ enum TdxCommand {
     InitVcpu,
     InitMemRegion,
     Finalize,
-    #[allow(dead_code)] // Used once KVM_TDX_GET_CPUID support is added
     GetCpuid,
 }
 
@@ -3792,6 +3791,41 @@ impl cpu::Vcpu for KvmVcpu {
 
         tdx_command(&self.fd.as_raw_fd(), TdxCommand::InitVcpu, 0, hob_address)
             .map_err(cpu::HypervisorCpuError::InitializeTdx)
+    }
+
+    ///
+    /// Retrieve the CPUID the TDX module virtualizes for this TD vCPU.
+    ///
+    #[cfg(feature = "tdx")]
+    fn tdx_get_cpuid(&self) -> cpu::Result<Vec<CpuIdEntry>> {
+        // `struct kvm_cpuid2`: `nent`, `padding`, then `nent` entries. Size the
+        // buffer to KVM_MAX_CPUID_ENTRIES, which is also the kernel's own upper
+        // bound when filling the TD CPUID, so KVM never returns -E2BIG here.
+        const MAX: usize = kvm_bindings::KVM_MAX_CPUID_ENTRIES;
+        #[repr(C)]
+        struct TdxCpuid2 {
+            nent: u32,
+            padding: u32,
+            entries: [kvm_bindings::kvm_cpuid_entry2; MAX],
+        }
+        let mut data = TdxCpuid2 {
+            nent: MAX as u32,
+            padding: 0,
+            entries: [kvm_bindings::kvm_cpuid_entry2::default(); MAX],
+        };
+
+        // KVM_TDX_GET_CPUID is a vCPU ioctl that writes the TD CPUID (and the
+        // actual entry count) back into `data`.
+        tdx_command(
+            &self.fd.as_raw_fd(),
+            TdxCommand::GetCpuid,
+            0,
+            (&raw mut data).cast(),
+        )
+        .map_err(|e| cpu::HypervisorCpuError::GetCpuid(e.into()))?;
+
+        let nent = (data.nent as usize).min(MAX);
+        Ok(data.entries[..nent].iter().map(|e| (*e).into()).collect())
     }
 
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1511,26 +1511,32 @@ impl vm::Vm for KvmVm {
         // CPUID.0xD reports the XSAVE state the TD is allowed to manage:
         // sub-leaf 0 carries the XCR0-managed bits (EAX:low, EDX:high) and
         // sub-leaf 1 carries the IA32_XSS-managed bits (ECX:low, EDX:high).
+        // This is masked to the configurable set below.
         let xfam = tdx_xfam_from_cpuid(&guest_cpuid);
 
-        // Derive the TD ATTRIBUTES from the guest CPUID. SEPT_VE_DISABLE is
-        // always requested; PKS and PERFMON must match the features exposed to
-        // the guest, otherwise the TDX module rejects KVM_TDX_INIT_VM.
+        // Derive the TD ATTRIBUTES from the guest CPUID (SEPT_VE_DISABLE plus
+        // any PKS/PERFMON hints). This is masked to the configurable set below.
         let attributes = tdx_attributes_from_cpuid(&guest_cpuid);
 
         // The upstream Linux 6.16 `struct kvm_tdx_init_vm` no longer carries
-        // `max_vcpus`; the limit must be configured via KVM_CAP_MAX_VCPUS
-        // before KVM_TDX_INIT_VM and before any vCPU is created. tdx_init()
-        // runs after the VM fd is created but before create_boot_vcpus(), so
-        // this is the correct point to enable the capability.
+        // `max_vcpus`; the TDX module derives the TD's `TD_PARAMS.max_vcpus`
+        // from the VM's `kvm->max_vcpus`. Some kernels let userspace lower that
+        // bound via KVM_CAP_MAX_VCPUS before KVM_TDX_INIT_VM (and before any
+        // vCPU is created); others do not implement setting that capability and
+        // simply rely on the default (capped at the number of present CPUs).
+        // Attempt it best-effort so we honor an explicit limit where supported,
+        // but never fail TDX init when the capability is query-only.
         let cap = kvm_bindings::kvm_enable_cap {
             cap: kvm_bindings::KVM_CAP_MAX_VCPUS,
             args: [max_vcpus as u64, 0, 0, 0],
             ..Default::default()
         };
-        self.fd.enable_cap(&cap).map_err(|e| {
-            vm::HypervisorVmError::InitializeTdx(io::Error::from_raw_os_error(e.errno()))
-        })?;
+        if let Err(e) = self.fd.enable_cap(&cap) {
+            warn!(
+                "KVM_CAP_MAX_VCPUS not settable ({e}); TD max_vcpus will use the \
+                 kernel default derived from kvm->max_vcpus"
+            );
+        }
 
         // Query the TDX capabilities (a VM-scoped ioctl) to learn both the
         // supported attribute/XFAM masks and the set of CPUID leaves the TDX
@@ -1541,25 +1547,16 @@ impl vm::Vm for KvmVm {
             )))
         })?;
 
-        // Validate the requested attributes and XFAM against what the TDX
-        // module and KVM actually support before KVM_TDX_INIT_VM, mirroring
-        // the kernel's own checks in setup_tdparams().
-        if attributes & !caps.supported_attrs != 0 {
-            return Err(vm::HypervisorVmError::InitializeTdx(io::Error::other(
-                format!(
-                    "requested TD attributes {attributes:#x} not supported (supported {:#x})",
-                    caps.supported_attrs
-                ),
-            )));
-        }
-        if xfam & !caps.supported_xfam != 0 {
-            return Err(vm::HypervisorVmError::InitializeTdx(io::Error::other(
-                format!(
-                    "requested TD XFAM {xfam:#x} not supported (supported {:#x})",
-                    caps.supported_xfam
-                ),
-            )));
-        }
+        // Restrict the requested ATTRIBUTES and XFAM to the bits the TDX
+        // module lets userspace configure. KVM's setup_tdparams() requires
+        // `init_vm->attributes` (and xfam) to be a subset of the configurable
+        // mask (fixed0) and then ORs in the module's fixed1 bits itself, so
+        // any feature that is forced on (e.g. PERFMON) must NOT be requested
+        // here or KVM_TDX_INIT_VM fails with EINVAL. Masking rather than
+        // erroring keeps us forward-compatible: the module supplies the fixed
+        // bits and virtualizes CPUID to match.
+        let attributes = attributes & caps.supported_attrs;
+        let xfam = xfam & caps.supported_xfam;
 
         // Build the TD CPUID table. KVM (setup_tdparams_cpuids) only accepts
         // entries whose (function, index) is in the TDX module's configurable
@@ -1578,12 +1575,32 @@ impl vm::Vm for KvmVm {
                 continue;
             };
             let mut entry = *entry;
+            // Each `cfg` entry from KVM_TDX_CAPABILITIES carries, in its
+            // eax/ebx/ecx/edx, the mask of bits the TDX module lets userspace
+            // *configure* for that leaf. Bits outside the mask are fixed by the
+            // module; TDH.MNG.INIT returns TDX_OPERAND_INVALID if we leave any
+            // of them set. So restrict the guest's values to the configurable
+            // bits and let the module supply the rest.
+            entry.eax &= cfg.eax;
+            entry.ebx &= cfg.ebx;
+            entry.ecx &= cfg.ecx;
+            entry.edx &= cfg.edx;
             if entry.function == 7 && entry.index == 0 {
                 // The TDX module rejects TSX (HLE bit 4, RTM bit 11 in EBX) and
                 // WAITPKG (bit 5 in ECX); clear them like the kernel's
                 // tdx_clear_unsupported_cpuid().
                 entry.ebx &= !((1 << 4) | (1 << 11));
                 entry.ecx &= !(1 << 5);
+            }
+            if entry.function == 0x8000_0008 {
+                // KVM repurposes CPUID.0x80000008.EAX[23:16] (normally reserved)
+                // as the interface to select the TD's GPAW / EPT depth in
+                // setup_tdparams_eptp_controls(): only 48 (GPAW-48, 4-level EPT)
+                // and 52 (GPAW-52, 5-level EPT) are accepted, and any other
+                // value fails KVM_TDX_INIT_VM with EINVAL. The guest CPUID
+                // leaves those bits zero, so encode GPAW-48, the standard width
+                // for TDs that do not require 5-level guest-physical addressing.
+                entry.eax = (entry.eax & !(0xff << 16)) | (48 << 16);
             }
             cpuid_entries[count] = entry;
             count += 1;
@@ -1617,6 +1634,7 @@ impl vm::Vm for KvmVm {
             cpuid_entries,
         };
 
+        debug!("KVM_TDX_INIT_VM: attributes={attributes:#x} xfam={xfam:#x} cpuid_nent={count}");
         tdx_command(
             &self.fd.as_raw_fd(),
             TdxCommand::InitVm,

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1504,19 +1504,19 @@ impl vm::Vm for KvmVm {
     ///
     #[cfg(feature = "tdx")]
     fn tdx_init(&self, cpuid: &[CpuIdEntry], max_vcpus: u32) -> vm::Result<()> {
-        let mut cpuid: Vec<kvm_bindings::kvm_cpuid_entry2> =
+        let guest_cpuid: Vec<kvm_bindings::kvm_cpuid_entry2> =
             cpuid.iter().map(|e| (*e).into()).collect();
 
-        // Derive XFAM (the TD's extended feature mask) from the guest CPUID
-        // before padding the table. CPUID.0xD reports the XSAVE state the TD
-        // is allowed to manage: sub-leaf 0 carries the XCR0-managed bits
-        // (EAX:low, EDX:high) and sub-leaf 1 carries the IA32_XSS-managed bits
-        // (ECX:low, EDX:high). The CPUID has already been masked by the TDX
-        // capabilities' supported_xfam, so this value is within the allowed
-        // set.
-        let xfam = tdx_xfam_from_cpuid(&cpuid);
+        // Derive XFAM (the TD's extended feature mask) from the guest CPUID.
+        // CPUID.0xD reports the XSAVE state the TD is allowed to manage:
+        // sub-leaf 0 carries the XCR0-managed bits (EAX:low, EDX:high) and
+        // sub-leaf 1 carries the IA32_XSS-managed bits (ECX:low, EDX:high).
+        let xfam = tdx_xfam_from_cpuid(&guest_cpuid);
 
-        cpuid.resize(256, kvm_bindings::kvm_cpuid_entry2::default());
+        // Derive the TD ATTRIBUTES from the guest CPUID. SEPT_VE_DISABLE is
+        // always requested; PKS and PERFMON must match the features exposed to
+        // the guest, otherwise the TDX module rejects KVM_TDX_INIT_VM.
+        let attributes = tdx_attributes_from_cpuid(&guest_cpuid);
 
         // The upstream Linux 6.16 `struct kvm_tdx_init_vm` no longer carries
         // `max_vcpus`; the limit must be configured via KVM_CAP_MAX_VCPUS
@@ -1532,35 +1532,18 @@ impl vm::Vm for KvmVm {
             vm::HypervisorVmError::InitializeTdx(io::Error::from_raw_os_error(e.errno()))
         })?;
 
-        // `struct kvm_tdx_init_vm`: the space before the trailing CPUIDs is a
-        // fixed 256 bytes (attributes + xfam + 3 sha384 digests + reserved).
-        #[repr(C)]
-        struct TdxInitVm {
-            attributes: u64,
-            xfam: u64,
-            mrconfigid: [u64; 6],
-            mrowner: [u64; 6],
-            mrownerconfig: [u64; 6],
-            reserved: [u64; 12],
-            // Trailing `struct kvm_cpuid2`: nent + padding + entries[].
-            cpuid_nent: u32,
-            cpuid_padding: u32,
-            cpuid_entries: [kvm_bindings::kvm_cpuid_entry2; 256],
-        }
-
-        // Derive the TD ATTRIBUTES from the guest CPUID. SEPT_VE_DISABLE is
-        // always requested; PKS and PERFMON must match the features exposed to
-        // the guest, otherwise the TDX module rejects KVM_TDX_INIT_VM.
-        let attributes = tdx_attributes_from_cpuid(&cpuid);
-        // Validate the requested attributes and XFAM against what the TDX
-        // module and KVM actually support before KVM_TDX_INIT_VM, mirroring
-        // the kernel's own checks in setup_tdparams(). The supported masks
-        // come from KVM_TDX_CAPABILITIES (a VM-scoped ioctl).
+        // Query the TDX capabilities (a VM-scoped ioctl) to learn both the
+        // supported attribute/XFAM masks and the set of CPUID leaves the TDX
+        // module allows userspace to configure.
         let caps = self.tdx_capabilities().map_err(|e| {
             vm::HypervisorVmError::InitializeTdx(io::Error::other(format!(
                 "failed to query TDX capabilities: {e}"
             )))
         })?;
+
+        // Validate the requested attributes and XFAM against what the TDX
+        // module and KVM actually support before KVM_TDX_INIT_VM, mirroring
+        // the kernel's own checks in setup_tdparams().
         if attributes & !caps.supported_attrs != 0 {
             return Err(vm::HypervisorVmError::InitializeTdx(io::Error::other(
                 format!(
@@ -1578,6 +1561,50 @@ impl vm::Vm for KvmVm {
             )));
         }
 
+        // Build the TD CPUID table. KVM (setup_tdparams_cpuids) only accepts
+        // entries whose (function, index) is in the TDX module's configurable
+        // set reported by KVM_TDX_CAPABILITIES, and rejects the whole request
+        // unless *every* entry passed corresponds to such a leaf. So walk the
+        // configurable leaves and, for each one the guest provides, forward the
+        // guest's chosen values. Leaves the guest does not expose are skipped.
+        let nent = (caps.cpuid_nent as usize).min(caps.cpuid_entries.len());
+        let mut cpuid_entries = [kvm_bindings::kvm_cpuid_entry2::default(); 256];
+        let mut count = 0usize;
+        for cfg in &caps.cpuid_entries[..nent] {
+            let Some(entry) = guest_cpuid
+                .iter()
+                .find(|e| e.function == cfg.function && e.index == cfg.index)
+            else {
+                continue;
+            };
+            let mut entry = *entry;
+            if entry.function == 7 && entry.index == 0 {
+                // The TDX module rejects TSX (HLE bit 4, RTM bit 11 in EBX) and
+                // WAITPKG (bit 5 in ECX); clear them like the kernel's
+                // tdx_clear_unsupported_cpuid().
+                entry.ebx &= !((1 << 4) | (1 << 11));
+                entry.ecx &= !(1 << 5);
+            }
+            cpuid_entries[count] = entry;
+            count += 1;
+        }
+
+        // `struct kvm_tdx_init_vm`: the space before the trailing CPUIDs is a
+        // fixed 256 bytes (attributes + xfam + 3 sha384 digests + reserved).
+        #[repr(C)]
+        struct TdxInitVm {
+            attributes: u64,
+            xfam: u64,
+            mrconfigid: [u64; 6],
+            mrowner: [u64; 6],
+            mrownerconfig: [u64; 6],
+            reserved: [u64; 12],
+            // Trailing `struct kvm_cpuid2`: nent + padding + entries[].
+            cpuid_nent: u32,
+            cpuid_padding: u32,
+            cpuid_entries: [kvm_bindings::kvm_cpuid_entry2; 256],
+        }
+
         let data = TdxInitVm {
             attributes,
             xfam,
@@ -1585,9 +1612,9 @@ impl vm::Vm for KvmVm {
             mrowner: [0; 6],
             mrownerconfig: [0; 6],
             reserved: [0; 12],
-            cpuid_nent: cpuid.len() as u32,
+            cpuid_nent: count as u32,
             cpuid_padding: 0,
-            cpuid_entries: cpuid.as_slice().try_into().unwrap(),
+            cpuid_entries,
         };
 
         tdx_command(
@@ -1610,7 +1637,7 @@ impl vm::Vm for KvmVm {
 
     #[cfg(feature = "tdx")]
     fn tdx_capabilities(&self) -> hypervisor::Result<TdxCapabilities> {
-        let data = TdxCapabilities {
+        let mut data = TdxCapabilities {
             supported_attrs: 0,
             supported_xfam: 0,
             kernel_tdvmcallinfo_1_r11: 0,
@@ -1624,12 +1651,14 @@ impl vm::Vm for KvmVm {
         };
 
         // KVM_TDX_CAPABILITIES is a VM-scoped ioctl in Linux 6.16: it must be
-        // issued on the TD VM fd, not on the /dev/kvm system fd.
+        // issued on the TD VM fd, not on the /dev/kvm system fd. KVM writes the
+        // supported masks and the configurable CPUID leaves back into `data`,
+        // so pass a mutable pointer.
         tdx_command(
             &self.fd.as_raw_fd(),
             TdxCommand::Capabilities,
             0,
-            (&raw const data).cast(),
+            (&raw mut data).cast(),
         )
         .map_err(|e| hypervisor::HypervisorError::TdxCapabilities(e.into()))?;
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1503,7 +1503,13 @@ impl vm::Vm for KvmVm {
     /// Initialize TDX for this VM
     ///
     #[cfg(feature = "tdx")]
-    fn tdx_init(&self, cpuid: &[CpuIdEntry]) -> vm::Result<()> {
+    fn tdx_init(
+        &self,
+        cpuid: &[CpuIdEntry],
+        mrconfigid: &[u8; 48],
+        mrowner: &[u8; 48],
+        mrownerconfig: &[u8; 48],
+    ) -> vm::Result<()> {
         let guest_cpuid: Vec<kvm_bindings::kvm_cpuid_entry2> =
             cpuid.iter().map(|e| (*e).into()).collect();
 
@@ -1595,13 +1601,17 @@ impl vm::Vm for KvmVm {
 
         // `struct kvm_tdx_init_vm`: the space before the trailing CPUIDs is a
         // fixed 256 bytes (attributes + xfam + 3 sha384 digests + reserved).
+        // The kernel treats mrconfigid/mrowner/mrownerconfig as raw 48-byte
+        // SHA384 digests (declared `__u64[6]`, populated by a byte copy), so
+        // store them as byte arrays to forward the caller's values verbatim
+        // without any endianness conversion.
         #[repr(C)]
         struct TdxInitVm {
             attributes: u64,
             xfam: u64,
-            mrconfigid: [u64; 6],
-            mrowner: [u64; 6],
-            mrownerconfig: [u64; 6],
+            mrconfigid: [u8; 48],
+            mrowner: [u8; 48],
+            mrownerconfig: [u8; 48],
             reserved: [u64; 12],
             // Trailing `struct kvm_cpuid2`: nent + padding + entries[].
             cpuid_nent: u32,
@@ -1612,9 +1622,9 @@ impl vm::Vm for KvmVm {
         let data = TdxInitVm {
             attributes,
             xfam,
-            mrconfigid: [0; 6],
-            mrowner: [0; 6],
-            mrownerconfig: [0; 6],
+            mrconfigid: *mrconfigid,
+            mrowner: *mrowner,
+            mrownerconfig: *mrownerconfig,
             reserved: [0; 12],
             cpuid_nent: count as u32,
             cpuid_padding: 0,

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1504,8 +1504,6 @@ impl vm::Vm for KvmVm {
     ///
     #[cfg(feature = "tdx")]
     fn tdx_init(&self, cpuid: &[CpuIdEntry], max_vcpus: u32) -> vm::Result<()> {
-        const TDX_ATTR_SEPT_VE_DISABLE: usize = 28;
-
         let mut cpuid: Vec<kvm_bindings::kvm_cpuid_entry2> =
             cpuid.iter().map(|e| (*e).into()).collect();
 
@@ -1550,8 +1548,10 @@ impl vm::Vm for KvmVm {
             cpuid_entries: [kvm_bindings::kvm_cpuid_entry2; 256],
         }
 
-        let attributes: u64 = 1 << TDX_ATTR_SEPT_VE_DISABLE;
-
+        // Derive the TD ATTRIBUTES from the guest CPUID. SEPT_VE_DISABLE is
+        // always requested; PKS and PERFMON must match the features exposed to
+        // the guest, otherwise the TDX module rejects KVM_TDX_INIT_VM.
+        let attributes = tdx_attributes_from_cpuid(&cpuid);
         // Validate the requested attributes and XFAM against what the TDX
         // module and KVM actually support before KVM_TDX_INIT_VM, mirroring
         // the kernel's own checks in setup_tdparams(). The supported masks
@@ -1674,6 +1674,36 @@ impl vm::Vm for KvmVm {
     fn as_any(&self) -> &dyn Any {
         self
     }
+}
+
+/// Inject #VE on unexpected Secure-EPT violations instead of exiting the TD.
+#[cfg(feature = "tdx")]
+const TDX_TD_ATTR_SEPT_VE_DISABLE: u64 = 1 << 28;
+/// Protection Keys for Supervisor-mode pages (PKS) are available to the TD.
+#[cfg(feature = "tdx")]
+const TDX_TD_ATTR_PKS: u64 = 1 << 30;
+/// Performance Monitoring (PMU) is available to the TD.
+#[cfg(feature = "tdx")]
+const TDX_TD_ATTR_PERFMON: u64 = 1 << 63;
+
+/// Derive the TD's ATTRIBUTES from the guest CPUID view.
+///
+/// SEPT_VE_DISABLE is always requested. PKS and PERFMON must match the
+/// features exposed to the guest via CPUID, otherwise the TDX module rejects
+/// KVM_TDX_INIT_VM:
+///   - PKS (bit 30)     <- CPUID.(EAX=7,ECX=0).ECX[31]
+///   - PERFMON (bit 63) <- CPUID.(EAX=0xA,ECX=0).EAX[7:0] (PMU version) != 0
+#[cfg(feature = "tdx")]
+fn tdx_attributes_from_cpuid(cpuid: &[kvm_bindings::kvm_cpuid_entry2]) -> u64 {
+    let mut attributes = TDX_TD_ATTR_SEPT_VE_DISABLE;
+    for entry in cpuid {
+        match (entry.function, entry.index) {
+            (0x7, 0) if entry.ecx & (1 << 31) != 0 => attributes |= TDX_TD_ATTR_PKS,
+            (0xA, 0) if entry.eax & 0xff != 0 => attributes |= TDX_TD_ATTR_PERFMON,
+            _ => {}
+        }
+    }
+    attributes
 }
 
 /// Compute the TD's XFAM (extended features available mask) from the guest

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -284,6 +284,7 @@ ioctl_iowr_nr!(KVM_MEMORY_ENCRYPT_OP, KVMIO, 0xba, raw::c_ulong);
 // in the upstream Linux 6.16 UAPI (arch/x86/include/uapi/asm/kvm.h).
 #[cfg(feature = "tdx")]
 #[repr(u32)]
+#[derive(Debug, Clone, Copy)]
 enum TdxCommand {
     Capabilities = 0,
     InitVm,
@@ -1739,20 +1740,36 @@ fn tdx_command(
         data: u64,
         hw_error: u64,
     }
-    let cmd = TdxIoctlCmd {
+    let mut cmd = TdxIoctlCmd {
         command,
         flags,
         data: data as _,
         hw_error: 0,
     };
-    // SAFETY: FFI call. All input parameters are valid.
-    let ret =
-        unsafe { ioctl_with_val(fd, KVM_MEMORY_ENCRYPT_OP(), &raw const cmd as raw::c_ulong) };
+    // KVM_TDX_INIT_MEM_REGION processes the region one page at a time and
+    // returns -EINTR when a signal is pending, after writing the advanced
+    // region (source address, GPA and remaining page count) back into `data`.
+    // Re-issuing the ioctl then resumes where it left off, so retry on EINTR
+    // to make forward progress instead of failing the whole operation.
+    loop {
+        // SAFETY: FFI call. All input parameters are valid.
+        let ret =
+            unsafe { ioctl_with_val(fd, KVM_MEMORY_ENCRYPT_OP(), &raw mut cmd as raw::c_ulong) };
 
-    if ret < 0 {
-        return Err(io::Error::last_os_error());
+        if ret >= 0 {
+            return Ok(());
+        }
+
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EINTR) {
+            continue;
+        }
+        error!(
+            "TDX ioctl command {:?} failed: {err} (hw_error={:#x})",
+            cmd.command, cmd.hw_error
+        );
+        return Err(err);
     }
-    Ok(())
 }
 
 /// Wrapper over KVM system ioctls.

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::mem::offset_of;
 #[cfg(feature = "sev_snp")]
 use std::num;
-#[cfg(feature = "sev_snp")]
+#[cfg(any(feature = "sev_snp", feature = "tdx"))]
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
 #[cfg(feature = "tdx")]
@@ -44,10 +44,10 @@ use anyhow::anyhow;
 #[cfg(feature = "sev_snp")]
 use igvm::snp_defs::{SevSelector, SevVmsa};
 use kvm_bindings::fam_wrappers::KvmIrqRouting;
-#[cfg(feature = "sev_snp")]
+#[cfg(any(feature = "sev_snp", feature = "tdx"))]
 use kvm_bindings::kvm_create_guest_memfd;
 use kvm_ioctls::{NoDatamatch, VcpuFd, VmFd};
-#[cfg(feature = "sev_snp")]
+#[cfg(any(feature = "sev_snp", feature = "tdx"))]
 use log::debug;
 #[cfg(target_arch = "x86_64")]
 use log::warn;
@@ -141,7 +141,7 @@ use kvm_bindings::{
 #[cfg(target_arch = "riscv64")]
 use kvm_bindings::{KVM_REG_RISCV_CORE, KVM_REG_RISCV_TIMER, kvm_riscv_core};
 #[cfg(feature = "tdx")]
-use kvm_bindings::{KVM_X86_SW_PROTECTED_VM, KVMIO};
+use kvm_bindings::{KVM_X86_TDX_VM, KVMIO};
 #[cfg(target_arch = "x86_64")]
 use kvm_bindings::{Xsave as xsave2, kvm_xsave2};
 pub use kvm_ioctls::{self, Cap, Kvm, VcpuExit};
@@ -209,10 +209,10 @@ ioctl_iow_nr!(
 
 #[cfg(feature = "sev_snp")]
 use igvm_defs::PAGE_SIZE_4K;
+#[cfg(any(feature = "sev_snp", feature = "tdx"))]
+use kvm_bindings::{KVM_MEMORY_ATTRIBUTE_PRIVATE, kvm_memory_attributes};
 #[cfg(feature = "sev_snp")]
-use kvm_bindings::{
-    KVM_MEMORY_ATTRIBUTE_PRIVATE, KVM_X86_SNP_VM, kvm_memory_attributes, kvm_segment as Segment,
-};
+use kvm_bindings::{KVM_X86_SNP_VM, kvm_segment as Segment};
 use vm_memory::GuestAddress;
 #[cfg(feature = "sev_snp")]
 use x86_64::sev;
@@ -618,6 +618,8 @@ struct KvmDirtyLogSlot {
 }
 
 struct KvmMemorySlot {
+    // These fields are currently only read by the SEV-SNP isolated-import
+    // path; the TDX path populates them for future shared/private bookkeeping.
     #[cfg_attr(not(feature = "sev_snp"), expect(dead_code))]
     guest_memfd: OwnedFd,
     #[cfg_attr(not(feature = "sev_snp"), expect(dead_code))]
@@ -946,7 +948,7 @@ impl vm::Vm for KvmVm {
             xsave_size,
             #[cfg(target_arch = "x86_64")]
             has_xcrs: self.check_extension(Cap::Xcrs),
-            #[cfg(feature = "sev_snp")]
+            #[cfg(any(feature = "sev_snp", feature = "tdx"))]
             vm_fd: self.fd.clone(),
             #[cfg(feature = "sev_snp")]
             memory_slots: self.memory_slots.clone(),
@@ -1121,7 +1123,7 @@ impl vm::Vm for KvmVm {
 
         // Create a per-region guest_memfd when supported.
         // Each region gets its own fd sized exactly to memory_size
-        #[cfg(feature = "sev_snp")]
+        #[cfg(any(feature = "sev_snp", feature = "tdx"))]
         let guest_memfd = if let Some(slots) = &self.memory_slots {
             // SAFETY: Safe because guest regions are guaranteed not to overlap.
             let fd = unsafe {
@@ -1147,7 +1149,7 @@ impl vm::Vm for KvmVm {
         } else {
             0
         };
-        #[cfg(not(feature = "sev_snp"))]
+        #[cfg(not(any(feature = "sev_snp", feature = "tdx")))]
         let guest_memfd = 0;
 
         let mut region = kvm_userspace_memory_region2 {
@@ -1194,7 +1196,7 @@ impl vm::Vm for KvmVm {
                 .map_err(|e| vm::HypervisorVmError::CreateUserMemory(e.into()))?;
         }
 
-        #[cfg(feature = "sev_snp")]
+        #[cfg(any(feature = "sev_snp", feature = "tdx"))]
         if self.memory_slots.is_some() {
             self.fd
                 .set_memory_attributes(kvm_memory_attributes {
@@ -1495,13 +1497,31 @@ impl vm::Vm for KvmVm {
 
         let mut cpuid: Vec<kvm_bindings::kvm_cpuid_entry2> =
             cpuid.iter().map(|e| (*e).into()).collect();
+
+        // Derive XFAM (the TD's extended feature mask) from the guest CPUID
+        // before padding the table. CPUID.0xD reports the XSAVE state the TD
+        // is allowed to manage: sub-leaf 0 carries the XCR0-managed bits
+        // (EAX:low, EDX:high) and sub-leaf 1 carries the IA32_XSS-managed bits
+        // (ECX:low, EDX:high). The CPUID has already been masked by the TDX
+        // capabilities' supported_xfam, so this value is within the allowed
+        // set.
+        let xfam = tdx_xfam_from_cpuid(&cpuid);
+
         cpuid.resize(256, kvm_bindings::kvm_cpuid_entry2::default());
 
         // The upstream Linux 6.16 `struct kvm_tdx_init_vm` no longer carries
-        // `max_vcpus`; it must be configured via KVM_CAP_MAX_VCPUS before vCPU
-        // creation. Wiring that up belongs with the guest_memfd memory-model
-        // rework, so the argument is intentionally unused here for now.
-        let _ = max_vcpus;
+        // `max_vcpus`; the limit must be configured via KVM_CAP_MAX_VCPUS
+        // before KVM_TDX_INIT_VM and before any vCPU is created. tdx_init()
+        // runs after the VM fd is created but before create_boot_vcpus(), so
+        // this is the correct point to enable the capability.
+        let cap = kvm_bindings::kvm_enable_cap {
+            cap: kvm_bindings::KVM_CAP_MAX_VCPUS,
+            args: [max_vcpus as u64, 0, 0, 0],
+            ..Default::default()
+        };
+        self.fd.enable_cap(&cap).map_err(|e| {
+            vm::HypervisorVmError::InitializeTdx(io::Error::from_raw_os_error(e.errno()))
+        })?;
 
         // `struct kvm_tdx_init_vm`: the space before the trailing CPUIDs is a
         // fixed 256 bytes (attributes + xfam + 3 sha384 digests + reserved).
@@ -1520,8 +1540,7 @@ impl vm::Vm for KvmVm {
         }
         let data = TdxInitVm {
             attributes: 1 << TDX_ATTR_SEPT_VE_DISABLE,
-            // TODO: derive XFAM from the guest's enabled XCR0/XSS state.
-            xfam: 0,
+            xfam,
             mrconfigid: [0; 6],
             mrowner: [0; 6],
             mrownerconfig: [0; 6],
@@ -1587,6 +1606,30 @@ impl vm::Vm for KvmVm {
     fn as_any(&self) -> &dyn Any {
         self
     }
+}
+
+/// Compute the TD's XFAM (extended features available mask) from the guest
+/// CPUID view of the XSAVE state components.
+///
+/// CPUID.(EAX=0xD,ECX=0) reports the state managed via XCR0 (EAX = low 32
+/// bits, EDX = high 32 bits) and CPUID.(EAX=0xD,ECX=1) reports the state
+/// managed via IA32_XSS (ECX = low 32 bits, EDX = high 32 bits). XFAM is the
+/// union of both.
+#[cfg(feature = "tdx")]
+fn tdx_xfam_from_cpuid(cpuid: &[kvm_bindings::kvm_cpuid_entry2]) -> u64 {
+    let mut xcr0: u64 = 0;
+    let mut xss: u64 = 0;
+    for entry in cpuid {
+        if entry.function != 0xD {
+            continue;
+        }
+        match entry.index {
+            0 => xcr0 = u64::from(entry.eax) | (u64::from(entry.edx) << 32),
+            1 => xss = u64::from(entry.ecx) | (u64::from(entry.edx) << 32),
+            _ => {}
+        }
+    }
+    xcr0 | xss
 }
 
 #[cfg(feature = "tdx")]
@@ -1741,11 +1784,7 @@ impl hypervisor::Hypervisor for KvmHypervisor {
 
             #[cfg(feature = "tdx")]
             if _config.tdx_enabled {
-                // TODO: Align with upstream Linux 6.16 by switching to
-                // KVM_X86_TDX_VM (type 5). That requires guest_memfd-backed
-                // private memory plus KVM_SET_MEMORY_ATTRIBUTES, so it is
-                // deferred together with the TDX memory-model rework.
-                vm_type = KVM_X86_SW_PROTECTED_VM.into();
+                vm_type = KVM_X86_TDX_VM.into();
             }
         }
 
@@ -1784,6 +1823,12 @@ impl hypervisor::Hypervisor for KvmHypervisor {
             let mut memory_slots = None;
             #[cfg(feature = "sev_snp")]
             if _config.sev_snp_enabled && fd.check_extension(Cap::GuestMemfd) {
+                memory_slots = Some(Arc::new(RwLock::new(HashMap::new())));
+            }
+            // TDX requires guest_memfd-backed private memory as well, so enable
+            // the per-region tracking that drives KVM_SET_USER_MEMORY_REGION2.
+            #[cfg(feature = "tdx")]
+            if _config.tdx_enabled && fd.check_extension(Cap::GuestMemfd) {
                 memory_slots = Some(Arc::new(RwLock::new(HashMap::new())));
             }
 
@@ -1965,7 +2010,7 @@ pub struct KvmVcpu {
     xsave_size: i32,
     #[cfg(target_arch = "x86_64")]
     has_xcrs: bool,
-    #[cfg(feature = "sev_snp")]
+    #[cfg(any(feature = "sev_snp", feature = "tdx"))]
     vm_fd: Arc<VmFd>,
     #[cfg(feature = "sev_snp")]
     memory_slots: Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
@@ -2699,7 +2744,7 @@ impl cpu::Vcpu for KvmVcpu {
                     }
                 }
 
-                #[cfg(feature = "sev_snp")]
+                #[cfg(any(feature = "sev_snp", feature = "tdx"))]
                 VcpuExit::MemoryFault { flags, gpa, size } => {
                     debug!("VcpuExit::MemoryFault: flags={flags:#x}, gpa={gpa:#x}, size={size:#x}");
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1503,7 +1503,7 @@ impl vm::Vm for KvmVm {
     /// Initialize TDX for this VM
     ///
     #[cfg(feature = "tdx")]
-    fn tdx_init(&self, cpuid: &[CpuIdEntry], max_vcpus: u32) -> vm::Result<()> {
+    fn tdx_init(&self, cpuid: &[CpuIdEntry]) -> vm::Result<()> {
         let guest_cpuid: Vec<kvm_bindings::kvm_cpuid_entry2> =
             cpuid.iter().map(|e| (*e).into()).collect();
 
@@ -1520,23 +1520,10 @@ impl vm::Vm for KvmVm {
 
         // The upstream Linux 6.16 `struct kvm_tdx_init_vm` no longer carries
         // `max_vcpus`; the TDX module derives the TD's `TD_PARAMS.max_vcpus`
-        // from the VM's `kvm->max_vcpus`. Some kernels let userspace lower that
-        // bound via KVM_CAP_MAX_VCPUS before KVM_TDX_INIT_VM (and before any
-        // vCPU is created); others do not implement setting that capability and
-        // simply rely on the default (capped at the number of present CPUs).
-        // Attempt it best-effort so we honor an explicit limit where supported,
-        // but never fail TDX init when the capability is query-only.
-        let cap = kvm_bindings::kvm_enable_cap {
-            cap: kvm_bindings::KVM_CAP_MAX_VCPUS,
-            args: [max_vcpus as u64, 0, 0, 0],
-            ..Default::default()
-        };
-        if let Err(e) = self.fd.enable_cap(&cap) {
-            warn!(
-                "KVM_CAP_MAX_VCPUS not settable ({e}); TD max_vcpus will use the \
-                 kernel default derived from kvm->max_vcpus"
-            );
-        }
+        // from the VM's `kvm->max_vcpus`. We do not attempt to lower that bound
+        // here (KVM_CAP_MAX_VCPUS): like QEMU, we leave it at the kernel default
+        // and rely on the query+compare check performed earlier against
+        // KVM_CAP_MAX_VCPUS (see CpuManager::new) to reject over-provisioning.
 
         // Query the TDX capabilities (a VM-scoped ioctl) to learn both the
         // supported attribute/XFAM masks and the set of CPUID leaves the TDX

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1664,40 +1664,6 @@ impl vm::Vm for KvmVm {
         Ok(data)
     }
 
-    /// Initialize memory regions for the TDX VM
-    ///
-    /// # Safety
-    ///
-    /// `host_address` must be valid for `size` bytes
-    #[cfg(feature = "tdx")]
-    unsafe fn tdx_init_memory_region(
-        &self,
-        host_address: *mut u8,
-        guest_address: u64,
-        size: usize,
-        measure: bool,
-    ) -> vm::Result<()> {
-        #[repr(C)]
-        struct TdxInitMemRegion {
-            host_address: u64,
-            guest_address: u64,
-            pages: u64,
-        }
-        let data = TdxInitMemRegion {
-            host_address: host_address as _,
-            guest_address,
-            pages: (size / 4096).try_into().unwrap(),
-        };
-
-        tdx_command(
-            &self.fd.as_raw_fd(),
-            TdxCommand::InitMemRegion,
-            u32::from(measure),
-            (&raw const data).cast(),
-        )
-        .map_err(vm::HypervisorVmError::InitMemRegionTdx)
-    }
-
     /// Downcast to the underlying KvmVm type
     fn as_any(&self) -> &dyn Any {
         self
@@ -3791,6 +3757,42 @@ impl cpu::Vcpu for KvmVcpu {
 
         tdx_command(&self.fd.as_raw_fd(), TdxCommand::InitVcpu, 0, hob_address)
             .map_err(cpu::HypervisorCpuError::InitializeTdx)
+    }
+
+    ///
+    /// Add a TDX memory region to the TD's initial image via this vCPU.
+    ///
+    #[cfg(feature = "tdx")]
+    unsafe fn tdx_init_memory_region(
+        &self,
+        host_address: *const u8,
+        guest_address: u64,
+        size: usize,
+        measure: bool,
+    ) -> cpu::Result<()> {
+        #[repr(C)]
+        struct TdxInitMemRegion {
+            host_address: u64,
+            guest_address: u64,
+            pages: u64,
+        }
+        let mut data = TdxInitMemRegion {
+            host_address: host_address as u64,
+            guest_address,
+            pages: (size / 4096).try_into().unwrap(),
+        };
+
+        // KVM_TDX_INIT_MEM_REGION is a vCPU ioctl: the module maps the private
+        // page through this vCPU's Secure-EPT and copies from `host_address`.
+        // The kernel may write the advanced region back into `data` and return
+        // -EINTR; tdx_command retries in that case, resuming from `data`.
+        tdx_command(
+            &self.fd.as_raw_fd(),
+            TdxCommand::InitMemRegion,
+            u32::from(measure),
+            (&raw mut data).cast(),
+        )
+        .map_err(cpu::HypervisorCpuError::InitializeTdxMemoryRegion)
     }
 
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -639,6 +639,8 @@ pub struct KvmVm {
     snp_guest_policy: OnceLock<u64>,
     dirty_log_slots: RwLock<HashMap<u32, KvmDirtyLogSlot>>,
     memory_slots: Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
+    #[cfg(any(feature = "tdx", feature = "sev_snp"))]
+    mem_conversion_handler: Arc<RwLock<Option<Arc<dyn vm::MemoryConversionHandler>>>>,
 }
 
 impl KvmVm {
@@ -952,8 +954,15 @@ impl vm::Vm for KvmVm {
             vm_fd: self.fd.clone(),
             #[cfg(feature = "sev_snp")]
             memory_slots: self.memory_slots.clone(),
+            #[cfg(any(feature = "tdx", feature = "sev_snp"))]
+            mem_conversion_handler: self.mem_conversion_handler.clone(),
         };
         Ok(Box::new(vcpu))
+    }
+
+    #[cfg(any(feature = "tdx", feature = "sev_snp"))]
+    fn set_memory_conversion_handler(&self, handler: Arc<dyn vm::MemoryConversionHandler>) {
+        *self.mem_conversion_handler.write().unwrap() = Some(handler);
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -1864,6 +1873,8 @@ impl hypervisor::Hypervisor for KvmHypervisor {
                 #[cfg(feature = "sev_snp")]
                 snp_guest_policy: OnceLock::new(),
                 memory_slots,
+                #[cfg(any(feature = "tdx", feature = "sev_snp"))]
+                mem_conversion_handler: Arc::new(RwLock::new(None)),
             }))
         }
 
@@ -2014,6 +2025,20 @@ pub struct KvmVcpu {
     vm_fd: Arc<VmFd>,
     #[cfg(feature = "sev_snp")]
     memory_slots: Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
+    #[cfg(any(feature = "tdx", feature = "sev_snp"))]
+    mem_conversion_handler: Arc<RwLock<Option<Arc<dyn vm::MemoryConversionHandler>>>>,
+}
+
+#[cfg(any(feature = "tdx", feature = "sev_snp"))]
+impl KvmVcpu {
+    /// Notify the registered handler (if any) that the guest converted
+    /// `[gpa, gpa + size)` between shared and private, so the VMM can refresh
+    /// host IOMMU (VFIO) mappings.
+    fn notify_memory_conversion(&self, gpa: u64, size: u64, to_private: bool) {
+        if let Some(handler) = self.mem_conversion_handler.read().unwrap().as_ref() {
+            handler.convert(gpa, size, to_private);
+        }
+    }
 }
 
 #[cfg(feature = "sev_snp")]
@@ -2738,6 +2763,11 @@ impl cpu::Vcpu for KvmVcpu {
                                 Self::punch_holes_in_guest_memfd(&self.memory_slots, address, size);
                             }
 
+                            // Refresh host IOMMU (VFIO) mappings for the
+                            // converted range: map when shared, unmap when
+                            // private.
+                            self.notify_memory_conversion(address, size, set_private_attr != 0);
+
                             Ok(cpu::VmExit::Ignore)
                         }
                         _ => Ok(cpu::VmExit::Ignore),
@@ -2765,6 +2795,8 @@ impl cpu::Vcpu for KvmVcpu {
                         0u64
                     };
 
+                    let to_private = flags & KVM_MEMORY_EXIT_FLAG_PRIVATE != 0;
+
                     self.vm_fd
                         .set_memory_attributes(kvm_memory_attributes {
                             address: gpa,
@@ -2772,8 +2804,13 @@ impl cpu::Vcpu for KvmVcpu {
                             attributes,
                             flags: 0,
                         })
-                        .map(|_| cpu::VmExit::Ignore)
-                        .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()))
+                        .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()))?;
+
+                    // Refresh host IOMMU (VFIO) mappings for the converted
+                    // range: map when shared, unmap when private.
+                    self.notify_memory_conversion(gpa, size, to_private);
+
+                    Ok(cpu::VmExit::Ignore)
                 }
 
                 r => Err(cpu::HypervisorCpuError::RunVcpu(anyhow!(

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -207,8 +207,9 @@ ioctl_iow_nr!(
     kvm_bindings::kvm_device_attr
 );
 
-#[cfg(feature = "sev_snp")]
-use igvm_defs::PAGE_SIZE_4K;
+#[cfg(any(feature = "sev_snp", feature = "tdx"))]
+/// 4 KiB, the granularity of guest private/shared memory conversions.
+const PAGE_SIZE_4K: u64 = 4096;
 #[cfg(any(feature = "sev_snp", feature = "tdx"))]
 use kvm_bindings::{KVM_MEMORY_ATTRIBUTE_PRIVATE, kvm_memory_attributes};
 #[cfg(feature = "sev_snp")]
@@ -618,13 +619,14 @@ struct KvmDirtyLogSlot {
 }
 
 struct KvmMemorySlot {
-    // These fields are currently only read by the SEV-SNP isolated-import
-    // path; the TDX path populates them for future shared/private bookkeeping.
-    #[cfg_attr(not(feature = "sev_snp"), expect(dead_code))]
+    // These fields are read by the SEV-SNP isolated-import path and by the TDX
+    // private<->shared conversion path (punch_holes_in_guest_memfd); they are
+    // unused only when neither confidential-VM backend is compiled in.
+    #[cfg_attr(not(any(feature = "sev_snp", feature = "tdx")), expect(dead_code))]
     guest_memfd: OwnedFd,
-    #[cfg_attr(not(feature = "sev_snp"), expect(dead_code))]
+    #[cfg_attr(not(any(feature = "sev_snp", feature = "tdx")), expect(dead_code))]
     guest_phys_addr: u64,
-    #[cfg_attr(not(feature = "sev_snp"), expect(dead_code))]
+    #[cfg_attr(not(any(feature = "sev_snp", feature = "tdx")), expect(dead_code))]
     memory_size: u64,
 }
 
@@ -952,7 +954,7 @@ impl vm::Vm for KvmVm {
             has_xcrs: self.check_extension(Cap::Xcrs),
             #[cfg(any(feature = "sev_snp", feature = "tdx"))]
             vm_fd: self.fd.clone(),
-            #[cfg(feature = "sev_snp")]
+            #[cfg(any(feature = "sev_snp", feature = "tdx"))]
             memory_slots: self.memory_slots.clone(),
             #[cfg(any(feature = "tdx", feature = "sev_snp"))]
             mem_conversion_handler: self.mem_conversion_handler.clone(),
@@ -1841,6 +1843,23 @@ impl hypervisor::Hypervisor for KvmHypervisor {
                 memory_slots = Some(Arc::new(RwLock::new(HashMap::new())));
             }
 
+            // A TD converts TDG.VP.VMCALL<MapGPA> into KVM_HC_MAP_GPA_RANGE,
+            // which KVM only forwards to userspace when the hypercall exit is
+            // opted into. Enable every hypercall exit KVM advertises (the mask
+            // includes KVM_HC_MAP_GPA_RANGE) so private<->shared conversions
+            // reach the run loop instead of being rejected as unsupported.
+            #[cfg(feature = "tdx")]
+            if _config.tdx_enabled {
+                let mask = self.kvm.check_extension_int(Cap::ExitHypercall);
+                let cap = kvm_bindings::kvm_enable_cap {
+                    cap: kvm_bindings::KVM_CAP_EXIT_HYPERCALL,
+                    args: [mask as _, 0, 0, 0],
+                    ..Default::default()
+                };
+                fd.enable_cap(&cap)
+                    .map_err(|e| hypervisor::HypervisorError::VmCreate(e.into()))?;
+            }
+
             #[cfg(feature = "sev_snp")]
             let sev_fd = {
                 let sev_snp_enabled = vm_type == KVM_X86_SNP_VM as u64;
@@ -2023,7 +2042,7 @@ pub struct KvmVcpu {
     has_xcrs: bool,
     #[cfg(any(feature = "sev_snp", feature = "tdx"))]
     vm_fd: Arc<VmFd>,
-    #[cfg(feature = "sev_snp")]
+    #[cfg(any(feature = "sev_snp", feature = "tdx"))]
     memory_slots: Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
     #[cfg(any(feature = "tdx", feature = "sev_snp"))]
     mem_conversion_handler: Arc<RwLock<Option<Arc<dyn vm::MemoryConversionHandler>>>>,
@@ -2041,7 +2060,7 @@ impl KvmVcpu {
     }
 }
 
-#[cfg(feature = "sev_snp")]
+#[cfg(any(feature = "sev_snp", feature = "tdx"))]
 impl KvmVcpu {
     fn punch_holes_in_guest_memfd(
         memory_slots: &Option<Arc<RwLock<HashMap<u32, KvmMemorySlot>>>>,
@@ -2720,7 +2739,7 @@ impl cpu::Vcpu for KvmVcpu {
                 #[cfg(feature = "tdx")]
                 VcpuExit::Unsupported(KVM_EXIT_TDX) => Ok(cpu::VmExit::Tdx),
                 VcpuExit::Debug(_) => Ok(cpu::VmExit::Debug),
-                #[cfg(feature = "sev_snp")]
+                #[cfg(any(feature = "sev_snp", feature = "tdx"))]
                 VcpuExit::Hypercall(hypercall) => {
                     // https://docs.kernel.org/virt/kvm/x86/hypercalls.html#kvm-hc-map-gpa-range
                     const KVM_HC_MAP_GPA_RANGE: u64 = 12;

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1549,8 +1549,37 @@ impl vm::Vm for KvmVm {
             cpuid_padding: u32,
             cpuid_entries: [kvm_bindings::kvm_cpuid_entry2; 256],
         }
+
+        let attributes: u64 = 1 << TDX_ATTR_SEPT_VE_DISABLE;
+
+        // Validate the requested attributes and XFAM against what the TDX
+        // module and KVM actually support before KVM_TDX_INIT_VM, mirroring
+        // the kernel's own checks in setup_tdparams(). The supported masks
+        // come from KVM_TDX_CAPABILITIES (a VM-scoped ioctl).
+        let caps = self.tdx_capabilities().map_err(|e| {
+            vm::HypervisorVmError::InitializeTdx(io::Error::other(format!(
+                "failed to query TDX capabilities: {e}"
+            )))
+        })?;
+        if attributes & !caps.supported_attrs != 0 {
+            return Err(vm::HypervisorVmError::InitializeTdx(io::Error::other(
+                format!(
+                    "requested TD attributes {attributes:#x} not supported (supported {:#x})",
+                    caps.supported_attrs
+                ),
+            )));
+        }
+        if xfam & !caps.supported_xfam != 0 {
+            return Err(vm::HypervisorVmError::InitializeTdx(io::Error::other(
+                format!(
+                    "requested TD XFAM {xfam:#x} not supported (supported {:#x})",
+                    caps.supported_xfam
+                ),
+            )));
+        }
+
         let data = TdxInitVm {
-            attributes: 1 << TDX_ATTR_SEPT_VE_DISABLE,
+            attributes,
             xfam,
             mrconfigid: [0; 6],
             mrowner: [0; 6],
@@ -1577,6 +1606,34 @@ impl vm::Vm for KvmVm {
     fn tdx_finalize(&self) -> vm::Result<()> {
         tdx_command(&self.fd.as_raw_fd(), TdxCommand::Finalize, 0, ptr::null())
             .map_err(vm::HypervisorVmError::FinalizeTdx)
+    }
+
+    #[cfg(feature = "tdx")]
+    fn tdx_capabilities(&self) -> hypervisor::Result<TdxCapabilities> {
+        let data = TdxCapabilities {
+            supported_attrs: 0,
+            supported_xfam: 0,
+            kernel_tdvmcallinfo_1_r11: 0,
+            user_tdvmcallinfo_1_r11: 0,
+            kernel_tdvmcallinfo_1_r12: 0,
+            user_tdvmcallinfo_1_r12: 0,
+            reserved: [0; 250],
+            cpuid_nent: 256,
+            cpuid_padding: 0,
+            cpuid_entries: [kvm_bindings::kvm_cpuid_entry2::default(); 256],
+        };
+
+        // KVM_TDX_CAPABILITIES is a VM-scoped ioctl in Linux 6.16: it must be
+        // issued on the TD VM fd, not on the /dev/kvm system fd.
+        tdx_command(
+            &self.fd.as_raw_fd(),
+            TdxCommand::Capabilities,
+            0,
+            (&raw const data).cast(),
+        )
+        .map_err(|e| hypervisor::HypervisorError::TdxCapabilities(e.into()))?;
+
+        Ok(data)
     }
 
     /// Initialize memory regions for the TDX VM
@@ -1974,35 +2031,6 @@ impl hypervisor::Hypervisor for KvmHypervisor {
     ///
     fn get_host_ipa_limit(&self) -> i32 {
         self.kvm.get_host_ipa_limit()
-    }
-
-    ///
-    /// Retrieve TDX capabilities
-    ///
-    #[cfg(feature = "tdx")]
-    fn tdx_capabilities(&self) -> hypervisor::Result<TdxCapabilities> {
-        let data = TdxCapabilities {
-            supported_attrs: 0,
-            supported_xfam: 0,
-            kernel_tdvmcallinfo_1_r11: 0,
-            user_tdvmcallinfo_1_r11: 0,
-            kernel_tdvmcallinfo_1_r12: 0,
-            user_tdvmcallinfo_1_r12: 0,
-            reserved: [0; 250],
-            cpuid_nent: 256,
-            cpuid_padding: 0,
-            cpuid_entries: [kvm_bindings::kvm_cpuid_entry2::default(); 256],
-        };
-
-        tdx_command(
-            &self.kvm.as_raw_fd(),
-            TdxCommand::Capabilities,
-            0,
-            (&raw const data).cast(),
-        )
-        .map_err(|e| hypervisor::HypervisorError::TdxCapabilities(e.into()))?;
-
-        Ok(data)
     }
 
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -2060,6 +2060,75 @@ impl KvmVcpu {
     }
 }
 
+#[cfg(feature = "tdx")]
+impl KvmVcpu {
+    /// Parse and log a `TDG.VP.VMCALL<ReportFatalError>` request delivered as a
+    /// `KVM_SYSTEM_EVENT_TDX_FATAL` system event.
+    ///
+    /// `data` is the `kvm_run.system_event.data[]` array, which KVM populates
+    /// with the guest's general-purpose registers indexed by their x86 GPR
+    /// number. The decoding mirrors QEMU's `tdx_handle_report_fatal_error()`.
+    fn handle_tdx_fatal_error(data: &[u64]) {
+        // x86 GPR indices within `kvm_run.system_event.data[]`.
+        const R_RCX: usize = 1;
+        const R_RDX: usize = 2;
+        const R_RBX: usize = 3;
+        const R_RSI: usize = 6;
+        const R_RDI: usize = 7;
+        const R_R8: usize = 8;
+        const R_R9: usize = 9;
+        const R_R12: usize = 12;
+        const R_R13: usize = 13;
+        const R_R14: usize = 14;
+        const R_R15: usize = 15;
+        // Bit 63 of the error code signals that R13 carries a valid GPA.
+        const TDX_REPORT_FATAL_ERROR_GPA_VALID: u64 = 1 << 63;
+
+        let reg = |i: usize| data.get(i).copied().unwrap_or(0);
+
+        let error_code = reg(R_R12);
+        let reg_mask = reg(R_RCX);
+
+        // Optional 64-byte ASCII message. Per the TDX GHCI spec only these 8
+        // registers may carry it, in this fixed order: R14, R15, RBX, RDI,
+        // RSI, R8, R9, RDX. `reg_mask` flags which of them are valid.
+        let mut bytes = Vec::new();
+        if reg_mask != 0 {
+            for r in [R_R14, R_R15, R_RBX, R_RDI, R_RSI, R_R8, R_R9, R_RDX] {
+                if reg_mask & (1u64 << r) != 0 {
+                    bytes.extend_from_slice(&reg(r).to_le_bytes());
+                }
+            }
+        }
+        let message: String = bytes
+            .iter()
+            .take_while(|&&b| b != 0)
+            .map(|&b| {
+                if b.is_ascii_graphic() || b == b' ' {
+                    b as char
+                } else {
+                    '.'
+                }
+            })
+            .collect();
+
+        let gpa = (error_code & TDX_REPORT_FATAL_ERROR_GPA_VALID != 0).then(|| reg(R_R13));
+
+        error!(
+            "TD guest reported a fatal error: error_code={error_code:#x}{}{}",
+            if message.is_empty() {
+                String::new()
+            } else {
+                format!(", message: {message:?}")
+            },
+            match gpa {
+                Some(gpa) => format!(", gpa={gpa:#x}"),
+                None => String::new(),
+            },
+        );
+    }
+}
+
 #[cfg(any(feature = "sev_snp", feature = "tdx"))]
 impl KvmVcpu {
     fn punch_holes_in_guest_memfd(
@@ -2697,6 +2766,26 @@ impl cpu::Vcpu for KvmVcpu {
                 VcpuExit::Hlt => {
                     error!("Received a HLT exit but KVM should handle this in kernel space");
                     Ok(cpu::VmExit::Reset)
+                }
+
+                #[cfg(all(target_arch = "x86_64", feature = "tdx"))]
+                VcpuExit::SystemEvent(event_type, flags) => {
+                    // A TD guest requests termination via
+                    // TDG.VP.VMCALL<ReportFatalError>, which KVM surfaces as a
+                    // KVM_SYSTEM_EVENT_TDX_FATAL system event. Log the reported
+                    // error and shut the guest down.
+                    //
+                    // Not yet exposed by kvm-bindings 0.14; value from the
+                    // Linux 6.16 UAPI (`enum` in <linux/kvm.h>).
+                    const KVM_SYSTEM_EVENT_TDX_FATAL: u32 = 7;
+                    if event_type == KVM_SYSTEM_EVENT_TDX_FATAL {
+                        Self::handle_tdx_fatal_error(flags);
+                        Ok(cpu::VmExit::Shutdown)
+                    } else {
+                        Err(cpu::HypervisorCpuError::RunVcpu(anyhow!(
+                            "Unexpected system event with type 0x{event_type:x}, flags 0x{flags:x?}",
+                        )))
+                    }
                 }
 
                 #[cfg(target_arch = "aarch64")]

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -62,6 +62,8 @@ pub use device::HypervisorDeviceError;
 pub use kvm::aarch64;
 #[cfg(all(feature = "kvm", target_arch = "riscv64"))]
 pub use kvm::{AiaState, riscv64};
+#[cfg(any(feature = "tdx", feature = "sev_snp"))]
+pub use vm::MemoryConversionHandler;
 pub use vm::{
     DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig, MsiIrqSourceConfig,
     Vm, VmOps,

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -462,7 +462,7 @@ pub trait Vm: Send + Sync + Any {
     fn sev_snp_init(&self, guest_policy: SnpPolicy) -> Result<()>;
     #[cfg(feature = "tdx")]
     /// Initialize TDX on this VM
-    fn tdx_init(&self, _cpuid: &[CpuIdEntry], _max_vcpus: u32) -> Result<()> {
+    fn tdx_init(&self, _cpuid: &[CpuIdEntry]) -> Result<()> {
         unimplemented!()
     }
     #[cfg(feature = "tdx")]

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -242,12 +242,6 @@ pub enum HypervisorVmError {
     ///
     #[error("Failed to finalize TDX")]
     FinalizeTdx(#[source] io::Error),
-    #[cfg(feature = "tdx")]
-    ///
-    /// Error initializing the TDX memory region
-    ///
-    #[error("Failed to initialize memory region TDX")]
-    InitMemRegionTdx(#[source] io::Error),
     ///
     /// Create Vgic error
     ///
@@ -479,21 +473,6 @@ pub trait Vm: Send + Sync + Any {
     #[cfg(feature = "tdx")]
     /// Retrieve the TDX capabilities supported for this VM
     fn tdx_capabilities(&self) -> result::Result<TdxCapabilities, HypervisorError> {
-        unimplemented!()
-    }
-    #[cfg(feature = "tdx")]
-    /// Initialize a TDX memory region for this VM
-    ///
-    /// # Safety
-    ///
-    /// `_host_address` must be valid for `_size` bytes
-    unsafe fn tdx_init_memory_region(
-        &self,
-        _host_address: *mut u8,
-        _guest_address: u64,
-        _size: usize,
-        _measure: bool,
-    ) -> Result<()> {
         unimplemented!()
     }
     /// Downcast to the underlying hypervisor VM type

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -462,7 +462,13 @@ pub trait Vm: Send + Sync + Any {
     fn sev_snp_init(&self, guest_policy: SnpPolicy) -> Result<()>;
     #[cfg(feature = "tdx")]
     /// Initialize TDX on this VM
-    fn tdx_init(&self, _cpuid: &[CpuIdEntry]) -> Result<()> {
+    fn tdx_init(
+        &self,
+        _cpuid: &[CpuIdEntry],
+        _mrconfigid: &[u8; 48],
+        _mrowner: &[u8; 48],
+        _mrownerconfig: &[u8; 48],
+    ) -> Result<()> {
         unimplemented!()
     }
     #[cfg(feature = "tdx")]

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -329,6 +329,23 @@ pub enum InterruptSourceConfig {
     MsiIrq(MsiIrqSourceConfig),
 }
 
+/// Notifies the VMM when confidential-VM guest memory is converted between
+/// shared and private, so it can keep host IOMMU (VFIO) mappings consistent.
+///
+/// For confidential guests (TDX, SEV-SNP) backed by `guest_memfd`, a
+/// passthrough device may only DMA to *shared* memory. The host IOMMU must
+/// therefore map a range when the guest makes it shared and unmap it when the
+/// guest makes it private, so that the IOMMU only ever holds shared GPA to HPA
+/// translations. This mirrors QEMU's `RamDiscardManager`-on-`guest_memfd`
+/// mechanism, where shared is "populated" and private is "discarded".
+#[cfg(any(feature = "tdx", feature = "sev_snp"))]
+pub trait MemoryConversionHandler: Send + Sync {
+    /// Called after the guest converted `[gpa, gpa + size)`. `to_private` is
+    /// `true` for shared to private (unmap) and `false` for private to shared
+    /// (map). `gpa` and `size` are host-page aligned.
+    fn convert(&self, gpa: u64, size: u64, to_private: bool);
+}
+
 ///
 /// Trait to represent a Vm
 ///
@@ -517,6 +534,12 @@ pub trait Vm: Send + Sync + Any {
     fn enable_x2apic_api(&self) -> Result<()> {
         unimplemented!("x2Apic is only supported on KVM/Linux hosts")
     }
+
+    /// Register a handler notified on shared/private memory conversions so the
+    /// VMM can keep host IOMMU (VFIO) mappings in sync. No-op by default and on
+    /// backends that do not support confidential VMs.
+    #[cfg(any(feature = "tdx", feature = "sev_snp"))]
+    fn set_memory_conversion_handler(&self, _handler: Arc<dyn MemoryConversionHandler>) {}
 }
 
 pub trait VmOps: Send + Sync {

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -27,6 +27,8 @@ use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(target_arch = "x86_64")]
 use crate::ClockData;
+#[cfg(feature = "tdx")]
+use crate::HypervisorError;
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::{Vgic, VgicConfig};
 #[cfg(target_arch = "riscv64")]
@@ -36,6 +38,8 @@ use crate::arch::x86::CpuIdEntry;
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::VcpuMsrConfigUpdate;
 use crate::cpu::Vcpu;
+#[cfg(feature = "tdx")]
+use crate::kvm::TdxCapabilities;
 use crate::{ClockRestoreMode, ClockState, IoEventAddress, IrqRoutingEntry};
 
 ///
@@ -470,6 +474,11 @@ pub trait Vm: Send + Sync + Any {
     #[cfg(feature = "tdx")]
     /// Finalize the configuration of TDX on this VM
     fn tdx_finalize(&self) -> Result<()> {
+        unimplemented!()
+    }
+    #[cfg(feature = "tdx")]
+    /// Retrieve the TDX capabilities supported for this VM
+    fn tdx_capabilities(&self) -> result::Result<TdxCapabilities, HypervisorError> {
         unimplemented!()
     }
     #[cfg(feature = "tdx")]

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -12,6 +12,8 @@ cargo_args=("")
 # shellcheck disable=SC2154
 if [[ $hypervisor = "mshv" ]]; then
     cargo_args+=("--features $hypervisor")
+elif [[ $(uname -m) = "x86_64" ]]; then
+    cargo_args+=("--features tdx")
 fi
 
 export RUST_BACKTRACE=1

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -38,7 +38,7 @@ sev_snp = [
   "igvm",
   "virtio-devices/sev_snp",
 ]
-tdx = ["arch/tdx", "hypervisor/tdx"]
+tdx = ["arch/tdx", "hex", "hypervisor/tdx"]
 tracing = ["tracer/tracing"]
 
 [dependencies]

--- a/vmm/src/coco_dma.rs
+++ b/vmm/src/coco_dma.rs
@@ -1,0 +1,216 @@
+// Copyright © 2025 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Synchronizes host IOMMU (VFIO) mappings with guest shared/private memory
+//! conversions for confidential VMs (TDX, SEV-SNP).
+//!
+//! This mirrors the design of QEMU upstream commit 5d6483edaa9, where a
+//! `RamDiscardManager` tracks the shared state of guest RAM at 4 KiB
+//! granularity and notifies VFIO to map newly-shared pages and unmap pages
+//! that become private. The host IOMMU must only ever hold mappings for
+//! shared guest memory: the host cannot access private (encrypted) pages, so
+//! a device DMA targeting such a page would fault or corrupt guest state.
+
+use std::sync::{Arc, Mutex};
+
+use hypervisor::MemoryConversionHandler;
+use log::error;
+use vm_device::dma_mapping::ExternalDmaMapping;
+
+const PAGE_SIZE: u64 = 4096;
+const PAGE_SHIFT: u64 = 12;
+
+/// A contiguous guest RAM region tracked for conversion, with a per-4 KiB
+/// bitmap recording whether each page is currently mapped into the host IOMMU
+/// (i.e. shared). All pages start private (bit clear), matching the initial
+/// state of confidential guest memory.
+struct TrackedRegion {
+    base: u64,
+    size: u64,
+    /// One bit per 4 KiB page; set means "shared and mapped in the IOMMU".
+    shared: Vec<u64>,
+}
+
+impl TrackedRegion {
+    fn new(base: u64, size: u64) -> Self {
+        let pages = size.div_ceil(PAGE_SIZE) as usize;
+        let words = pages.div_ceil(64);
+        TrackedRegion {
+            base,
+            size,
+            shared: vec![0u64; words],
+        }
+    }
+
+    fn is_shared(&self, page_idx: usize) -> bool {
+        (self.shared[page_idx / 64] >> (page_idx % 64)) & 1 != 0
+    }
+
+    fn set_shared(&mut self, page_idx: usize, shared: bool) {
+        let word = page_idx / 64;
+        let bit = 1u64 << (page_idx % 64);
+        if shared {
+            self.shared[word] |= bit;
+        } else {
+            self.shared[word] &= !bit;
+        }
+    }
+}
+
+/// Bridges guest memory conversion events to host IOMMU map/unmap operations.
+///
+/// The shared GPA is identity-mapped into the host IOMMU (`iova == gpa`),
+/// matching how the static boot-time mapping is set up for non-confidential
+/// VMs. Map and unmap are always issued at 4 KiB granularity so the request
+/// granularity always matches the underlying VFIO mapping, which keeps partial
+/// conversions safe.
+pub struct SharedMemoryConverter {
+    dma_mapping: Arc<dyn ExternalDmaMapping>,
+    regions: Mutex<Vec<TrackedRegion>>,
+}
+
+impl SharedMemoryConverter {
+    /// Build a converter wrapping `dma_mapping` and tracking the given guest
+    /// RAM regions, each expressed as a `(base, size)` pair.
+    pub fn new(
+        dma_mapping: Arc<dyn ExternalDmaMapping>,
+        regions: impl IntoIterator<Item = (u64, u64)>,
+    ) -> Self {
+        let regions = regions
+            .into_iter()
+            .map(|(base, size)| TrackedRegion::new(base, size))
+            .collect();
+        SharedMemoryConverter {
+            dma_mapping,
+            regions: Mutex::new(regions),
+        }
+    }
+}
+
+impl MemoryConversionHandler for SharedMemoryConverter {
+    fn convert(&self, gpa: u64, size: u64, to_private: bool) {
+        if size == 0 {
+            return;
+        }
+
+        // Align the requested range to 4 KiB. Conversions are page-granular in
+        // practice, but be defensive against unaligned inputs.
+        let start = gpa & !(PAGE_SIZE - 1);
+        let end = gpa.saturating_add(size).div_ceil(PAGE_SIZE) * PAGE_SIZE;
+
+        let mut regions = self.regions.lock().unwrap();
+        for region in regions.iter_mut() {
+            let region_end = region.base.saturating_add(region.size);
+            let overlap_start = start.max(region.base);
+            let overlap_end = end.min(region_end);
+            if overlap_start >= overlap_end {
+                continue;
+            }
+
+            let mut page = overlap_start;
+            while page < overlap_end {
+                let idx = ((page - region.base) >> PAGE_SHIFT) as usize;
+                let currently_shared = region.is_shared(idx);
+
+                if to_private {
+                    if currently_shared {
+                        if let Err(e) = self.dma_mapping.unmap(page, PAGE_SIZE) {
+                            // A failed unmap leaves a stale host IOMMU mapping
+                            // pointing at memory that is about to become
+                            // private. This is a security concern, so log it
+                            // loudly; the bit is still cleared to avoid a later
+                            // double unmap.
+                            error!(
+                                "Failed to unmap shared page {page:#x} from host IOMMU on private conversion: {e}"
+                            );
+                        }
+                        region.set_shared(idx, false);
+                    }
+                } else if !currently_shared {
+                    // Identity-map the newly shared GPA into the host IOMMU.
+                    if let Err(e) = self.dma_mapping.map(page, page, PAGE_SIZE) {
+                        error!(
+                            "Failed to map shared page {page:#x} into host IOMMU on shared conversion: {e}"
+                        );
+                    } else {
+                        region.set_shared(idx, true);
+                    }
+                }
+
+                page = page.saturating_add(PAGE_SIZE);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeMapping {
+        events: Mutex<Vec<(bool, u64, u64)>>,
+    }
+
+    impl ExternalDmaMapping for FakeMapping {
+        fn map(&self, iova: u64, _gpa: u64, size: u64) -> io::Result<()> {
+            self.events.lock().unwrap().push((true, iova, size));
+            Ok(())
+        }
+
+        fn unmap(&self, iova: u64, size: u64) -> io::Result<()> {
+            self.events.lock().unwrap().push((false, iova, size));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_shared_then_private_roundtrip() {
+        let fake = Arc::new(FakeMapping::default());
+        let converter = SharedMemoryConverter::new(fake.clone(), [(0x1000, 0x4000)]);
+
+        // Convert two pages to shared.
+        converter.convert(0x1000, 0x2000, false);
+        // Convert the same range to private.
+        converter.convert(0x1000, 0x2000, true);
+
+        let events = fake.events.lock().unwrap();
+        assert_eq!(
+            *events,
+            vec![
+                (true, 0x1000, PAGE_SIZE),
+                (true, 0x2000, PAGE_SIZE),
+                (false, 0x1000, PAGE_SIZE),
+                (false, 0x2000, PAGE_SIZE),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_redundant_conversions_are_skipped() {
+        let fake = Arc::new(FakeMapping::default());
+        let converter = SharedMemoryConverter::new(fake.clone(), [(0x0, 0x1000)]);
+
+        converter.convert(0x0, 0x1000, false);
+        // Repeating the shared conversion must not re-map.
+        converter.convert(0x0, 0x1000, false);
+
+        let events = fake.events.lock().unwrap();
+        assert_eq!(*events, vec![(true, 0x0, PAGE_SIZE)]);
+    }
+
+    #[test]
+    fn test_out_of_range_is_ignored() {
+        let fake = Arc::new(FakeMapping::default());
+        let converter = SharedMemoryConverter::new(fake.clone(), [(0x1000, 0x1000)]);
+
+        // Entirely outside the tracked region.
+        converter.convert(0x100000, 0x1000, false);
+
+        assert!(fake.events.lock().unwrap().is_empty());
+    }
+}

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -3218,17 +3218,22 @@ impl VmConfig {
     pub fn validate(&mut self) -> ValidationResult<BTreeSet<String>> {
         let mut id_list = BTreeSet::new();
 
+        #[cfg(feature = "tdx")]
+        let tdx_enabled = self.platform.as_ref().is_some_and(|p| p.tdx);
+
         // Is the payload configuration bootable?
         self.payload
             .as_mut()
             .ok_or(ValidationError::PayloadError(
                 PayloadConfigError::MissingBootitem,
             ))?
-            .validate()?;
+            .validate(
+                #[cfg(feature = "tdx")]
+                tdx_enabled,
+            )?;
 
         #[cfg(feature = "tdx")]
         {
-            let tdx_enabled = self.platform.as_ref().is_some_and(|p| p.tdx);
             // At this point we know payload isn't None.
             if tdx_enabled && self.payload.as_ref().unwrap().firmware.is_none() {
                 return Err(ValidationError::TdxFirmwareMissing);

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -290,6 +290,10 @@ pub enum ValidationError {
     #[cfg(feature = "tdx")]
     #[error("No TDX firmware specified")]
     TdxFirmwareMissing,
+    /// Invalid TDX measurement-configuration digest
+    #[cfg(feature = "tdx")]
+    #[error("TDX '{0}' must be a 96-character (48-byte) hex SHA384 digest: {1}")]
+    TdxInvalidMeasurement(&'static str, String),
     /// Insufficient vCPUs for queues
     #[error("Queue count ({0}) must not exceed boot vCPUs ({1})")]
     TooManyQueues(usize /* queues */, usize /* vCPUs */),
@@ -892,6 +896,8 @@ impl PlatformConfig {
 
             if cfg!(feature = "tdx") {
                 syntax.push_str(",tdx=on|off");
+                syntax.push_str(",mrconfigid=<hex_sha384>,mrowner=<hex_sha384>");
+                syntax.push_str(",mrownerconfig=<hex_sha384>");
             }
 
             if cfg!(feature = "sev_snp") {
@@ -963,6 +969,12 @@ impl PlatformConfig {
         }
         #[cfg(feature = "tdx")]
         parser.add("tdx");
+        #[cfg(feature = "tdx")]
+        parser.add("mrconfigid");
+        #[cfg(feature = "tdx")]
+        parser.add("mrowner");
+        #[cfg(feature = "tdx")]
+        parser.add("mrownerconfig");
         #[cfg(feature = "sev_snp")]
         parser.add("sev_snp");
         parser.parse(platform).map_err(Error::ParsePlatform)?;
@@ -1002,6 +1014,18 @@ impl PlatformConfig {
             .map_err(Error::ParsePlatform)?
             .unwrap_or(Toggle(false))
             .0;
+        #[cfg(feature = "tdx")]
+        let tdx_mrconfigid = parser
+            .convert::<String>("mrconfigid")
+            .map_err(Error::ParsePlatform)?;
+        #[cfg(feature = "tdx")]
+        let tdx_mrowner = parser
+            .convert::<String>("mrowner")
+            .map_err(Error::ParsePlatform)?;
+        #[cfg(feature = "tdx")]
+        let tdx_mrownerconfig = parser
+            .convert::<String>("mrownerconfig")
+            .map_err(Error::ParsePlatform)?;
         #[cfg(feature = "sev_snp")]
         let sev_snp = parser
             .convert::<Toggle>("sev_snp")
@@ -1026,6 +1050,12 @@ impl PlatformConfig {
             iommufd_fd,
             #[cfg(feature = "tdx")]
             tdx,
+            #[cfg(feature = "tdx")]
+            tdx_mrconfigid,
+            #[cfg(feature = "tdx")]
+            tdx_mrowner,
+            #[cfg(feature = "tdx")]
+            tdx_mrownerconfig,
             #[cfg(feature = "sev_snp")]
             sev_snp,
             vfio_p2p_dma,
@@ -1086,7 +1116,32 @@ impl PlatformConfig {
             return Err(ValidationError::IommufdFdRequiresIommufd);
         }
 
+        #[cfg(feature = "tdx")]
+        self.tdx_measurements()?;
+
         Ok(())
+    }
+
+    /// Decode the optional TDX SHA384 measurement-configuration digests
+    /// (`mrconfigid`, `mrowner`, `mrownerconfig`) from their hex string form
+    /// into 48-byte arrays. Any register left unset decodes to all zeros,
+    /// preserving the previous hardcoded behavior.
+    #[cfg(feature = "tdx")]
+    pub fn tdx_measurements(&self) -> ValidationResult<([u8; 48], [u8; 48], [u8; 48])> {
+        fn decode(name: &'static str, value: &Option<String>) -> ValidationResult<[u8; 48]> {
+            let mut out = [0u8; 48];
+            if let Some(s) = value {
+                hex::decode_to_slice(s, &mut out)
+                    .map_err(|e| ValidationError::TdxInvalidMeasurement(name, e.to_string()))?;
+            }
+            Ok(out)
+        }
+
+        Ok((
+            decode("mrconfigid", &self.tdx_mrconfigid)?,
+            decode("mrowner", &self.tdx_mrowner)?,
+            decode("mrownerconfig", &self.tdx_mrownerconfig)?,
+        ))
     }
 }
 
@@ -5098,6 +5153,38 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         Ok(())
     }
 
+    #[cfg(feature = "tdx")]
+    #[test]
+    fn test_platform_tdx_measurements() -> Result<()> {
+        // Unset registers decode to all zeros.
+        let p = PlatformConfig::parse("tdx=on")?;
+        assert_eq!(p.tdx_measurements(), Ok(([0u8; 48], [0u8; 48], [0u8; 48])));
+
+        // A valid 96-character hex digest decodes into the matching register.
+        let hexid = "01".repeat(48);
+        let p = PlatformConfig::parse(&format!("tdx=on,mrconfigid={hexid}"))?;
+        let (mrconfigid, mrowner, mrownerconfig) = p.tdx_measurements().unwrap();
+        assert_eq!(mrconfigid, [1u8; 48]);
+        assert_eq!(mrowner, [0u8; 48]);
+        assert_eq!(mrownerconfig, [0u8; 48]);
+
+        // Wrong length is rejected by validation.
+        let p = PlatformConfig::parse("tdx=on,mrowner=00")?;
+        assert!(matches!(
+            p.tdx_measurements(),
+            Err(ValidationError::TdxInvalidMeasurement("mrowner", _))
+        ));
+
+        // Non-hex characters are rejected too.
+        let p = PlatformConfig::parse(&format!("tdx=on,mrownerconfig={}", "zz".repeat(48)))?;
+        assert!(matches!(
+            p.tdx_measurements(),
+            Err(ValidationError::TdxInvalidMeasurement("mrownerconfig", _))
+        ));
+
+        Ok(())
+    }
+
     #[test]
     fn test_vsock_parsing() -> Result<()> {
         // socket and cid is required
@@ -5765,6 +5852,12 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             chassis_asset_tag: None,
             #[cfg(feature = "tdx")]
             tdx: false,
+            #[cfg(feature = "tdx")]
+            tdx_mrconfigid: None,
+            #[cfg(feature = "tdx")]
+            tdx_mrowner: None,
+            #[cfg(feature = "tdx")]
+            tdx_mrownerconfig: None,
             #[cfg(feature = "sev_snp")]
             sev_snp: false,
         }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -895,7 +895,7 @@ impl PlatformConfig {
                 .to_string();
 
             if cfg!(feature = "tdx") {
-                syntax.push_str(",tdx=on|off");
+                syntax.push_str(",tdx=on|off,quote_generation_socket=<qgs_unix_socket_path>");
                 syntax.push_str(",mrconfigid=<hex_sha384>,mrowner=<hex_sha384>");
                 syntax.push_str(",mrownerconfig=<hex_sha384>");
             }
@@ -970,6 +970,8 @@ impl PlatformConfig {
         #[cfg(feature = "tdx")]
         parser.add("tdx");
         #[cfg(feature = "tdx")]
+        parser.add("quote_generation_socket");
+        #[cfg(feature = "tdx")]
         parser.add("mrconfigid");
         #[cfg(feature = "tdx")]
         parser.add("mrowner");
@@ -1015,6 +1017,10 @@ impl PlatformConfig {
             .unwrap_or(Toggle(false))
             .0;
         #[cfg(feature = "tdx")]
+        let tdx_quote_generation_socket = parser
+            .convert::<PathBuf>("quote_generation_socket")
+            .map_err(Error::ParsePlatform)?;
+        #[cfg(feature = "tdx")]
         let tdx_mrconfigid = parser
             .convert::<String>("mrconfigid")
             .map_err(Error::ParsePlatform)?;
@@ -1050,6 +1056,8 @@ impl PlatformConfig {
             iommufd_fd,
             #[cfg(feature = "tdx")]
             tdx,
+            #[cfg(feature = "tdx")]
+            tdx_quote_generation_socket,
             #[cfg(feature = "tdx")]
             tdx_mrconfigid,
             #[cfg(feature = "tdx")]
@@ -5852,6 +5860,8 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             chassis_asset_tag: None,
             #[cfg(feature = "tdx")]
             tdx: false,
+            #[cfg(feature = "tdx")]
+            tdx_quote_generation_socket: None,
             #[cfg(feature = "tdx")]
             tdx_mrconfigid: None,
             #[cfg(feature = "tdx")]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -895,7 +895,9 @@ impl PlatformConfig {
                 .to_string();
 
             if cfg!(feature = "tdx") {
-                syntax.push_str(",tdx=on|off,quote_generation_socket=<qgs_unix_socket_path>");
+                syntax.push_str(
+                    ",tdx=on|off,quote_generation_socket=<[unix:]path|vsock:cid:port|tcp:host:port>",
+                );
                 syntax.push_str(",mrconfigid=<hex_sha384>,mrowner=<hex_sha384>");
                 syntax.push_str(",mrownerconfig=<hex_sha384>");
             }
@@ -1018,7 +1020,7 @@ impl PlatformConfig {
             .0;
         #[cfg(feature = "tdx")]
         let tdx_quote_generation_socket = parser
-            .convert::<PathBuf>("quote_generation_socket")
+            .convert::<TdxQuoteGenerationSocket>("quote_generation_socket")
             .map_err(Error::ParsePlatform)?;
         #[cfg(feature = "tdx")]
         let tdx_mrconfigid = parser

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -554,6 +554,7 @@ impl Vcpu {
         #[cfg(target_arch = "x86_64")] kvm_hyperv: bool,
         #[cfg(target_arch = "x86_64")] topology: (u16, u16, u16, u16),
         #[cfg(target_arch = "x86_64")] nested: bool,
+        #[cfg(feature = "tdx")] tdx_enabled: bool,
         #[cfg(feature = "igvm")] igvm_enabled: bool,
     ) -> Result<()> {
         #[cfg(target_arch = "aarch64")]
@@ -581,6 +582,8 @@ impl Vcpu {
                     let setup_registers = true;
                 }
             }
+            #[cfg(not(feature = "tdx"))]
+            let tdx_enabled = false;
             arch::configure_vcpu(
                 self.vcpu.as_ref(),
                 self.id,
@@ -591,6 +594,7 @@ impl Vcpu {
                 topology,
                 nested,
                 setup_registers,
+                tdx_enabled,
             )
             .map_err(Error::VcpuConfiguration)?;
         }
@@ -741,6 +745,11 @@ pub struct CpuManager {
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
     #[cfg(feature = "sev_snp")]
     sev_snp_enabled: bool,
+    // Whether this VM is a TDX Trust Domain. TD vCPU register/APIC/FPU state is
+    // owned by the TDX module, so the standard KVM vCPU state configuration must
+    // be skipped for TDs.
+    #[cfg(feature = "tdx")]
+    tdx_enabled: bool,
     // State of the core scheduling group leader election (VM mode).
     core_scheduling_group_leader: Arc<AtomicI32>,
     #[cfg(feature = "igvm")]
@@ -980,6 +989,8 @@ impl CpuManager {
             hypervisor,
             #[cfg(feature = "sev_snp")]
             sev_snp_enabled,
+            #[cfg(feature = "tdx")]
+            tdx_enabled,
             core_scheduling_group_leader: Arc::new(AtomicI32::new(
                 CoreSchedulingLeader::Initial as i32,
             )),
@@ -1092,6 +1103,8 @@ impl CpuManager {
             self.config.kvm_hyperv,
             topology,
             self.config.nested,
+            #[cfg(feature = "tdx")]
+            self.tdx_enabled,
             #[cfg(feature = "igvm")]
             self.igvm_enabled,
         )?;

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -198,6 +198,14 @@ pub enum Error {
     #[error("Error initializing TDX")]
     InitializeTdx(#[source] hypervisor::HypervisorCpuError),
 
+    #[cfg(feature = "tdx")]
+    #[error("Error initializing TDX memory region")]
+    InitializeTdxMemoryRegion(#[source] hypervisor::HypervisorCpuError),
+
+    #[cfg(feature = "tdx")]
+    #[error("No vCPU available to initialize TDX memory region")]
+    InitializeTdxNoVcpu,
+
     #[cfg(target_arch = "aarch64")]
     #[error("Error initializing PMU")]
     InitPmu(#[source] hypervisor::HypervisorCpuError),
@@ -1729,6 +1737,32 @@ impl CpuManager {
             Self::compare_tdx_cpuid(vcpu.id, vcpu.vcpu.as_ref());
         }
         Ok(())
+    }
+
+    /// Add a TDX memory region to the TD's initial image.
+    ///
+    /// `KVM_TDX_INIT_MEM_REGION` is a vCPU-scoped ioctl, so route it through
+    /// the boot vCPU.
+    ///
+    /// # Safety
+    ///
+    /// `host_address` must be valid for `size` bytes.
+    #[cfg(feature = "tdx")]
+    pub unsafe fn init_tdx_memory_region(
+        &self,
+        host_address: *const u8,
+        guest_address: u64,
+        size: usize,
+        measure: bool,
+    ) -> Result<()> {
+        let vcpu = self.vcpus.first().ok_or(Error::InitializeTdxNoVcpu)?;
+        let vcpu = vcpu.lock().unwrap();
+        // SAFETY: caller guarantees `host_address` is valid for `size` bytes.
+        unsafe {
+            vcpu.vcpu
+                .tdx_init_memory_region(host_address, guest_address, size, measure)
+                .map_err(Error::InitializeTdxMemoryRegion)
+        }
     }
 
     /// Cross-check the CPUID the TDX module virtualizes for a TD vCPU

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -16,8 +16,6 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::mem::zeroed;
 use std::os::unix::thread::JoinHandleExt;
-#[cfg(feature = "tdx")]
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{any, cmp, hint, io, panic, result, thread, time};
@@ -100,6 +98,8 @@ use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::tdx_quote;
 #[cfg(target_arch = "x86_64")]
 use crate::vm::physical_bits;
+#[cfg(feature = "tdx")]
+use crate::vm_config::TdxQuoteGenerationSocket;
 use crate::vm_config::{CoreScheduling, CpusConfig};
 use crate::{CPU_MANAGER_SNAPSHOT_ID, GuestMemoryMmap};
 
@@ -762,9 +762,9 @@ pub struct CpuManager {
     // be skipped for TDs.
     #[cfg(feature = "tdx")]
     tdx_enabled: bool,
-    // QGS Unix socket used to answer TDX `GetQuote` requests, if configured.
+    // QGS endpoint used to answer TDX `GetQuote` requests, if configured.
     #[cfg(feature = "tdx")]
-    tdx_quote_generation_socket: Option<PathBuf>,
+    tdx_quote_generation_socket: Option<TdxQuoteGenerationSocket>,
     // State of the core scheduling group leader election (VM mode).
     core_scheduling_group_leader: Arc<AtomicI32>,
     #[cfg(feature = "igvm")]
@@ -897,7 +897,7 @@ impl CpuManager {
         seccomp_action: SeccompAction,
         vm_ops: Arc<dyn VmOps>,
         #[cfg(feature = "tdx")] tdx_enabled: bool,
-        #[cfg(feature = "tdx")] tdx_quote_generation_socket: Option<PathBuf>,
+        #[cfg(feature = "tdx")] tdx_quote_generation_socket: Option<TdxQuoteGenerationSocket>,
         numa_nodes: &NumaNodes,
         #[cfg(feature = "sev_snp")] sev_snp_enabled: bool,
         #[cfg(feature = "igvm")] igvm_enabled: bool,
@@ -1519,7 +1519,7 @@ impl CpuManager {
                                                             tdx_vm_ops.as_ref(),
                                                             shared_gpa,
                                                             buf_len,
-                                                            tdx_quote_generation_socket.as_deref(),
+                                                            tdx_quote_generation_socket.as_ref(),
                                                         );
                                                         vcpu.vcpu.set_tdx_status(status);
                                                     }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -16,6 +16,8 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::mem::zeroed;
 use std::os::unix::thread::JoinHandleExt;
+#[cfg(feature = "tdx")]
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{any, cmp, hint, io, panic, result, thread, time};
@@ -94,6 +96,8 @@ use crate::gdb::{Debuggable, DebuggableError, get_raw_tid};
 #[cfg(all(feature = "sev_snp", feature = "mshv"))]
 use crate::igvm::HV_PAGE_SIZE;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
+#[cfg(feature = "tdx")]
+use crate::tdx_quote;
 #[cfg(target_arch = "x86_64")]
 use crate::vm::physical_bits;
 use crate::vm_config::{CoreScheduling, CpusConfig};
@@ -758,6 +762,9 @@ pub struct CpuManager {
     // be skipped for TDs.
     #[cfg(feature = "tdx")]
     tdx_enabled: bool,
+    // QGS Unix socket used to answer TDX `GetQuote` requests, if configured.
+    #[cfg(feature = "tdx")]
+    tdx_quote_generation_socket: Option<PathBuf>,
     // State of the core scheduling group leader election (VM mode).
     core_scheduling_group_leader: Arc<AtomicI32>,
     #[cfg(feature = "igvm")]
@@ -890,6 +897,7 @@ impl CpuManager {
         seccomp_action: SeccompAction,
         vm_ops: Arc<dyn VmOps>,
         #[cfg(feature = "tdx")] tdx_enabled: bool,
+        #[cfg(feature = "tdx")] tdx_quote_generation_socket: Option<PathBuf>,
         numa_nodes: &NumaNodes,
         #[cfg(feature = "sev_snp")] sev_snp_enabled: bool,
         #[cfg(feature = "igvm")] igvm_enabled: bool,
@@ -999,6 +1007,8 @@ impl CpuManager {
             sev_snp_enabled,
             #[cfg(feature = "tdx")]
             tdx_enabled,
+            #[cfg(feature = "tdx")]
+            tdx_quote_generation_socket,
             core_scheduling_group_leader: Arc::new(AtomicI32::new(
                 CoreSchedulingLeader::Initial as i32,
             )),
@@ -1279,6 +1289,11 @@ impl CpuManager {
         #[cfg(target_arch = "x86_64")]
         let interrupt_controller_clone = self.interrupt_controller.as_ref().cloned();
 
+        #[cfg(feature = "tdx")]
+        let tdx_vm_ops = panic::AssertUnwindSafe(self.vm_ops.clone());
+        #[cfg(feature = "tdx")]
+        let tdx_quote_generation_socket = self.tdx_quote_generation_socket.clone();
+
         debug!("Starting vCPU: cpu_id = {vcpu_id}");
 
         let handle = Some(
@@ -1496,14 +1511,28 @@ impl CpuManager {
                                     VmExit::Tdx => {
                                             match vcpu.vcpu.get_tdx_exit_details() {
                                                 Ok(details) => match details {
-                                                    TdxExitDetails::GetQuote => warn!("TDG_VP_VMCALL_GET_QUOTE not supported"),
+                                                    TdxExitDetails::GetQuote {
+                                                        shared_gpa,
+                                                        buf_len,
+                                                    } => {
+                                                        let status = tdx_quote::handle_get_quote(
+                                                            tdx_vm_ops.as_ref(),
+                                                            shared_gpa,
+                                                            buf_len,
+                                                            tdx_quote_generation_socket.as_deref(),
+                                                        );
+                                                        vcpu.vcpu.set_tdx_status(status);
+                                                    }
                                                     TdxExitDetails::SetupEventNotifyInterrupt => {
                                                         warn!("TDG_VP_VMCALL_SETUP_EVENT_NOTIFY_INTERRUPT not supported");
+                                                        vcpu.vcpu.set_tdx_status(TdxExitStatus::InvalidOperand);
                                                     }
                                                 },
-                                                Err(e) => error!("Unexpected TDX VMCALL: {e}"),
+                                                Err(e) => {
+                                                    error!("Unexpected TDX VMCALL: {e}");
+                                                    vcpu.vcpu.set_tdx_status(TdxExitStatus::InvalidOperand);
+                                                }
                                             }
-                                            vcpu.vcpu.set_tdx_status(TdxExitStatus::InvalidOperand);
                                     }
                                 },
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1709,13 +1709,74 @@ impl CpuManager {
     #[cfg(feature = "tdx")]
     pub fn initialize_tdx(&self, hob_address: u64) -> Result<()> {
         for vcpu in &self.vcpus {
-            vcpu.lock()
-                .unwrap()
-                .vcpu
+            let vcpu = vcpu.lock().unwrap();
+            vcpu.vcpu
                 .tdx_init(hob_address)
                 .map_err(Error::InitializeTdx)?;
+            Self::compare_tdx_cpuid(vcpu.id, vcpu.vcpu.as_ref());
         }
         Ok(())
+    }
+
+    /// Cross-check the CPUID the TDX module virtualizes for a TD vCPU
+    /// (KVM_TDX_GET_CPUID) against the CPUID programmed via KVM_SET_CPUID2 and
+    /// log any per-register differences. Comparing the same vCPU keeps the
+    /// per-vCPU topology leaves aligned, so a difference is a genuine feature
+    /// discrepancy: bits advertised to the guest that the TD does not
+    /// virtualize ("unavailable"), or bits the TD forces on regardless
+    /// ("forced-on", e.g. fixed1). This mirrors QEMU's `tdx_check_features()`.
+    /// It is purely diagnostic and best-effort.
+    #[cfg(feature = "tdx")]
+    fn compare_tdx_cpuid(id: u32, vcpu: &dyn hypervisor::Vcpu) {
+        let programmed = match vcpu.get_cpuid2(256) {
+            Ok(c) => c,
+            Err(e) => {
+                info!("TDX vCPU {id}: could not read programmed CPUID for cross-check: {e}");
+                return;
+            }
+        };
+        let td = match vcpu.tdx_get_cpuid() {
+            Ok(c) => c,
+            Err(e) => {
+                info!("TDX vCPU {id}: could not read TDX-virtualized CPUID for cross-check: {e}");
+                return;
+            }
+        };
+
+        for p in &programmed {
+            let Some(t) = td
+                .iter()
+                .find(|t| t.function == p.function && t.index == p.index)
+            else {
+                info!(
+                    "TDX vCPU {id}: CPUID leaf {:#x}/{:#x} advertised to guest is not virtualized by the TDX module",
+                    p.function, p.index
+                );
+                continue;
+            };
+
+            for (reg, prog, tdval) in [
+                ("eax", p.eax, t.eax),
+                ("ebx", p.ebx, t.ebx),
+                ("ecx", p.ecx, t.ecx),
+                ("edx", p.edx, t.edx),
+            ] {
+                let unavailable = prog & !tdval;
+                if unavailable != 0 {
+                    info!(
+                        "TDX vCPU {id}: CPUID {:#x}/{:#x} {reg}: bits {unavailable:#x} advertised to guest but not virtualized by the TDX module",
+                        p.function, p.index
+                    );
+                }
+                let forced_on = tdval & !prog;
+                if forced_on != 0 {
+                    info!(
+                        "TDX vCPU {id}: CPUID {:#x}/{:#x} {reg}: bits {forced_on:#x} forced on by the TDX module",
+                        p.function, p.index
+                    );
+                }
+            }
+        }
     }
 
     pub fn boot_vcpus(&self) -> u32 {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -930,6 +930,8 @@ impl CpuManager {
             let phys_bits = physical_bits(hypervisor.as_ref(), config.max_phys_bits);
             arch::generate_common_cpuid(
                 hypervisor.as_ref(),
+                #[cfg(feature = "tdx")]
+                Some(vm.as_ref()),
                 &arch::CpuidConfig {
                     phys_bits,
                     kvm_hyperv: config.kvm_hyperv,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -125,6 +125,8 @@ use vm_virtio::{AccessPlatform, VirtioDeviceType};
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 
+#[cfg(any(feature = "tdx", feature = "sev_snp"))]
+use crate::coco_dma::SharedMemoryConverter;
 use crate::console_devices::{ConsoleDeviceError, ConsoleInfo, ConsoleTransport};
 use crate::cpu::{AcpiCpuHotplugController, CPU_MANAGER_ACPI_SIZE, CpuManager};
 use crate::device_tree::{DeviceNode, DeviceTree};
@@ -4095,24 +4097,45 @@ impl DeviceManager {
         };
 
         if needs_dma_mapping {
-            // Register DMA mapping in IOMMU.
-            // Do not register virtio-mem regions, as they are handled directly by
-            // virtio-mem device itself.
-            for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
-                for region in zone.regions() {
-                    // vfio_dma_map is unsound and ought to be marked as unsafe
-                    #[allow(unused_unsafe)]
-                    // SAFETY: GuestMemoryMmap guarantees that region points
-                    // to len bytes of valid memory starting at as_ptr()
-                    // that will only be freed with munmap().
-                    unsafe {
-                        vfio_ops.vfio_dma_map(
-                            region.start_addr().raw_value(),
-                            region.len() as usize,
-                            region.as_ptr(),
-                        )
+            // For confidential VMs (TDX, SEV-SNP), guest RAM starts private and
+            // must not be statically mapped into the host IOMMU: the host
+            // cannot access private (encrypted) pages. Instead, a conversion
+            // handler maps pages as they become shared and unmaps them when
+            // they become private. See QEMU upstream commit 5d6483edaa9.
+            let is_confidential_vm = {
+                #[allow(unused_mut)]
+                let mut confidential = false;
+                #[cfg(feature = "tdx")]
+                {
+                    confidential |= self.config.lock().unwrap().is_tdx_enabled();
+                }
+                #[cfg(feature = "sev_snp")]
+                {
+                    confidential |= self.config.lock().unwrap().is_sev_snp_enabled();
+                }
+                confidential
+            };
+
+            if !is_confidential_vm {
+                // Register DMA mapping in IOMMU.
+                // Do not register virtio-mem regions, as they are handled directly by
+                // virtio-mem device itself.
+                for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
+                    for region in zone.regions() {
+                        // vfio_dma_map is unsound and ought to be marked as unsafe
+                        #[allow(unused_unsafe)]
+                        // SAFETY: GuestMemoryMmap guarantees that region points
+                        // to len bytes of valid memory starting at as_ptr()
+                        // that will only be freed with munmap().
+                        unsafe {
+                            vfio_ops.vfio_dma_map(
+                                region.start_addr().raw_value(),
+                                region.len() as usize,
+                                region.as_ptr(),
+                            )
+                        }
+                        .map_err(DeviceManagerError::VfioDmaMap)?;
                     }
-                    .map_err(DeviceManagerError::VfioDmaMap)?;
                 }
             }
 
@@ -4121,6 +4144,30 @@ impl DeviceManager {
                 Arc::new(self.memory_manager.lock().unwrap().guest_memory()),
                 Arc::clone(&self.mmio_regions),
             ));
+
+            #[cfg(any(feature = "tdx", feature = "sev_snp"))]
+            if is_confidential_vm {
+                // Collect the guest RAM regions (excluding virtio-mem, which is
+                // handled by the device itself) so the converter only ever
+                // maps real RAM into the host IOMMU.
+                let regions: Vec<(u64, u64)> = self
+                    .memory_manager
+                    .lock()
+                    .unwrap()
+                    .memory_zones()
+                    .values()
+                    .flat_map(|zone| zone.regions())
+                    .map(|region| (region.start_addr().raw_value(), region.len()))
+                    .collect();
+
+                let converter = SharedMemoryConverter::new(
+                    vfio_mapping.clone() as Arc<dyn ExternalDmaMapping>,
+                    regions,
+                );
+                self.address_manager
+                    .vm
+                    .set_memory_conversion_handler(Arc::new(converter));
+            }
 
             for virtio_mem_device in self.virtio_mem_devices.iter() {
                 virtio_mem_device

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1637,6 +1637,8 @@ impl Vmm {
 
             arch::generate_common_cpuid(
                 hypervisor,
+                #[cfg(feature = "tdx")]
+                None,
                 &arch::CpuidConfig {
                     phys_bits,
                     kvm_hyperv,
@@ -1933,6 +1935,8 @@ impl Vmm {
 
             arch::generate_common_cpuid(
                 self.hypervisor.as_ref(),
+                #[cfg(feature = "tdx")]
+                None,
                 &arch::CpuidConfig {
                     phys_bits,
                     kvm_hyperv: vm_config.cpus.kvm_hyperv,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -76,6 +76,8 @@ use crate::vm_config::{
 mod acpi;
 pub mod api;
 mod clone3;
+#[cfg(any(feature = "tdx", feature = "sev_snp"))]
+mod coco_dma;
 pub mod config;
 pub mod console_devices;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -101,6 +101,8 @@ pub(crate) mod sev;
 mod sigwinch_listener;
 pub mod sparse;
 mod sync_utils;
+#[cfg(feature = "tdx")]
+mod tdx_quote;
 mod uffd;
 mod userfaultfd;
 pub mod vm;

--- a/vmm/src/tdx_quote.rs
+++ b/vmm/src/tdx_quote.rs
@@ -7,8 +7,9 @@
 //! On a GetQuote request the guest places a request buffer in shared memory (a
 //! 24-byte GHCI header followed by a TD report) and traps to the VMM. This
 //! module reads that buffer, forwards the report to a Quote Generation Service
-//! (QGS) over a host Unix socket using the QGS message framing, and writes the
-//! returned quote back into the same shared buffer.
+//! (QGS) using the QGS message framing, and writes the returned quote back into
+//! the same shared buffer. The QGS endpoint may be a host Unix, AF_VSOCK or TCP
+//! socket, mirroring QEMU's `SocketAddress`-typed `quote-generation-socket`.
 //!
 //! This is a synchronous port of QEMU's
 //! `target/i386/kvm/tdx-quote-generator.c` (commit 40da501d8989). Unlike QEMU,
@@ -17,15 +18,18 @@
 //! completion immediately. TDs that strictly wait for the
 //! `SetupEventNotifyInterrupt` completion interrupt are not yet supported.
 
-use std::fmt;
 use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::net::UnixStream;
-use std::path::Path;
 use std::time::Duration;
+use std::{fmt, mem};
 
 use hypervisor::VmOps;
 use hypervisor::kvm::TdxExitStatus;
 use log::{error, warn};
+
+use crate::vm_config::TdxQuoteGenerationSocket;
 
 /// Size of the shared GHCI GetQuote header, in bytes.
 const GHCI_HDR_SIZE: usize = 24;
@@ -169,15 +173,142 @@ fn parse_qgs_response(msg: &[u8]) -> Result<Vec<u8>, QuoteError> {
     Ok(msg[quote_start..quote_start + quote_size].to_vec())
 }
 
+/// A connected, byte-stream QGS transport (Unix, TCP or AF_VSOCK).
+trait QgsStream: Read + Write {}
+impl<T: Read + Write> QgsStream for T {}
+
+/// A connected AF_VSOCK stream socket, backed by an owned file descriptor.
+///
+/// Rust's standard library has no AF_VSOCK support, so read/write go through
+/// the raw `read(2)`/`write(2)` syscalls. The connected socket carries
+/// `SO_RCVTIMEO`/`SO_SNDTIMEO`, so a stalled QGS surfaces as a `WouldBlock`
+/// error just like the timeouts on the Unix/TCP transports.
+struct VsockStream(OwnedFd);
+
+impl Read for VsockStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // SAFETY: `buf` is valid for writes of `buf.len()` bytes and the fd is
+        // a valid, owned, connected socket.
+        let ret = unsafe {
+            libc::read(
+                self.0.as_raw_fd(),
+                buf.as_mut_ptr() as *mut libc::c_void,
+                buf.len(),
+            )
+        };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(ret as usize)
+        }
+    }
+}
+
+impl Write for VsockStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // SAFETY: `buf` is valid for reads of `buf.len()` bytes and the fd is a
+        // valid, owned, connected socket.
+        let ret = unsafe {
+            libc::write(
+                self.0.as_raw_fd(),
+                buf.as_ptr() as *const libc::c_void,
+                buf.len(),
+            )
+        };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(ret as usize)
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Apply a send/receive timeout to a raw socket fd via `SO_SNDTIMEO`/`SO_RCVTIMEO`.
+fn set_socket_timeouts(fd: RawFd, timeout: Duration) -> io::Result<()> {
+    let tv = libc::timeval {
+        tv_sec: timeout.as_secs() as libc::time_t,
+        tv_usec: timeout.subsec_micros() as libc::suseconds_t,
+    };
+    for opt in [libc::SO_RCVTIMEO, libc::SO_SNDTIMEO] {
+        // SAFETY: `tv` outlives the call and its size is passed correctly.
+        let ret = unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                opt,
+                std::ptr::addr_of!(tv) as *const libc::c_void,
+                size_of::<libc::timeval>() as libc::socklen_t,
+            )
+        };
+        if ret < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+/// Connect to a QGS reachable over AF_VSOCK at `cid:port`.
+fn connect_vsock(cid: u32, port: u32, timeout: Duration) -> io::Result<VsockStream> {
+    // SAFETY: FFI call with constant, valid arguments; returns an fd or -1.
+    let fd = unsafe { libc::socket(libc::AF_VSOCK, libc::SOCK_STREAM, 0) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `fd` is a fresh, valid socket fd owned by us from here on.
+    let owned = unsafe { OwnedFd::from_raw_fd(fd) };
+
+    // SAFETY: `sockaddr_vm` is a plain-old-data struct; zeroing is a valid
+    // initial state before filling in the address family, CID and port.
+    let mut addr: libc::sockaddr_vm = unsafe { mem::zeroed() };
+    addr.svm_family = libc::AF_VSOCK as libc::sa_family_t;
+    addr.svm_cid = cid;
+    addr.svm_port = port;
+
+    // SAFETY: `addr` is a properly-initialized `sockaddr_vm` and its size is
+    // passed correctly; `owned` holds a valid socket fd.
+    let ret = unsafe {
+        libc::connect(
+            owned.as_raw_fd(),
+            std::ptr::addr_of!(addr) as *const libc::sockaddr,
+            size_of::<libc::sockaddr_vm>() as libc::socklen_t,
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    set_socket_timeouts(owned.as_raw_fd(), timeout)?;
+    Ok(VsockStream(owned))
+}
+
+/// Connect to the configured QGS endpoint, applying the QGS transaction timeout.
+fn connect_qgs(addr: &TdxQuoteGenerationSocket) -> io::Result<Box<dyn QgsStream>> {
+    match addr {
+        TdxQuoteGenerationSocket::Unix { path } => {
+            let stream = UnixStream::connect(path)?;
+            stream.set_read_timeout(Some(QGS_TIMEOUT))?;
+            stream.set_write_timeout(Some(QGS_TIMEOUT))?;
+            Ok(Box::new(stream))
+        }
+        TdxQuoteGenerationSocket::Inet { host, port } => {
+            let stream = TcpStream::connect((host.as_str(), *port))?;
+            stream.set_read_timeout(Some(QGS_TIMEOUT))?;
+            stream.set_write_timeout(Some(QGS_TIMEOUT))?;
+            Ok(Box::new(stream))
+        }
+        TdxQuoteGenerationSocket::Vsock { cid, port } => {
+            Ok(Box::new(connect_vsock(*cid, *port, QGS_TIMEOUT)?))
+        }
+    }
+}
+
 /// Connect to the QGS, forward the TD report and return the generated quote.
-fn generate_quote(socket: &Path, report: &[u8]) -> Result<Vec<u8>, QuoteError> {
-    let mut stream = UnixStream::connect(socket).map_err(QuoteError::Connect)?;
-    stream
-        .set_read_timeout(Some(QGS_TIMEOUT))
-        .map_err(QuoteError::Io)?;
-    stream
-        .set_write_timeout(Some(QGS_TIMEOUT))
-        .map_err(QuoteError::Io)?;
+fn generate_quote(addr: &TdxQuoteGenerationSocket, report: &[u8]) -> Result<Vec<u8>, QuoteError> {
+    let mut stream = connect_qgs(addr).map_err(QuoteError::Connect)?;
 
     let request = build_qgs_request(report);
     stream.write_all(&request).map_err(QuoteError::Io)?;
@@ -206,14 +337,15 @@ fn write_header(vm_ops: &dyn VmOps, gpa: u64, hdr: &GhciHeader) {
 /// Handle a `TDG.VP.VMCALL<GetQuote>` exit.
 ///
 /// `gpa`/`buf_len` describe the shared GetQuote buffer; `socket`, when present,
-/// is the host QGS Unix socket. The returned [`TdxExitStatus`] is the VMCALL
-/// status reported back to the guest; quote-level results are conveyed through
-/// the GHCI header written into the shared buffer.
+/// is the host QGS endpoint (Unix, AF_VSOCK or TCP). The returned
+/// [`TdxExitStatus`] is the VMCALL status reported back to the guest;
+/// quote-level results are conveyed through the GHCI header written into the
+/// shared buffer.
 pub fn handle_get_quote(
     vm_ops: &dyn VmOps,
     gpa: u64,
     buf_len: u64,
-    socket: Option<&Path>,
+    socket: Option<&TdxQuoteGenerationSocket>,
 ) -> TdxExitStatus {
     // Transport-level validation, mapped to the VMCALL status register.
     if buf_len == 0 {

--- a/vmm/src/tdx_quote.rs
+++ b/vmm/src/tdx_quote.rs
@@ -1,0 +1,375 @@
+// Copyright © 2025 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Host-side handling of the TDX `TDG.VP.VMCALL<GetQuote>` GHCI call.
+//!
+//! On a GetQuote request the guest places a request buffer in shared memory (a
+//! 24-byte GHCI header followed by a TD report) and traps to the VMM. This
+//! module reads that buffer, forwards the report to a Quote Generation Service
+//! (QGS) over a host Unix socket using the QGS message framing, and writes the
+//! returned quote back into the same shared buffer.
+//!
+//! This is a synchronous port of QEMU's
+//! `target/i386/kvm/tdx-quote-generator.c` (commit 40da501d8989). Unlike QEMU,
+//! the transaction runs inline on the vCPU thread and completes before the
+//! VMCALL returns, so a TD that polls the GHCI header's status field observes
+//! completion immediately. TDs that strictly wait for the
+//! `SetupEventNotifyInterrupt` completion interrupt are not yet supported.
+
+use std::fmt;
+use std::io::{self, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::time::Duration;
+
+use hypervisor::VmOps;
+use hypervisor::kvm::TdxExitStatus;
+use log::{error, warn};
+
+/// Size of the shared GHCI GetQuote header, in bytes.
+const GHCI_HDR_SIZE: usize = 24;
+/// Only GHCI GetQuote structure version 1 is defined today.
+const GHCI_STRUCTURE_VERSION: u64 = 1;
+
+// GHCI GetQuote status codes, written into the header's `error_code` field.
+const GET_QUOTE_SUCCESS: u64 = 0;
+const GET_QUOTE_IN_FLIGHT: u64 = u64::MAX;
+const GET_QUOTE_ERROR: u64 = 0x8000_0000_0000_0000;
+const GET_QUOTE_QGS_UNAVAILABLE: u64 = 0x8000_0000_0000_0001;
+
+/// Upper bound on the shared buffer size, mirroring QEMU's safeguard.
+const MAX_BUF_LEN: u64 = 128 * 1024;
+/// 4 KiB alignment required for both the buffer address and its length.
+const PAGE_SIZE: u64 = 4096;
+
+/// Transaction timeout matching QEMU's 30s threshold.
+const QGS_TIMEOUT: Duration = Duration::from_secs(30);
+
+// QGS message framing (see QEMU's tdx-quote-generator.c).
+const QGS_MSG_LIB_MAJOR_VER: u16 = 1;
+const QGS_MSG_LIB_MINOR_VER: u16 = 1;
+const QGS_MSG_GET_QUOTE_REQ: u32 = 0;
+const QGS_MSG_GET_QUOTE_RESP: u32 = 1;
+/// Size of the big-endian length prefix that frames each QGS message.
+const QGS_FRAME_LEN_SIZE: usize = 4;
+/// `qgs_msg_header_t`: major(u16) minor(u16) type(u32) size(u32) error_code(u32).
+const QGS_MSG_HEADER_SIZE: usize = 16;
+/// `qgs_msg_get_quote_req_t` = header + report_size(u32) + id_list_size(u32).
+const QGS_GET_QUOTE_REQ_SIZE: usize = QGS_MSG_HEADER_SIZE + 8;
+/// `qgs_msg_get_quote_resp_t` = header + selected_id_size(u32) + quote_size(u32).
+const QGS_GET_QUOTE_RESP_SIZE: usize = QGS_MSG_HEADER_SIZE + 8;
+
+#[derive(Debug)]
+enum QuoteError {
+    /// Could not connect to the QGS socket.
+    Connect(io::Error),
+    /// I/O error while talking to the QGS.
+    Io(io::Error),
+    /// The QGS reply did not conform to the expected framing.
+    Protocol(String),
+}
+
+impl fmt::Display for QuoteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            QuoteError::Connect(e) => write!(f, "failed to connect to QGS socket: {e}"),
+            QuoteError::Io(e) => write!(f, "QGS I/O error: {e}"),
+            QuoteError::Protocol(msg) => write!(f, "QGS protocol error: {msg}"),
+        }
+    }
+}
+
+/// Shared GHCI GetQuote header. All fields are little-endian on the wire.
+struct GhciHeader {
+    structure_version: u64,
+    error_code: u64,
+    in_len: u32,
+    out_len: u32,
+}
+
+impl GhciHeader {
+    fn from_bytes(b: &[u8; GHCI_HDR_SIZE]) -> Self {
+        Self {
+            structure_version: u64::from_le_bytes(b[0..8].try_into().unwrap()),
+            error_code: u64::from_le_bytes(b[8..16].try_into().unwrap()),
+            in_len: u32::from_le_bytes(b[16..20].try_into().unwrap()),
+            out_len: u32::from_le_bytes(b[20..24].try_into().unwrap()),
+        }
+    }
+
+    fn to_bytes(&self) -> [u8; GHCI_HDR_SIZE] {
+        let mut b = [0u8; GHCI_HDR_SIZE];
+        b[0..8].copy_from_slice(&self.structure_version.to_le_bytes());
+        b[8..16].copy_from_slice(&self.error_code.to_le_bytes());
+        b[16..20].copy_from_slice(&self.in_len.to_le_bytes());
+        b[20..24].copy_from_slice(&self.out_len.to_le_bytes());
+        b
+    }
+}
+
+/// Build a framed QGS `GET_QUOTE_REQ` message wrapping `report`.
+fn build_qgs_request(report: &[u8]) -> Vec<u8> {
+    let msg_size = (QGS_GET_QUOTE_REQ_SIZE + report.len()) as u32;
+    let mut buf = Vec::with_capacity(QGS_FRAME_LEN_SIZE + msg_size as usize);
+    // 4-byte big-endian frame length prefix.
+    buf.extend_from_slice(&msg_size.to_be_bytes());
+    // qgs_msg_header_t
+    buf.extend_from_slice(&QGS_MSG_LIB_MAJOR_VER.to_le_bytes());
+    buf.extend_from_slice(&QGS_MSG_LIB_MINOR_VER.to_le_bytes());
+    buf.extend_from_slice(&QGS_MSG_GET_QUOTE_REQ.to_le_bytes());
+    buf.extend_from_slice(&msg_size.to_le_bytes());
+    buf.extend_from_slice(&0u32.to_le_bytes()); // error_code
+    // qgs_msg_get_quote_req_t tail
+    buf.extend_from_slice(&(report.len() as u32).to_le_bytes()); // report_size
+    buf.extend_from_slice(&0u32.to_le_bytes()); // id_list_size
+    buf.extend_from_slice(report);
+    buf
+}
+
+/// Validate a QGS `GET_QUOTE_RESP` message and extract the raw quote bytes.
+fn parse_qgs_response(msg: &[u8]) -> Result<Vec<u8>, QuoteError> {
+    if msg.len() < QGS_GET_QUOTE_RESP_SIZE {
+        return Err(QuoteError::Protocol(format!(
+            "QGS response too short: {} bytes",
+            msg.len()
+        )));
+    }
+    let major = u16::from_le_bytes(msg[0..2].try_into().unwrap());
+    let minor = u16::from_le_bytes(msg[2..4].try_into().unwrap());
+    if major != QGS_MSG_LIB_MAJOR_VER || minor != QGS_MSG_LIB_MINOR_VER {
+        return Err(QuoteError::Protocol(format!(
+            "invalid QGS message version {major}.{minor}"
+        )));
+    }
+    let msg_type = u32::from_le_bytes(msg[4..8].try_into().unwrap());
+    if msg_type != QGS_MSG_GET_QUOTE_RESP {
+        return Err(QuoteError::Protocol(format!(
+            "invalid QGS message type {msg_type}"
+        )));
+    }
+    let error_code = u32::from_le_bytes(msg[12..16].try_into().unwrap());
+    if error_code != 0 {
+        return Err(QuoteError::Protocol(format!("QGS error code {error_code}")));
+    }
+    let selected_id_size = u32::from_le_bytes(msg[16..20].try_into().unwrap());
+    if selected_id_size != 0 {
+        return Err(QuoteError::Protocol(format!(
+            "unexpected QGS selected ID size {selected_id_size}"
+        )));
+    }
+    let quote_size = u32::from_le_bytes(msg[20..24].try_into().unwrap()) as usize;
+    let quote_start = QGS_GET_QUOTE_RESP_SIZE;
+    if quote_size == 0 || quote_start + quote_size > msg.len() {
+        return Err(QuoteError::Protocol(format!(
+            "QGS quote size {quote_size} does not fit in {} bytes",
+            msg.len().saturating_sub(quote_start)
+        )));
+    }
+    Ok(msg[quote_start..quote_start + quote_size].to_vec())
+}
+
+/// Connect to the QGS, forward the TD report and return the generated quote.
+fn generate_quote(socket: &Path, report: &[u8]) -> Result<Vec<u8>, QuoteError> {
+    let mut stream = UnixStream::connect(socket).map_err(QuoteError::Connect)?;
+    stream
+        .set_read_timeout(Some(QGS_TIMEOUT))
+        .map_err(QuoteError::Io)?;
+    stream
+        .set_write_timeout(Some(QGS_TIMEOUT))
+        .map_err(QuoteError::Io)?;
+
+    let request = build_qgs_request(report);
+    stream.write_all(&request).map_err(QuoteError::Io)?;
+
+    // Read the 4-byte big-endian frame length, then the message body.
+    let mut len_buf = [0u8; QGS_FRAME_LEN_SIZE];
+    stream.read_exact(&mut len_buf).map_err(QuoteError::Io)?;
+    let resp_len = u32::from_be_bytes(len_buf) as usize;
+    if resp_len == 0 || resp_len > MAX_BUF_LEN as usize {
+        return Err(QuoteError::Protocol(format!(
+            "invalid QGS response length {resp_len}"
+        )));
+    }
+    let mut msg = vec![0u8; resp_len];
+    stream.read_exact(&mut msg).map_err(QuoteError::Io)?;
+
+    parse_qgs_response(&msg)
+}
+
+fn write_header(vm_ops: &dyn VmOps, gpa: u64, hdr: &GhciHeader) {
+    if let Err(e) = vm_ops.guest_mem_write(gpa, &hdr.to_bytes()) {
+        error!("TDX GetQuote: failed to update GHCI header: {e}");
+    }
+}
+
+/// Handle a `TDG.VP.VMCALL<GetQuote>` exit.
+///
+/// `gpa`/`buf_len` describe the shared GetQuote buffer; `socket`, when present,
+/// is the host QGS Unix socket. The returned [`TdxExitStatus`] is the VMCALL
+/// status reported back to the guest; quote-level results are conveyed through
+/// the GHCI header written into the shared buffer.
+pub fn handle_get_quote(
+    vm_ops: &dyn VmOps,
+    gpa: u64,
+    buf_len: u64,
+    socket: Option<&Path>,
+) -> TdxExitStatus {
+    // Transport-level validation, mapped to the VMCALL status register.
+    if buf_len == 0 {
+        return TdxExitStatus::InvalidOperand;
+    }
+    if !gpa.is_multiple_of(PAGE_SIZE) || !buf_len.is_multiple_of(PAGE_SIZE) {
+        return TdxExitStatus::AlignError;
+    }
+    if buf_len > MAX_BUF_LEN {
+        return TdxExitStatus::InvalidOperand;
+    }
+
+    // Read and validate the GHCI header.
+    let mut hdr_bytes = [0u8; GHCI_HDR_SIZE];
+    if let Err(e) = vm_ops.guest_mem_read(gpa, &mut hdr_bytes) {
+        error!("TDX GetQuote: failed to read GHCI header: {e}");
+        return TdxExitStatus::InvalidOperand;
+    }
+    let mut hdr = GhciHeader::from_bytes(&hdr_bytes);
+    if hdr.structure_version != GHCI_STRUCTURE_VERSION {
+        warn!(
+            "TDX GetQuote: unsupported GHCI structure version {}",
+            hdr.structure_version
+        );
+        return TdxExitStatus::InvalidOperand;
+    }
+    let payload_capacity = buf_len - GHCI_HDR_SIZE as u64;
+    if u64::from(hdr.in_len) > payload_capacity {
+        warn!(
+            "TDX GetQuote: in_len {} exceeds payload capacity {payload_capacity}",
+            hdr.in_len
+        );
+        return TdxExitStatus::InvalidOperand;
+    }
+
+    // Without a configured QGS, report unavailability via the header and let
+    // the VMCALL itself succeed.
+    let Some(socket) = socket else {
+        hdr.error_code = GET_QUOTE_QGS_UNAVAILABLE;
+        hdr.out_len = 0;
+        write_header(vm_ops, gpa, &hdr);
+        return TdxExitStatus::Success;
+    };
+
+    // Read the TD report (the in-message) from the shared payload area.
+    let mut report = vec![0u8; hdr.in_len as usize];
+    if let Err(e) = vm_ops.guest_mem_read(gpa + GHCI_HDR_SIZE as u64, &mut report) {
+        error!("TDX GetQuote: failed to read TD report: {e}");
+        return TdxExitStatus::InvalidOperand;
+    }
+
+    // Mark the request in-flight for any observer before the blocking QGS
+    // transaction, matching the GHCI contract.
+    hdr.error_code = GET_QUOTE_IN_FLIGHT;
+    hdr.out_len = 0;
+    write_header(vm_ops, gpa, &hdr);
+
+    match generate_quote(socket, &report) {
+        Ok(quote) => {
+            if quote.len() as u64 > payload_capacity {
+                error!(
+                    "TDX GetQuote: quote ({} bytes) exceeds payload capacity {payload_capacity}",
+                    quote.len()
+                );
+                hdr.error_code = GET_QUOTE_ERROR;
+                hdr.out_len = 0;
+            } else if let Err(e) = vm_ops.guest_mem_write(gpa + GHCI_HDR_SIZE as u64, &quote) {
+                error!("TDX GetQuote: failed to write quote: {e}");
+                hdr.error_code = GET_QUOTE_ERROR;
+                hdr.out_len = 0;
+            } else {
+                hdr.error_code = GET_QUOTE_SUCCESS;
+                hdr.out_len = quote.len() as u32;
+            }
+        }
+        Err(QuoteError::Connect(e)) => {
+            warn!("TDX GetQuote: QGS unavailable: {e}");
+            hdr.error_code = GET_QUOTE_QGS_UNAVAILABLE;
+            hdr.out_len = 0;
+        }
+        Err(e) => {
+            error!("TDX GetQuote: quote generation failed: {e}");
+            hdr.error_code = GET_QUOTE_ERROR;
+            hdr.out_len = 0;
+        }
+    }
+
+    write_header(vm_ops, gpa, &hdr);
+    TdxExitStatus::Success
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ghci_header_roundtrip() {
+        let hdr = GhciHeader {
+            structure_version: GHCI_STRUCTURE_VERSION,
+            error_code: GET_QUOTE_IN_FLIGHT,
+            in_len: 1024,
+            out_len: 4096,
+        };
+        let parsed = GhciHeader::from_bytes(&hdr.to_bytes());
+        assert_eq!(parsed.structure_version, GHCI_STRUCTURE_VERSION);
+        assert_eq!(parsed.error_code, GET_QUOTE_IN_FLIGHT);
+        assert_eq!(parsed.in_len, 1024);
+        assert_eq!(parsed.out_len, 4096);
+    }
+
+    #[test]
+    fn qgs_request_framing() {
+        let report = vec![0xabu8; 64];
+        let req = build_qgs_request(&report);
+        assert_eq!(
+            req.len(),
+            QGS_FRAME_LEN_SIZE + QGS_GET_QUOTE_REQ_SIZE + report.len()
+        );
+        let frame_len = u32::from_be_bytes(req[0..4].try_into().unwrap()) as usize;
+        assert_eq!(frame_len, QGS_GET_QUOTE_REQ_SIZE + report.len());
+        let msg_type = u32::from_le_bytes(req[8..12].try_into().unwrap());
+        assert_eq!(msg_type, QGS_MSG_GET_QUOTE_REQ);
+        let report_size = u32::from_le_bytes(req[20..24].try_into().unwrap());
+        assert_eq!(report_size as usize, report.len());
+        assert_eq!(
+            &req[QGS_FRAME_LEN_SIZE + QGS_GET_QUOTE_REQ_SIZE..],
+            &report[..]
+        );
+    }
+
+    fn build_qgs_response(quote: &[u8]) -> Vec<u8> {
+        let mut msg = Vec::new();
+        msg.extend_from_slice(&QGS_MSG_LIB_MAJOR_VER.to_le_bytes());
+        msg.extend_from_slice(&QGS_MSG_LIB_MINOR_VER.to_le_bytes());
+        msg.extend_from_slice(&QGS_MSG_GET_QUOTE_RESP.to_le_bytes());
+        let size = (QGS_GET_QUOTE_RESP_SIZE + quote.len()) as u32;
+        msg.extend_from_slice(&size.to_le_bytes());
+        msg.extend_from_slice(&0u32.to_le_bytes()); // error_code
+        msg.extend_from_slice(&0u32.to_le_bytes()); // selected_id_size
+        msg.extend_from_slice(&(quote.len() as u32).to_le_bytes()); // quote_size
+        msg.extend_from_slice(quote);
+        msg
+    }
+
+    #[test]
+    fn qgs_response_parsing() {
+        let quote = vec![0x5au8; 128];
+        let msg = build_qgs_response(&quote);
+        assert_eq!(parse_qgs_response(&msg).unwrap(), quote);
+    }
+
+    #[test]
+    fn qgs_response_rejects_bad_type() {
+        let quote = vec![0u8; 16];
+        let mut msg = build_qgs_response(&quote);
+        msg[4..8].copy_from_slice(&QGS_MSG_GET_QUOTE_REQ.to_le_bytes());
+        assert!(parse_qgs_response(&msg).is_err());
+    }
+}

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -828,7 +828,15 @@ impl Vm {
     ) -> Result<()> {
         if config.lock().unwrap().is_tdx_enabled() {
             let cpuid = cpu_manager.lock().unwrap().common_cpuid();
-            vm.tdx_init(&cpuid)
+            let (mrconfigid, mrowner, mrownerconfig) = config
+                .lock()
+                .unwrap()
+                .platform
+                .as_ref()
+                .expect("TDX requires a platform configuration")
+                .tdx_measurements()
+                .map_err(Error::ConfigValidation)?;
+            vm.tdx_init(&cpuid, &mrconfigid, &mrowner, &mrownerconfig)
                 .map_err(Error::InitializeTdxVm)?;
         }
         Ok(())

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3345,6 +3345,8 @@ impl Snapshottable for Vm {
 
             arch::generate_common_cpuid(
                 self.hypervisor.as_ref(),
+                #[cfg(feature = "tdx")]
+                None,
                 &arch::CpuidConfig {
                     phys_bits,
                     kvm_hyperv,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -784,6 +784,13 @@ impl Vm {
     ) -> Result<Arc<Mutex<cpu::CpuManager>>> {
         #[cfg(feature = "tdx")]
         let tdx_enabled = config.lock().unwrap().is_tdx_enabled();
+        #[cfg(feature = "tdx")]
+        let tdx_quote_generation_socket = config
+            .lock()
+            .unwrap()
+            .platform
+            .as_ref()
+            .and_then(|p| p.tdx_quote_generation_socket.clone());
         #[cfg(feature = "sev_snp")]
         let sev_snp_enabled = config.lock().unwrap().is_sev_snp_enabled();
         #[cfg(feature = "igvm")]
@@ -809,6 +816,8 @@ impl Vm {
             vm_ops,
             #[cfg(feature = "tdx")]
             tdx_enabled,
+            #[cfg(feature = "tdx")]
+            tdx_quote_generation_socket,
             numa_nodes,
             #[cfg(feature = "sev_snp")]
             sev_snp_enabled,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2596,6 +2596,7 @@ impl Vm {
                         // the HOB.
                         payload_info = Some(PayloadInfo {
                             image_type: PayloadImageType::BzImage,
+                            reserved: 0,
                             entry_point: section.address,
                         });
                     }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -828,8 +828,7 @@ impl Vm {
     ) -> Result<()> {
         if config.lock().unwrap().is_tdx_enabled() {
             let cpuid = cpu_manager.lock().unwrap().common_cpuid();
-            let max_vcpus = cpu_manager.lock().unwrap().max_vcpus();
-            vm.tdx_init(&cpuid, max_vcpus)
+            vm.tdx_init(&cpuid)
                 .map_err(Error::InitializeTdxVm)?;
         }
         Ok(())

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -323,10 +323,6 @@ pub enum Error {
     InitializeTdxVm(#[source] hypervisor::HypervisorVmError),
 
     #[cfg(feature = "tdx")]
-    #[error("Error enabling TDX memory region")]
-    InitializeTdxMemoryRegion(#[source] hypervisor::HypervisorVmError),
-
-    #[cfg(feature = "tdx")]
     #[error("Error finalizing TDX VM")]
     FinalizeTdx(#[source] hypervisor::HypervisorVmError),
 
@@ -2687,11 +2683,12 @@ impl Vm {
         let guest_memory = self.memory_manager.lock().as_ref().unwrap().guest_memory();
         let mem = guest_memory.memory();
 
+        let cpu_manager = self.cpu_manager.lock().unwrap();
         for section in sections {
             let size = section.size.try_into().unwrap();
             // SAFETY: get_host_address_range does proper bounds checking
             unsafe {
-                self.vm.tdx_init_memory_region(
+                cpu_manager.init_tdx_memory_region(
                     virtio_devices::get_host_address_range(
                         &*mem,
                         GuestAddress(section.address),
@@ -2704,7 +2701,7 @@ impl Vm {
                     section.attributes == 1,
                 )
             }
-            .map_err(Error::InitializeTdxMemoryRegion)?;
+            .map_err(Error::CpuManager)?;
         }
 
         Ok(())

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -156,6 +156,12 @@ pub struct PlatformConfig {
     #[cfg(feature = "tdx")]
     #[serde(default)]
     pub tdx: bool,
+    // Unix socket path of the Quote Generation Service (QGS) used to answer
+    // `TDG.VP.VMCALL<GetQuote>` requests. When unset, GetQuote requests are
+    // completed with the GHCI `QGS_UNAVAILABLE` status.
+    #[cfg(feature = "tdx")]
+    #[serde(default)]
+    pub tdx_quote_generation_socket: Option<PathBuf>,
     // Optional SHA384 measurement-configuration digests, hex encoded (96 hex
     // characters = 48 bytes each), forwarded verbatim to `KVM_TDX_INIT_VM` as
     // the TD's `mrconfigid`, `mrowner` and `mrownerconfig` registers. When

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -1062,7 +1062,10 @@ impl PayloadConfig {
     ///
     /// Succeeds if Cloud Hypervisor will be able to boot the configuration.
     /// Further, warns for some odd configurations.
-    pub fn validate(&mut self) -> Result<(), PayloadConfigError> {
+    pub fn validate(
+        &mut self,
+        #[cfg(feature = "tdx")] tdx_enabled: bool,
+    ) -> Result<(), PayloadConfigError> {
         #[cfg(feature = "igvm")]
         {
             if self.igvm.is_some() {
@@ -1073,7 +1076,22 @@ impl PayloadConfig {
             }
         }
         match (&self.firmware, &self.kernel) {
-            (Some(_firmware), Some(_kernel)) => Err(PayloadConfigError::FirmwarePlusOtherPayloads),
+            (Some(_firmware), Some(_kernel)) => {
+                // With TDX, a firmware such as td-shim boots a kernel supplied
+                // as its payload: the kernel is loaded into the firmware's
+                // Payload metadata region and the cmdline into PayloadParam.
+                // Hence firmware + kernel is a valid combination under TDX.
+                #[cfg(feature = "tdx")]
+                let firmware_with_kernel_allowed = tdx_enabled;
+                #[cfg(not(feature = "tdx"))]
+                let firmware_with_kernel_allowed = false;
+
+                if firmware_with_kernel_allowed {
+                    Ok(())
+                } else {
+                    Err(PayloadConfigError::FirmwarePlusOtherPayloads)
+                }
+            }
             (Some(_firmware), None) => {
                 if self.cmdline.is_some() {
                     warn!("Ignoring cmdline parameter as firmware is provided as the payload");

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -156,6 +156,19 @@ pub struct PlatformConfig {
     #[cfg(feature = "tdx")]
     #[serde(default)]
     pub tdx: bool,
+    // Optional SHA384 measurement-configuration digests, hex encoded (96 hex
+    // characters = 48 bytes each), forwarded verbatim to `KVM_TDX_INIT_VM` as
+    // the TD's `mrconfigid`, `mrowner` and `mrownerconfig` registers. When
+    // unset each register is left as all zeros.
+    #[cfg(feature = "tdx")]
+    #[serde(default)]
+    pub tdx_mrconfigid: Option<String>,
+    #[cfg(feature = "tdx")]
+    #[serde(default)]
+    pub tdx_mrowner: Option<String>,
+    #[cfg(feature = "tdx")]
+    #[serde(default)]
+    pub tdx_mrownerconfig: Option<String>,
     #[cfg(feature = "sev_snp")]
     #[serde(default)]
     pub sev_snp: bool,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 use std::collections::HashSet;
+#[cfg(feature = "tdx")]
+use std::fmt;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
-#[cfg(feature = "fw_cfg")]
+#[cfg(any(feature = "fw_cfg", feature = "tdx"))]
 use std::str::FromStr;
 use std::{fs, result};
 
@@ -126,6 +128,97 @@ pub fn default_platformconfig_vfio_p2p_dma() -> bool {
     true
 }
 
+/// QGS endpoint used to answer TDX `TDG.VP.VMCALL<GetQuote>` requests,
+/// modeled after QEMU's `SocketAddress` so the same transports are expressible.
+///
+/// Accepted string forms (CLI and JSON):
+///   - `<path>` or `unix:<path>`                 -> host Unix socket
+///   - `vsock:<cid>:<port>`                       -> host AF_VSOCK socket
+///   - `tcp:<host>:<port>` / `inet:<host>:<port>` -> host TCP socket
+#[cfg(feature = "tdx")]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub enum TdxQuoteGenerationSocket {
+    Unix { path: PathBuf },
+    Vsock { cid: u32, port: u32 },
+    Inet { host: String, port: u16 },
+}
+
+#[cfg(feature = "tdx")]
+impl FromStr for TdxQuoteGenerationSocket {
+    type Err = String;
+
+    fn from_str(s: &str) -> result::Result<Self, Self::Err> {
+        if let Some(rest) = s.strip_prefix("vsock:") {
+            let (cid, port) = rest.split_once(':').ok_or_else(|| {
+                format!("invalid vsock QGS address '{s}', expected vsock:<cid>:<port>")
+            })?;
+            let cid = cid
+                .parse::<u32>()
+                .map_err(|e| format!("invalid vsock CID '{cid}': {e}"))?;
+            let port = port
+                .parse::<u32>()
+                .map_err(|e| format!("invalid vsock port '{port}': {e}"))?;
+            return Ok(TdxQuoteGenerationSocket::Vsock { cid, port });
+        }
+        if let Some(rest) = s.strip_prefix("tcp:").or_else(|| s.strip_prefix("inet:")) {
+            // Split off the trailing `:port`; `rsplit_once` keeps IPv6 literals
+            // (whose host part contains embedded colons) intact.
+            let (host, port) = rest.rsplit_once(':').ok_or_else(|| {
+                format!("invalid tcp QGS address '{s}', expected tcp:<host>:<port>")
+            })?;
+            let host = host.trim_start_matches('[').trim_end_matches(']');
+            if host.is_empty() {
+                return Err(format!("invalid tcp QGS address '{s}', empty host"));
+            }
+            let port = port
+                .parse::<u16>()
+                .map_err(|e| format!("invalid tcp port '{port}': {e}"))?;
+            return Ok(TdxQuoteGenerationSocket::Inet {
+                host: host.to_string(),
+                port,
+            });
+        }
+        // No recognized scheme: treat the whole value as a Unix socket path,
+        // keeping backward compatibility with the historical path-only syntax.
+        let path = s.strip_prefix("unix:").unwrap_or(s);
+        if path.is_empty() {
+            return Err("empty QGS socket path".to_string());
+        }
+        Ok(TdxQuoteGenerationSocket::Unix {
+            path: PathBuf::from(path),
+        })
+    }
+}
+
+#[cfg(feature = "tdx")]
+impl fmt::Display for TdxQuoteGenerationSocket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            // A bare path keeps the common case's serialized form unchanged.
+            TdxQuoteGenerationSocket::Unix { path } => write!(f, "{}", path.display()),
+            TdxQuoteGenerationSocket::Vsock { cid, port } => write!(f, "vsock:{cid}:{port}"),
+            TdxQuoteGenerationSocket::Inet { host, port } => write!(f, "tcp:{host}:{port}"),
+        }
+    }
+}
+
+#[cfg(feature = "tdx")]
+impl TryFrom<String> for TdxQuoteGenerationSocket {
+    type Error = String;
+
+    fn try_from(s: String) -> result::Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+#[cfg(feature = "tdx")]
+impl From<TdxQuoteGenerationSocket> for String {
+    fn from(s: TdxQuoteGenerationSocket) -> String {
+        s.to_string()
+    }
+}
+
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PlatformConfig {
@@ -156,12 +249,13 @@ pub struct PlatformConfig {
     #[cfg(feature = "tdx")]
     #[serde(default)]
     pub tdx: bool,
-    // Unix socket path of the Quote Generation Service (QGS) used to answer
-    // `TDG.VP.VMCALL<GetQuote>` requests. When unset, GetQuote requests are
-    // completed with the GHCI `QGS_UNAVAILABLE` status.
+    // QGS endpoint of the Quote Generation Service (QGS) used to answer
+    // `TDG.VP.VMCALL<GetQuote>` requests. Supports Unix, AF_VSOCK and TCP
+    // transports (see `TdxQuoteGenerationSocket`). When unset, GetQuote
+    // requests are completed with the GHCI `QGS_UNAVAILABLE` status.
     #[cfg(feature = "tdx")]
     #[serde(default)]
-    pub tdx_quote_generation_socket: Option<PathBuf>,
+    pub tdx_quote_generation_socket: Option<TdxQuoteGenerationSocket>,
     // Optional SHA384 measurement-configuration digests, hex encoded (96 hex
     // characters = 48 bytes each), forwarded verbatim to `KVM_TDX_INIT_VM` as
     // the TD's `mrconfigid`, `mrowner` and `mrownerconfig` registers. When
@@ -1360,6 +1454,85 @@ impl VmConfig {
             ))
         } else {
             self.cpus.max_vcpus
+        }
+    }
+}
+
+#[cfg(all(test, feature = "tdx"))]
+mod tdx_tests {
+    use super::*;
+
+    #[test]
+    fn qgs_socket_parse_unix() {
+        assert_eq!(
+            "/var/run/tdx-qgs/qgs.socket"
+                .parse::<TdxQuoteGenerationSocket>()
+                .unwrap(),
+            TdxQuoteGenerationSocket::Unix {
+                path: PathBuf::from("/var/run/tdx-qgs/qgs.socket"),
+            }
+        );
+        // An explicit `unix:` scheme is stripped.
+        assert_eq!(
+            "unix:/run/qgs.sock"
+                .parse::<TdxQuoteGenerationSocket>()
+                .unwrap(),
+            TdxQuoteGenerationSocket::Unix {
+                path: PathBuf::from("/run/qgs.sock"),
+            }
+        );
+    }
+
+    #[test]
+    fn qgs_socket_parse_vsock() {
+        assert_eq!(
+            "vsock:2:4050".parse::<TdxQuoteGenerationSocket>().unwrap(),
+            TdxQuoteGenerationSocket::Vsock { cid: 2, port: 4050 }
+        );
+        assert!("vsock:2".parse::<TdxQuoteGenerationSocket>().is_err());
+        assert!("vsock:x:1".parse::<TdxQuoteGenerationSocket>().is_err());
+    }
+
+    #[test]
+    fn qgs_socket_parse_tcp() {
+        assert_eq!(
+            "tcp:127.0.0.1:4050"
+                .parse::<TdxQuoteGenerationSocket>()
+                .unwrap(),
+            TdxQuoteGenerationSocket::Inet {
+                host: "127.0.0.1".to_string(),
+                port: 4050,
+            }
+        );
+        // IPv6 literal in brackets keeps the embedded colons.
+        assert_eq!(
+            "inet:[::1]:4050"
+                .parse::<TdxQuoteGenerationSocket>()
+                .unwrap(),
+            TdxQuoteGenerationSocket::Inet {
+                host: "::1".to_string(),
+                port: 4050,
+            }
+        );
+        assert!("tcp:host".parse::<TdxQuoteGenerationSocket>().is_err());
+        assert!(
+            "tcp:host:99999"
+                .parse::<TdxQuoteGenerationSocket>()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn qgs_socket_display_roundtrip() {
+        for s in ["/run/qgs.sock", "vsock:2:4050", "tcp:127.0.0.1:4050"] {
+            let parsed: TdxQuoteGenerationSocket = s.parse().unwrap();
+            assert_eq!(
+                parsed
+                    .to_string()
+                    .parse::<TdxQuoteGenerationSocket>()
+                    .unwrap(),
+                parsed
+            );
         }
     }
 }


### PR DESCRIPTION
To address merging requests from local Intel TDX customers, who have already built ready-to-use IaaS level infrastructures, and as TDX 1.0 foundational features are all merged to Linux upstream, especially KVM part to v6.16. This PR  aims to push official TDX support in Cloud Hypervisor formally forward to fill the gap.

## Summary

Realign Cloud Hypervisor's TDX backend with the interface that landed upstream in **Linux 6.16**: the finalized `KVM_TDX_*` ioctl ABI, the `guest_memfd`-backed private memory model, and `KVM_X86_TDX_VM`. On top of the ABI/memory-model rework, this series adds runtime shared/private memory conversion (with host IOMMU tracking for VFIO passthrough), fixes the TD init parameter derivation/validation (CPUID, ATTRIBUTES, XFAM, max_vcpus) so TD creation succeeds on real hardware, hardens the boot path, and wires up in-guest remote attestation (`GetQuote`).

The change is split into self-contained commits; see the individual commit messages for the rationale of each step. Non-confidential and SEV-SNP paths are unchanged — new behavior is gated on the TDX build / confidential-VM configuration.

### Highlights

- Align the TDX ioctl ABI with Linux 6.16; switch to `guest_memfd` + `KVM_X86_TDX_VM`.
- Propagate shared/private conversions to the VMM and keep host IOMMU mappings in sync for VFIO passthrough.
- Query `KVM_TDX_CAPABILITIES` on the VM fd and mask/validate TD params; derive CPUID/ATTRIBUTES from the guest CPUID and cross-check via `KVM_TDX_GET_CPUID`.
- Boot robustness: route `INIT_MEM_REGION` through the boot vCPU, retry on `EINTR`, skip LAPIC LINT, handle `KVM_SYSTEM_EVENT_TDX_FATAL`.
- Attestation: handle the `GetQuote` VM exit via a QGS socket (QEMU-style `SocketAddress` endpoints).
- Refresh `docs/intel_tdx.md` for upstream support.

### Testing

- Builds with `--features "kvm,tdx"`, `sev_snp`, and plain `kvm`.
- Workspace unit tests (`--lib --bins`) and doc tests pass.
- Smoke-tested a TD guest boot (TDShim + direct kernel) and a legacy non-TDX guest boot.