### PR TITLE
docs: Document userfaultfd permissions for ondemand restore

### DIFF
--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -126,6 +126,22 @@ Current constraints for `memory_restore_mode=ondemand`:
 
 - `prefault=on` is not supported
 - the snapshot memory ranges must be page-aligned
+- the process must be able to create a `userfaultfd` object
+
+Cloud Hypervisor first tries to open `/dev/userfaultfd`, which is governed by
+file permissions, and falls back to the `userfaultfd(2)` syscall, which is
+restricted to privileged processes unless `vm.unprivileged_userfaultfd` is `1`.
+If neither is permitted, the restore fails.
+
+To grant access to a single user, add an ACL on the device:
+
+```bash
+sudo setfacl -m u:${USER}:rw /dev/userfaultfd
+```
+
+Setting `vm.unprivileged_userfaultfd=1` also works, but it enables
+`userfaultfd(2)` for every process on the host, whereas the ACL grants access
+to one user.
 
 ## Restore a VM with new Net FDs
 For a VM created with FDs explicitly passed to NetConfig, a set of valid FDs


### PR DESCRIPTION
`memory_restore_mode=ondemand` has to create a `userfaultfd` object. On a host where
  `/dev/userfaultfd` is root-only and `vm.unprivileged_userfaultfd` is `0`, an unprivileged Cloud
  Hypervisor cannot, and because the mode is strict the restore fails outright rather than falling back
  to `copy`. The documented constraints for the mode do not mention this today.

  The failure is also hard to act on, because only the syscall fallback's error propagates out of
  `uffd::create()`, so `/dev/userfaultfd` is never named:

  ```
  Error: Cloud Hypervisor exited with the following chain of errors:
    0: Error restoring VM
    1: The VM could not be restored
    2: Memory manager error
    3: Cannot restore VM
    4: On-demand restore failed
    5: Failed to create userfaultfd
    6: Operation not permitted (os error 1)
  ```

  ## Reproduction

  Snapshot a VM, then restore it on the same host as an unprivileged user. This was tested with a
  single-vCPU, 1 GiB guest and a file-backed snapshot:

  ```bash
  sudo sysctl vm.unprivileged_userfaultfd=0

  ./cloud-hypervisor --api-socket /tmp/ch.sock \
      --restore source_url=file:///path/to/snapshot,memory_restore_mode=ondemand
  # exits 1 with the chain above; the UFFD handler never spawns

  sudo setfacl -m u:${USER}:rw /dev/userfaultfd

  # the same command now completes the restore:
  # "UFFD: spawning handler for 1 region(s)",
  # "UFFD restore: demand-paged restore enabled", and
  # "UFFD handler: prefault done in 447.099ms — prefaulted=262144 served=0 total=262144"
  ```
Tested on Linux 7.0.0 x86_64, same snapshot and same command line in both cases, the ACL entry the
  only difference. `resume` was not requested, so the successful case leaves the VM restored and paused.
  `vm.unprivileged_userfaultfd=1` works too, which is why the patch mentions both and notes that the
  sysctl is host-wide while the ACL is per-user.

  Firecracker documents the equivalent constraint and the same `setfacl` remedy in
  `docs/snapshotting/handling-page-faults-on-snapshot-resume.md`.

  Documentation only, no functional change.