### PR TITLE
vmm: Make device removal retryable

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -5097,9 +5097,7 @@ impl DeviceManager {
             }
         }
 
-        if !self.config.lock().unwrap().remove_device(id) {
-            return Err(DeviceManagerError::UnknownDeviceId(id.to_string()));
-        }
+        self.config.lock().unwrap().remove_device(id);
 
         // Update the PCID bitmap
         self.pci_segments[pci_segment_id as usize].pci_devices_down |= 1 << pci_device_bdf.device();


### PR DESCRIPTION
When the guest is under heavy load the interrupt for the ACPI GED device
may not be handled promptly or even ignored. This method was originally
safe to retry but 5b53f4202d183c2f890d651b6281b66c1e6cd9fe changed the
behaviour to generate an error if it was missing from the config.

This additional error return was unnecessary as if it was an invalid
device ID the check for the device in the separate DeviceTree would fail
with the same error.

Simply ignore the return value from removing the device from the config.

Signed-off-by: Rob Bradford <rbradford@meta.com>
