### PR TITLE
Misc CI Speedups (~5 minutes)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -587,6 +587,29 @@ jobs:
         run: cargo build --locked --package cloud-hypervisor --no-default-features --features "kvm" --target riscv64gc-unknown-linux-gnu
       - name: Check build did not modify any files
         run: test -z "$(git status --porcelain)"
+  # Run x86 unit tests on GitHub-hosted runners to save self-hosted capacity.
+  # aarch64 stays self-hosted because hosted arm64 runners do not provide KVM.
+  unit-tests-x86-64:
+    name: unit-tests-x86-64
+    needs: [preflight]
+    if: needs.preflight.outputs.full == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        libc: [gnu, musl]
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Verify KVM is available
+        run: |
+          set -eufo pipefail
+          test -e /dev/kvm || { echo "::error::/dev/kvm missing on runner"; exit 1; }
+      - name: Run unit tests
+        run: scripts/dev_cli.sh tests --unit --libc ${{ matrix.libc }}
   # PR-only: delay integration testing until the build and quality gates pass.
   integration-x86-64-pr:
     name: integration-x86-64-pr
@@ -623,8 +646,6 @@ jobs:
           sudo apt install -y docker-ce docker-ce-cli
       - name: Prepare for VDPA
         run: scripts/prepare_vdpa.sh
-      - name: Run unit tests
-        run: scripts/dev_cli.sh tests --unit --libc ${{ matrix.libc }}
       - name: Load openvswitch module
         run: sudo modprobe openvswitch
       - name: Run integration tests
@@ -966,6 +987,7 @@ jobs:
       - shlint
       - taplo
       - typos
+      - unit-tests-x86-64
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -740,7 +740,11 @@ jobs:
     if: >-
       github.event_name == 'merge_group' && needs.preflight.outputs.full == 'true'
     runs-on: garm-noble-16
-    timeout-minutes: 50
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        libc: [gnu, musl]
     steps:
       - name: Code checkout
         uses: actions/checkout@v7
@@ -771,10 +775,7 @@ jobs:
           az storage blob download --container-name private-images --file "$HOME/workloads/windows-server-2025-amd64-1.raw" --name windows-server-2025-amd64-1.raw --connection-string "${{ secrets.CH_PRIVATE_IMAGES }}"
       - name: Run Windows guest integration tests
         timeout-minutes: 15
-        run: scripts/dev_cli.sh tests --integration-windows
-      - name: Run Windows guest integration tests for musl
-        timeout-minutes: 15
-        run: scripts/dev_cli.sh tests --integration-windows --libc musl
+        run: scripts/dev_cli.sh tests --integration-windows --libc ${{ matrix.libc }}
   integration-mshv-x86-64:
     name: integration-mshv-x86-64
     needs: [preflight]

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -179,7 +179,7 @@ if [ $RES -eq 0 ]; then
     cargo build --features "mshv,dbus_api" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
     # integration tests now do not reply on build feature "dbus_api"
-    time cargo nextest run -p cloud-hypervisor $test_features --profile dbus --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile dbus --no-tests=pass --test-threads="${PARALLEL_INTEGRATION_TESTS_NUM}" "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
@@ -187,14 +187,14 @@ fi
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,fw_cfg" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
-    time cargo nextest run -p cloud-hypervisor $test_features --profile fw_cfg --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile fw_cfg --no-tests=pass --test-threads="${PARALLEL_INTEGRATION_TESTS_NUM}" "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,ivshmem" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
-    time cargo nextest run -p cloud-hypervisor $test_features --profile ivshmem --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile ivshmem --no-tests=pass --test-threads="${PARALLEL_INTEGRATION_TESTS_NUM}" "$test_filter" -- ${test_binary_args[*]}
 
     RES=$?
 fi

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -198,20 +198,20 @@ RES=$?
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,dbus_api" --all --release --target "$BUILD_TARGET"
     # integration tests now do not reply on build feature "dbus_api"
-    time cargo nextest run -p cloud-hypervisor $test_features --profile dbus --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile dbus --no-tests=pass --test-threads="${PARALLEL_INTEGRATION_TESTS_NUM}" "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
 # Run tests on fw_cfg
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,fw_cfg" --all --release --target "$BUILD_TARGET"
-    time cargo nextest run -p cloud-hypervisor $test_features --profile fw_cfg --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile fw_cfg --no-tests=pass --test-threads="${PARALLEL_INTEGRATION_TESTS_NUM}" "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,ivshmem" --all --release --target "$BUILD_TARGET"
-    time cargo nextest run -p cloud-hypervisor $test_features --profile ivshmem --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile ivshmem --no-tests=pass --test-threads="${PARALLEL_INTEGRATION_TESTS_NUM}" "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 


### PR DESCRIPTION
Speed up CI by picking some rather low-hanging fruits: use the configured parallelism for all nextest runs, move the x86-64 unit tests to hosted runners, and run the gnu and musl Windows guest suites concurrently. Estimated speedup of all commits combined is ~5–6 minutes per x86-64 integration job (plus ~5 minutes on integration-windows), without changing what is tested. Detailed measurements from merge-queue run 33050129199 are in the commit bodies.