### PR TITLE
vmm: rename `unit_tests` to `tests`

### DIFF
--- a/vmm/src/locked_unix_listener.rs
+++ b/vmm/src/locked_unix_listener.rs
@@ -112,7 +112,7 @@ impl Drop for LockedUnixListener {
 }
 
 #[cfg(test)]
-mod unit_tests {
+mod tests {
     use std::os::unix::net::UnixStream;
 
     use vmm_sys_util::tempdir::TempDir;


### PR DESCRIPTION
Missed this in https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8733 after https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8807.