### PR TITLE
hypervisor: Simplify kvm_userspace_memory_region2 flags logic

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1117,10 +1117,6 @@ impl vm::Vm for KvmVm {
         if readonly {
             flags |= KVM_MEM_READONLY;
         }
-        if log_dirty_pages {
-            flags |= KVM_MEM_LOG_DIRTY_PAGES;
-        }
-
         const _: () = assert!(size_of::<usize>() <= size_of::<u64>());
 
         // Create a per-region guest_memfd when supported.
@@ -1154,7 +1150,7 @@ impl vm::Vm for KvmVm {
         #[cfg(not(feature = "sev_snp"))]
         let guest_memfd = 0;
 
-        let mut region = kvm_userspace_memory_region2 {
+        let region = kvm_userspace_memory_region2 {
             slot,
             flags: self.get_kvm_userspace_memory_region_flag(flags),
             guest_phys_addr,
@@ -1167,7 +1163,7 @@ impl vm::Vm for KvmVm {
             guest_memfd_offset: 0,
             ..Default::default()
         };
-        if (region.flags & KVM_MEM_LOG_DIRTY_PAGES) != 0 {
+        if log_dirty_pages {
             if (region.flags & KVM_MEM_READONLY) != 0 {
                 return Err(vm::HypervisorVmError::CreateUserMemory(anyhow!(
                     "Error creating regions with both 'dirty-pages-log' and 'read-only'."
@@ -1186,10 +1182,6 @@ impl vm::Vm for KvmVm {
                     guest_memfd: region.guest_memfd,
                 },
             );
-
-            // Always create guest physical memory region without `KVM_MEM_LOG_DIRTY_PAGES`.
-            // For regions that need this flag, dirty pages log will be turned on in `start_dirty_log`.
-            region.flags = self.get_kvm_userspace_memory_region_flag(0);
         }
 
         // SAFETY: Safe because caller promised this is safe.

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1216,17 +1216,8 @@ impl vm::Vm for KvmVm {
         guest_phys_addr: u64,
         memory_size: usize,
         userspace_addr: *mut u8,
-        readonly: bool,
-        log_dirty_pages: bool,
+        _readonly: bool,
     ) -> vm::Result<()> {
-        let mut flags = 0;
-        if readonly {
-            flags |= KVM_MEM_READONLY;
-        }
-        if log_dirty_pages {
-            flags |= KVM_MEM_LOG_DIRTY_PAGES;
-        }
-
         const _: () = assert!(size_of::<usize>() <= size_of::<u64>());
 
         let mut region = kvm_userspace_memory_region2 {
@@ -1234,7 +1225,7 @@ impl vm::Vm for KvmVm {
             guest_phys_addr,
             memory_size: memory_size as u64,
             userspace_addr: userspace_addr as usize as u64,
-            flags,
+            flags: 0,
             ..Default::default()
         };
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -2067,7 +2067,6 @@ impl vm::Vm for MshvVm {
         memory_size: usize,
         userspace_addr: *mut u8,
         readonly: bool,
-        _log_dirty_pages: bool,
     ) -> vm::Result<()> {
         let mut flags = 1 << MSHV_SET_MEM_BIT_EXECUTABLE;
         if !readonly {

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -400,7 +400,6 @@ pub trait Vm: Send + Sync + Any {
         memory_size: usize,
         userspace_addr: *mut u8,
         readonly: bool,
-        log_dirty_pages: bool,
     ) -> Result<()>;
     /// Returns the preferred CPU target type which can be emulated by KVM on underlying host.
     #[cfg(target_arch = "aarch64")]

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -2321,7 +2321,6 @@ impl VfioPciDevice {
                         len,
                         host_addr,
                         false,
-                        false,
                     )
                 } {
                     error!("Could not remove the userspace memory region: {e}");
@@ -2495,7 +2494,6 @@ iova 0x{:x}, size 0x{:x}: {}, ",
                             user_memory_region.start,
                             len,
                             host_addr,
-                            false,
                             false,
                         )
                     }

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -223,7 +223,6 @@ impl VfioUserPciDevice {
                         user_memory_region.mapping.len(),
                         user_memory_region.mapping.addr(),
                         false,
-                        false,
                     )
                 } {
                     error!("Could not remove the userspace memory region: {e}");
@@ -446,7 +445,6 @@ impl PciDevice for VfioUserPciDevice {
                             user_memory_region.start,
                             user_memory_region.mapping.len(),
                             user_memory_region.mapping.addr(),
-                            false,
                             false,
                         )
                     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -895,7 +895,6 @@ impl DeviceRelocation for AddressManager {
                                 shm_regions.mapping.len(),
                                 shm_regions.mapping.as_ptr(),
                                 false,
-                                false,
                             )
                             .map_err(|e| {
                                 io::Error::other(format!(

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -2559,7 +2559,6 @@ impl MemoryManager {
                     memory_size,
                     userspace_addr,
                     false, /* readonly -- don't care */
-                    false, /* log dirty */
                 )
                 .map_err(Error::RemoveUserMemoryRegion)?;
         }


### PR DESCRIPTION
Simplify some of the logic around `kvm_userspace_memory_region2`.
First, stop redundantly setting and unsetting `KVM_MEM_LOG_DIRTY_PAGES`, and second, stop redundantly passing any flags when removing a memory region.