### PR TITLE
Fuzzer changes should skip integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -295,12 +295,17 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
+          components: clippy
       - name: Install Cargo fuzz
         run: cargo install cargo-fuzz
       - name: Fuzz Build
         run: cargo fuzz build
       - name: Fuzz Check
         run: cargo fuzz check
+      - name: Clippy
+        env:
+          RUSTFLAGS: --cfg fuzzing
+        run: cargo clippy --locked --bins --manifest-path fuzz/Cargo.toml -- -D warnings
   openapi:
     name: openapi
     needs: [preflight]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
       full: ${{ steps.classify.outputs.full }}
       rust: ${{ steps.changes.outputs.rust }}
       cargo: ${{ steps.changes.outputs.cargo }}
+      fuzz: ${{ steps.changes.outputs.fuzz }}
       openapi: ${{ steps.changes.outputs.openapi }}
       dockerfile: ${{ steps.changes.outputs.dockerfile }}
       shell: ${{ steps.changes.outputs.shell }}
@@ -30,6 +31,7 @@ jobs:
           filters: |
             rust:
               - '**/*.rs'
+              - '!fuzz/**'
               - 'build.rs'
               - '**/Cargo.toml'
               - '**/Cargo.lock'
@@ -37,6 +39,10 @@ jobs:
             cargo:
               - '**/Cargo.toml'
               - '**/Cargo.lock'
+              - '!fuzz/Cargo.toml'
+              - '!fuzz/Cargo.lock'
+            fuzz:
+              - 'fuzz/**'
             openapi:
               - 'vmm/src/api/openapi/**'
             dockerfile:
@@ -220,7 +226,7 @@ jobs:
   formatting:
     name: formatting
     needs: [preflight]
-    if: needs.preflight.outputs.full == 'true'
+    if: needs.preflight.outputs.full == 'true' || needs.preflight.outputs.fuzz == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -247,7 +253,7 @@ jobs:
   package-consistency:
     name: package-consistency
     needs: [preflight]
-    if: needs.preflight.outputs.full == 'true'
+    if: needs.preflight.outputs.full == 'true' || needs.preflight.outputs.fuzz == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -272,7 +278,7 @@ jobs:
   fuzz-build:
     name: fuzz-build
     needs: [preflight]
-    if: needs.preflight.outputs.full == 'true'
+    if: needs.preflight.outputs.full == 'true' || needs.preflight.outputs.fuzz == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/fuzz/fuzz_targets/balloon.rs
+++ b/fuzz/fuzz_targets/balloon.rs
@@ -61,7 +61,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
 
     // Setup the guest memory with the input bytes
     let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MEM_SIZE)]).unwrap();
-    if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
+    if mem.write_slice(mem_bytes, GuestAddress(0)).is_err() {
         return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);

--- a/fuzz/fuzz_targets/console.rs
+++ b/fuzz/fuzz_targets/console.rs
@@ -29,7 +29,7 @@ const CONSOLE_INPUT_SIZE: usize = 128;
 const QUEUE_DATA_SIZE: usize = 4;
 const MEM_SIZE: usize = 32 * 1024 * 1024;
 // Guest memory gap
-const GUEST_MEM_GAP: u64 = 1 * 1024 * 1024;
+const GUEST_MEM_GAP: u64 = 1024 * 1024;
 // Guest physical address for the first virt queue
 const BASE_VIRT_QUEUE_ADDR: u64 = MEM_SIZE as u64 + GUEST_MEM_GAP;
 // Number of queues
@@ -110,7 +110,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
     {
         return Corpus::Reject;
     }
-    if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
+    if mem.write_slice(mem_bytes, GuestAddress(0)).is_err() {
         return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -24,8 +24,13 @@ use vmm::{EpollContext, EpollDispatch};
 use vmm_sys_util::eventfd::EventFd;
 
 // Need to be ordered for test case reproducibility
-static ROUTES: LazyLock<Vec<&Box<dyn EndpointHandler + Sync + Send>>> =
-    LazyLock::new(|| HTTP_ROUTES.routes.values().collect());
+static ROUTES: LazyLock<Vec<&'static (dyn EndpointHandler + Sync + Send)>> = LazyLock::new(|| {
+    HTTP_ROUTES
+        .routes
+        .values()
+        .map(|route| route.as_ref())
+        .collect()
+});
 
 fuzz_target!(|bytes: &[u8]| -> Corpus {
     if bytes.len() < 2 {
@@ -68,7 +73,7 @@ fn generate_request(bytes: &[u8]) -> Option<Request> {
     let request_line = format!("{} http://localhost/home HTTP/1.1\r\n", req_method);
 
     let req_body = &bytes[1..];
-    let request = if req_body.len() > 0 {
+    let request = if !req_body.is_empty() {
         [
             format!("{}Content-Length: {}\r\n", request_line, req_body.len()).as_bytes(),
             req_body,
@@ -312,7 +317,7 @@ fn http_receiver_stub(exit_evt: EventFd, api_evt: EventFd, api_receiver: Receive
     epoll.add_event(&api_evt, EpollDispatch::Api).unwrap();
 
     let epoll_fd = epoll.as_raw_fd();
-    let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); 2];
+    let mut events = [epoll::Event::new(epoll::Events::empty(), 0); 2];
     let num_events;
     loop {
         num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {

--- a/fuzz/fuzz_targets/iommu.rs
+++ b/fuzz/fuzz_targets/iommu.rs
@@ -44,7 +44,7 @@ const AVAIL_RING_SIZE: u64 = 6_u64 + 2 * QUEUE_SIZE as u64;
 const USED_RING_SIZE: u64 = 6_u64 + 8 * QUEUE_SIZE as u64;
 
 // Guest memory gap
-const GUEST_MEM_GAP: u64 = 1 * 1024 * 1024;
+const GUEST_MEM_GAP: u64 = 1024 * 1024;
 // Guest physical address for descriptor table.
 const DESC_TABLE_ADDR: u64 = align!(MEM_SIZE as u64 + GUEST_MEM_GAP, DESC_TABLE_ALIGN_SIZE);
 // Guest physical address for available ring
@@ -95,7 +95,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
     {
         return Corpus::Reject;
     }
-    if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
+    if mem.write_slice(mem_bytes, GuestAddress(0)).is_err() {
         return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);
@@ -146,7 +146,7 @@ fn setup_virt_queue(bytes: &[u8; QUEUE_DATA_SIZE]) -> Queue {
     let mut q = Queue::new(QUEUE_SIZE).unwrap();
     q.set_next_avail(bytes[0] as u16); // 'u8' is enough given the 'QUEUE_SIZE' is small
     q.set_next_used(bytes[1] as u16);
-    q.set_event_idx(bytes[2] % 2 != 0);
+    q.set_event_idx(!bytes[2].is_multiple_of(2));
     q.set_size(bytes[3] as u16 % QUEUE_SIZE);
 
     q.try_set_desc_table_address(GuestAddress(DESC_TABLE_ADDR))

--- a/fuzz/fuzz_targets/linux_loader.rs
+++ b/fuzz/fuzz_targets/linux_loader.rs
@@ -27,7 +27,7 @@ const HIGH_RAM_START: GuestAddress = GuestAddress(0x100000);
 fuzz_target!(|bytes| {
     let shm = memfd_create(&ffi::CString::new("fuzz_load_kernel").unwrap(), 0).unwrap();
     let mut kernel_file: File = unsafe { File::from_raw_fd(shm) };
-    kernel_file.write_all(&bytes).unwrap();
+    kernel_file.write_all(bytes).unwrap();
     kernel_file.seek(SeekFrom::Start(0)).unwrap();
 
     let guest_memory = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MEM_SIZE)]).unwrap();

--- a/fuzz/fuzz_targets/linux_loader_cmdline.rs
+++ b/fuzz/fuzz_targets/linux_loader_cmdline.rs
@@ -22,7 +22,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
     let payload_config = vmm::vm_config::PayloadConfig {
         firmware: None,
         kernel: None,
-        cmdline: Some(String::from_utf8_lossy(&bytes).to_string()),
+        cmdline: Some(String::from_utf8_lossy(bytes).to_string()),
         initramfs: None,
         #[cfg(feature = "igvm")]
         igvm: None,

--- a/fuzz/fuzz_targets/mem.rs
+++ b/fuzz/fuzz_targets/mem.rs
@@ -47,7 +47,7 @@ const AVAIL_RING_SIZE: u64 = 6_u64 + 2 * QUEUE_SIZE as u64;
 const USED_RING_SIZE: u64 = 6_u64 + 8 * QUEUE_SIZE as u64;
 
 // Guest memory gap
-const GUEST_MEM_GAP: u64 = 1 * 1024 * 1024;
+const GUEST_MEM_GAP: u64 = 1024 * 1024;
 // Guest physical address for descriptor table.
 const DESC_TABLE_ADDR: u64 = align!(MEM_SIZE as u64 + GUEST_MEM_GAP, DESC_TABLE_ALIGN_SIZE);
 // Guest physical address for available ring
@@ -138,7 +138,11 @@ impl VirtioInterrupt for NoopVirtioInterrupt {
 
 // Create a dummy virtio-mem device for fuzzing purpose only
 fn create_dummy_virtio_mem(bytes: &[u8; VIRTIO_MEM_DATA_SIZE]) -> (Mem, Arc<GuestRegionMmap>) {
-    let numa_id = if bytes[0] % 2 != 0 { Some(0) } else { None };
+    let numa_id = if !bytes[0].is_multiple_of(2) {
+        Some(0)
+    } else {
+        None
+    };
 
     let region = vmm::memory_manager::MemoryManager::create_ram_region(
         &None,
@@ -179,7 +183,7 @@ fn setup_virt_queue(bytes: &[u8; QUEUE_DATA_SIZE]) -> Queue {
     let mut q = Queue::new(QUEUE_SIZE).unwrap();
     q.set_next_avail(bytes[0] as u16); // 'u8' is enough given the 'QUEUE_SIZE' is small
     q.set_next_used(bytes[1] as u16);
-    q.set_event_idx(bytes[2] % 2 != 0);
+    q.set_event_idx(!bytes[2].is_multiple_of(2));
     q.set_size(bytes[3] as u16 % QUEUE_SIZE);
 
     q.try_set_desc_table_address(GuestAddress(DESC_TABLE_ADDR))

--- a/fuzz/fuzz_targets/net.rs
+++ b/fuzz/fuzz_targets/net.rs
@@ -31,7 +31,7 @@ const TAP_INPUT_SIZE: usize = 128;
 const QUEUE_DATA_SIZE: usize = 4;
 const MEM_SIZE: usize = 32 * 1024 * 1024;
 // Guest memory gap
-const GUEST_MEM_GAP: u64 = 1 * 1024 * 1024;
+const GUEST_MEM_GAP: u64 = 1024 * 1024;
 // Guest physical address for the first virt queue
 const BASE_VIRT_QUEUE_ADDR: u64 = MEM_SIZE as u64 + GUEST_MEM_GAP;
 // Number of queues
@@ -114,7 +114,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
     {
         return Corpus::Reject;
     }
-    if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
+    if mem.write_slice(mem_bytes, GuestAddress(0)).is_err() {
         return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);
@@ -266,7 +266,7 @@ fn tap_backend_stub(
         .unwrap();
 
     let epoll_fd = epoll.as_raw_fd();
-    let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); 3];
+    let mut events = [epoll::Event::new(epoll::Events::empty(), 0); 3];
     loop {
         let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
             Ok(num_events) => num_events,
@@ -276,24 +276,16 @@ fn tap_backend_stub(
             },
         };
 
-        for event in events.iter().take(num_events) {
+        if let Some(event) = events.iter().take(num_events).next() {
             let dispatch_event: EpollEvent = event.data.into();
             match dispatch_event {
-                EpollEvent::Exit => {
-                    return;
-                }
-                EpollEvent::Rx => {
-                    dummy_tap.write_all(tap_input_bytes).unwrap();
-                    break;
-                }
+                EpollEvent::Exit => return,
+                EpollEvent::Rx => dummy_tap.write_all(tap_input_bytes).unwrap(),
                 EpollEvent::Tx => {
                     let mut buffer = Vec::new();
                     dummy_tap.read_to_end(&mut buffer).ok();
-                    break;
                 }
-                _ => {
-                    panic!("Unexpected Epoll event");
-                }
+                _ => panic!("Unexpected Epoll event"),
             }
         }
     }

--- a/fuzz/fuzz_targets/pmem.rs
+++ b/fuzz/fuzz_targets/pmem.rs
@@ -50,7 +50,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
 
     // Setup the guest memory with the input bytes
     let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MEM_SIZE)]).unwrap();
-    if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
+    if mem.write_slice(mem_bytes, GuestAddress(0)).is_err() {
         return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);
@@ -148,7 +148,7 @@ fn setup_virt_queue(bytes: &[u8; QUEUE_DATA_SIZE]) -> Queue {
     let mut q = Queue::new(QUEUE_SIZE).unwrap();
     q.set_next_avail(bytes[0] as u16); // 'u8' is enough given the 'QUEUE_SIZE' is small
     q.set_next_used(bytes[1] as u16);
-    q.set_event_idx(bytes[2] % 2 != 0);
+    q.set_event_idx(!bytes[2].is_multiple_of(2));
     q.set_size(bytes[3] as u16 % QUEUE_SIZE);
 
     q.try_set_desc_table_address(GuestAddress(DESC_TABLE_ADDR))

--- a/fuzz/fuzz_targets/rng.rs
+++ b/fuzz/fuzz_targets/rng.rs
@@ -24,7 +24,7 @@ macro_rules! align {
 }
 
 const QUEUE_DATA_SIZE: usize = 4;
-const MEM_SIZE: usize = 1 * 1024 * 1024;
+const MEM_SIZE: usize = 1024 * 1024;
 
 // Max entries in the queue.
 const QUEUE_SIZE: u16 = 256;
@@ -42,7 +42,7 @@ const AVAIL_RING_SIZE: u64 = 6_u64 + 2 * QUEUE_SIZE as u64;
 const USED_RING_SIZE: u64 = 6_u64 + 8 * QUEUE_SIZE as u64;
 
 // Guest memory gap
-const GUEST_MEM_GAP: u64 = 1 * 1024 * 1024;
+const GUEST_MEM_GAP: u64 = 1024 * 1024;
 // Guest physical address for descriptor table.
 const DESC_TABLE_ADDR: u64 = align!(MEM_SIZE as u64 + GUEST_MEM_GAP, DESC_TABLE_ALIGN_SIZE);
 // Guest physical address for available ring
@@ -88,7 +88,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
     {
         return Corpus::Reject;
     }
-    if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
+    if mem.write_slice(mem_bytes, GuestAddress(0)).is_err() {
         return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);
@@ -134,7 +134,7 @@ fn setup_virt_queue(bytes: &[u8; QUEUE_DATA_SIZE]) -> Queue {
     let mut q = Queue::new(QUEUE_SIZE).unwrap();
     q.set_next_avail(bytes[0] as u16); // 'u8' is enough given the 'QUEUE_SIZE' is small
     q.set_next_used(bytes[1] as u16);
-    q.set_event_idx(bytes[2] % 2 != 0);
+    q.set_event_idx(!bytes[2].is_multiple_of(2));
     q.set_size(bytes[3] as u16 % QUEUE_SIZE);
 
     q.try_set_desc_table_address(GuestAddress(DESC_TABLE_ADDR))

--- a/fuzz/fuzz_targets/vsock.rs
+++ b/fuzz/fuzz_targets/vsock.rs
@@ -26,7 +26,7 @@ macro_rules! align {
 }
 
 const QUEUE_DATA_SIZE: usize = 4;
-const MEM_SIZE: usize = 1 * 1024 * 1024;
+const MEM_SIZE: usize = 1024 * 1024;
 
 // Max entries in the queue.
 const QUEUE_SIZE: u16 = 256;
@@ -44,7 +44,7 @@ const AVAIL_RING_SIZE: u64 = 6_u64 + 2 * QUEUE_SIZE as u64;
 const USED_RING_SIZE: u64 = 6_u64 + 8 * QUEUE_SIZE as u64;
 
 // Guest memory gap
-const GUEST_MEM_GAP: u64 = 1 * 1024 * 1024;
+const GUEST_MEM_GAP: u64 = 1024 * 1024;
 // Guest physical address for descriptor table.
 const DESC_TABLE_ADDR: u64 = align!(MEM_SIZE as u64 + GUEST_MEM_GAP, DESC_TABLE_ALIGN_SIZE);
 // Guest physical address for available ring
@@ -84,7 +84,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
     {
         return Corpus::Reject;
     }
-    if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
+    if mem.write_slice(mem_bytes, GuestAddress(0)).is_err() {
         return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);
@@ -143,7 +143,7 @@ fn setup_virt_queue(bytes: &[u8; QUEUE_DATA_SIZE]) -> Queue {
     let mut q = Queue::new(QUEUE_SIZE).unwrap();
     q.set_next_avail(bytes[0] as u16); // 'u8' is enough given the 'QUEUE_SIZE' is small
     q.set_next_used(bytes[1] as u16);
-    q.set_event_idx(bytes[2] % 2 != 0);
+    q.set_event_idx(!bytes[2].is_multiple_of(2));
     q.set_size(bytes[3] as u16 % QUEUE_SIZE);
 
     q.try_set_desc_table_address(GuestAddress(DESC_TABLE_ADDR))

--- a/fuzz/fuzz_targets/watchdog.rs
+++ b/fuzz/fuzz_targets/watchdog.rs
@@ -53,7 +53,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
 
     // Setup the guest memory with the input bytes
     let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MEM_SIZE)]).unwrap();
-    if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
+    if mem.write_slice(mem_bytes, GuestAddress(0)).is_err() {
         return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);
@@ -100,7 +100,7 @@ fn setup_virt_queue(bytes: &[u8; QUEUE_DATA_SIZE]) -> Queue {
     let mut q = Queue::new(QUEUE_SIZE).unwrap();
     q.set_next_avail(bytes[0] as u16); // 'u8' is enough given the 'QUEUE_SIZE' is small
     q.set_next_used(bytes[1] as u16);
-    q.set_event_idx(bytes[2] % 2 != 0);
+    q.set_event_idx(!bytes[2].is_multiple_of(2));
     q.set_size(bytes[3] as u16 % QUEUE_SIZE);
 
     q.try_set_desc_table_address(GuestAddress(DESC_TABLE_ADDR))


### PR DESCRIPTION
If only fuzzer code is change, we only need to build the fuzzers and run the relevant quality checks. No need to run the full integration suite.