### PR TITLE
vmm: seccomp: Add SYS_stat to vcpu thread

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -955,6 +955,8 @@ fn vcpu_thread_rules(
         (libc::SYS_sendto, vec![]),
         (libc::SYS_shutdown, vec![]),
         (libc::SYS_sigaltstack, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_stat, vec![]),
         (libc::SYS_statx, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_unlink, vec![]),


### PR DESCRIPTION
Already present on VMM thread.

Fixes: #8806

Signed-off-by: Rob Bradford <rbradford@meta.com>
