### PR TITLE
vmm: Announce the migration memory mode through the protocol

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7066,11 +7066,7 @@ mod common_parallel {
         let migration_port = get_available_port();
         let host_ip = "127.0.0.1";
 
-        let receive_arg = if postcopy {
-            format!("receiver_url=tcp:0.0.0.0:{migration_port},memory_mode=postcopy")
-        } else {
-            format!("receiver_url=tcp:0.0.0.0:{migration_port}")
-        };
+        let receive_arg = format!("receiver_url=tcp:0.0.0.0:{migration_port}");
 
         // Start the 'receive-migration' command on the destination
         let receive_migration = Command::new(clh_command("ch-remote"))
@@ -9391,17 +9387,13 @@ mod snapshot_restore_common {
             )));
 
             // receive-migration blocks until done. Run it in a thread so
-            // we can start the daemon as the sender in parallel. On demand
-            // mode adds `memory_mode=postcopy`.
+            // we can start the daemon as the sender in parallel. The daemon
+            // announces on-demand (postcopy) mode through the migration
+            // protocol, so the receive call is identical in both modes.
             let api_socket_restored_clone = api_socket_restored.clone();
             let restore_socket_clone = restore_socket.clone();
-            let ondemand_for_thread = ondemand;
             let restore_thread = thread::spawn(move || {
-                let arg = if ondemand_for_thread {
-                    format!("receiver_url=unix:{restore_socket_clone},memory_mode=postcopy")
-                } else {
-                    format!("receiver_url=unix:{restore_socket_clone}")
-                };
+                let arg = format!("receiver_url=unix:{restore_socket_clone}");
                 remote_command(&api_socket_restored_clone, "receive-migration", Some(&arg))
             });
 

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -308,13 +308,14 @@ you might end up in an undefined state leading to possible bugs.
 For speeding up a VM restore, the daemon's `--ondemand` mode hands CH
 empty memfds and serves page contents on demand via userfaultfd.
 
-This requires `memory_mode=postcopy` on the receive-migration call so CH
+The daemon announces postcopy mode through the migration protocol, so CH
 registers userfaultfd on the memfds before resuming vCPUs and keeps
-the daemon's socket open for `PageFault` requests:
+the daemon's socket open for `PageFault` requests. The receive-migration
+call is the same as for a regular restore:
 
 ```bash
 ./ch-remote --api-socket /tmp/cloud-hypervisor.sock \
-    receive-migration receiver_url=unix:/tmp/restore.sock,memory_mode=postcopy &
+    receive-migration receiver_url=unix:/tmp/restore.sock &
 
 ./offload_daemon restore \
     --socket /tmp/restore.sock \

--- a/offload_daemon/src/main.rs
+++ b/offload_daemon/src/main.rs
@@ -37,6 +37,7 @@ use vm_memory::{
 use vm_migration::MigratableError;
 use vm_migration::protocol::{Command, ConnectionRole, MemoryRange, Request, Response, Status};
 use vmm::VmMigrationConfig;
+use vmm::api::MigrationMode;
 use vmm::migration::SNAPSHOT_STATE_FILE;
 use vmm::sparse::copy_region;
 use vmm_sys_util::errno;
@@ -397,8 +398,16 @@ fn parse_guest_ram_mappings(value: &serde_json::Value) -> Result<Vec<(u32, u64, 
 fn run_restore(socket_path: &Path, input_dir: &Path, resume: bool, ondemand: bool) -> Result<()> {
     let migration_config_bytes =
         fs::read(input_dir.join(MIGRATION_CONFIG_FILENAME)).map_err(Error::ReadFile)?;
-    let migration_config: VmMigrationConfig = serde_json::from_slice(&migration_config_bytes)?;
+    let mut migration_config: VmMigrationConfig = serde_json::from_slice(&migration_config_bytes)?;
     let state_bytes = fs::read(input_dir.join(SNAPSHOT_STATE_FILE)).map_err(Error::ReadFile)?;
+
+    migration_config.set_memory_mode(if ondemand {
+        MigrationMode::Postcopy
+    } else {
+        // Ignored
+        MigrationMode::default()
+    });
+    let migration_config_bytes = serde_json::to_vec(&migration_config)?;
 
     let mut stream = UnixStream::connect(socket_path).map_err(Error::Connect)?;
     info!("Offload daemon connected to {socket_path:?} (ondemand={ondemand})");

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -322,9 +322,6 @@ pub struct VmReceiveMigrationData {
     /// If this is `Some`, the migration is instructed to use mTLS.
     #[serde(default)]
     pub tls_dir: Option<PathBuf>,
-    /// Memory transfer mode.
-    #[serde(default)]
-    pub memory_mode: MigrationMode,
     /// Optional VFIO device id to cdev FD pairs, used to substitute each
     /// device's saved path or stale FD in the received VmConfig.
     #[serde(default)]
@@ -384,7 +381,7 @@ pub enum VmReceiveMigrationConfigError {
 
 impl VmReceiveMigrationData {
     pub const SYNTAX: &'static str = "VM receive migration parameters \
-        \"<receiver_url>\" or \"receiver_url=<url>[,tls_dir=<path>][,memory_mode=precopy|postcopy]\
+        \"<receiver_url>\" or \"receiver_url=<url>[,tls_dir=<path>]\
         [,vfio_fds=<list_of_vfio_ids_with_their_associated_fd>][,iommufd_fd=<fd>]\
         [,zone_updates=[<id@host_numa_node>]]\"";
 
@@ -393,7 +390,6 @@ impl VmReceiveMigrationData {
         parser
             .add("receiver_url")
             .add("tls_dir")
-            .add("memory_mode")
             .add("vfio_fds")
             .add("iommufd_fd")
             .add("zone_updates");
@@ -410,10 +406,6 @@ impl VmReceiveMigrationData {
             .convert::<String>("tls_dir")
             .map_err(VmReceiveMigrationConfigError::ParseError)?
             .map(|path| PathBuf::from(&path));
-        let memory_mode = parser
-            .convert::<MigrationMode>("memory_mode")
-            .map_err(VmReceiveMigrationConfigError::ParseError)?
-            .unwrap_or_default();
         let vfio_fds = parser
             .convert::<TupleList<String, u64>>("vfio_fds")
             .map_err(VmReceiveMigrationConfigError::ParseError)?
@@ -444,7 +436,6 @@ impl VmReceiveMigrationData {
         let data = Self {
             receiver_url,
             tls_dir,
-            memory_mode,
             vfio_fds,
             iommufd_fd,
             zone_updates,
@@ -2225,7 +2216,6 @@ mod tests {
             VmReceiveMigrationData {
                 receiver_url: "tcp:192.168.1.1:8080".to_string(),
                 tls_dir: None,
-                memory_mode: MigrationMode::Precopy,
                 vfio_fds: None,
                 iommufd_fd: None,
                 zone_updates: vec![],
@@ -2255,7 +2245,6 @@ mod tests {
             VmReceiveMigrationData {
                 receiver_url: "tcp:192.168.1.1:8080".to_string(),
                 tls_dir: Some(tls_dir_path),
-                memory_mode: MigrationMode::Precopy,
                 vfio_fds: None,
                 iommufd_fd: None,
                 zone_updates: vec![],
@@ -2310,38 +2299,11 @@ mod tests {
             VmReceiveMigrationConfigError::TlsEncryptionUsedForUnixSocket,
         );
 
-        // memory_mode defaults to precopy when not specified.
-        let data = VmReceiveMigrationData::parse("receiver_url=tcp:127.0.0.1:1234").unwrap();
-        assert_eq!(
-            data,
-            VmReceiveMigrationData {
-                receiver_url: "tcp:127.0.0.1:1234".to_string(),
-                tls_dir: None,
-                memory_mode: MigrationMode::Precopy,
-                vfio_fds: None,
-                iommufd_fd: None,
-                ..Default::default()
-            }
-        );
-
-        // Explicit receiver_url with memory_mode=postcopy.
-        let data =
-            VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,memory_mode=postcopy")
-                .unwrap();
-        assert_eq!(
-            data,
-            VmReceiveMigrationData {
-                receiver_url: "unix:/tmp/sock".to_string(),
-                tls_dir: None,
-                memory_mode: MigrationMode::Postcopy,
-                vfio_fds: None,
-                iommufd_fd: None,
-                ..Default::default()
-            }
-        );
+        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,memory_mode=postcopy")
+            .unwrap_err();
 
         // Missing receiver_url in keyed form must fail.
-        let e = VmReceiveMigrationData::parse("memory_mode=postcopy").unwrap_err();
+        let e = VmReceiveMigrationData::parse("tls_dir=/tmp/certs").unwrap_err();
         assert!(
             matches!(e, VmReceiveMigrationConfigError::ParseError(_)),
             "Expected \"ParseError\"; got \"{e:?}\"",

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1680,8 +1680,6 @@ components:
             Directory containing the TLS server certificate (server-cert.pem), the TLS
             server key (server-key.pem), and the client TLS root CA certificate (ca-cert.pem).
             TLS is only supported with tcp:<host>:<port> receiver URLs.
-        memory_mode:
-          $ref: "#/components/schemas/MigrationMode"
         zone_updates:
           type: array
           items:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -620,11 +620,26 @@ pub struct VmMigrationConfig {
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     common_cpuid: Vec<x86::CpuIdEntry>,
     memory_manager_data: MemoryManagerSnapshotData,
+    /// The memory transfer mode the sender uses. The receiver derives its
+    /// behavior (e.g., serving page faults for postcopy).
+    #[serde(default)]
+    memory_mode: MigrationMode,
 }
 
 impl VmMigrationConfig {
     pub fn memory_manager_data(&self) -> &MemoryManagerSnapshotData {
         &self.memory_manager_data
+    }
+
+    pub fn memory_mode(&self) -> MigrationMode {
+        self.memory_mode
+    }
+
+    /// Override the memory transfer mode. Used by senders that replay a
+    /// persisted config, e.g. an offload daemon restoring a snapshot in
+    /// on-demand (postcopy) mode.
+    pub fn set_memory_mode(&mut self, memory_mode: MigrationMode) {
+        self.memory_mode = memory_mode;
     }
 }
 
@@ -726,6 +741,9 @@ struct ReceiveMigrationConfiguredData {
     connections: ReceiveAdditionalConnections,
     shared_backing: bool,
     fault_rx: Receiver<SocketStream>,
+    /// The memory transfer mode announced by the sender in the received
+    /// [`VmMigrationConfig`].
+    memory_mode: MigrationMode,
 }
 
 /// The receiver's state machine behind the migration protocol.
@@ -990,7 +1008,7 @@ impl Vmm {
              memory_files: HashMap<u32, File>|
              -> result::Result<ReceiveMigrationConfiguredData, MigratableError> {
                 let shared_backing = !memory_files.is_empty();
-                let memory_manager =
+                let (memory_manager, memory_mode) =
                     self.vm_receive_config(req, socket, memory_files, receive_data_migration)?;
                 let guest_memory = memory_manager.lock().unwrap().guest_memory();
                 // Create the additional-connection receiver even in the single-connection case.
@@ -1013,6 +1031,7 @@ impl Vmm {
                     connections,
                     shared_backing,
                     fault_rx,
+                    memory_mode,
                 })
             };
 
@@ -1071,9 +1090,7 @@ impl Vmm {
                     })?;
                     Ok(Configured(config_data))
                 }
-                Command::State => {
-                    self.vm_receive_state_command(req, socket, config_data, receive_data_migration)
-                }
+                Command::State => self.vm_receive_state_command(req, socket, config_data),
                 c => invalid_command(state_name, c),
             },
             StateReceived {
@@ -1118,12 +1135,11 @@ impl Vmm {
         req: &Request,
         socket: &mut SocketStream,
         mut config_data: ReceiveMigrationConfiguredData,
-        receive_data_migration: &VmReceiveMigrationData,
     ) -> result::Result<ReceiveMigrationState, MigratableError> {
         let state_receive_begin = Instant::now();
 
         // Serve faults before restore so accesses during restore resolve on demand.
-        if matches!(receive_data_migration.memory_mode, MigrationMode::Postcopy) {
+        if matches!(config_data.memory_mode, MigrationMode::Postcopy) {
             let shared_backing = config_data.shared_backing;
             let fault_stream = config_data
                 .fault_rx
@@ -1175,11 +1191,10 @@ impl Vmm {
         socket: &mut T,
         existing_memory_files: HashMap<u32, File>,
         receive_data_migration: &VmReceiveMigrationData,
-    ) -> result::Result<Arc<Mutex<MemoryManager>>, MigratableError>
+    ) -> result::Result<(Arc<Mutex<MemoryManager>>, MigrationMode), MigratableError>
     where
         T: Read,
     {
-        let mode = receive_data_migration.memory_mode;
         let zone_updates = &receive_data_migration.zone_updates;
 
         // Read in config data along with memory manager data
@@ -1192,6 +1207,8 @@ impl Vmm {
         let vm_migration_config: VmMigrationConfig = serde_json::from_slice(&data)
             .context("Error deserialising config")
             .map_err(MigratableError::MigrateReceive)?;
+
+        let mode = vm_migration_config.memory_mode();
 
         // Mirrors the vm_restore handling of RestoreConfig.vfio_fds. The
         // received VmConfig carries the source's device paths or stale FDs,
@@ -1284,7 +1301,7 @@ impl Vmm {
         .context("Error creating MemoryManager from snapshot")
         .map_err(MigratableError::MigrateReceive)?;
 
-        Ok(memory_manager)
+        Ok((memory_manager, mode))
     }
 
     /// Receives the final VM state (devices, vCPUs) and restores the VM.
@@ -1669,6 +1686,7 @@ impl Vmm {
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             common_cpuid,
             memory_manager_data: vm.memory_manager_data(),
+            memory_mode: send_data_migration.memory_mode,
         };
         transport::send_config(&mut socket, &vm_migration_config)?;
 
@@ -4034,7 +4052,6 @@ mod tests {
         VmReceiveMigrationData {
             receiver_url: "tcp:127.0.0.1:4321".to_string(),
             tls_dir: None,
-            memory_mode: MigrationMode::default(),
             vfio_fds,
             iommufd_fd,
             zone_updates: vec![],


### PR DESCRIPTION
IMHO important cleanup/fix of the API. I missed this in @sboeuf PR I think. The new solution is more flexible and easy to integrate.

Move memory_mode into the migration protocol because the sender controls the memory transfer strategy and the receiver must derive its behavior from the same source of truth. This prevents mismatched configurations and supports future strategies such as transitioning from precopy to postcopy. Postcopy is officialyl experimental, so removing its receiver-side API option is acceptable