### PR TITLE
vmm: api: Raise the HTTP request body size limit

### DIFF
--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -45,6 +45,8 @@ pub mod http_endpoint;
 
 pub type HttpApiHandle = (thread::JoinHandle<Result<()>>, EventFd);
 
+const HTTP_PAYLOAD_MAX_SIZE: usize = 4 << 20;
+
 /// Errors associated with VMM management
 #[derive(Error, Debug)]
 pub enum HttpError {
@@ -359,6 +361,7 @@ fn start_http_thread(
     let api_shutdown_fd = EventFd::new(libc::EFD_NONBLOCK).map_err(VmmError::EventFdCreate)?;
     let api_shutdown_fd_clone = api_shutdown_fd.try_clone().unwrap();
 
+    server.set_payload_max_size(HTTP_PAYLOAD_MAX_SIZE);
     server
         .add_kill_switch(api_shutdown_fd_clone)
         .map_err(VmmError::CreateApiServer)?;


### PR DESCRIPTION
micro_http rejects request bodies above its 51200 byte default before parsing. The default was sized for Firecracker's microVM API, where a request carries a few KB of machine config, and the crate exposes set_payload_max_size to configure larger payloads.

A vm.create config crosses the default once its disks carry queue affinity spanning a large VM's cpuset. Since the affinity list is repeated for every queue, so one disk with 16 queues on a 176 vCPU VM costs about 10 KB and five such disks push the whole config past the cap.

Raise the limit to 4 MiB, the smallest power of two clearing large VM configs (EPYC Venice 512 threads per socket) by a comfortable margin.