### PR TITLE
tests: Make test_vfio() use of TempDir

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -2831,8 +2831,8 @@ mod common_parallel {
 
         let kernel_path = direct_kernel_boot_path();
 
-        let mut vfio_path = workload_path.clone();
-        vfio_path.push("vfio");
+        let temp_dir = TempDir::new_with_prefix("/tmp/ch-vfio-test").unwrap();
+        let vfio_path = temp_dir.as_path().to_path_buf();
 
         let mut cloud_init_vfio_base_path = vfio_path.clone();
         cloud_init_vfio_base_path.push("cloudinit.img");


### PR DESCRIPTION
This is a follow up for #8738 . Change is use "/tmp/ch-vfio-test" instead of nested directory.

test_vfio() uses $HOME/workload/vfio for temporal files to be copied into the guest image by rate_limited_copy().  It should use TempDir under "/tmp/" for rate_limited_copy() and its clean up.


Assisted-by: Claude:Opus-4.8 (1M context)