### PR TITLE
Write down PR cover letter style in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,13 @@ removed in the next commit).
 > your fix and aid reviewers. _This is not required for opening a pull request
 > nor is any agreement required before implementation._
 
+We aim for small, reviewable, and short-lived PRs that follow the commit
+style described above. PR cover letters are optional but can be helpful for
+larger changes. Keep them short and focused to prepare reviewers for a
+commit-by-commit review. For example, include a brief motivation and, where
+useful, benchmark results or testing notes. Include links to issues and other
+discussions, if relevant.
+
 Cloud Hypervisor uses the “fork-and-pull” development model. Follow these steps if
 you want to merge your changes to `cloud-hypervisor`:
 


### PR DESCRIPTION
In the discussion of PR https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8772 we noticed that we weren't aligned on the PR cover letter style (verbose vs minimal/none). Let's try to find a common ground in CONTRIBUTING.md.