### PR TITLE
pci: Allow an endpoint to be assigned as PCI device 0

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -1028,7 +1028,7 @@ pub(crate) fn _test_virtio_fs(
 
             if let Some(pci_segment) = pci_segment {
                 assert!(String::from_utf8_lossy(&cmd_output).contains(&format!(
-                    "{{\"id\":\"myfs0\",\"bdf\":\"{pci_segment:04x}:00:01.0\"}}"
+                    "{{\"id\":\"myfs0\",\"bdf\":\"{pci_segment:04x}:00:00.0\"}}"
                 )));
             } else {
                 assert!(
@@ -1138,7 +1138,7 @@ pub(crate) fn _test_virtio_fs(
             assert!(cmd_success);
             if let Some(pci_segment) = pci_segment {
                 assert!(String::from_utf8_lossy(&cmd_output).contains(&format!(
-                    "{{\"id\":\"myfs0\",\"bdf\":\"{pci_segment:04x}:00:01.0\"}}"
+                    "{{\"id\":\"myfs0\",\"bdf\":\"{pci_segment:04x}:00:00.0\"}}"
                 )));
             } else {
                 assert!(
@@ -1914,10 +1914,9 @@ pub(crate) fn _test_pci_multiple_segments(
 
     guest.wait_vm_boot().unwrap();
 
-    let grep_cmd = "lspci | grep \"Host bridge\" | wc -l";
+    let grep_cmd = "ls /sys/class/pci_bus | grep -c ':00$'";
 
     let r = panic::catch_unwind(|| {
-        // There should be MAX_NUM_PCI_SEGMENTS PCI host bridges in the guest.
         assert_eq!(
             guest
                 .ssh_command(grep_cmd)
@@ -3255,7 +3254,7 @@ pub(crate) fn _test_net_hotplug(
 
         if let Some(pci_segment) = pci_segment {
             assert!(String::from_utf8_lossy(&cmd_output).contains(&format!(
-                "{{\"id\":\"test0\",\"bdf\":\"{pci_segment:04x}:00:01.0\"}}"
+                "{{\"id\":\"test0\",\"bdf\":\"{pci_segment:04x}:00:00.0\"}}"
             )));
         } else {
             assert!(
@@ -3316,7 +3315,7 @@ pub(crate) fn _test_net_hotplug(
 
         if let Some(pci_segment) = pci_segment {
             assert!(String::from_utf8_lossy(&cmd_output).contains(&format!(
-                "{{\"id\":\"test1\",\"bdf\":\"{pci_segment:04x}:00:01.0\"}}"
+                "{{\"id\":\"test1\",\"bdf\":\"{pci_segment:04x}:00:00.0\"}}"
             )));
         } else {
             assert!(
@@ -3788,7 +3787,7 @@ pub(crate) fn _test_vdpa_block(guest: &Guest) {
         assert!(cmd_success);
         assert!(
             String::from_utf8_lossy(&cmd_output)
-                .contains("{\"id\":\"myvdpa0\",\"bdf\":\"0001:00:01.0\"}")
+                .contains("{\"id\":\"myvdpa0\",\"bdf\":\"0001:00:00.0\"}")
         );
 
         // Wait for the hotplugged device to appear
@@ -3799,7 +3798,7 @@ pub(crate) fn _test_vdpa_block(guest: &Guest) {
             guest
                 .ssh_command("ls /sys/kernel/iommu_groups/*/devices")
                 .unwrap()
-                .contains("0001:00:01.0")
+                .contains("0001:00:00.0")
         );
 
         // Check both if /dev/vdd exists and if the block size is 128M.

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -391,7 +391,7 @@ mod common_parallel {
             assert!(cmd_success);
             assert!(
                 String::from_utf8_lossy(&cmd_output)
-                    .contains("{\"id\":\"test0\",\"bdf\":\"0001:00:01.0\"}")
+                    .contains("{\"id\":\"test0\",\"bdf\":\"0001:00:00.0\"}")
             );
 
             // Check IOMMU setup
@@ -404,7 +404,7 @@ mod common_parallel {
                 guest
                     .ssh_command("ls /sys/kernel/iommu_groups/*/devices")
                     .unwrap()
-                    .contains("0001:00:01.0")
+                    .contains("0001:00:00.0")
             );
         });
 
@@ -5449,7 +5449,7 @@ mod common_parallel {
             assert!(cmd_success);
             if let Some(pci_segment) = pci_segment {
                 assert!(String::from_utf8_lossy(&cmd_output).contains(&format!(
-                    "{{\"id\":\"test0\",\"bdf\":\"{pci_segment:04x}:00:01.0\"}}"
+                    "{{\"id\":\"test0\",\"bdf\":\"{pci_segment:04x}:00:00.0\"}}"
                 )));
             } else {
                 assert!(

--- a/docs/vdpa.md
+++ b/docs/vdpa.md
@@ -104,7 +104,8 @@ PCI device ID to assign to the vDPA device on its PCI bus.
 This parameter is optional. If not specified, a device ID is automatically
 allocated.
 
-Value is an unsigned integer in the range 1-31.
+Value is an unsigned integer in the range 1-31 on PCI segment 0, and it is
+an unsigned integer in the range 0-31 for all other PCI segments.
 
 _Example_
 

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -115,19 +115,20 @@ enum DeviceIdState {
 
 pub struct PciBus {
     /// Devices attached to this bus.
-    /// Device 0 is host bridge.
     devices: HashMap<u8, Arc<Mutex<dyn PciDevice>>>,
     device_reloc: Arc<dyn DeviceRelocation>,
     device_ids: [DeviceIdState; NUM_DEVICE_IDS as usize],
 }
 
 impl PciBus {
-    pub fn new(pci_root: PciRoot, device_reloc: Arc<dyn DeviceRelocation>) -> Self {
+    pub fn new(pci_root: Option<PciRoot>, device_reloc: Arc<dyn DeviceRelocation>) -> Self {
         let mut devices: HashMap<u8, Arc<Mutex<dyn PciDevice>>> = HashMap::new();
         let mut device_ids = [DeviceIdState::Free; NUM_DEVICE_IDS as usize];
 
-        devices.insert(PCI_ROOT_DEVICE_ID, Arc::new(Mutex::new(pci_root)));
-        device_ids[PCI_ROOT_DEVICE_ID as usize] = DeviceIdState::Allocated;
+        if let Some(pci_root) = pci_root {
+            devices.insert(PCI_ROOT_DEVICE_ID, Arc::new(Mutex::new(pci_root)));
+            device_ids[PCI_ROOT_DEVICE_ID as usize] = DeviceIdState::Allocated;
+        }
 
         PciBus {
             devices,
@@ -547,7 +548,11 @@ mod unit_tests {
     fn setup_bus() -> PciBus {
         let pci_root = PciRoot::new(None);
         let mock_device_reloc = Arc::new(MockDeviceRelocation {});
-        PciBus::new(pci_root, mock_device_reloc)
+        PciBus::new(Some(pci_root), mock_device_reloc)
+    }
+
+    fn setup_bus_without_host_bridge() -> PciBus {
+        PciBus::new(None, Arc::new(MockDeviceRelocation {}))
     }
 
     #[test]
@@ -570,6 +575,39 @@ mod unit_tests {
         assert_eq!(0x10_u8, bus.allocate_device_id(Some(0x10))?);
         assert_eq!(max_id, bus.allocate_device_id(Some(max_id))?);
         Ok(())
+    }
+
+    #[test]
+    fn allocate_device_id_zero_is_taken_by_the_host_bridge() {
+        let mut bus = setup_bus();
+        assert!(matches!(
+            bus.allocate_device_id(Some(PCI_ROOT_DEVICE_ID)),
+            Err(PciRootError::AlreadyInUsePciDeviceSlot(0))
+        ));
+    }
+
+    #[test]
+    fn allocate_device_id_zero_without_host_bridge() -> Result<(), Box<dyn Error>> {
+        let mut bus = setup_bus_without_host_bridge();
+        assert!(bus.devices.is_empty());
+
+        assert_eq!(
+            PCI_ROOT_DEVICE_ID,
+            bus.allocate_device_id(Some(PCI_ROOT_DEVICE_ID))?
+        );
+        assert!(matches!(
+            bus.allocate_device_id(Some(PCI_ROOT_DEVICE_ID)),
+            Err(PciRootError::AlreadyInUsePciDeviceSlot(0))
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn allocate_device_id_next_free_without_host_bridge() {
+        let mut bus = setup_bus_without_host_bridge();
+        for expected_id in 0..NUM_DEVICE_IDS {
+            assert_eq!(expected_id, bus.allocate_device_id(None).unwrap());
+        }
     }
 
     #[test]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -459,11 +459,11 @@ pub fn add_to_config<T>(items: &mut Option<Vec<T>>, item: T) {
 
 /// Check that the PCI device supplied is neither out of range nor does
 /// it use any reserved device ID.
-fn validate_pci_device_id(device_id: u8) -> ValidationResult<()> {
+fn validate_pci_device_id(device_id: u8, segment_id: u16) -> ValidationResult<()> {
     if device_id >= pci::NUM_DEVICE_IDS {
         // Check the given ID is not out of range
         return Err(ValidationError::InvalidPciDeviceId(device_id));
-    } else if device_id == pci::PCI_ROOT_DEVICE_ID {
+    } else if device_id == pci::PCI_ROOT_DEVICE_ID && segment_id == 0 {
         // Check the ID isn't any reserved one. Currently, only the device ID
         // for the root device is reserved.
         return Err(ValidationError::ReservedPciDeviceId(device_id));
@@ -1430,7 +1430,7 @@ impl PciDeviceCommonConfig {
         }
 
         if let Some(device_id) = self.pci_device_id {
-            validate_pci_device_id(device_id)?;
+            validate_pci_device_id(device_id, self.pci_segment)?;
         }
 
         Ok(())

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -60,7 +60,7 @@ impl PciSegment {
         mem64_allocator: Arc<Mutex<AddressAllocator>>,
         pci_irq_slots: &[u8; 32],
     ) -> DeviceManagerResult<PciSegment> {
-        let pci_root = PciRoot::new(None);
+        let pci_root = (id == 0).then(|| PciRoot::new(None));
         let pci_bus = Arc::new(Mutex::new(PciBus::new(
             pci_root,
             Arc::clone(address_manager) as Arc<dyn DeviceRelocation>,
@@ -236,7 +236,7 @@ impl PciSegment {
         pci_irq_slots: &[u8; 32],
         device_reloc: &Arc<dyn DeviceRelocation>,
     ) -> DeviceManagerResult<Self> {
-        let pci_root = PciRoot::new(None);
+        let pci_root = (id == 0).then(|| PciRoot::new(None));
         let pci_bus = Arc::new(Mutex::new(PciBus::new(pci_root, device_reloc.clone())));
 
         let pci_config_mmio = Arc::new(Mutex::new(PciConfigMmio::new(Arc::clone(&pci_bus))));
@@ -577,6 +577,10 @@ mod unit_tests {
     }
 
     fn setup() -> PciSegment {
+        setup_segment(0)
+    }
+
+    fn setup_segment(id: u16) -> PciSegment {
         let guest_addr = 0_u64;
         let guest_size = 0x1000_usize;
         let allocator_1 = Arc::new(Mutex::new(
@@ -589,7 +593,7 @@ mod unit_tests {
         let arr = [0_u8; 32];
 
         PciSegment::new_without_address_manager(
-            0,
+            id,
             0,
             allocator_1,
             allocator_2,
@@ -608,6 +612,16 @@ mod unit_tests {
         assert_eq!(bdf.segment(), segment.id);
         assert_eq!(bdf.bus(), 0);
         assert_eq!(bdf.device(), 1);
+        assert_eq!(bdf.function(), 0);
+    }
+
+    #[test]
+    fn allocate_device_id_default_secondary_segment() {
+        let segment = setup_segment(1);
+        let bdf = segment.allocate_device_id(None).unwrap();
+        assert_eq!(bdf.segment(), segment.id);
+        assert_eq!(bdf.bus(), 0);
+        assert_eq!(bdf.device(), 0);
         assert_eq!(bdf.function(), 0);
     }
 


### PR DESCRIPTION
The NVIDIA driver for Grace GPUs rejects a non zero device number in the SRAT Generic Initiator entry describing the GPU, so such a device has to be assigned PCI device 0, function 0. That slot was held by a host bridge on every segment, but the host bridge is only really needed on segment 0 if we don't want to disrupt firmware and OS expectations.

We solve this problem by not creating a host bridge on segments other than 0. That allows devices on PCI segment greater than 0 to be assigned as device 0.

Fixes #8727 