### PR TITLE
Some fixes for CVM on performance test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,6 +2411,7 @@ dependencies = [
  "epoll",
  "libc",
  "rand 0.10.2",
+ "regex",
  "serde_json",
  "ssh2",
  "thiserror",

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -328,10 +328,21 @@ impl PerformanceTest {
 
     // Calculate the timeout for each test
     // Note: To cover the setup/cleanup time, 20s is added for each iteration of the test
-    pub fn calc_timeout(&self, test_iterations: &Option<u32>, test_timeout: &Option<u32>) -> u64 {
+    // Confidential VMS can take up to DEFAULT_CVM_TCP_LISTENER_TIMEOUT
+    pub fn calc_timeout(
+        &self,
+        test_iterations: &Option<u32>,
+        test_timeout: &Option<u32>,
+        vm_type: GuestVmType,
+    ) -> u64 {
         let total_iterations = test_iterations.unwrap_or(self.control.test_iterations)
             + self.control.warmup_iterations;
-        ((test_timeout.unwrap_or(self.control.test_timeout) + 20) * total_iterations) as u64
+        let per_iter_overhead = match vm_type {
+            GuestVmType::Confidential => test_infra::DEFAULT_CVM_TCP_LISTENER_TIMEOUT,
+            _ => 20,
+        };
+        ((test_timeout.unwrap_or(self.control.test_timeout) + per_iter_overhead) * total_iterations)
+            as u64
     }
 }
 
@@ -1728,6 +1739,7 @@ fn run_test_with_timeout(
     let (sender, receiver) = channel::<Result<PerformanceTestResult, Error>>();
     let test_iterations = overrides.test_iterations;
     let test_timeout = overrides.test_timeout;
+    let vm_type = overrides.vm_type;
     let overrides = overrides.clone();
     thread::Builder::new()
         .name(test.name.into())
@@ -1752,7 +1764,7 @@ fn run_test_with_timeout(
         })
         .unwrap();
 
-    let test_timeout = test.calc_timeout(&test_iterations, &test_timeout);
+    let test_timeout = test.calc_timeout(&test_iterations, &test_timeout, vm_type);
     let result = receiver
         .recv_timeout(Duration::from_secs(test_timeout))
         .map_err(|_| {

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -655,6 +655,18 @@ mod unit_tests {
     }
 
     #[test]
+    fn test_parse_ethr_latency_output_mixed_units() {
+        let output = r#"{"Time":"2026-08-26T00:40:37Z","Title":"","Type":"INFO","Message":"Using destination: 172.19.0.2, ip: 172.19.0.2, port: 8888"}
+{"Time":"2026-08-26T00:40:38Z","Title":"","Type":"LatencyResult","RemoteAddr":"172.19.0.2","Protocol":"TCP","Avg":"971.230us","Min":"452.887us","P50":"43.396ms","Max":"42.165ms"}
+{"Time":"2026-08-26T00:40:40Z","Title":"","Type":"LatencyResult","RemoteAddr":"172.19.0.2","Protocol":"TCP","Avg":"1.619ms","Min":"430.866us","P50":"99.767ms","Max":"60.616ms"}
+{"Time":"2026-08-26T00:40:42Z","Title":"","Type":"LatencyResult","RemoteAddr":"172.19.0.2","Protocol":"TCP","Avg":"1.5s","Min":"430.866us","P50":"99.767ms","Max":"60.616ms"}"#;
+
+        let ret = parse_ethr_latency_output(output.as_bytes()).unwrap();
+        let reference = vec![971.230_f64, 1_619.0_f64, 1_500_000.0_f64];
+        assert_eq!(ret, reference);
+    }
+
+    #[test]
     fn test_parse_boot_time_output() {
         let output = r#"
 cloud-hypervisor: 161.167103ms: <vcpu0> INFO:vmm/src/vm.rs:392 -- [Debug I/O port: Kernel code 0x40] 0.132 seconds

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -10,6 +10,7 @@ dirs = { workspace = true }
 epoll = { workspace = true }
 libc = { workspace = true }
 rand = "0.10.1"
+regex = "1.13.1"
 serde_json = { workspace = true }
 ssh2 = { version = "0.9.5", features = ["vendored-openssl"] }
 thiserror = { workspace = true }

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2532,11 +2532,9 @@ pub fn parse_ethr_latency_output(output: &[u8]) -> Result<Vec<f64>, Error> {
             let v: Value = serde_json::from_str(l).expect("'ethr' parse error: invalid json line");
             // Skip header/summary lines
             if let Some(avg) = v["Avg"].as_str() {
-                // Assume the latency unit is always "us"
+                // Normalize latency measurements to microseconds.
                 latency.push(
-                    avg.split("us").collect::<Vec<&str>>()[0]
-                        .parse::<f64>()
-                        .expect("'ethr' parse error: invalid 'Avg' entry"),
+                    parse_ethr_duration_us(avg).expect("'ethr' parse error: invalid 'Avg' entry"),
                 );
             }
         }
@@ -2555,6 +2553,20 @@ pub fn parse_ethr_latency_output(output: &[u8]) -> Result<Vec<f64>, Error> {
         );
         Error::EthrLogParse
     })
+}
+
+fn parse_ethr_duration_us(s: &str) -> Option<f64> {
+    let re = regex::Regex::new(r"^\s*([0-9]+(?:\.[0-9]+)?)\s*(µs|us|ns|ms|s)\s*$").unwrap();
+    let caps = re.captures(s)?;
+    let value: f64 = caps.get(1)?.as_str().parse().ok()?;
+    let mult_us = match caps.get(2)?.as_str() {
+        "µs" | "us" => 1.0,
+        "ns" => 1.0 / 1_000.0,
+        "ms" => 1_000.0,
+        "s" => 1_000_000.0,
+        _ => return None,
+    };
+    Some(value * mult_us)
 }
 
 pub fn measure_virtio_net_latency(guest: &Guest, test_timeout: u32) -> Result<Vec<f64>, Error> {


### PR DESCRIPTION
Running performance tests on confidential VM is failing due to two issues manly as follow
1. Current timeout is not enough for CVM to finish boot and cleanups
2. CVM guest might give net performance measurement other than micro seconds.