### PR TITLE
[1/3] UFFD pagefault multithreading

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1142,14 +1142,19 @@ impl MemoryManager {
             .name("uffd-handler".to_string())
             .spawn(move || {
                 panic::catch_unwind(panic::AssertUnwindSafe(move || {
-                    let result = Self::uffd_handler_loop(
+                    let mut result = Self::uffd_handler_loop(
                         uffd_fd,
-                        thread_stop_event,
+                        &thread_stop_event,
                         source,
                         &handler_ranges,
                         &ready_tx,
                         &thread_prefault_complete,
                     );
+
+                    if result.is_err() && thread_stop_event.read().is_ok() {
+                        // Error during shutdown is expected
+                        result = Ok(());
+                    }
 
                     if let Err(e) = &result {
                         error!("UFFD handler exited with error: {e}");
@@ -1235,7 +1240,7 @@ impl MemoryManager {
     #[expect(clippy::needless_pass_by_value)]
     fn uffd_handler_loop(
         uffd_fd: OwnedFd,
-        stop_event: EventFd,
+        stop_event: &EventFd,
         mut source: Box<dyn UffdMemorySource>,
         ranges: &[UffdRange],
         ready_tx: &SyncSender<()>,
@@ -1301,22 +1306,28 @@ impl MemoryManager {
                 Err(e) => return Err(e),
             };
 
+            // Check the entire batch before handling UFFD events so a pending
+            // stop cannot be delayed by a blocking page resolution.
+            if events
+                .iter()
+                .take(num_events)
+                .any(|event| event.data == EVENT_STOP)
+            {
+                stop_event.read().ok();
+                info!("UFFD handler: received stop event, exiting");
+                return Ok(());
+            }
+
             let mut got_uffd_data = false;
             for event in events.iter().take(num_events) {
                 let token = event.data;
                 let evt_flags = event.events;
 
-                if token == EVENT_STOP {
-                    stop_event.read().ok();
-                    info!("UFFD handler: received stop event, exiting");
-                    return Ok(());
-                }
-
                 if token == EVENT_UFFD
                     && (evt_flags & epoll::Events::EPOLLHUP.bits()) != 0
                     && (evt_flags & epoll::Events::EPOLLIN.bits()) == 0
                 {
-                    info!("UFFD handler: fd closed (EPOLLHUP), exiting");
+                    debug!("UFFD handler: fd closed (EPOLLHUP), exiting");
                     return Ok(());
                 }
 
@@ -1344,7 +1355,7 @@ impl MemoryManager {
                     return Err(err);
                 }
                 if n == 0 {
-                    info!("UFFD handler: EOF on fd, exiting");
+                    debug!("UFFD handler: EOF on fd, exiting");
                     return Ok(());
                 }
                 if n as usize != size_of::<uffd::UffdMsg>() {
@@ -1405,9 +1416,9 @@ impl MemoryManager {
                     return Ok(());
                 }
                 Ok(prefaulted) => pages_prefaulted += prefaulted,
-                Err(_) => {
+                Err(e) => {
                     // Give up prefaulting but continue serving demand faults.
-                    warn!("UFFD prefault: abandoning background prefault after error");
+                    warn!("UFFD prefault: abandoning background prefault after error: {e}");
                     prefault_active = false;
                 }
             }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -11,7 +11,7 @@ use std::io::{self, Seek, SeekFrom};
 use std::mem::{MaybeUninit, zeroed};
 use std::num::NonZeroUsize;
 use std::ops::{BitAnd, Not, Sub};
-use std::os::fd::{AsFd, OwnedFd};
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -1260,10 +1260,9 @@ impl MemoryManager {
             })
             .collect();
 
-        // Prefault cursor: (range index, page index within range). `None`
-        // means prefault was given up due to an error (natural completion
-        // returns from the function instead).
-        let mut prefault_cursor: Option<(usize, u64)> = (!ranges.is_empty()).then_some((0, 0));
+        let mut prefault_active = !ranges.is_empty();
+        let mut range_idx = 0;
+        let mut page_idx = 0;
         let prefault_start = time::Instant::now();
 
         const EVENT_STOP: u64 = 0;
@@ -1295,7 +1294,7 @@ impl MemoryManager {
         loop {
             // Block only when prefault is done; otherwise poll non-blocking
             // so we can advance prefault between faults.
-            let timeout = if prefault_cursor.is_some() { 0 } else { -1 };
+            let timeout = if prefault_active { 0 } else { -1 };
             let num_events = match epoll::wait(epoll_fd, timeout, &mut events) {
                 Ok(n) => n,
                 Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
@@ -1383,19 +1382,19 @@ impl MemoryManager {
                 continue;
             }
 
-            // No fault pending — advance the prefault cursor past served and
-            // end-of-range pages, then prefault one fresh page below.
-            let cursor = loop {
-                let Some((range_idx, page_idx)) = prefault_cursor else {
-                    break None;
-                };
-                if page_idx >= ranges[range_idx].num_pages() {
-                    if range_idx + 1 < ranges.len() {
-                        prefault_cursor = Some((range_idx + 1, 0));
-                        continue;
-                    }
-                    // Reached the end of the last range — every page is
-                    // mapped, so no future faults can occur. Exit.
+            if !prefault_active {
+                continue;
+            }
+
+            match Self::uffd_prefault(
+                uffd_fd.as_fd(),
+                &mut range_idx,
+                &mut page_idx,
+                ranges,
+                &mut source,
+                &served_bitmap,
+            ) {
+                Ok(0) => {
                     let elapsed = prefault_start.elapsed();
                     info!(
                         "UFFD handler: prefault done in {elapsed:.3?} — \
@@ -1405,43 +1404,65 @@ impl MemoryManager {
                     prefault_complete.store(true, Ordering::Release);
                     return Ok(());
                 }
-                if served_bitmap[range_idx].is_bit_set(page_idx as usize) {
-                    prefault_cursor = Some((range_idx, page_idx + 1));
-                    continue;
+                Ok(prefaulted) => pages_prefaulted += prefaulted,
+                Err(_) => {
+                    // Give up prefaulting but continue serving demand faults.
+                    warn!("UFFD prefault: abandoning background prefault after error");
+                    prefault_active = false;
                 }
-                break Some((range_idx, page_idx));
-            };
+            }
+        }
+    }
 
-            let Some((range_idx, page_idx)) = cursor else {
-                // Prefault was given up earlier (or the range list was
-                // empty). Keep serving on-demand faults.
-                continue;
-            };
+    fn uffd_prefault(
+        uffd_fd: BorrowedFd,
+        range_idx: &mut usize,
+        page_idx: &mut u64,
+        ranges: &[UffdRange],
+        source: &mut Box<dyn UffdMemorySource>,
+        served_bitmap: &[AtomicBitmap],
+    ) -> Result<u64, io::Error> {
+        let mut current_page_idx = *page_idx;
+        let mut current_range_idx = *range_idx;
 
-            let range = &ranges[range_idx];
+        'outer: loop {
+            'find_range: loop {
+                if current_page_idx >= ranges[current_range_idx].num_pages() {
+                    if current_range_idx + 1 < ranges.len() {
+                        current_range_idx += 1;
+                        current_page_idx = 0;
+                        continue 'find_range;
+                    }
 
-            let advance = match source.resolve(uffd_fd.as_fd(), range, page_idx) {
-                Ok(()) => {
-                    pages_prefaulted += 1;
-                    served_bitmap[range_idx].set_bit(page_idx as usize);
-                    true
+                    *range_idx = current_range_idx;
+                    *page_idx = current_page_idx;
+                    return Ok(0);
                 }
-                Err(e) => {
-                    let page_addr = range.page_addr(page_idx);
-                    warn!("UFFD prefault: source error at {page_addr:#x}: {e}");
-                    false
-                }
-            };
-
-            if !advance {
-                // Prefault hit an unrecoverable error; give up but keep
-                // serving on-demand faults.
-                warn!("UFFD prefault: abandoning background prefault after error");
-                prefault_cursor = None;
-                continue;
+                break 'find_range;
             }
 
-            prefault_cursor = Some((range_idx, page_idx + 1));
+            if served_bitmap[current_range_idx].is_bit_set(current_page_idx as usize) {
+                current_page_idx += 1;
+                continue 'outer;
+            }
+
+            let range = &ranges[current_range_idx];
+
+            match source.resolve(uffd_fd, range, current_page_idx) {
+                Ok(()) => {
+                    served_bitmap[current_range_idx].set_bit(current_page_idx as usize);
+                    current_page_idx += 1;
+
+                    *range_idx = current_range_idx;
+                    *page_idx = current_page_idx;
+                    return Ok(1);
+                }
+                Err(e) => {
+                    let page_addr = range.page_addr(current_page_idx);
+                    warn!("UFFD prefault: source error at {page_addr:#x}: {e}");
+                    return Err(e);
+                }
+            }
         }
     }
 
@@ -3639,9 +3660,179 @@ mod tests {
 
     use super::*;
 
+    struct RecordingUffdMemorySource {
+        attempts: Arc<Mutex<Vec<(u64, u64)>>>,
+        fail_next: bool,
+    }
+
+    impl UffdMemorySource for RecordingUffdMemorySource {
+        fn resolve(
+            &mut self,
+            _uffd_fd: BorrowedFd<'_>,
+            range: &UffdRange,
+            page_idx: u64,
+        ) -> Result<(), io::Error> {
+            self.attempts
+                .lock()
+                .unwrap()
+                .push((range.host_addr, page_idx));
+
+            if self.fail_next {
+                self.fail_next = false;
+                return Err(io::Error::other("test source failure"));
+            }
+
+            Ok(())
+        }
+
+        fn requires_uffd_minor_mode(&self) -> bool {
+            false
+        }
+    }
+
     fn page_size() -> u64 {
         // SAFETY: sysconf(_SC_PAGESIZE) has no failure mode relevant here.
         unsafe { libc::sysconf(libc::_SC_PAGESIZE) as u64 }
+    }
+
+    fn new_served_bitmap(ranges: &[UffdRange]) -> Vec<AtomicBitmap> {
+        ranges
+            .iter()
+            .map(|range| {
+                AtomicBitmap::new(
+                    range.length as usize,
+                    NonZeroUsize::new(range.page_size as usize).unwrap(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn uffd_prefault_skips_present_pages_and_crosses_ranges() {
+        let page = page_size();
+        let ranges = [
+            UffdRange {
+                host_addr: 0x10_0000,
+                length: 2 * page,
+                source_offset: 0,
+                page_size: page,
+            },
+            UffdRange {
+                host_addr: 0x20_0000,
+                length: page,
+                source_offset: 2 * page,
+                page_size: page,
+            },
+        ];
+        let served_bitmap = new_served_bitmap(&ranges);
+        served_bitmap[0].set_bit(0);
+
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let mut source: Box<dyn UffdMemorySource> = Box::new(RecordingUffdMemorySource {
+            attempts: Arc::clone(&attempts),
+            fail_next: false,
+        });
+        let uffd_file = tempfile::tempfile().unwrap();
+        let mut range_idx = 0;
+        let mut page_idx = 0;
+
+        assert_eq!(
+            MemoryManager::uffd_prefault(
+                uffd_file.as_fd(),
+                &mut range_idx,
+                &mut page_idx,
+                &ranges,
+                &mut source,
+                &served_bitmap,
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!((range_idx, page_idx), (0, 2));
+
+        assert_eq!(
+            MemoryManager::uffd_prefault(
+                uffd_file.as_fd(),
+                &mut range_idx,
+                &mut page_idx,
+                &ranges,
+                &mut source,
+                &served_bitmap,
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!((range_idx, page_idx), (1, 1));
+
+        assert_eq!(
+            MemoryManager::uffd_prefault(
+                uffd_file.as_fd(),
+                &mut range_idx,
+                &mut page_idx,
+                &ranges,
+                &mut source,
+                &served_bitmap,
+            )
+            .unwrap(),
+            0
+        );
+        assert_eq!((range_idx, page_idx), (1, 1));
+        assert_eq!(
+            *attempts.lock().unwrap(),
+            vec![(ranges[0].host_addr, 1), (ranges[1].host_addr, 0)]
+        );
+    }
+
+    #[test]
+    fn uffd_prefault_retries_page_after_source_failure() {
+        let page = page_size();
+        let ranges = [UffdRange {
+            host_addr: 0x10_0000,
+            length: page,
+            source_offset: 0,
+            page_size: page,
+        }];
+        let served_bitmap = new_served_bitmap(&ranges);
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let mut source: Box<dyn UffdMemorySource> = Box::new(RecordingUffdMemorySource {
+            attempts: Arc::clone(&attempts),
+            fail_next: true,
+        });
+        let uffd_file = tempfile::tempfile().unwrap();
+        let mut range_idx = 0;
+        let mut page_idx = 0;
+
+        let error = MemoryManager::uffd_prefault(
+            uffd_file.as_fd(),
+            &mut range_idx,
+            &mut page_idx,
+            &ranges,
+            &mut source,
+            &served_bitmap,
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "test source failure");
+        assert_eq!((range_idx, page_idx), (0, 0));
+        assert!(!served_bitmap[0].is_bit_set(0));
+
+        assert_eq!(
+            MemoryManager::uffd_prefault(
+                uffd_file.as_fd(),
+                &mut range_idx,
+                &mut page_idx,
+                &ranges,
+                &mut source,
+                &served_bitmap,
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!((range_idx, page_idx), (0, 1));
+        assert!(served_bitmap[0].is_bit_set(0));
+        assert_eq!(
+            *attempts.lock().unwrap(),
+            vec![(ranges[0].host_addr, 0), (ranges[0].host_addr, 0)]
+        );
     }
 
     #[test]

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -59,8 +59,7 @@ use crate::migration::transport::SocketStream;
 use crate::migration::url_to_path;
 use crate::sparse::{next_data_extent, write_region_sparse};
 use crate::uffd::{
-    self, FaultResolution, FileUffdMemorySource, SocketUffdMemorySource, UffdMemorySource,
-    UffdRange,
+    self, FileUffdMemorySource, SocketUffdMemorySource, UffdMemorySource, UffdRange,
 };
 use crate::vm_config::{HotplugMethod, MemoryConfig, MemoryZoneConfig};
 use crate::{GuestMemoryMmap, GuestRegionMmap, MEMORY_MANAGER_SNAPSHOT_ID, userfaultfd};
@@ -1368,20 +1367,9 @@ impl MemoryManager {
                         continue;
                     };
 
-                    loop {
-                        match source.resolve(uffd_fd.as_fd(), range, page_idx)? {
-                            FaultResolution::Served => {
-                                pages_served += 1;
-                                served_bitmap[range_idx].set_bit(page_idx as usize);
-                                break;
-                            }
-                            FaultResolution::Retry => {
-                                // The kernel reported a transient state while the fault
-                                // is being resolved; yield and retry instead of aborting.
-                                thread::yield_now();
-                            }
-                        }
-                    }
+                    source.resolve(uffd_fd.as_fd(), range, page_idx)?;
+                    pages_served += 1;
+                    served_bitmap[range_idx].set_bit(page_idx as usize);
                     served = true;
                     break;
                 }
@@ -1433,16 +1421,9 @@ impl MemoryManager {
             let range = &ranges[range_idx];
 
             let advance = match source.resolve(uffd_fd.as_fd(), range, page_idx) {
-                Ok(FaultResolution::Served) => {
+                Ok(()) => {
                     pages_prefaulted += 1;
                     served_bitmap[range_idx].set_bit(page_idx as usize);
-                    true
-                }
-                Ok(FaultResolution::Retry) => {
-                    // Unlike the on demand handler (which must retry to wake
-                    // the faulting thread), prefault can safely skip: any
-                    // future guest access will simply page-fault and be
-                    // served by the on demand path.
                     true
                 }
                 Err(e) => {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -5,7 +5,7 @@
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use std::collections::BTreeMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Seek, SeekFrom};
 use std::mem::{MaybeUninit, zeroed};
@@ -1265,6 +1265,8 @@ impl MemoryManager {
             })
             .collect();
 
+        let pages_loading: Mutex<HashSet<(usize, u64)>> = Mutex::new(HashSet::new());
+
         let mut prefault_active = !ranges.is_empty();
         let mut range_idx = 0;
         let mut page_idx = 0;
@@ -1370,6 +1372,7 @@ impl MemoryManager {
                 }
 
                 let fault_addr = msg.pf_address;
+                let minor_fault = msg.pf_flags & userfaultfd::UFFD_PAGEFAULT_FLAG_MINOR != 0;
 
                 let mut served = false;
                 for (range_idx, range) in ranges.iter().enumerate() {
@@ -1377,9 +1380,60 @@ impl MemoryManager {
                         continue;
                     };
 
-                    source.resolve(uffd_fd.as_fd(), range, page_idx)?;
-                    pages_served += 1;
-                    served_bitmap[range_idx].set_bit(page_idx as usize);
+                    let key = (range_idx, page_idx);
+                    let bitmap_idx = page_idx as usize;
+
+                    let served_minor = {
+                        let mut loading = pages_loading.lock().expect("failed to lock mutex");
+                        let served = served_bitmap[range_idx].is_bit_set(bitmap_idx);
+
+                        if served && minor_fault {
+                            true
+                        } else if !loading.insert(key) {
+                            // Another worker owns this page. The thread that's
+                            // handling this page will call UFFDIO_COPY or
+                            // UFFDIO_CONTINUE on the page range. The kernel
+                            // guarantees us that it will wake all the threads
+                            // waiting on this range, so we don't need to do
+                            // anything here.
+                            continue;
+                        } else {
+                            if served {
+                                // The page has been discarded (ie. virtio-balloon)
+                                served_bitmap[range_idx].reset_bit(bitmap_idx);
+                            }
+                            false
+                        }
+                    };
+
+                    if served_minor {
+                        // The backing page is already in the page cache. A
+                        // minor fault only needs the page mapped into this VMA.
+                        if let Err(e) = uffd::uffd_continue(
+                            uffd_fd.as_fd(),
+                            range.page_addr(page_idx),
+                            range.page_size,
+                        ) && e.raw_os_error() != Some(libc::EEXIST)
+                        {
+                            return Err(e);
+                        }
+                    } else {
+                        let result = source.resolve(uffd_fd.as_fd(), range, page_idx);
+
+                        {
+                            let mut loading = pages_loading.lock().expect("failed to lock mutex");
+
+                            if result.is_ok() {
+                                served_bitmap[range_idx].set_bit(bitmap_idx);
+                            }
+
+                            loading.remove(&key);
+                        }
+
+                        result?;
+                        pages_served += 1;
+                    }
+
                     served = true;
                     break;
                 }
@@ -1404,6 +1458,7 @@ impl MemoryManager {
                 ranges,
                 &mut source,
                 &served_bitmap,
+                &pages_loading,
             ) {
                 Ok(0) => {
                     let elapsed = prefault_start.elapsed();
@@ -1432,6 +1487,7 @@ impl MemoryManager {
         ranges: &[UffdRange],
         source: &mut Box<dyn UffdMemorySource>,
         served_bitmap: &[AtomicBitmap],
+        pages_loading: &Mutex<HashSet<(usize, u64)>>,
     ) -> Result<u64, io::Error> {
         let mut current_page_idx = *page_idx;
         let mut current_range_idx = *range_idx;
@@ -1452,16 +1508,40 @@ impl MemoryManager {
                 break 'find_range;
             }
 
-            if served_bitmap[current_range_idx].is_bit_set(current_page_idx as usize) {
-                current_page_idx += 1;
+            let range = &ranges[current_range_idx];
+            let key = (current_range_idx, current_page_idx);
+            let claimed = {
+                let mut loading = pages_loading.lock().unwrap();
+
+                if served_bitmap[current_range_idx].is_bit_set(current_page_idx as usize) {
+                    current_page_idx += 1;
+                    continue 'outer;
+                }
+
+                loading.insert(key)
+            };
+
+            if !claimed {
+                // Do not advance the cursor until the page's owner publishes
+                // completion or makes the page available for another attempt.
+                thread::yield_now();
                 continue 'outer;
             }
 
-            let range = &ranges[current_range_idx];
+            let result = source.resolve(uffd_fd, range, current_page_idx);
 
-            match source.resolve(uffd_fd, range, current_page_idx) {
-                Ok(()) => {
+            {
+                let mut loading = pages_loading.lock().unwrap();
+
+                if result.is_ok() {
                     served_bitmap[current_range_idx].set_bit(current_page_idx as usize);
+                }
+
+                loading.remove(&key);
+            }
+
+            match result {
+                Ok(()) => {
                     current_page_idx += 1;
 
                     *range_idx = current_range_idx;
@@ -3737,6 +3817,7 @@ mod tests {
         ];
         let served_bitmap = new_served_bitmap(&ranges);
         served_bitmap[0].set_bit(0);
+        let pages_loading = Mutex::new(HashSet::new());
 
         let attempts = Arc::new(Mutex::new(Vec::new()));
         let mut source: Box<dyn UffdMemorySource> = Box::new(RecordingUffdMemorySource {
@@ -3755,6 +3836,7 @@ mod tests {
                 &ranges,
                 &mut source,
                 &served_bitmap,
+                &pages_loading,
             )
             .unwrap(),
             1
@@ -3769,6 +3851,7 @@ mod tests {
                 &ranges,
                 &mut source,
                 &served_bitmap,
+                &pages_loading,
             )
             .unwrap(),
             1
@@ -3783,6 +3866,7 @@ mod tests {
                 &ranges,
                 &mut source,
                 &served_bitmap,
+                &pages_loading,
             )
             .unwrap(),
             0
@@ -3804,6 +3888,7 @@ mod tests {
             page_size: page,
         }];
         let served_bitmap = new_served_bitmap(&ranges);
+        let pages_loading = Mutex::new(HashSet::new());
         let attempts = Arc::new(Mutex::new(Vec::new()));
         let mut source: Box<dyn UffdMemorySource> = Box::new(RecordingUffdMemorySource {
             attempts: Arc::clone(&attempts),
@@ -3820,10 +3905,12 @@ mod tests {
             &ranges,
             &mut source,
             &served_bitmap,
+            &pages_loading,
         )
         .unwrap_err();
         assert_eq!(error.to_string(), "test source failure");
         assert_eq!((range_idx, page_idx), (0, 0));
+        assert!(pages_loading.lock().unwrap().is_empty());
         assert!(!served_bitmap[0].is_bit_set(0));
 
         assert_eq!(
@@ -3834,11 +3921,13 @@ mod tests {
                 &ranges,
                 &mut source,
                 &served_bitmap,
+                &pages_loading,
             )
             .unwrap(),
             1
         );
         assert_eq!((range_idx, page_idx), (0, 1));
+        assert!(pages_loading.lock().unwrap().is_empty());
         assert!(served_bitmap[0].is_bit_set(0));
         assert_eq!(
             *attempts.lock().unwrap(),

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1374,75 +1374,76 @@ impl MemoryManager {
                 let fault_addr = msg.pf_address;
                 let minor_fault = msg.pf_flags & userfaultfd::UFFD_PAGEFAULT_FLAG_MINOR != 0;
 
-                let mut served = false;
-                for (range_idx, range) in ranges.iter().enumerate() {
-                    let Some(page_idx) = range.page_index_of(fault_addr) else {
+                // Find the corresponding page info from the fault address
+                let (range, range_idx, page_idx) = ranges
+                    .iter()
+                    .enumerate()
+                    .find_map(|(range_idx, uffd_range)| {
+                        uffd_range.page_index_of(fault_addr).map(|page_idx| (uffd_range, range_idx, page_idx))
+                    })
+                    .ok_or_else(|| io::Error::other(format!(
+                        "UFFD handler: fault at {fault_addr:#x} does not belong to any registered range",
+                    )))?;
+
+                let key = (range_idx, page_idx);
+
+                let served_minor = {
+                    let mut loading = pages_loading.lock().unwrap();
+                    let served = served_bitmap[range_idx].is_bit_set(page_idx as usize);
+
+                    if served && minor_fault {
+                        true
+                    } else if !loading.insert(key) {
+                        // Another worker owns this page. The thread that's
+                        // handling this page will call UFFDIO_COPY or
+                        // UFFDIO_CONTINUE on the page range. The kernel
+                        // guarantees us that it will wake all the threads
+                        // waiting on this range, so we don't need to do
+                        // anything here.
                         continue;
-                    };
-
-                    let key = (range_idx, page_idx);
-                    let bitmap_idx = page_idx as usize;
-
-                    let served_minor = {
-                        let mut loading = pages_loading.lock().expect("failed to lock mutex");
-                        let served = served_bitmap[range_idx].is_bit_set(bitmap_idx);
-
-                        if served && minor_fault {
-                            true
-                        } else if !loading.insert(key) {
-                            // Another worker owns this page. The thread that's
-                            // handling this page will call UFFDIO_COPY or
-                            // UFFDIO_CONTINUE on the page range. The kernel
-                            // guarantees us that it will wake all the threads
-                            // waiting on this range, so we don't need to do
-                            // anything here.
-                            continue;
-                        } else {
-                            if served {
-                                // The page has been discarded (ie. virtio-balloon)
-                                served_bitmap[range_idx].reset_bit(bitmap_idx);
-                            }
-                            false
-                        }
-                    };
-
-                    if served_minor {
-                        // The backing page is already in the page cache. A
-                        // minor fault only needs the page mapped into this VMA.
-                        if let Err(e) = uffd::uffd_continue(
-                            uffd_fd.as_fd(),
-                            range.page_addr(page_idx),
-                            range.page_size,
-                        ) && e.raw_os_error() != Some(libc::EEXIST)
-                        {
-                            return Err(e);
-                        }
                     } else {
-                        let result = source.resolve(uffd_fd.as_fd(), range, page_idx);
-
-                        {
-                            let mut loading = pages_loading.lock().expect("failed to lock mutex");
-
-                            if result.is_ok() {
-                                served_bitmap[range_idx].set_bit(bitmap_idx);
-                            }
-
-                            loading.remove(&key);
+                        if served {
+                            // The page has been discarded (ie. virtio-balloon)
+                            served_bitmap[range_idx].reset_bit(page_idx as usize);
                         }
+                        false
+                    }
+                };
 
-                        result?;
-                        pages_served += 1;
+                if served_minor {
+                    // The backing page is already in the page cache. A
+                    // minor fault only needs the page mapped into this VMA.
+                    uffd::uffd_continue(
+                        uffd_fd.as_fd(),
+                        range.page_addr(page_idx),
+                        range.page_size,
+                    )
+                    .or_else(|e| {
+                        if e.raw_os_error() == Some(libc::EEXIST) {
+                            Ok(())
+                        } else {
+                            Err(e)
+                        }
+                    })?;
+
+                    // Do not fall through and resolve an already present page.
+                    continue;
+                }
+
+                let result = source.resolve(uffd_fd.as_fd(), range, page_idx);
+
+                {
+                    let mut loading = pages_loading.lock().unwrap();
+
+                    if result.is_ok() {
+                        served_bitmap[range_idx].set_bit(page_idx as usize);
                     }
 
-                    served = true;
-                    break;
+                    loading.remove(&key);
                 }
 
-                if !served {
-                    return Err(io::Error::other(format!(
-                        "UFFD handler: fault at {fault_addr:#x} does not belong to any registered range",
-                    )));
-                }
+                result?;
+                pages_served += 1;
 
                 continue;
             }

--- a/vmm/src/uffd.rs
+++ b/vmm/src/uffd.rs
@@ -13,11 +13,11 @@
 //! original memory mapping, so it remains compatible with VFIO device
 //! passthrough and shared-memory-backed guest RAM.
 
-use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Error, Read};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::fs::FileExt;
+use std::{fmt, thread};
 
 use vm_migration::protocol::{MemoryRange, Request, Response, Status};
 
@@ -182,18 +182,25 @@ pub(crate) fn copy(fd: BorrowedFd<'_>, dst: u64, src: *const u8, len: u64) -> Re
         mode: 0,
         copy: 0,
     };
-    // SAFETY: `cp` is a valid, correctly-sized struct for this ioctl.
-    let ret = unsafe {
-        libc::ioctl(
-            fd.as_raw_fd(),
-            userfaultfd::UFFDIO_COPY as libc::Ioctl,
-            &mut cp,
-        )
-    };
-    if ret < 0 {
-        return Err(Error::last_os_error());
+    loop {
+        // SAFETY: `cp` is a valid, correctly-sized struct for this ioctl.
+        let ret = unsafe {
+            libc::ioctl(
+                fd.as_raw_fd(),
+                userfaultfd::UFFDIO_COPY as libc::Ioctl,
+                &mut cp,
+            )
+        };
+        if ret >= 0 {
+            return Ok(());
+        }
+
+        let error = Error::last_os_error();
+        if error.raw_os_error() != Some(libc::EAGAIN) {
+            return Err(error);
+        }
+        thread::yield_now();
     }
-    Ok(())
 }
 
 /// Resolves a minor page fault by installing PTEs for a range.
@@ -204,18 +211,25 @@ pub(crate) fn uffd_continue(fd: BorrowedFd<'_>, dst: u64, len: u64) -> Result<()
         mode: 0,
         mapped: 0,
     };
-    // SAFETY: `cont` is a valid, correctly-sized struct for this ioctl.
-    let ret = unsafe {
-        libc::ioctl(
-            fd.as_raw_fd(),
-            userfaultfd::UFFDIO_CONTINUE as libc::Ioctl,
-            &mut cont,
-        )
-    };
-    if ret < 0 {
-        return Err(Error::last_os_error());
+    loop {
+        // SAFETY: `cont` is a valid, correctly-sized struct for this ioctl.
+        let ret = unsafe {
+            libc::ioctl(
+                fd.as_raw_fd(),
+                userfaultfd::UFFDIO_CONTINUE as libc::Ioctl,
+                &mut cont,
+            )
+        };
+        if ret >= 0 {
+            return Ok(());
+        }
+
+        let error = Error::last_os_error();
+        if error.raw_os_error() != Some(libc::EAGAIN) {
+            return Err(error);
+        }
+        thread::yield_now();
     }
-    Ok(())
 }
 
 #[repr(C)]
@@ -253,14 +267,6 @@ impl UffdRange {
     }
 }
 
-/// Result of a page fault being resolved.
-pub(crate) enum FaultResolution {
-    /// Page installed.
-    Served,
-    /// Indicates the page couldn't be installed and it's worth retrying.
-    Retry,
-}
-
 /// Provider of guest-memory page contents for a UFFD handler.
 pub(crate) trait UffdMemorySource: Send {
     fn resolve(
@@ -268,7 +274,7 @@ pub(crate) trait UffdMemorySource: Send {
         uffd_fd: BorrowedFd<'_>,
         range: &UffdRange,
         page_idx: u64,
-    ) -> Result<FaultResolution, io::Error>;
+    ) -> Result<(), io::Error>;
 
     fn requires_uffd_minor_mode(&self) -> bool;
 }
@@ -294,7 +300,7 @@ impl UffdMemorySource for FileUffdMemorySource {
         uffd_fd: BorrowedFd<'_>,
         range: &UffdRange,
         page_idx: u64,
-    ) -> Result<FaultResolution, io::Error> {
+    ) -> Result<(), io::Error> {
         let page_size = range.page_size as usize;
         let page_addr = range.page_addr(page_idx);
         let file_pos = range.page_source_offset(page_idx);
@@ -306,15 +312,14 @@ impl UffdMemorySource for FileUffdMemorySource {
             .read_exact_at(&mut self.buf[..page_size], file_pos)?;
 
         match copy(uffd_fd, page_addr, self.buf.as_ptr(), range.page_size) {
-            Ok(()) => Ok(FaultResolution::Served),
+            Ok(()) => Ok(()),
             Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
                 // Installed concurrently. Wake any blocked threads.
                 if let Err(e) = wake(uffd_fd, page_addr, range.page_size) {
                     log::warn!("UFFDIO_WAKE failed at {page_addr:#x}: {e}");
                 }
-                Ok(FaultResolution::Served)
+                Ok(())
             }
-            Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => Ok(FaultResolution::Retry),
             Err(e) => Err(e),
         }
     }
@@ -366,7 +371,7 @@ impl UffdMemorySource for SocketUffdMemorySource {
         uffd_fd: BorrowedFd<'_>,
         range: &UffdRange,
         page_idx: u64,
-    ) -> Result<FaultResolution, io::Error> {
+    ) -> Result<(), io::Error> {
         let page_size = range.page_size;
         let page_addr = range.page_addr(page_idx);
         let page_gpa = range.page_source_offset(page_idx);
@@ -380,15 +385,14 @@ impl UffdMemorySource for SocketUffdMemorySource {
                 )));
             }
             match uffd_continue(uffd_fd, page_addr, page_size) {
-                Ok(()) => Ok(FaultResolution::Served),
+                Ok(()) => Ok(()),
                 // This is fine, someone mapped the page before us.
                 Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
                     if let Err(e) = wake(uffd_fd, page_addr, page_size) {
                         log::warn!("UFFDIO_WAKE failed at {page_addr:#x}: {e}");
                     }
-                    Ok(FaultResolution::Served)
+                    Ok(())
                 }
-                Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => Ok(FaultResolution::Retry),
                 Err(e) => Err(e),
             }
         } else {
@@ -403,14 +407,13 @@ impl UffdMemorySource for SocketUffdMemorySource {
             }
             self.stream.read_exact(&mut self.buf[..len])?;
             match copy(uffd_fd, page_addr, self.buf.as_ptr(), page_size) {
-                Ok(()) => Ok(FaultResolution::Served),
+                Ok(()) => Ok(()),
                 Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
                     if let Err(e) = wake(uffd_fd, page_addr, page_size) {
                         log::warn!("UFFDIO_WAKE failed at {page_addr:#x}: {e}");
                     }
-                    Ok(FaultResolution::Served)
+                    Ok(())
                 }
-                Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => Ok(FaultResolution::Retry),
                 Err(e) => Err(e),
             }
         }

--- a/vmm/src/userfaultfd.rs
+++ b/vmm/src/userfaultfd.rs
@@ -38,6 +38,7 @@ pub(crate) const UFFD_API: u64 = 0xAA;
 pub(crate) const UFFDIO_REGISTER_MODE_MISSING: u64 = 1;
 pub(crate) const UFFDIO_REGISTER_MODE_MINOR: u64 = 1 << 2;
 pub(crate) const UFFD_EVENT_PAGEFAULT: u8 = 0x12;
+pub(crate) const UFFD_PAGEFAULT_FLAG_MINOR: u64 = 1 << 2;
 pub(crate) const UFFD_FEATURE_MISSING_HUGETLBFS: u64 = 1 << 4;
 pub(crate) const UFFD_FEATURE_MISSING_SHMEM: u64 = 1 << 5;
 pub(crate) const UFFD_FEATURE_MINOR_HUGETLBFS: u64 = 1 << 9;


### PR DESCRIPTION
Stage 1 of 3 of patchsets to introduce UFFD pagefault multithreading. This patch consists mainly of refactors/fixes/small behavior change that are unrelated to eachother but that will make the second patchset easier to review and focused on the technical aspects. This can be merged safely without ever introducing concurrent pagefault servicing.

See #8756 for broader context.
See https://github.com/lucido-simon/cloud-hypervisor/tree/offload_daemon_multithreading for the full tree