### PR TITLE
vmm: api - Don't log successful pings

### DIFF
--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -2007,8 +2007,6 @@ impl ApiAction for VmmPing {
 
     fn request(&self, _: Self::RequestBody, response_sender: Sender<ApiResponse>) -> ApiRequest {
         Box::new(move |vmm| {
-            info!("API request event: VmmPing");
-
             let response = ApiResponsePayload::VmmPing(vmm.vmm_ping());
 
             response_sender


### PR DESCRIPTION
Because of how often VMM state is checked these are currently 98% of our log storage.