### PR TITLE
tests: Disable seccomp for source VM on upgrade tests

### DIFF
--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -450,7 +450,7 @@ pub(crate) fn setup_ovs_dpdk_guests(
         .args(["--net", guest2.default_net_string().as_str(), OVS_DPDK_NET2])
         .capture_output();
     if release_binary {
-        cmd2.legacy_default_disks();
+        cmd2.args(["--seccomp", "false"]).legacy_default_disks();
     } else {
         cmd2.default_disks();
     }

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6656,7 +6656,9 @@ mod common_parallel {
                 format!("file={}", pmem_temp_file.as_path().to_str().unwrap(),).as_str(),
             ]);
         if upgrade_test {
-            src_vm_cmd.legacy_default_disks();
+            src_vm_cmd
+                .args(["--seccomp", "false"])
+                .legacy_default_disks();
         } else {
             src_vm_cmd.default_disks();
         }
@@ -10024,7 +10026,9 @@ mod common_sequential {
                 format!("file={}", pmem_temp_file.as_path().to_str().unwrap(),).as_str(),
             ]);
         if upgrade_test {
-            src_vm_cmd.legacy_default_disks();
+            src_vm_cmd
+                .args(["--seccomp", "false"])
+                .legacy_default_disks();
         } else {
             src_vm_cmd.default_disks();
         }
@@ -10226,7 +10230,9 @@ mod common_sequential {
                 format!("file={}", pmem_temp_file.as_path().to_str().unwrap(),).as_str(),
             ]);
         if upgrade_test {
-            src_vm_cmd.legacy_default_disks();
+            src_vm_cmd
+                .args(["--seccomp", "false"])
+                .legacy_default_disks();
         } else {
             src_vm_cmd.default_disks();
         }
@@ -10629,7 +10635,9 @@ mod common_sequential {
             ])
             .args(["--watchdog"]);
         if upgrade_test {
-            src_vm_cmd.legacy_default_disks();
+            src_vm_cmd
+                .args(["--seccomp", "false"])
+                .legacy_default_disks();
         } else {
             src_vm_cmd.default_disks();
         }


### PR DESCRIPTION
During a live upgrade there are seccomp violations now appearing on the
source VM. Since these are on the source VM running the pre-built binary
the only solution is to disable the seccomp filter at the source.

Signed-off-by: Rob Bradford <rbradford@meta.com>
