### PR TITLE
block: Make image type mismatch detection safer

### DIFF
--- a/block/src/error.rs
+++ b/block/src/error.rs
@@ -45,10 +45,7 @@ pub enum BlockErrorKind {
     /// An internal counter or limit was exceeded.
     Overflow,
     /// Image type mismatch
-    ImageTypeMismatch {
-        specified: ImageType,
-        detected: ImageType,
-    },
+    ImageTypeMismatch { specified: ImageType },
 }
 
 impl Display for BlockErrorKind {
@@ -61,14 +58,8 @@ impl Display for BlockErrorKind {
             Self::OutOfBounds => write!(f, "Out of bounds"),
             Self::NotFound => write!(f, "Not found"),
             Self::Overflow => write!(f, "Overflow"),
-            Self::ImageTypeMismatch {
-                specified,
-                detected,
-            } => {
-                write!(
-                    f,
-                    "Image type mismatch: specified = {specified}, detected = {detected}"
-                )
+            Self::ImageTypeMismatch { specified } => {
+                write!(f, "Image type mismatch: specified = {specified}")
             }
         }
     }
@@ -80,8 +71,8 @@ impl Display for BlockErrorKind {
 pub enum ErrorOp {
     /// Opening a disk image file.
     Open,
-    /// Detecting the image format.
-    DetectImageType,
+    /// Validating the image format.
+    ValidateImageType,
     /// Duplicating a backing-file descriptor.
     DupBackingFd,
     /// Resizing a disk image.
@@ -92,7 +83,7 @@ impl Display for ErrorOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Open => write!(f, "open"),
-            Self::DetectImageType => write!(f, "detect_image_type"),
+            Self::ValidateImageType => write!(f, "validate_image_type"),
             Self::DupBackingFd => write!(f, "dup_backing_fd"),
             Self::Resize => write!(f, "resize"),
         }

--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -26,7 +26,7 @@ use crate::formats::vhd::VhdDisk;
 use crate::formats::vhdx::VhdxDisk;
 use crate::formats::vmdk::VmdkDisk;
 use crate::{
-    ImageType, block_aio_is_supported, detect_image_type, open_disk_image, preallocate_disk,
+    ImageType, block_aio_is_supported, open_disk_image, preallocate_disk, validate_image_type,
 };
 
 /// Options for opening a disk image via [`open_disk`].
@@ -76,12 +76,9 @@ pub fn open_disk(
     }
 
     let mut file = open_disk_image(options.path, &fs_options)?;
-    let detected_image_type = detect_image_type(&mut file)?;
-
-    if image_type != detected_image_type {
+    if !validate_image_type(&mut file, image_type)? {
         return Err(BlockError::from_kind(BlockErrorKind::ImageTypeMismatch {
             specified: image_type,
-            detected: detected_image_type,
         })
         .with_path(options.path));
     }
@@ -277,7 +274,6 @@ mod unit_tests {
                 e.kind(),
                 BlockErrorKind::ImageTypeMismatch {
                     specified: ImageType::Qcow2,
-                    detected: ImageType::Raw,
                 }
             ),
             Ok(_) => panic!("expected error for mismatched image type"),

--- a/block/src/formats/vhd/footer.rs
+++ b/block/src/formats/vhd/footer.rs
@@ -207,7 +207,7 @@ impl VhdFooter {
     }
 }
 
-/// Determine image type through file parsing.
+/// Returns true when the file contains a fixed VHD footer.
 pub fn is_fixed_vhd(f: &mut File) -> io::Result<bool> {
     let footer = match VhdFooter::new(f) {
         Ok(footer) => footer,

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -65,8 +65,8 @@ pub enum Error {
     DescriptorChainTooShort,
     #[error("Guest gave us a descriptor that was too short to use")]
     DescriptorLengthTooSmall,
-    #[error("Failed to detect image type")]
-    DetectImageType(#[source] io::Error),
+    #[error("Failed to validate image type")]
+    ValidateImageType(#[source] io::Error),
     #[error("Failure in fixed vhd")]
     FixedVhdError(#[source] io::Error),
     #[error("Getting a block's metadata failed")]
@@ -540,8 +540,8 @@ pub fn open_disk_image(path: &Path, options: &OpenOptions) -> BlockResult<File> 
     })
 }
 
-/// Determine image type through file parsing.
-pub fn detect_image_type(f: &mut File) -> BlockResult<ImageType> {
+/// Validate image type through file parsing.
+pub fn validate_image_type(f: &mut File, image_type: ImageType) -> BlockResult<bool> {
     let aligned = AlignedFile::new(f.try_clone()?, true);
     // A VMDK descriptor file is small few hundred bytes of text. Read
     // best-effort so a short file yields a zero-padded partial block instead
@@ -555,31 +555,30 @@ pub fn detect_image_type(f: &mut File) -> BlockResult<ImageType> {
             Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
             Err(e) => {
                 return Err(
-                    BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::DetectImageType)
+                    BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::ValidateImageType)
                 );
             }
         }
     }
 
-    // Check 4 first bytes to get the header value and determine the image type
-    let image_type = if u32::from_be_bytes(block[0..4].try_into().unwrap()) == QCOW_MAGIC {
-        ImageType::Qcow2
-    } else if formats::vhd::is_fixed_vhd(f)
-        .map_err(|e| BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::DetectImageType))?
-    {
-        ImageType::FixedVhd
-    } else if u64::from_le_bytes(block[0..8].try_into().unwrap()) == VHDX_SIGN {
-        ImageType::Vhdx
-    } else if formats::vmdk::has_descriptor_header(&block)
-        && formats::vmdk::is_flat_vmdk(f)
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::DetectImageType))?
-    {
-        ImageType::FlatVmdk
-    } else {
-        ImageType::Raw
-    };
-
-    Ok(image_type)
+    match image_type {
+        ImageType::Qcow2 => Ok(u32::from_be_bytes(block[0..4].try_into().unwrap()) == QCOW_MAGIC),
+        ImageType::FixedVhd => formats::vhd::is_fixed_vhd(f).map_err(|e| {
+            BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::ValidateImageType)
+        }),
+        ImageType::Vhdx => Ok(u64::from_le_bytes(block[0..8].try_into().unwrap()) == VHDX_SIGN),
+        ImageType::FlatVmdk => {
+            if formats::vmdk::has_descriptor_header(&block) {
+                formats::vmdk::is_flat_vmdk(f).map_err(|e| {
+                    BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::ValidateImageType)
+                })
+            } else {
+                Ok(false)
+            }
+        }
+        ImageType::Raw => Ok(true),
+        ImageType::Unknown => Ok(false),
+    }
 }
 
 #[derive(Debug)]
@@ -706,15 +705,15 @@ mod unit_tests {
     use super::*;
 
     #[test]
-    fn detect_short_file_is_not_eof_error() {
+    fn validate_short_file_is_not_eof_error() {
         let tmp = TempFile::new().unwrap();
         let mut f = tmp.into_file();
         f.write_all(b"not-a-disk-magic-just-some-short-text\n")
             .unwrap();
         f.sync_all().unwrap();
 
-        let image_type = detect_image_type(&mut f).unwrap();
-        assert_eq!(image_type, ImageType::Raw);
+        assert!(validate_image_type(&mut f, ImageType::Raw).unwrap());
+        assert!(!validate_image_type(&mut f, ImageType::Qcow2).unwrap());
     }
 
     #[test]

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -903,10 +903,7 @@ pub(crate) fn compute_backing_checksum(
     let path = resolve_disk_path(path_or_image_name);
 
     let mut file = File::open(&path).ok()?;
-    if !matches!(
-        block::detect_image_type(&mut file).ok()?,
-        block::ImageType::Qcow2
-    ) {
+    if !block::validate_image_type(&mut file, block::ImageType::Qcow2).ok()? {
         return None;
     }
 


### PR DESCRIPTION
Previously the code ran the image type autodetection always and then
compared the detected type with the supplied type. Instead take the
supplied type as input to a validate function and check the file matches
that type. This is safer as some of the detection paths involve reading
the whole file in.

Unfortunately this does mean that we can not longer identify if the user
accidentally specified ImageType::Raw for a QCOW2 image.

Signed-off-by: Rob Bradford <rbradford@meta.com>
