### PR TITLE
tests: Fix top flaky test and reduce nextest retries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,7 +7,7 @@ windows = { max-threads = 4 }
 
 [profile.integration]
 fail-fast = false
-retries = 3
+retries = 2
 
 [profile.common_tests]
 inherits = "integration"

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -2918,7 +2918,10 @@ mod common_parallel {
             GuestNetworkConfig::wait_vm_boot_from(
                 guest.network.l2_tcp_listener_port,
                 &guest.network.l2_guest_ip2,
-                DEFAULT_TCP_LISTENER_TIMEOUT,
+                // Nested L2 guests can exceed the default 120s timeout on loaded
+                // hosts. The listener still returns immediately once the guest
+                // reports in.
+                300,
             )
             .unwrap();
 


### PR DESCRIPTION
I asked an LLM to analyze all test runs of the past days to look for flaky tests (a fantastic usage of an LLM!). I figured out that we do not need the many retries and that we can have quicker feedback for failing tests.


@rbradford I think if we start/increase efforts for large scale log analysis of CI runs (Codex/Claude can download old logs via the API) we will be able to discover many time saving patterns, reoccurring flakiness etc.