### PR TITLE
tests: Improve huge page handling in tests

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -3744,7 +3744,7 @@ pub(crate) fn _test_vdpa_block(guest: &Guest) {
 
     let mut child = GuestCommand::new(guest)
         .default_cpus()
-        .args(["--memory", "size=512M,hugepages=on"])
+        .args(["--memory", "size=1G,hugepages=on"])
         .default_kernel_cmdline_with_platform(Some("num_pci_segments=2,iommu_segments=1"))
         .default_disks()
         .default_net()

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6020,7 +6020,7 @@ mod common_parallel {
 
         let mut child = GuestCommand::new(&guest)
             .args(["--cpus", "boot=2"])
-            .args(["--memory", "size=512M,hugepages=on"])
+            .args(["--memory", "size=1G,hugepages=on"])
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .default_disks()

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -156,7 +156,7 @@ sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 # Both test_vfio and ovs-dpdk rely on hugepages
 HUGEPAGESIZE=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
 PAGE_NUM=$((6144 * 1024 / HUGEPAGESIZE))
-echo "$PAGE_NUM" | sudo tee /proc/sys/vm/nr_hugepages
+setup_hugepages_pool "$HUGEPAGESIZE" "$PAGE_NUM"
 sudo chmod a+rwX /dev/hugepages
 
 TEST_THREADS_DEFAULT="$(($(nproc) / 4))"

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -179,7 +179,7 @@ sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 # Both test_vfio, ovs-dpdk and vDPA tests rely on hugepages
 HUGEPAGESIZE=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
 PAGE_NUM=$((6144 * 1024 / HUGEPAGESIZE))
-echo "$PAGE_NUM" | sudo tee /proc/sys/vm/nr_hugepages
+setup_hugepages_pool "$HUGEPAGESIZE" "$PAGE_NUM"
 sudo chmod a+rwX /dev/hugepages
 
 # Update max locked memory to 'unlimited' to avoid issues with vDPA

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -62,7 +62,7 @@ cargo build --features "$build_features" --all --release --target "$BUILD_TARGET
 # setup hugepages
 HUGEPAGESIZE=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
 PAGE_NUM=$((12288 * 1024 / HUGEPAGESIZE))
-echo "$PAGE_NUM" | sudo tee /proc/sys/vm/nr_hugepages
+setup_hugepages_pool "$HUGEPAGESIZE" "$PAGE_NUM"
 sudo chmod a+rwX /dev/hugepages
 
 if [ -n "$test_filter" ]; then

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -383,3 +383,13 @@ download_x86_guest_images() {
         popd || exit
     fi
 }
+
+setup_hugepages_pool() {
+    local HUGEPAGE_SIZE="$1"
+    local PAGE_NUM="$2"
+    local NR_HUGEPAGE_PATH="/sys/kernel/mm/hugepages/hugepages-${HUGEPAGE_SIZE}kB/nr_hugepages"
+
+    if [ "$(cat ${NR_HUGEPAGE_PATH} 2>/dev/null || echo 0)" -lt "$PAGE_NUM" ]; then
+        echo "$PAGE_NUM" | sudo tee ${NR_HUGEPAGE_PATH}
+    fi
+}


### PR DESCRIPTION
Some integration tests boot with size=512M,hugepages=on without
explicit hugepage_size. The existing tests happen to pick 512M, 1G,
2G for guest memory size.  When hugepage_size is not specified,
cloud-hypervisor uses the host default hugepage size.  It can be 1GB
depending on the host configuration instead of 2MB.
create_memory_regions_from_zones() checks if memory size is aligned
with hugepage size.  If the default huge page size is 1G,
"size=512M,hugepages=on" results in an error,
Error::MisalignedMemorySize or "Memory size is misaligned with default
page size or its hugepage size"

Bump guest memory size from 512M to 1G if hugepage_size is not specified.
Also don't shrink hugepage pool size. The unconditional write to nr_hugepage
doesn't play nice with the shared environment.

Fixes: #8620
