### PR TITLE
pci: vfio: Identity map the BARs of a GB GPU

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -5,9 +5,10 @@
 
 use std::any::Any;
 use std::collections::{BTreeMap, HashMap};
+use std::fs::read_to_string;
 use std::os::fd::BorrowedFd;
 use std::os::unix::io::AsRawFd;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{cmp, io, result};
 
@@ -98,6 +99,8 @@ pub enum VfioPciError {
     RetrievePciConfigurationState(#[source] anyhow::Error),
     #[error("Failed to retrieve VfioCommonState")]
     RetrieveVfioCommonState(#[source] anyhow::Error),
+    #[error("Failed to read the BAR addresses of the device that needs fixed BARs: {0}")]
+    DiscoverFixedBars(PathBuf),
     #[error("Failed to restore VFIO migration state")]
     RestoreMigration(#[source] anyhow::Error),
 }
@@ -666,6 +669,48 @@ pub(crate) struct ConfigPatch {
     patch: u32,
 }
 
+const NVIDIA_VENDOR_ID: u64 = 0x10de;
+const NVIDIA_COHERENT_DEVICE_IDS: [u64; 2] = [0x2941, 0x31c2];
+const IORESOURCE_PREFETCH: u64 = 0x2000;
+
+type FixedBarAddrs = [Option<GuestAddress>; VFIO_PCI_CONFIG_REGION_INDEX as usize];
+
+fn discover_fixed_bars(device_path: Option<&Path>) -> Result<FixedBarAddrs, VfioPciError> {
+    let mut addrs: FixedBarAddrs = [None; VFIO_PCI_CONFIG_REGION_INDEX as usize];
+
+    let Some(device_path) = device_path else {
+        return Ok(addrs);
+    };
+
+    let parse_hex = |value: &str| u64::from_str_radix(value.trim_start_matches("0x"), 16).ok();
+    let read_hex = |name: &str| -> Option<u64> {
+        parse_hex(read_to_string(device_path.join(name)).ok()?.trim())
+    };
+
+    if read_hex("vendor") != Some(NVIDIA_VENDOR_ID)
+        || !read_hex("device").is_some_and(|id| NVIDIA_COHERENT_DEVICE_IDS.contains(&id))
+    {
+        return Ok(addrs);
+    }
+
+    // Line N is "<start> <end> <flags>" in hex for BAR N.
+    let resource = read_to_string(device_path.join("resource"))
+        .map_err(|_| VfioPciError::DiscoverFixedBars(device_path.to_path_buf()))?;
+    for (addr, line) in addrs.iter_mut().zip(resource.lines()) {
+        let mut fields = line.split_whitespace();
+
+        if let Some(base) = fields.next().and_then(parse_hex)
+            && let Some(flags) = fields.nth(1).and_then(parse_hex)
+            && base != 0
+            && flags & IORESOURCE_PREFETCH != 0
+        {
+            *addr = Some(GuestAddress(base));
+        }
+    }
+
+    Ok(addrs)
+}
+
 pub(crate) struct VfioCommon {
     pub(crate) configuration: PciConfiguration,
     pub(crate) mmio_regions: Vec<MmioRegion>,
@@ -676,6 +721,7 @@ pub(crate) struct VfioCommon {
     pub(crate) patches: HashMap<usize, ConfigPatch>,
     x_nv_gpudirect_clique: Option<u8>,
     x_exclude_mmap_bars: Vec<u8>,
+    fixed_bar_addrs: FixedBarAddrs,
     pub(crate) migration_flags: Option<u64>,
     // Negotiated dirty bitmap granularity while DMA logging is active.
     dma_logging_page_size: Option<u64>,
@@ -685,6 +731,7 @@ pub(crate) struct VfioCommon {
 pub(crate) struct VfioCommonConfig {
     pub(crate) x_nv_gpudirect_clique: Option<u8>,
     pub(crate) x_exclude_mmap_bars: Vec<u8>,
+    pub(crate) device_path: Option<PathBuf>,
 }
 
 impl VfioCommon {
@@ -753,6 +800,7 @@ impl VfioCommon {
             patches: HashMap::new(),
             x_nv_gpudirect_clique: config.x_nv_gpudirect_clique,
             x_exclude_mmap_bars: config.x_exclude_mmap_bars,
+            fixed_bar_addrs: discover_fixed_bars(config.device_path.as_deref())?,
             migration_flags,
             dma_logging_page_size: None,
         };
@@ -974,16 +1022,17 @@ impl VfioCommon {
                     // We need do some fixup to keep MMIO RW region and msix cap region page size
                     // aligned.
                     region_size = self.fixup_msix_region(bar_id, region_size);
+                    let align = cmp::max(
+                        // SAFETY: FFI call. Trivially safe.
+                        unsafe { sysconf(_SC_PAGESIZE) as GuestUsize },
+                        region_size,
+                    );
+
+                    let requested_addr =
+                        restored_bar_addr.or(self.fixed_bar_addrs[bar_id as usize]);
+
                     mmio64_allocator
-                        .allocate(
-                            restored_bar_addr,
-                            region_size,
-                            Some(cmp::max(
-                                // SAFETY: FFI call. Trivially safe.
-                                unsafe { sysconf(_SC_PAGESIZE) as GuestUsize },
-                                region_size,
-                            )),
-                        )
+                        .allocate(requested_addr, region_size, Some(align))
                         .ok_or(PciDeviceError::IoAllocationFailed(region_size))?
                 }
             };
@@ -1948,6 +1997,7 @@ impl VfioPciDevice {
             VfioCommonConfig {
                 x_nv_gpudirect_clique,
                 x_exclude_mmap_bars,
+                device_path: Some(device_path.clone()),
             },
         )?;
 
@@ -2751,6 +2801,7 @@ mod unit_tests {
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
+    use std::{env, fs, process};
 
     use super::*;
 
@@ -3002,9 +3053,52 @@ mod tests {
             patches: HashMap::new(),
             x_nv_gpudirect_clique: None,
             x_exclude_mmap_bars: Vec::new(),
+            fixed_bar_addrs: [None; VFIO_PCI_CONFIG_REGION_INDEX as usize],
             migration_flags,
             dma_logging_page_size: None,
         }
+    }
+
+    #[test]
+    fn discover_fixed_bars_detects_gb_gpus() {
+        let count = |addrs: FixedBarAddrs| addrs.iter().flatten().count();
+
+        assert_eq!(count(discover_fixed_bars(None).unwrap()), 0);
+
+        let dir = env::temp_dir().join(format!("ch-idbar-test-{}", process::id()));
+        let _ = fs::create_dir_all(&dir);
+        assert_eq!(count(discover_fixed_bars(Some(&dir)).unwrap()), 0);
+
+        fs::write(dir.join("vendor"), "0x10de\n").unwrap();
+        fs::write(dir.join("device"), "0x1234\n").unwrap();
+        assert_eq!(count(discover_fixed_bars(Some(&dir)).unwrap()), 0);
+
+        fs::write(dir.join("vendor"), "0x8086\n").unwrap();
+        fs::write(dir.join("device"), "0x2941\n").unwrap();
+        assert_eq!(count(discover_fixed_bars(Some(&dir)).unwrap()), 0);
+
+        fs::write(dir.join("vendor"), "0x10de\n").unwrap();
+        let err = discover_fixed_bars(Some(&dir)).unwrap_err();
+        assert!(matches!(err, VfioPciError::DiscoverFixedBars(_)));
+
+        fs::write(
+            dir.join("resource"),
+            "0x0000600000000000 0x0000600001ffffff 0x0000000000140204\n\
+             0x0000000000000000 0x0000000000000000 0x0000000000000000\n\
+             0x0000663ffc000000 0x0000663fffffffff 0x000000000014220c\n\
+             0x0000000000000000 0x0000000000000000 0x0000000000000000\n\
+             0x0000664000000000 0x0000667fffffffff 0x000000000014220c\n",
+        )
+        .unwrap();
+        let addrs = discover_fixed_bars(Some(&dir)).unwrap();
+        assert_eq!(count(addrs), 2);
+        assert!(addrs[0].is_none());
+        assert_eq!(addrs[2], Some(GuestAddress(0x0000_663f_fc00_0000)));
+        assert_eq!(addrs[4], Some(GuestAddress(0x0000_6640_0000_0000)));
+
+        fs::write(dir.join("device"), "0x31c2\n").unwrap();
+        assert_eq!(count(discover_fixed_bars(Some(&dir)).unwrap()), 2);
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
An NVIDIA Grace Blackwell GPU reaches its HBM over a cache coherent fabric that bypasses SMMU translation and issues raw physical addresses. Therefore, the guest must see the coherent BAR at the host physical address, otherwise the GPU driver will fail to initialize the device.