### PR TITLE
Clean up a stale serial socket under a lock before bind

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -12,6 +12,7 @@ use std::fs::{File, OpenOptions, copy};
 use std::io::{BufRead, BufReader, Read, Seek, Write};
 use std::net::TcpListener;
 use std::os::unix::io::AsRawFd;
+use std::os::unix::net::UnixListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::string::String;
@@ -2775,6 +2776,64 @@ mod common_parallel {
         let _ = socat_child.wait();
 
         let r = panic::catch_unwind(|| {
+            guest.ssh_command("sudo shutdown -h now").unwrap();
+        });
+
+        let _ = child.wait_timeout(Duration::from_secs(20));
+        kill_child(&mut child);
+        let output = child.wait_with_output().unwrap();
+        handle_child_output(r, &output);
+
+        let r = panic::catch_unwind(|| {
+            // Check that the cloud-hypervisor binary actually terminated
+            if !output.status.success() {
+                panic!(
+                    "Cloud Hypervisor process failed to terminate gracefully: {:?}",
+                    output.status
+                );
+            }
+        });
+        handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_serial_socket_stale_cleanup() {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+        let serial_socket = guest.tmp_dir.as_path().join("serial.socket");
+        let serial_option = if cfg!(target_arch = "x86_64") {
+            " console=ttyS0"
+        } else {
+            " console=ttyAMA0"
+        };
+        let cmdline = DIRECT_KERNEL_BOOT_CMDLINE.to_owned() + serial_option;
+
+        // Leave a socket behind on the path, as a crashed instance would:
+        // binding and dropping a UnixListener closes the fd but keeps the file.
+        {
+            let _stale = UnixListener::bind(&serial_socket).unwrap();
+        }
+        assert!(serial_socket.exists());
+
+        // The VM must remove the stale socket under the lock and bind anew;
+        // without the cleanup this would fail with EADDRINUSE.
+        let mut child = GuestCommand::new(&guest)
+            .default_cpus()
+            .default_memory()
+            .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
+            .args(["--cmdline", &cmdline])
+            .default_disks()
+            .default_net()
+            .args(["--console", "null"])
+            .args([
+                "--serial",
+                format!("socket={}", serial_socket.to_str().unwrap()).as_str(),
+            ])
+            .spawn()
+            .unwrap();
+
+        let r = panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
             guest.ssh_command("sudo shutdown -h now").unwrap();
         });
 

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -5,16 +5,14 @@
 
 use std::collections::BTreeMap;
 use std::error::Error;
-use std::fs::{File, OpenOptions};
-use std::os::unix::io::{IntoRawFd, RawFd};
-use std::os::unix::net::UnixListener;
+use std::fs::File;
+use std::os::unix::io::{AsFd, IntoRawFd, RawFd};
 use std::panic::AssertUnwindSafe;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::LazyLock;
 use std::sync::mpsc::Sender;
-use std::{fs, panic, result, thread};
+use std::{panic, result, thread};
 
-use block::fcntl::{LockError, LockGranularity, LockType, try_acquire_lock};
 use log::{error, info};
 use micro_http::{
     Body, HttpServer, MediaType, Method, Request, Response, ServerError, StatusCode, Version,
@@ -36,6 +34,7 @@ use crate::api::{
 use crate::config::ValidationError;
 use crate::device_manager::DeviceManagerError;
 use crate::landlock::Landlock;
+use crate::locked_unix_listener::{LockedUnixListener, LockedUnixListenerError};
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::util::{error_chain_messages, flatten_error_chain_to_string};
 use crate::vm::Error as VmError;
@@ -43,7 +42,11 @@ use crate::{Error as VmmError, Result};
 
 pub mod http_endpoint;
 
-pub type HttpApiHandle = (thread::JoinHandle<Result<()>>, EventFd);
+pub type HttpApiHandle = (
+    thread::JoinHandle<Result<()>>,
+    EventFd,
+    Option<LockedUnixListener>,
+);
 
 /// Errors associated with VMM management
 #[derive(Error, Debug)]
@@ -350,7 +353,7 @@ fn start_http_thread(
     seccomp_action: &SeccompAction,
     exit_evt: EventFd,
     landlock_enable: bool,
-    api_socket_lock: Option<File>,
+    locked_listener: Option<LockedUnixListener>,
 ) -> Result<HttpApiHandle> {
     // Retrieve seccomp filter for API thread
     let api_seccomp_filter = get_seccomp_filter(seccomp_action, Thread::HttpApi, None)
@@ -366,9 +369,6 @@ fn start_http_thread(
     let thread = thread::Builder::new()
         .name("http-server".to_string())
         .spawn(move || {
-            // Keep the API socket lock (if any) alive for the server thread.
-            let _api_socket_lock = api_socket_lock;
-
             // Apply seccomp filter for API thread.
             if !api_seccomp_filter.is_empty() {
                 apply_filter(&api_seccomp_filter)
@@ -425,29 +425,7 @@ fn start_http_thread(
         })
         .map_err(VmmError::HttpThreadSpawn)?;
 
-    Ok((thread, api_shutdown_fd))
-}
-
-/// Acquires an exclusive lock for the socket path.
-///
-/// This prevents opening (and potentially deleting) a socket that is in active
-/// use by another Cloud Hypervisor instance.
-fn acquire_api_socket_lock(socket_path: &Path) -> Result<File> {
-    let mut lock_path = socket_path.to_path_buf().into_os_string();
-    lock_path.push(".lock");
-
-    let lock = OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .write(true)
-        .open(&lock_path)
-        .map_err(VmmError::CreateApiServerSocket)?;
-
-    match try_acquire_lock(&lock, LockType::Write, LockGranularity::WholeFile) {
-        Ok(()) => Ok(lock),
-        Err(LockError::AlreadyLocked) => Err(VmmError::ApiSocketInUse(socket_path.to_path_buf())),
-        Err(LockError::Io(e)) => Err(VmmError::CreateApiServerSocket(e)),
-    }
+    Ok((thread, api_shutdown_fd, locked_listener))
 }
 
 pub fn start_http_path_thread(
@@ -460,14 +438,18 @@ pub fn start_http_path_thread(
 ) -> Result<HttpApiHandle> {
     let socket_path = PathBuf::from(path);
 
-    let lock = acquire_api_socket_lock(&socket_path)?;
-    // We hold the lock, so any socket at this path is stale from a crashed
-    // run: remove it before bind. Ignore errors (it is usually not present).
-    let _ = fs::remove_file(&socket_path);
+    let locked_listener = LockedUnixListener::bind(&socket_path).map_err(|e| match e {
+        LockedUnixListenerError::InUse(path) => VmmError::ApiSocketInUse(path),
+        LockedUnixListenerError::Io(e) => VmmError::CreateApiServerSocket(e),
+    })?;
 
-    let socket_fd = UnixListener::bind(socket_path).map_err(VmmError::CreateApiServerSocket)?;
-    // SAFETY: Valid FD just opened
-    let server = unsafe { HttpServer::new_from_fd(socket_fd.into_raw_fd()) }
+    let server_fd = locked_listener
+        .as_fd()
+        .try_clone_to_owned()
+        .map_err(VmmError::CreateApiServerSocket)?;
+
+    // SAFETY: Valid FD just duplicated
+    let server = unsafe { HttpServer::new_from_fd(server_fd.into_raw_fd()) }
         .map_err(VmmError::CreateApiServer)?;
 
     start_http_thread(
@@ -477,7 +459,7 @@ pub fn start_http_path_thread(
         seccomp_action,
         exit_evt,
         landlock_enable,
-        Some(lock),
+        Some(locked_listener),
     )
 }
 
@@ -503,7 +485,9 @@ pub fn start_http_fd_thread(
 }
 
 pub fn http_api_graceful_shutdown(http_handle: HttpApiHandle) -> Result<()> {
-    let (api_thread, api_shutdown_fd) = http_handle;
+    // `_locked_listener` is dropped after the join, on a thread allowed to
+    // unlink the socket.
+    let (api_thread, api_shutdown_fd, _locked_listener) = http_handle;
 
     api_shutdown_fd.write(1).unwrap();
     api_thread.join().map_err(VmmError::ThreadCleanup)?

--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -14,7 +14,6 @@ use std::fs::{File, OpenOptions, read_link};
 use std::mem::zeroed;
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::fs::OpenOptionsExt;
-use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{io, result};
@@ -24,6 +23,7 @@ use thiserror::Error;
 use vmm_sys_util::errno;
 
 use crate::Vmm;
+use crate::locked_unix_listener::{LockedUnixListener, LockedUnixListenerError};
 use crate::sigwinch_listener::listen_for_sigwinch_on_tty;
 use crate::vm_config::ConsoleOutputMode;
 
@@ -40,6 +40,10 @@ pub enum ConsoleDeviceError {
     /// No socket option support for console device
     #[error("No socket option support for console device")]
     NoSocketOptionSupportForConsoleDevice,
+
+    /// The serial socket is already in use by another running instance
+    #[error("Serial socket {0:?} is already in use by another running instance")]
+    SerialSocketInUse(PathBuf),
 
     /// Error setting pty raw mode
     #[error("Error setting pty raw mode")]
@@ -62,7 +66,7 @@ pub enum ConsoleTransport {
     Pty(Arc<File>),
     Tty(Arc<File>),
     Null,
-    Socket(Arc<UnixListener>),
+    Socket(Arc<LockedUnixListener>),
     Off,
 }
 
@@ -177,6 +181,10 @@ fn dup_stdout() -> errno::Result<File> {
 }
 
 pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<ConsoleInfo> {
+    // Drop the previous VM's console devices so a reboot can rebind the serial
+    // socket (its OFD lock is held until they drop).
+    vmm.console_info = None;
+
     let vm_config = vmm.vm_config.as_mut().unwrap().clone();
     let mut vmconfig = vm_config.lock().unwrap();
     let mut original_termios_opt = vmm.original_termios_opt.lock().unwrap();
@@ -256,9 +264,17 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                 ConsoleTransport::Tty(Arc::new(stdout))
             }
             ConsoleOutputMode::Socket => {
-                let listener = UnixListener::bind(vmconfig.serial.common.socket.as_ref().unwrap())
-                    .map_err(ConsoleDeviceError::CreateConsoleDevice)?;
-                ConsoleTransport::Socket(Arc::new(listener))
+                let socket =
+                    LockedUnixListener::bind(vmconfig.serial.common.socket.as_ref().unwrap())
+                        .map_err(|e| match e {
+                            LockedUnixListenerError::InUse(path) => {
+                                ConsoleDeviceError::SerialSocketInUse(path)
+                            }
+                            LockedUnixListenerError::Io(e) => {
+                                ConsoleDeviceError::CreateConsoleDevice(e)
+                            }
+                        })?;
+                ConsoleTransport::Socket(Arc::new(socket))
             }
             ConsoleOutputMode::Null => ConsoleTransport::Null,
             ConsoleOutputMode::Off => ConsoleTransport::Off,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -89,6 +89,7 @@ mod gdb;
 mod igvm;
 pub mod interrupt;
 pub mod landlock;
+pub mod locked_unix_listener;
 pub mod memory_manager;
 pub mod migration;
 mod pci_segment;

--- a/vmm/src/locked_unix_listener.rs
+++ b/vmm/src/locked_unix_listener.rs
@@ -1,0 +1,181 @@
+// Copyright © 2026 Contributors to the Cloud Hypervisor project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Unix sockets bound under an exclusive lock on their path.
+//!
+//! A socket file outlives the process that bound it, so a run that crashed
+//! leaves it behind and the next start fails with EADDRINUSE. Removing the
+//! leftover unconditionally would clobber a socket bound by a live instance,
+//! so it is removed while holding a lock on a sidecar "<socket>.lock" file.
+
+use std::fs::{File, OpenOptions};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use std::os::unix::fs::FileTypeExt;
+use std::os::unix::net::UnixListener;
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+
+use block::fcntl::{LockError, LockGranularity, LockType, try_acquire_lock};
+use thiserror::Error;
+
+/// Errors associated with locked Unix sockets
+#[derive(Debug, Error)]
+pub(crate) enum LockedUnixListenerError {
+    /// The socket is already in use by another running instance
+    #[error("Socket {0:?} is already in use by another running instance")]
+    InUse(PathBuf),
+
+    /// Error creating socket
+    #[error("Error creating socket")]
+    Io(#[source] io::Error),
+}
+
+/// A bound Unix socket together with the lock guarding its path.
+///
+/// The lock is held for as long as the socket is bound and released by the
+/// kernel when the process exits, including on a crash.
+pub struct LockedUnixListener {
+    listener: UnixListener,
+    _lock: File,
+    path: PathBuf,
+}
+
+impl LockedUnixListener {
+    /// Binds the socket, removing a stale one left behind by a crashed run.
+    ///
+    /// Fails with [`LockedUnixListenerError::InUse`] if another instance is bound to this
+    /// path.
+    pub(crate) fn bind(socket_path: &Path) -> Result<Self, LockedUnixListenerError> {
+        let lock = Self::acquire_lock(socket_path)?;
+        // We hold the lock, so a socket here is stale from a crash; remove it
+        // (only an actual socket, not another file at this path). metadata()
+        // rather than symlink_metadata() to avoid lstat(), which the vmm
+        // thread's seccomp filter does not allow.
+        if fs::metadata(socket_path).is_ok_and(|m| m.file_type().is_socket()) {
+            fs::remove_file(socket_path).map_err(LockedUnixListenerError::Io)?;
+        }
+
+        let listener = UnixListener::bind(socket_path).map_err(LockedUnixListenerError::Io)?;
+
+        Ok(Self {
+            listener,
+            _lock: lock,
+            path: socket_path.to_path_buf(),
+        })
+    }
+
+    fn acquire_lock(socket_path: &Path) -> Result<File, LockedUnixListenerError> {
+        let mut lock_path = socket_path.to_path_buf().into_os_string();
+        lock_path.push(".lock");
+
+        let lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+            .map_err(LockedUnixListenerError::Io)?;
+
+        match try_acquire_lock(&lock, LockType::Write, LockGranularity::WholeFile) {
+            Ok(()) => Ok(lock),
+            Err(LockError::AlreadyLocked) => {
+                Err(LockedUnixListenerError::InUse(socket_path.to_path_buf()))
+            }
+            Err(LockError::Io(e)) => Err(LockedUnixListenerError::Io(e)),
+        }
+    }
+
+    pub(crate) fn listener(&self) -> &UnixListener {
+        &self.listener
+    }
+}
+
+impl AsFd for LockedUnixListener {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.listener.as_fd()
+    }
+}
+
+impl AsRawFd for LockedUnixListener {
+    fn as_raw_fd(&self) -> RawFd {
+        self.listener.as_raw_fd()
+    }
+}
+
+impl Drop for LockedUnixListener {
+    fn drop(&mut self) {
+        // `self._lock` is still held while this runs, so it cannot unlink a
+        // socket bound by another instance.
+        fs::remove_file(&self.path).ok();
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::os::unix::net::UnixStream;
+
+    use vmm_sys_util::tempdir::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn test_stale_socket_is_replaced() {
+        let tmp_dir = TempDir::new_with_prefix("/tmp/locked-socket").unwrap();
+        let path = tmp_dir.as_path().join("test.sock");
+
+        // Leave a socket behind on the path, as a crashed instance would.
+        {
+            let _listener = UnixListener::bind(&path).unwrap();
+        }
+        assert_eq!(
+            UnixListener::bind(&path).unwrap_err().kind(),
+            io::ErrorKind::AddrInUse
+        );
+
+        // Nobody holds the lock, so the stale socket is removed before bind.
+        LockedUnixListener::bind(&path).unwrap();
+    }
+
+    #[test]
+    fn test_socket_in_use_is_protected() {
+        let tmp_dir = TempDir::new_with_prefix("/tmp/locked-socket").unwrap();
+        let path = tmp_dir.as_path().join("test.sock");
+
+        {
+            let _socket = LockedUnixListener::bind(&path).unwrap();
+            assert!(matches!(
+                LockedUnixListener::bind(&path),
+                Err(LockedUnixListenerError::InUse(p)) if p == path
+            ));
+        }
+
+        // The guard has been dropped, so the path can be taken again.
+        LockedUnixListener::bind(&path).unwrap();
+    }
+
+    #[test]
+    fn test_drop_unlinks_the_socket() {
+        let tmp_dir = TempDir::new_with_prefix("/tmp/locked-socket").unwrap();
+        let path = tmp_dir.as_path().join("test.sock");
+
+        {
+            let _socket = LockedUnixListener::bind(&path).unwrap();
+            assert!(path.exists());
+        }
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_cloned_fd_shares_the_socket() {
+        let tmp_dir = TempDir::new_with_prefix("/tmp/locked-socket").unwrap();
+        let path = tmp_dir.as_path().join("test.sock");
+
+        let socket = LockedUnixListener::bind(&path).unwrap();
+        // A dup of the listener accepts connections to the same socket, while
+        // the guard keeps ownership of the original fd.
+        let cloned = UnixListener::from(socket.as_fd().try_clone_to_owned().unwrap());
+        let _client = UnixStream::connect(&path).unwrap();
+        cloned.accept().unwrap();
+    }
+}

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -13,7 +13,7 @@ use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::{fs, io, panic, result, thread, time};
+use std::{io, panic, result, thread, time};
 
 #[cfg(target_arch = "aarch64")]
 use devices::legacy::Pl011;
@@ -80,10 +80,6 @@ pub enum Error {
     #[error("Error shutting down a connection")]
     ShutdownConnection(#[source] io::Error),
 
-    /// Cannot remove the serial socket
-    #[error("Error removing serial socket")]
-    RemoveUnixSocket(#[source] io::Error),
-
     /// Cannot duplicate file descriptor
     #[error("Error duplicating file descriptor")]
     DupFd(#[source] io::Error),
@@ -148,7 +144,6 @@ impl Write for SharedSerialBuffer {
 
 #[derive(Clone)]
 struct SocketConsole {
-    path: PathBuf,
     /// Persistent ring buffer: captures serial output while no client is
     /// connected and replays it on connect. Shared with the serial device's
     /// `out` sink and retargeted by the epoll thread.
@@ -261,7 +256,7 @@ impl SerialManager {
         // before the first client connects is captured rather than dropped.
         let mut socket_console = None;
         if let ConsoleTransport::Socket(_) = transport
-            && let Some(path) = socket_path
+            && socket_path.is_some()
         {
             let write_out = Arc::new(AtomicBool::new(false));
             let buffer = Arc::new(Mutex::new(SerialBuffer::new(
@@ -273,11 +268,7 @@ impl SerialManager {
                 .lock()
                 .unwrap()
                 .set_out(Some(Box::new(SharedSerialBuffer(buffer.clone()))));
-            socket_console = Some(SocketConsole {
-                path,
-                buffer,
-                write_out,
-            });
+            socket_console = Some(SocketConsole { buffer, write_out });
         }
 
         // Use 'OwnedFd' to manage lifetime
@@ -406,14 +397,16 @@ impl SerialManager {
                                             .map_err(Error::AcceptConnection)?;
                                     }
 
-                                    let ConsoleTransport::Socket(ref listener) = transport else {
+                                    let ConsoleTransport::Socket(ref socket) = transport else {
                                         unreachable!();
                                     };
 
                                     // Events on the listening socket will be connection requests.
                                     // Accept them, create a reader and a writer.
-                                    let (unix_stream, _) =
-                                        listener.accept().map_err(Error::AcceptConnection)?;
+                                    let (unix_stream, _) = socket
+                                        .listener()
+                                        .accept()
+                                        .map_err(Error::AcceptConnection)?;
                                     // Non-blocking so a slow client can't stall
                                     // the vCPU (SerialBuffer re-buffers on WouldBlock).
                                     unix_stream
@@ -537,11 +530,6 @@ impl Drop for SerialManager {
         self.kill_evt.write(1).ok();
         if let Some(handle) = self.handle.take() {
             handle.join().ok();
-        }
-        if let Some(socket_console) = self.socket_console.as_ref() {
-            fs::remove_file(&socket_console.path)
-                .map_err(Error::RemoveUnixSocket)
-                .ok();
         }
     }
 }


### PR DESCRIPTION
A crash leaves the serial socket on disk, so the next start fails with
EADDRINUSE. Before bind, take an exclusive OFD lock on "<socket>.lock":
if held, fail with SerialSocketInUse; otherwise remove the stale socket
and bind. Same fix as the API socket in 0a08f6551a9c.

Assisted-by: Claude:Opus-5