### PR TITLE
tests: Move live upgrade source version to v52.0

### DIFF
--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -191,10 +191,8 @@ pub(crate) fn cloud_hypervisor_release_path() -> String {
     workload_path.push("workloads");
 
     let mut ch_release_path = workload_path;
-    #[cfg(all(target_arch = "x86_64", not(feature = "mshv")))]
+    #[cfg(target_arch = "x86_64")]
     ch_release_path.push("cloud-hypervisor-static");
-    #[cfg(all(target_arch = "x86_64", feature = "mshv"))]
-    ch_release_path.push("cloud-hypervisor-static-mshv");
     #[cfg(target_arch = "aarch64")]
     ch_release_path.push("cloud-hypervisor-static-aarch64");
 

--- a/scripts/fetch_workloads.py
+++ b/scripts/fetch_workloads.py
@@ -7,7 +7,7 @@
 """Download workload assets for Cloud Hypervisor integration tests.
 
 Reads scripts/test_assets.yaml, downloads missing files, and verifies
-SHA-1 checksums.  Uses only the Python 3 standard library.
+SHA-1 and/or SHA-256 checksums.  Uses only the Python 3 standard library.
 
 Usage:
     fetch_workloads.py [--arch ARCH] [--test TEST] [--workloads-dir DIR]
@@ -81,15 +81,25 @@ def parse_yaml(path: Path) -> list[dict]:
     return assets
 
 
-def sha1_file(path: Path) -> str:
-    h = hashlib.sha1()
+def verify_checksums(path: Path, expected: dict[str, str]) -> list[str]:
+    """Return descriptions of any checksum mismatches for *path*."""
+    hashers = {algorithm: hashlib.new(algorithm) for algorithm in expected}
     with open(path, "rb") as f:
         while True:
             chunk = f.read(1 << 20)
             if not chunk:
                 break
-            h.update(chunk)
-    return h.hexdigest()
+            for hasher in hashers.values():
+                hasher.update(chunk)
+
+    mismatches = []
+    for algorithm, expected_digest in expected.items():
+        actual_digest = hashers[algorithm].hexdigest()
+        if actual_digest != expected_digest:
+            mismatches.append(
+                f"{algorithm}: expected {expected_digest}, got {actual_digest}"
+            )
+    return mismatches
 
 
 def _fmt_size(n: int) -> str:
@@ -173,22 +183,26 @@ def process_asset(asset: dict, workloads: Path, auth_token: str | None,
         _log(f"SKIPPED  {filename}: path traversal in filename")
         return False
     url = asset.get("url")
-    expected_sha1 = asset.get("sha1")
+    expected_checksums = {
+        algorithm: asset[algorithm]
+        for algorithm in ("sha1", "sha256")
+        if asset.get(algorithm)
+    }
     dest = workloads / filename
 
+    if not expected_checksums:
+        _log(f"INVALID  {filename}: sha1 or sha256 checksum required")
+        return False
+
     if dest.exists():
-        if expected_sha1:
-            actual = sha1_file(dest)
-            if actual != expected_sha1:
-                _log(f"MISMATCH {filename}: expected {expected_sha1}, got {actual}")
-                if verify_only:
-                    return False
-                dest.unlink()
-            else:
-                _log(f"OK       {filename}")
-                return True
+        mismatches = verify_checksums(dest, expected_checksums)
+        if mismatches:
+            _log(f"MISMATCH {filename}: {'; '.join(mismatches)}")
+            if verify_only:
+                return False
+            dest.unlink()
         else:
-            _log(f"OK       {filename} (no checksum)")
+            _log(f"OK       {filename}")
             return True
 
     if verify_only:
@@ -203,12 +217,11 @@ def process_asset(asset: dict, workloads: Path, auth_token: str | None,
         _log(f"FAILED   {filename}")
         return False
 
-    if expected_sha1:
-        actual = sha1_file(dest)
-        if actual != expected_sha1:
-            _log(f"CORRUPT  {filename}: expected {expected_sha1}, got {actual}")
-            dest.unlink()
-            return False
+    mismatches = verify_checksums(dest, expected_checksums)
+    if mismatches:
+        _log(f"CORRUPT  {filename}: {'; '.join(mismatches)}")
+        dest.unlink()
+        return False
 
     if (asset.get("executable") or "").lower() == "true":
         dest.chmod(0o755)

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -33,13 +33,7 @@ required_files=(
     "$WORKLOADS_DIR/vmlinux-x86_64"
     "$WORKLOADS_DIR/bzImage-x86_64"
     "$WORKLOADS_DIR/alpine-minirootfs-x86_64.tar.gz"
-)
-# MSHV support in that baseline stabilised on v50.2
-if [ "$hypervisor" = "mshv" ]; then
-    required_files+=("$WORKLOADS_DIR/cloud-hypervisor-static-mshv")
-else
-    required_files+=("$WORKLOADS_DIR/cloud-hypervisor-static")
-fi
+    "$WORKLOADS_DIR/cloud-hypervisor-static")
 
 for required in "${required_files[@]}"; do
     if [ ! -f "$required" ]; then

--- a/scripts/test_assets.yaml
+++ b/scripts/test_assets.yaml
@@ -78,23 +78,15 @@ assets:
 
   # Previous release binaries for live-upgrade tests
   - filename: cloud-hypervisor-static
-    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v39.0/cloud-hypervisor-static
-    sha1: 8516a22620021f2b39abff1836f2f2a8a025cbf9
+    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v52.0/cloud-hypervisor-static
+    sha256: 829af01ff075bb96c4f183905134c453a88d68cbabdc6b87df21098842581ee9
     executable: true
     arch: [x86_64]
     test: [integration]
 
   - filename: cloud-hypervisor-static-aarch64
-    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v39.0/cloud-hypervisor-static-aarch64
-    sha1: 588d0a12f38d87560b4a4cf95a43478064481aa2
+    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v52.0/cloud-hypervisor-static-aarch64
+    sha256: bf004ddc1a148f47caa87ac49a783b8dbd6bf9bc27abe522ed197df7b982d3b1
     executable: true
     arch: [aarch64]
-    test: [integration]
-
-  # MSHV only supports live upgrade from v50.2.
-  - filename: cloud-hypervisor-static-mshv
-    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v50.2/cloud-hypervisor-static
-    sha1: b148aad169257e3c2eaab19bfb703379f0ac57a6
-    executable: true
-    arch: [x86_64]
     test: [integration]


### PR DESCRIPTION
- **scripts: Update fetch_workfloads to accept sha256 too**
- **tests: Bump oldest supported migration version to v52.0**
