### PR TITLE
Fix Hanging TCP Migration Workers on Failure + Improve Diagnostic Messages

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -67,6 +67,7 @@ use crate::migration::worker::{
 };
 use crate::migration::{recv_vm_config, recv_vm_state};
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
+use crate::util::flatten_error_chain_to_string;
 use crate::vm::{Error as VmError, Vm, VmState};
 use crate::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, NetConfig, PmemConfig,
@@ -1707,14 +1708,13 @@ impl Vmm {
                 &mut ctx,
             )
             .inspect_err(|_| {
-                // Calling cleanup multiple times is fine, thus here we just make sure
-                // that it is called.
-                if let Err(e) = mem_send.cleanup() {
-                    warn!("Error cleaning up migration connections: {e}");
+                if let Err(e) = mem_send.cleanup_workers() {
+                    let msg = flatten_error_chain_to_string(&e);
+                    warn!("Error cleaning up migration connections: {msg}");
                 }
             })?;
 
-            mem_send.cleanup()?;
+            mem_send.cleanup_workers()?;
         }
 
         // We release the locks early to enable locking them on the destination host.

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -721,8 +721,8 @@ impl SendAdditionalConnections {
                 .spawn(move || {
                     if !seccomp_filter.is_empty() {
                         apply_filter(&seccomp_filter)
-                            .context("Error applying migration TCP worker seccomp filter")
-                            .map_err(MigratableError::MigrateReceive)?;
+                            .context("Error applying send-memory worker seccomp filter")
+                            .map_err(MigratableError::MigrateSend)?;
                     }
 
                     Self::worker_send_memory(
@@ -742,7 +742,7 @@ impl SendAdditionalConnections {
                         thread.join().ok();
                     });
                 })
-                .context("Error spawning send-memory thread")
+                .context("Error spawning send-memory worker")
                 .map_err(MigratableError::MigrateSend)?;
             threads.push(thread);
         }
@@ -777,7 +777,7 @@ impl SendAdditionalConnections {
                     notify_tx.send(SendMemoryThreadNotify::Error).ok();
                 })?
                 .recv()
-                .context("Error receiving message from main thread")
+                .context("Error receiving message from coordination thread")
                 .map_err(MigratableError::MigrateSend)
                 .inspect_err(|_| {
                     worker_error.store(true, Ordering::Release);
@@ -800,7 +800,7 @@ impl SendAdditionalConnections {
                 SendMemoryThreadMessage::Gate(gate) => {
                     notify_tx
                         .send(SendMemoryThreadNotify::Gate)
-                        .context("Error sending gate notification to main thread")
+                        .context("Error sending gate notification to coordination thread")
                         .map_err(MigratableError::MigrateSend)
                         .inspect_err(|_| {
                             // Sending via `notify_tx` just failed, so we don't try to send another
@@ -937,12 +937,12 @@ impl SendAdditionalConnections {
                 Ok(Ok(())) => None,
                 Ok(Err(e)) => Some(e),
                 Err(panic) => Some(MigratableError::MigrateSend(anyhow!(
-                    "send-memory thread panicked: {panic:?}"
+                    "send-memory worker panicked: {panic:?}"
                 ))),
             };
 
             if let Some(e) = err {
-                warn!("Error in send-memory thread: {e}");
+                warn!("Error in send-memory worker: {e}");
 
                 if first_err.is_ok() {
                     first_err = Err(e);

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -918,11 +918,15 @@ impl SendAdditionalConnections {
     pub(crate) fn cleanup(&mut self) -> Result<(), MigratableError> {
         // Send disconnect messages to all workers.
         for _ in 0..self.threads.len() {
-            // All threads may have terminated, leading to a dropped receiver. Thus we ignore
-            // errors here.
-            self.message_tx
-                .try_send(SendMemoryThreadMessage::Disconnect)
-                .ok();
+            // Use send() over try_send() as the bounded queue may be still
+            // fully populated with enqueued chunks.
+            if self
+                .message_tx
+                .send(SendMemoryThreadMessage::Disconnect)
+                .is_err()
+            {
+                debug!("Failed to send disconnect message to send-memory worker");
+            }
         }
 
         let mut first_err = Ok(());

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -756,6 +756,7 @@ impl SendAdditionalConnections {
         })
     }
 
+    /// The lifecycle loop a TCP worker thread executes.
     fn worker_send_memory(
         socket: &mut SocketStream,
         guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
@@ -838,16 +839,17 @@ impl SendAdditionalConnections {
         // The chunk size is chosen to be big enough so that even very fast links need some
         // milliseconds to send it.
         for chunk in table.partition(Self::CHUNK_SIZE) {
-            self.send_chunk(chunk)?;
+            self.enqueue_chunk(chunk)?;
         }
 
         self.wait_for_pending_data()?;
         Ok(true)
     }
 
-    fn send_chunk(&mut self, chunk: MemoryRangeTable) -> Result<(), MigratableError> {
+    /// Enqueues a request to send a memory range table for the send workers.
+    fn enqueue_chunk(&mut self, chunk: MemoryRangeTable) -> Result<(), MigratableError> {
         let mut chunk = SendMemoryThreadMessage::Memory(chunk);
-        // [`Self::message_tx`] has a limited size, so we may have to retry sending the chunk
+        // `message_tx` has a limited size, so we may have to retry sending the chunk
         loop {
             if self.worker_error.load(Ordering::Acquire) {
                 return self.cleanup();

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -489,15 +489,15 @@ impl ReceiveAdditionalConnections {
             .spawn(move || {
                 if !seccomp_filter_t.is_empty() {
                     apply_filter(&seccomp_filter_t)
-                        .context("Error applying migration TCP worker seccomp filter")
+                        .context("Error applying migration receive-memory seccomp filter")
                         .map_err(MigratableError::MigrateReceive)?;
                 }
                 Self::worker_receive_memory(&mut socket, &kill_evt, &guest_memory)
             })
             .map_err(|e| {
-                error!("Error spawning receive-memory thread: {e}");
+                error!("Error spawning receive-memory worker: {e}");
                 MigratableError::MigrateReceive(
-                    anyhow!(e).context("Error spawning receive-memory thread"),
+                    anyhow!(e).context("Error spawning receive-memory worker"),
                 )
             })
     }
@@ -511,12 +511,12 @@ impl ReceiveAdditionalConnections {
                 Ok(Ok(())) => None,
                 Ok(Err(e)) => Some(e),
                 Err(panic) => Some(MigratableError::MigrateReceive(anyhow!(
-                    "receive-memory thread panicked: {panic:?}"
+                    "receive-memory worker panicked: {panic:?}"
                 ))),
             };
 
             if let Some(e) = err {
-                warn!("Error in receive-memory thread: {e}");
+                warn!("Error in receive-memory worker: {e}");
 
                 if first_err.is_ok() {
                     first_err = Err(e);
@@ -1287,6 +1287,14 @@ pub(crate) fn receive_memory_ranges(
                 )
                 .context("Error receiving memory from socket")
                 .map_err(MigratableError::MigrateReceive)?;
+
+            // EOF: Don't spin forever on closed connection
+            if bytes_read == 0 {
+                return Err(MigratableError::MigrateReceive(anyhow!(
+                    "Connection closed while receiving memory: EOF"
+                )));
+            }
+
             offset += bytes_read as u64;
 
             if offset == range.length {

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -13,7 +13,7 @@ use std::result::Result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender, SyncSender, TrySendError, channel, sync_channel};
 use std::sync::{Arc, Mutex};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use anyhow::{Context, anyhow};
@@ -34,6 +34,7 @@ use vmm_sys_util::eventfd::EventFd;
 
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::sync_utils::Gate;
+use crate::util::flatten_error_chain_to_string;
 use crate::{GuestMemoryMmap, VmMigrationConfig};
 
 /// Hard upper bound for migration worker connections on both the sender and
@@ -734,13 +735,7 @@ impl SendAdditionalConnections {
                     )
                 })
                 .inspect_err(|_| {
-                    // If an error occurs here, we still do some light cleanup.
-                    for _ in 0..threads.len() {
-                        message_tx.send(SendMemoryThreadMessage::Disconnect).ok();
-                    }
-                    threads.drain(..).for_each(|thread| {
-                        thread.join().ok();
-                    });
+                    Self::cleanup_workers_internal(&mut threads, &message_tx).ok();
                 })
                 .context("Error spawning send-memory worker")
                 .map_err(MigratableError::MigrateSend)?;
@@ -852,7 +847,7 @@ impl SendAdditionalConnections {
         // `message_tx` has a limited size, so we may have to retry sending the chunk
         loop {
             if self.worker_error.load(Ordering::Acquire) {
-                return self.cleanup();
+                return self.cleanup_workers();
             }
 
             // Use try_send() so we can keep checking worker_error while the
@@ -869,9 +864,11 @@ impl SendAdditionalConnections {
                 }
                 Err(TrySendError::Disconnected(_)) => {
                     // The workers didn't disconnect for no reason, thus we do a cleanup.
-                    return Err(self.cleanup().err().unwrap_or(MigratableError::MigrateSend(
-                        anyhow!("All sending threads disconnected, but none returned an error?"),
-                    )));
+                    return Err(self.cleanup_workers().err().unwrap_or(
+                        MigratableError::MigrateSend(anyhow!(
+                            "All sending threads disconnected, but none returned an error?"
+                        )),
+                    ));
                 }
             }
         }
@@ -906,24 +903,24 @@ impl SendAdditionalConnections {
                     }
                 }
                 SendMemoryThreadNotify::Error => {
-                    // If an error occurred in one of the worker threads, we open
-                    // the gate to make sure that no thread hangs. After that, we
-                    // receive the error from Self::cleanup() and return it.
+                    // On worker error, open the gate to unblock all threads.
+                    // cleanup_workers() propagates the error.
                     gate.open();
-                    return self.cleanup();
+                    return self.cleanup_workers();
                 }
             }
         }
     }
 
-    /// Sends disconnect messages to all workers and joins them.
-    pub(crate) fn cleanup(&mut self) -> Result<(), MigratableError> {
+    fn cleanup_workers_internal(
+        threads: &mut Vec<JoinHandle<Result<(), MigratableError>>>,
+        message_tx: &SyncSender<SendMemoryThreadMessage>,
+    ) -> Result<(), MigratableError> {
         // Send disconnect messages to all workers.
-        for _ in 0..self.threads.len() {
+        for _ in 0..threads.len() {
             // Use send() over try_send() as the bounded queue may be still
             // fully populated with enqueued chunks.
-            if self
-                .message_tx
+            if message_tx
                 .send(SendMemoryThreadMessage::Disconnect)
                 .is_err()
             {
@@ -931,26 +928,32 @@ impl SendAdditionalConnections {
             }
         }
 
-        let mut first_err = Ok(());
-        self.threads.drain(..).for_each(|thread| {
+        let mut first_err = None;
+        for (idx, thread) in threads.drain(..).enumerate() {
             let err = match thread.join() {
-                Ok(Ok(())) => None,
-                Ok(Err(e)) => Some(e),
-                Err(panic) => Some(MigratableError::MigrateSend(anyhow!(
-                    "send-memory worker panicked: {panic:?}"
-                ))),
+                Ok(Ok(())) => continue,
+                Ok(Err(e)) => e,
+                Err(panic) => MigratableError::MigrateSend(anyhow!(
+                    "send-memory worker #{idx} panicked: {panic:?}"
+                )),
             };
 
-            if let Some(e) = err {
-                warn!("Error in send-memory worker: {e}");
+            let err_msg = flatten_error_chain_to_string(&err);
+            // The first error will also be logged higher up, but log all errors
+            // here for better debuggability, accepting a possible duplicate.
+            error!("Error in send-memory worker #{idx}: {err_msg}");
 
-                if first_err.is_ok() {
-                    first_err = Err(e);
-                }
-            }
-        });
+            first_err.get_or_insert(err);
+        }
+        first_err.map_or(Ok(()), Err)
+    }
 
-        first_err
+    /// Sends disconnect messages to all workers and joins them.
+    ///
+    /// Returns the first error that any worker encounters. Calling this is
+    /// idempotent.
+    pub(crate) fn cleanup_workers(&mut self) -> Result<(), MigratableError> {
+        Self::cleanup_workers_internal(&mut self.threads, &self.message_tx)
     }
 }
 
@@ -958,7 +961,7 @@ impl Drop for SendAdditionalConnections {
     fn drop(&mut self) {
         if !self.threads.is_empty() {
             warn!(
-                "SendAdditionalConnections was not cleaned up! Either cleanup() was never called (programming error) or it failed before completing."
+                "SendAdditionalConnections was not cleaned up! Either cleanup_workers() was never called (programming error) or it failed before completing."
             );
         }
     }

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -771,7 +771,7 @@ impl SendAdditionalConnections {
                 .lock()
                 .map_err(|_| MigratableError::MigrateSend(anyhow!("message_rx mutex is poisoned")))
                 .inspect_err(|_| {
-                    worker_error.store(true, Ordering::Relaxed);
+                    worker_error.store(true, Ordering::Release);
                     // We ignore errors during error handling.
                     notify_tx.send(SendMemoryThreadNotify::Error).ok();
                 })?
@@ -779,7 +779,7 @@ impl SendAdditionalConnections {
                 .context("Error receiving message from main thread")
                 .map_err(MigratableError::MigrateSend)
                 .inspect_err(|_| {
-                    worker_error.store(true, Ordering::Relaxed);
+                    worker_error.store(true, Ordering::Release);
                     notify_tx.send(SendMemoryThreadNotify::Error).ok();
                 })?;
             match message {
@@ -790,7 +790,7 @@ impl SendAdditionalConnections {
 
                     send_memory_ranges(guest_memory, &table, socket)
                         .inspect_err(|_| {
-                            worker_error.store(true, Ordering::Relaxed);
+                            worker_error.store(true, Ordering::Release);
                             notify_tx.send(SendMemoryThreadNotify::Error).ok();
                         })
                         .context("Error sending memory to receiver side")
@@ -804,7 +804,7 @@ impl SendAdditionalConnections {
                         .inspect_err(|_| {
                             // Sending via `notify_tx` just failed, so we don't try to send another
                             // message via it.
-                            worker_error.store(true, Ordering::Relaxed);
+                            worker_error.store(true, Ordering::Release);
                         })?;
                     gate.wait();
                 }
@@ -849,7 +849,7 @@ impl SendAdditionalConnections {
         let mut chunk = SendMemoryThreadMessage::Memory(chunk);
         // [`Self::message_tx`] has a limited size, so we may have to retry sending the chunk
         loop {
-            if self.worker_error.load(Ordering::Relaxed) {
+            if self.worker_error.load(Ordering::Acquire) {
                 return self.cleanup();
             }
 


### PR DESCRIPTION
We encountered a bug in production and it is easy to fix. While working on it, we figured there is room for multiple smaller improvements in the cleanup and logging paths.