### PR TITLE
fdt: Guard against division-by-zero on aarch64 cache topology

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -169,9 +169,11 @@ fn create_cpu_nodes(
     let num_cpus = vcpu_mpidr.len();
     let (threads_per_core, cores_per_die, dies_per_package, packages) =
         vcpu_topology.unwrap_or((1, 1, 1, 1));
-    let cores_per_package = cores_per_die * dies_per_package;
-    let max_cpus: u32 =
-        threads_per_core as u32 * cores_per_die as u32 * dies_per_package as u32 * packages as u32;
+    let cores_per_package = cmp::max(1, cores_per_die * dies_per_package);
+    let max_cpus: u32 = cmp::max(
+        1,
+        threads_per_core as u32 * cores_per_die as u32 * dies_per_package as u32 * packages as u32,
+    );
 
     // Add cache info.
     let cache_info = read_cache_topology();


### PR DESCRIPTION
### Summary
When generating the FDT CPU nodes on aarch64 hosts with shared L3 cache, `package_id` is computed as `cpu_id / cores_per_package`. If `cores_per_package` is `0` (e.g. from an uninitialized or empty topology), this triggers a divide-by-zero panic.

This patch guards `cores_per_package` and `max_cpus` with `cmp::max(1, ...)`.

Signed-off-by: Tim Ford <timford@google.com>