### PR TITLE
misc: Add .gitattribute to tell .rs file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+*.rs diff=rust


### PR DESCRIPTION
Git supports Rust diff driver since v2.23.0 (2019). [1] It shows better diff hunk headers.

[1] https://gitlab.com/git-scm/git/-/blob/HEAD/Documentation/RelNotes/2.23.0.adoc