### PR TITLE
Add missing AMX-related CPUID compatibility check

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -475,6 +475,12 @@ impl CpuidFeatureEntry {
                 feature_reg: CpuidReg::EAX,
                 compatible_check: CpuidCompatibleCheck::NumNotGreater,
             },
+            CpuidFeatureEntry {
+                function: 0x1e,
+                index: 0,
+                feature_reg: CpuidReg::EAX,
+                compatible_check: CpuidCompatibleCheck::NumNotGreater,
+            },
             // Leaf 0x8000_0001, ECX/EDX, CPUID features bits
             CpuidFeatureEntry {
                 function: 0x8000_0001,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -469,6 +469,12 @@ impl CpuidFeatureEntry {
                 feature_reg: CpuidReg::EDX,
                 compatible_check: CpuidCompatibleCheck::BitwiseSubset,
             },
+            CpuidFeatureEntry {
+                function: 0x1d,
+                index: 0,
+                feature_reg: CpuidReg::EAX,
+                compatible_check: CpuidCompatibleCheck::NumNotGreater,
+            },
             // Leaf 0x8000_0001, ECX/EDX, CPUID features bits
             CpuidFeatureEntry {
                 function: 0x8000_0001,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -481,6 +481,12 @@ impl CpuidFeatureEntry {
                 feature_reg: CpuidReg::EAX,
                 compatible_check: CpuidCompatibleCheck::NumNotGreater,
             },
+            CpuidFeatureEntry {
+                function: 0x1e,
+                index: 1,
+                feature_reg: CpuidReg::EAX,
+                compatible_check: CpuidCompatibleCheck::BitwiseSubset,
+            },
             // Leaf 0x8000_0001, ECX/EDX, CPUID features bits
             CpuidFeatureEntry {
                 function: 0x8000_0001,


### PR DESCRIPTION
Part of https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8494. We introduce missing CPUID compatibility checks for leaf 0x1d (Tile information) and leaf 0x1e (TMUL information) which are both related to Intel AMX.

Note that we only add checks that fit the current mode of relatively coarse grained comparison checks applying a  `CpuidCompatibilityCheck` variant to an entire register (EAX, EBX, ECX or EDX) at a time. 

The aforementioned coarse grained checking mode doesn't work for registers that pack more than one logical value (unless they are all feature bits, or all require equality). This is the case for CPUID 0x1d.0x1:(EBX and ECX) and also CPUID 0x1e.0x0:EBX. Since all existing Intel processors with AMX features report the exact same values in these cases however, we consider it fine to avoid checking those values for now.