### PR TITLE
vmm: Resolve an MSI IOVA through the virtual IOMMU

### DIFF
--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use virtio_queue::{DescriptorChain, Queue, QueueT};
 use vm_device::dma_mapping::ExternalDmaMapping;
+use vm_device::interrupt::{InterruptRemapping, MsiIrqSourceConfig};
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
     GuestMemoryBackend, GuestMemoryError, GuestMemoryLoadGuard,
@@ -974,6 +975,7 @@ pub struct IommuMapping {
     // Global flag indicating if endpoints that are not attached to any domain
     // are in bypass mode.
     bypass: AtomicBool,
+    msi_iova_space: (u64, u64),
 }
 
 // Inclusive end of `[addr, addr+size)`. Returns None for zero size or
@@ -1087,6 +1089,25 @@ impl DmaRemapping for IommuMapping {
     }
 }
 
+impl InterruptRemapping for IommuMapping {
+    fn translate_msi(&self, dev_id: u32, cfg: MsiIrqSourceConfig) -> Option<MsiIrqSourceConfig> {
+        let addr = (u64::from(cfg.high_addr) << 32) | u64::from(cfg.low_addr);
+        let (start, end) = self.msi_iova_space;
+        let gpa = if (start..=end).contains(&addr) {
+            addr
+        } else {
+            self.translate_gva(dev_id, addr, size_of::<u32>() as u64)
+                .ok()?
+        };
+
+        Some(MsiIrqSourceConfig {
+            high_addr: (gpa >> 32) as u32,
+            low_addr: gpa as u32,
+            ..cfg
+        })
+    }
+}
+
 #[derive(Debug)]
 pub struct AccessPlatformMapping {
     id: u32,
@@ -1195,6 +1216,7 @@ impl Iommu {
             endpoints: Arc::new(RwLock::new(endpoints)),
             domains: Arc::new(RwLock::new(domains)),
             bypass: AtomicBool::new(true),
+            msi_iova_space,
         });
 
         Ok((
@@ -1484,6 +1506,7 @@ mod tests {
             endpoints: Arc::new(RwLock::new(endpoints)),
             domains: Arc::new(RwLock::new(domains)),
             bypass: AtomicBool::new(false),
+            msi_iova_space: (0, 0),
         }
     }
 

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -89,6 +89,22 @@ pub struct MsiIrqGroupConfig {
     pub count: InterruptIndex,
 }
 
+/// Trait to resolve the address/data of MSI/MSI-X interrupts into a meaningful
+/// set when the device is attached to a virtual IOMMU.
+///
+/// When a PCI device (virtio or vfio) sits behind a virtual IOMMU, the address
+/// and data set from the guest through the vector table is an IOVA. Given the
+/// hypervisor doesn't know about this layer of indirection, the VMM is
+/// responsible for translating the IOVA into a GPA that can be understood by
+/// the hypervisor.
+///
+/// This trait is meant to be implemented by virtual IOMMU implementations so
+/// they can perform the IOVA translation based on the mappings the guest has
+/// been setting up.
+pub trait InterruptRemapping: Send + Sync {
+    fn translate_msi(&self, dev_id: u32, cfg: MsiIrqSourceConfig) -> Option<MsiIrqSourceConfig>;
+}
+
 /// Trait to manage interrupt sources for virtual device backends.
 ///
 /// The InterruptManager implementations should protect itself from concurrent accesses internally,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4059,6 +4059,11 @@ impl DeviceManager {
                 return Err(DeviceManagerError::MissingVirtualIommu);
             }
 
+            if let Some(mapping) = &self.iommu_mapping {
+                self.msi_interrupt_manager
+                    .register_remapping(pci_device_bdf.into(), mapping.clone());
+            }
+
             vfio_ops
         } else if let Some(vfio_ops) = &self.vfio_ops {
             Arc::clone(vfio_ops)
@@ -4503,6 +4508,8 @@ impl DeviceManager {
                 pci_device_bdf.into(),
                 mapping.clone(),
             )));
+            self.msi_interrupt_manager
+                .register_remapping(pci_device_bdf.into(), mapping.clone());
         }
 
         // If SEV-SNP is enabled create the AccessPlatform from SevSnpPageAccessProxy
@@ -5242,6 +5249,9 @@ impl DeviceManager {
                 .unwrap()
                 .remove_external_mapping(pci_device_bdf.into());
         }
+
+        self.msi_interrupt_manager
+            .unregister_remapping(pci_device_bdf.into());
 
         if remove_dma_handler {
             for virtio_mem_device in self.virtio_mem_devices.iter() {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -104,9 +104,7 @@ use virtio_devices::{
 };
 use vm_allocator::{AddressAllocator, InterruptAllocError, SystemAllocator};
 use vm_device::dma_mapping::ExternalDmaMapping;
-use vm_device::interrupt::{
-    InterruptIndex, InterruptManager, LegacyIrqGroupConfig, MsiIrqGroupConfig,
-};
+use vm_device::interrupt::{InterruptIndex, InterruptManager, LegacyIrqGroupConfig};
 use vm_device::{Bus, BusDevice, BusDeviceSync, Resource, UserspaceMapping};
 #[cfg(feature = "ivshmem")]
 use vm_memory::bitmap::AtomicBitmap;
@@ -1081,7 +1079,7 @@ pub struct DeviceManager {
 
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     // MSI Interrupt Manager
-    msi_interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
+    msi_interrupt_manager: Arc<MsiInterruptManager>,
 
     #[cfg_attr(feature = "mshv", allow(dead_code))]
     // Legacy Interrupt Manager
@@ -1322,11 +1320,10 @@ impl DeviceManager {
         // and then the legacy interrupt manager needs an IOAPIC. So we're
         // handling a linear dependency chain:
         // msi_interrupt_manager <- IOAPIC <- legacy_interrupt_manager.
-        let msi_interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>> =
-            Arc::new(MsiInterruptManager::new(
-                Arc::clone(&address_manager.allocator),
-                vm,
-            ));
+        let msi_interrupt_manager = Arc::new(MsiInterruptManager::new(
+            Arc::clone(&address_manager.allocator),
+            vm,
+        ));
 
         let acpi_address = address_manager
             .allocator
@@ -1814,7 +1811,7 @@ impl DeviceManager {
         let interrupt_controller: Arc<Mutex<gic::Gic>> = Arc::new(Mutex::new(
             gic::Gic::new(
                 self.config.lock().unwrap().cpus.boot_vcpus,
-                Arc::clone(&self.msi_interrupt_manager),
+                self.msi_interrupt_manager.clone(),
                 self.address_manager.vm.clone(),
             )
             .map_err(DeviceManagerError::CreateInterruptController)?,
@@ -1867,7 +1864,7 @@ impl DeviceManager {
         let interrupt_controller: Arc<Mutex<aia::Aia>> = Arc::new(Mutex::new(
             aia::Aia::new(
                 self.config.lock().unwrap().cpus.boot_vcpus,
-                Arc::clone(&self.msi_interrupt_manager),
+                self.msi_interrupt_manager.clone(),
                 self.address_manager.vm.clone(),
             )
             .map_err(DeviceManagerError::CreateInterruptController)?,

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -13,8 +13,8 @@ use hypervisor::IrqRoutingEntry;
 use vm_allocator::SystemAllocator;
 use vm_device::interrupt;
 use vm_device::interrupt::{
-    InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup,
-    LegacyIrqGroupConfig, MsiIrqGroupConfig,
+    InterruptIndex, InterruptManager, InterruptRemapping, InterruptSourceConfig,
+    InterruptSourceGroup, LegacyIrqGroupConfig, MsiIrqGroupConfig, MsiIrqSourceConfig,
 };
 use vmm_sys_util::eventfd::EventFd;
 
@@ -168,10 +168,35 @@ struct RoutingEntry {
     masked: bool,
 }
 
+#[derive(Default)]
+struct InterruptRemapper {
+    remappings: Mutex<HashMap<u32, Arc<dyn InterruptRemapping>>>,
+}
+
+impl InterruptRemapper {
+    fn register(&self, dev_id: u32, remapping: Arc<dyn InterruptRemapping>) {
+        self.remappings.lock().unwrap().insert(dev_id, remapping);
+    }
+
+    fn unregister(&self, dev_id: u32) {
+        self.remappings.lock().unwrap().remove(&dev_id);
+    }
+
+    fn resolve(&self, cfg: MsiIrqSourceConfig) -> MsiIrqSourceConfig {
+        self.remappings
+            .lock()
+            .unwrap()
+            .get(&cfg.devid)
+            .and_then(|remapping| remapping.translate_msi(cfg.devid, cfg))
+            .unwrap_or(cfg)
+    }
+}
+
 struct MsiInterruptGroup {
     vm: Arc<dyn hypervisor::Vm>,
     gsi_msi_routes: Arc<Mutex<HashMap<u32, RoutingEntry>>>,
     irq_routes: HashMap<InterruptIndex, Mutex<InterruptRoute>>,
+    interrupt_remapper: Arc<InterruptRemapper>,
 }
 
 impl MsiInterruptGroup {
@@ -179,11 +204,13 @@ impl MsiInterruptGroup {
         vm: Arc<dyn hypervisor::Vm>,
         gsi_msi_routes: Arc<Mutex<HashMap<u32, RoutingEntry>>>,
         irq_routes: HashMap<InterruptIndex, Mutex<InterruptRoute>>,
+        interrupt_remapper: Arc<InterruptRemapper>,
     ) -> Self {
         MsiInterruptGroup {
             vm,
             gsi_msi_routes,
             irq_routes,
+            interrupt_remapper,
         }
     }
 
@@ -241,10 +268,14 @@ impl InterruptSourceGroup for MsiInterruptGroup {
     fn update(
         &self,
         index: InterruptIndex,
-        config: InterruptSourceConfig,
+        mut config: InterruptSourceConfig,
         masked: bool,
         set_gsi: bool,
     ) -> Result<()> {
+        if let InterruptSourceConfig::MsiIrq(cfg) = &mut config {
+            *cfg = self.interrupt_remapper.resolve(*cfg);
+        }
+
         if let Some(route) = self.irq_routes.get(&index) {
             let mut route = route.lock().unwrap();
             let gsi = if masked {
@@ -358,6 +389,7 @@ pub struct MsiInterruptManager {
     allocator: Arc<Mutex<SystemAllocator>>,
     vm: Arc<dyn hypervisor::Vm>,
     gsi_msi_routes: Arc<Mutex<HashMap<u32, RoutingEntry>>>,
+    interrupt_remapper: Arc<InterruptRemapper>,
 }
 
 impl LegacyUserspaceInterruptManager {
@@ -378,7 +410,16 @@ impl MsiInterruptManager {
             allocator,
             vm,
             gsi_msi_routes,
+            interrupt_remapper: Arc::new(InterruptRemapper::default()),
         }
+    }
+
+    pub fn register_remapping(&self, dev_id: u32, remapping: Arc<dyn InterruptRemapping>) {
+        self.interrupt_remapper.register(dev_id, remapping);
+    }
+
+    pub fn unregister_remapping(&self, dev_id: u32) {
+        self.interrupt_remapper.unregister(dev_id);
     }
 }
 
@@ -412,6 +453,7 @@ impl MsiInterruptManager {
             self.vm.clone(),
             self.gsi_msi_routes.clone(),
             irq_routes,
+            self.interrupt_remapper.clone(),
         ))
     }
 }
@@ -430,6 +472,7 @@ impl InterruptManager for MsiInterruptManager {
             self.vm.clone(),
             self.gsi_msi_routes.clone(),
             irq_routes,
+            self.interrupt_remapper.clone(),
         )))
     }
 


### PR DESCRIPTION
In the context of exposing a virtual IOMMU to the guest, which happens
either with virtio-iommu now, or with an emulated SMMUv3 in the near
future, we want to be able to resolve MSI addresses which are IOVAs
instead of GPAs.

We define a new trait aimed at supporting any type of virtual IOMMU, so
that when the MSI route is programmed through KVM, the address can be
resolved into an actual GPA if needed.