### PR TITLE
vmm: memory_manager: Reinstate GPA padding between memory regions

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -220,6 +220,7 @@ pub struct MemoryManager {
     hotplug_method: HotplugMethod,
     boot_ram: u64,
     current_ram: u64,
+    hotplug_size: u64,
     next_hotplug_slot: usize,
     shared: bool,
     hugepages: bool,
@@ -277,8 +278,8 @@ pub enum Error {
     NoSlotAvailable,
 
     /// Not enough space in the hotplug RAM region
-    #[error("Not enough space in the hotplug RAM region")]
-    InsufficientHotplugRam,
+    #[error("Not enough space in the hotplug RAM region: {0} exceeds {1}")]
+    InsufficientHotplugRam(u64, u64),
 
     /// The requested hotplug memory addition is not a valid size
     #[error("The requested hotplug memory addition is not a valid size")]
@@ -1895,6 +1896,7 @@ impl MemoryManager {
             hotplug_method: config.hotplug_method,
             boot_ram,
             current_ram,
+            hotplug_size: config.hotplug_size.unwrap_or_default(),
             next_hotplug_slot,
             shared: config.shared,
             hugepages: config.hugepages,
@@ -2401,6 +2403,20 @@ impl MemoryManager {
             return Err(Error::InvalidSize);
         }
 
+        let total_hotplug_ram = self
+            .hotplug_slots
+            .iter()
+            .filter(|slot| slot.active)
+            .map(|slot| slot.length)
+            .sum::<u64>()
+            + size as u64;
+        if total_hotplug_ram > self.hotplug_size {
+            return Err(Error::InsufficientHotplugRam(
+                total_hotplug_ram,
+                self.hotplug_size,
+            ));
+        }
+
         let start_addr = MemoryManager::start_addr(self.guest_memory.memory().last_addr(), true)?;
 
         if start_addr
@@ -2408,7 +2424,10 @@ impl MemoryManager {
             .unwrap()
             > self.end_of_ram_area
         {
-            return Err(Error::InsufficientHotplugRam);
+            return Err(Error::InsufficientHotplugRam(
+                total_hotplug_ram,
+                self.hotplug_size,
+            ));
         }
 
         let region = self.add_ram_region(start_addr, size)?;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -83,6 +83,7 @@ const SNAPSHOT_FILENAME: &str = "memory-ranges";
 const X86_64_IRQ_BASE: u32 = 5;
 
 const HOTPLUG_COUNT: usize = 8;
+const HOTPLUG_RAM_ALIGN_SIZE: u64 = 128 << 20;
 
 // Memory policy constants
 const MPOL_BIND: u32 = 2;
@@ -2308,7 +2309,7 @@ impl MemoryManager {
     // And it must also start at the 64bit start.
     fn start_addr(mem_end: GuestAddress, allow_mem_hotplug: bool) -> Result<GuestAddress, Error> {
         let mut start_addr = if allow_mem_hotplug {
-            GuestAddress(mem_end.0 | ((128 << 20) - 1))
+            GuestAddress(mem_end.0 | (HOTPLUG_RAM_ALIGN_SIZE - 1))
         } else {
             mem_end
         };
@@ -2383,7 +2384,7 @@ impl MemoryManager {
         }
 
         // "Inserted" DIMM must have a size that is a multiple of 128MiB
-        if !size.is_multiple_of(128 << 20) {
+        if !size.is_multiple_of(HOTPLUG_RAM_ALIGN_SIZE as usize) {
             return Err(Error::InvalidSize);
         }
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -84,6 +84,8 @@ const X86_64_IRQ_BASE: u32 = 5;
 
 const HOTPLUG_COUNT: usize = 8;
 const HOTPLUG_RAM_ALIGN_SIZE: u64 = 128 << 20;
+// Gap needed to ensure regions are not contiguous in guest physical address space
+const HOTPLUG_RAM_GAP_SIZE: u64 = 256 << 20;
 
 // Memory policy constants
 const MPOL_BIND: u32 = 2;
@@ -2304,7 +2306,9 @@ impl MemoryManager {
     // Calculate the start address of an area next to RAM.
     //
     // If memory hotplug is allowed, the start address needs to be aligned
-    // (rounded-up) to 128MiB boundary.
+    // (rounded-up) to 128MiB boundary and separated from the previous RAM
+    // region by a 256MiB gap. This prevents the guest from accessing memory
+    // across two separate mappings with a single access.
     // If memory hotplug is not allowed, there is no alignment required.
     // And it must also start at the 64bit start.
     fn start_addr(mem_end: GuestAddress, allow_mem_hotplug: bool) -> Result<GuestAddress, Error> {
@@ -2321,6 +2325,12 @@ impl MemoryManager {
         #[cfg(not(target_arch = "riscv64"))]
         if mem_end < layout::MEM_32BIT_RESERVED_START {
             return Ok(layout::RAM_64BIT_START);
+        }
+
+        if allow_mem_hotplug {
+            start_addr = start_addr
+                .checked_add(HOTPLUG_RAM_GAP_SIZE)
+                .ok_or(Error::GuestAddressOverFlow)?;
         }
 
         Ok(start_addr)

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1762,8 +1762,11 @@ impl MemoryManager {
                         }
 
                         if !user_provided_zones && config.hotplug_method == HotplugMethod::Acpi {
+                            let hotplug_address_space_size = hotplug_size
+                                .checked_add(HOTPLUG_RAM_GAP_SIZE * (HOTPLUG_COUNT as u64 - 1))
+                                .ok_or(Error::GuestAddressOverFlow)?;
                             start_of_device_area = start_of_device_area
-                                .checked_add(hotplug_size)
+                                .checked_add(hotplug_address_space_size)
                                 .ok_or(Error::GuestAddressOverFlow)?;
                         } else {
                             // Alignment must be "natural" i.e. same as size of block


### PR DESCRIPTION
The GPAs need to be discontiguous to prevent the guest from trying to access
memory that spans multiple host mappings (which will be discontiguous in the
address space) and also prevent the guest requesting the VMM access memory that
spans two such regions for the same reason.


- **vmm: memory_manager: Add constant for ACPI hotplug RAM alignment**
- **vmm: memory_manager: Reinstate gap between boot RAM and ACPI hotplug regions**
- **vmm: memory_manager: Consider region gaps in device area start**
- **vmm: memory_manager: Improve validation of hotplug slot sizing**
