### PR TITLE
vmm: seccomp: Add SYS_openat{2} to vcpu thread

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -940,6 +940,8 @@ fn vcpu_thread_rules(
         (libc::SYS_newfstatat, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_open, vec![]),
+        (libc::SYS_openat, vec![]),
+        (libc::SYS_openat2, vec![]),
         (libc::SYS_pread64, vec![]),
         (libc::SYS_pwrite64, vec![]),
         (libc::SYS_pwritev2, vec![]),


### PR DESCRIPTION
Already had SYS_open but missing the other variants.

Fixes: #8806

Signed-off-by: Rob Bradford <rbradford@meta.com>
