### PR TITLE
build: use latest 0.7.0 mshv crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,9 +1463,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.6.9"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83303108160c2b7a7bdd25000ee679384e19471386d23e501ed832574c9229ef"
+checksum = "edab7a942dd5a9976cb30d316948ede2c3d0117ee4addf3404b48cb6a8666046"
 dependencies = [
  "libc",
  "num_enum",
@@ -1477,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.6.9"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db4449ac7012237b133da366f5b32ce4af1f8caf770486e5a9d54f7f6b73c4c"
+checksum = "5b7d71f039b096bdbb772f2181b0a62c28b9d9a0682ceec1839537b1375c1cd6"
 dependencies = [
  "libc",
  "mshv-bindings",
@@ -2387,7 +2387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2597,9 +2597,9 @@ dependencies = [
 
 [[package]]
 name = "vfio-ioctls"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f93a7f6cc51b8671b9282ed6487b0c905890be20ffa4a26835d2652a7c638"
+checksum = "e811560df37de4b473137c849f7b1f00a66d94ffb6abc3b03e6e3f555a56d79b"
 dependencies = [
  "byteorder",
  "iommufd-bindings",
@@ -2618,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "vfio_user"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39bb422ac00cd1d670dc0135c7b32f0a17125b47317d26e442931908c8dbf4a"
+checksum = "785d6f8ae8a88643cdd66f1ff82110292f1192f4b5e9549dff3e3410f3d3d8b2"
 dependencies = [
  "bitflags 2.13.1",
  "enumn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,12 @@ iommufd-ioctls = "0.2.0"
 kvm-bindings = "0.14.1"
 kvm-ioctls = "0.25.0"
 linux-loader = "0.14.0"
-mshv-bindings = "0.6.9"
-mshv-ioctls = "0.6.9"
+mshv-bindings = "0.7.0"
+mshv-ioctls = "0.7.0"
 seccompiler = "0.5.0"
 vfio-bindings = { version = "0.6.2", default-features = false }
-vfio-ioctls = { version = "0.8.0", default-features = false }
-vfio_user = { version = "0.1.4", default-features = false }
+vfio-ioctls = { version = "0.8.1", default-features = false }
+vfio_user = { version = "0.1.5", default-features = false }
 vhost = { version = "0.17.0", default-features = false }
 vhost-user-backend = { version = "0.23.0", default-features = false }
 virtio-bindings = "0.2.6"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2.186"
 libfuzzer-sys = "0.4.12"
 linux-loader = { version = "0.14.0", features = ["bzimage", "elf", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
-mshv-bindings = "0.6.9"
+mshv-bindings = "0.7.0"
 net_util = { path = "../net_util" }
 seccompiler = "0.5.0"
 virtio-devices = { path = "../virtio-devices" }

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -25,9 +25,7 @@ use log::{debug, warn};
 use mshv_bindings::*;
 #[cfg(target_arch = "x86_64")]
 use mshv_ioctls::InterruptRequest;
-use mshv_ioctls::{
-    Mshv, NoDatamatch, VcpuFd, VmFd, VmType, make_default_synthetic_features_mask, set_registers_64,
-};
+use mshv_ioctls::{Mshv, NoDatamatch, VcpuFd, VmFd, VmType, set_registers_64};
 use vfio_ioctls::VfioDeviceFd;
 use vm::DataMatch;
 #[cfg(feature = "sev_snp")]
@@ -332,7 +330,7 @@ impl hypervisor::Hypervisor for MshvHypervisor {
                 create_args.pt_cpu_fbanks[i as usize] = disable_proc_features.as_uint64[i as usize];
             }
         }
-        let synthetic_features_mask = make_default_synthetic_features_mask();
+        let synthetic_features_mask = self.mshv.make_default_synthetic_features_mask();
         let fd: VmFd;
         loop {
             match self.mshv.create_vm_with_args(&create_args) {


### PR DESCRIPTION
Use mshv-{ioctls, bindings) and vfio-{ioctls, user} with the latest versions that fix several bugs.