### PR TITLE
vmm: seccomp: Add mremap to HTTP thread

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -989,6 +989,7 @@ fn http_api_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError>
         (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
+        (libc::SYS_mremap, vec![]),
         (libc::SYS_munmap, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_recvfrom, vec![]),


### PR DESCRIPTION
glibc's malloc can trigger this on the HTTP thread when dealing with
moderately large payloads.

Signed-off-by: Rob Bradford <rbradford@meta.com>
