### PR TITLE
block: vhdx: avoid header sequence number overflow

### DIFF
--- a/block/src/formats/vhdx/header.rs
+++ b/block/src/formats/vhdx/header.rs
@@ -78,6 +78,8 @@ pub enum VhdxHeaderError {
     RegionOverlap,
     #[error("Reserved region has non-zero value")]
     ReservedIsNonZero,
+    #[error("Header sequence number would overflow")]
+    SequenceNumberOverflow,
     #[error("We do not recognize this entry")]
     UnrecognizedRegionEntry,
     #[error("Failed to write header {0}")]
@@ -164,10 +166,15 @@ impl Header {
             file_write_guid
         };
 
+        let sequence_number = current_header
+            .sequence_number
+            .checked_add(1)
+            .ok_or(VhdxHeaderError::SequenceNumberOverflow)?;
+
         let mut new_header = Header {
             signature: current_header.signature,
             checksum: 0,
-            sequence_number: current_header.sequence_number + 1,
+            sequence_number,
             file_write_guid,
             data_write_guid,
             log_guid: current_header.log_guid,


### PR DESCRIPTION
Found by fuzzing. In practice, CH should never hit this in a well-formed image.