### PR TITLE
build: upgrade mshv crates to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,9 +1463,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edab7a942dd5a9976cb30d316948ede2c3d0117ee4addf3404b48cb6a8666046"
+checksum = "9b4b2414499597c6e31b1cd25239f19e8e8c55023b3bf8fcfa44d927cff6a123"
 dependencies = [
  "libc",
  "num_enum",
@@ -1477,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d71f039b096bdbb772f2181b0a62c28b9d9a0682ceec1839537b1375c1cd6"
+checksum = "c30d1b5b76a709e30b46248f52bbb44dde04a659d6d58255c7f06c88d528d210"
 dependencies = [
  "libc",
  "mshv-bindings",
@@ -2387,7 +2387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ iommufd-ioctls = "0.2.0"
 kvm-bindings = "0.14.1"
 kvm-ioctls = "0.25.0"
 linux-loader = "0.14.0"
-mshv-bindings = "0.7.0"
-mshv-ioctls = "0.7.0"
+mshv-bindings = "0.7.1"
+mshv-ioctls = "0.7.1"
 seccompiler = "0.5.0"
 vfio-bindings = { version = "0.6.2", default-features = false }
 vfio-ioctls = { version = "0.8.1", default-features = false }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2.186"
 libfuzzer-sys = "0.4.12"
 linux-loader = { version = "0.14.0", features = ["bzimage", "elf", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
-mshv-bindings = "0.7.0"
+mshv-bindings = "0.7.1"
 net_util = { path = "../net_util" }
 seccompiler = "0.5.0"
 virtio-devices = { path = "../virtio-devices" }


### PR DESCRIPTION
The new MSHV crate release includes a critical fix for an issue that caused CLH to fail to boot guests on older versions of Microsoft Hypervisor.