### PR TITLE
Deprecate send-migration local flag in favor of memory_mode=memfds

### DIFF
--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -1137,7 +1137,7 @@ pub(crate) fn start_live_migration(
     migration_socket: &str,
     src_api_socket: &str,
     dest_api_socket: &str,
-    local: bool,
+    memfds: bool,
     paused: bool,
 ) -> bool {
     // Start to receive migration from the destination VM
@@ -1168,8 +1168,8 @@ pub(crate) fn start_live_migration(
         format!("--api-socket={src_api_socket}"),
         "send-migration".to_string(),
         format!(
-            "destination_url=unix:{migration_socket},local={}",
-            if local { "on" } else { "off" }
+            "destination_url=unix:{migration_socket},memory_mode={}",
+            if memfds { "memfds" } else { "precopy" }
         ),
     ]
     .to_vec();

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -9234,8 +9234,8 @@ mod snapshot_restore_common {
     }
 
     // Round-trip via the reference offload daemon over the existing
-    // `vm.send-migration local=on` / `vm.receive-migration` endpoints,
-    // proving parity with `vm.snapshot`/`vm.restore`.
+    // `vm.send-migration memory_mode=memfds` / `vm.receive-migration`
+    // endpoints, proving parity with `vm.snapshot`/`vm.restore`.
     pub(crate) fn _test_snapshot_restore_offload(virtio_mem: bool, ondemand: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
@@ -9327,7 +9327,7 @@ mod snapshot_restore_common {
             assert!(remote_command(
                 &api_socket_source,
                 "send-migration",
-                Some(format!("destination_url=unix:{snapshot_socket},local=on").as_str(),),
+                Some(format!("destination_url=unix:{snapshot_socket},memory_mode=memfds").as_str(),),
             ));
 
             // The daemon should exit cleanly after persisting the snapshot.
@@ -9584,6 +9584,8 @@ mod snapshot_restore_common {
 
                 // Pause, then snapshot while asking to preserve the source.
                 assert!(remote_command(&api_socket, "pause", None));
+                // Deliberately uses the deprecated `local=on` flag so the
+                // compatibility layer stays covered end-to-end.
                 assert!(remote_command(
                     &api_socket,
                     "send-migration",

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6729,7 +6729,7 @@ mod common_parallel {
     // 4. The destination VM is functional (including various virtio-devices are working properly) after
     //    live migration;
     // Note: This test does not use vsock as we can't create two identical vsock on the same host.
-    fn _test_live_migration(upgrade_test: bool, local: bool, paused: bool) {
+    fn _test_live_migration(upgrade_test: bool, memfds: bool, paused: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
@@ -6740,7 +6740,7 @@ mod common_parallel {
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
 
-        let memory_param: &[&str] = if local {
+        let memory_param: &[&str] = if memfds {
             &["--memory", "size=1500M,shared=on"]
         } else {
             &["--memory", "size=1500M"]
@@ -6828,7 +6828,7 @@ mod common_parallel {
                     &migration_socket,
                     &src_api_socket,
                     &dest_api_socket,
-                    local,
+                    memfds,
                     paused
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
@@ -7571,7 +7571,7 @@ mod common_parallel {
     }
 
     #[test]
-    fn test_live_migration_local() {
+    fn test_live_migration_memfds() {
         _test_live_migration(false, true, false);
     }
 
@@ -7581,7 +7581,7 @@ mod common_parallel {
     }
 
     #[test]
-    fn test_live_migration_local_paused() {
+    fn test_live_migration_memfds_paused() {
         _test_live_migration(false, true, true);
     }
 
@@ -7619,7 +7619,7 @@ mod common_parallel {
     }
 
     #[test]
-    fn test_live_upgrade_local() {
+    fn test_live_upgrade_memfds() {
         _test_live_migration(true, true, false);
     }
 
@@ -7629,7 +7629,7 @@ mod common_parallel {
         _test_live_migration_with_landlock();
     }
 
-    fn _test_live_migration_virtio_fs(local: bool) {
+    fn _test_live_migration_virtio_fs(memfds: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
@@ -7740,7 +7740,7 @@ mod common_parallel {
                     &migration_socket,
                     &src_api_socket,
                     &dest_api_socket,
-                    local,
+                    memfds,
                     false
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
@@ -7815,7 +7815,7 @@ mod common_parallel {
     }
 
     #[test]
-    fn test_live_migration_virtio_fs_local() {
+    fn test_live_migration_virtio_fs_memfds() {
         _test_live_migration_virtio_fs(true);
     }
 }
@@ -7945,7 +7945,7 @@ mod ivshmem {
 
     use crate::*;
 
-    fn _test_live_migration_ivshmem(local: bool) {
+    fn _test_live_migration_ivshmem(memfds: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
@@ -7956,7 +7956,7 @@ mod ivshmem {
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
 
-        let memory_param: &[&str] = if local {
+        let memory_param: &[&str] = if memfds {
             &["--memory", "size=4G,shared=on"]
         } else {
             &["--memory", "size=4G"]
@@ -8062,7 +8062,7 @@ mod ivshmem {
                     &migration_socket,
                     &src_api_socket,
                     &dest_api_socket,
-                    local,
+                    memfds,
                     false
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
@@ -8331,7 +8331,7 @@ mod ivshmem {
     }
 
     #[test]
-    fn test_live_migration_ivshmem_local() {
+    fn test_live_migration_ivshmem_memfds() {
         _test_live_migration_ivshmem(true);
     }
 
@@ -10085,7 +10085,7 @@ mod common_sequential {
         let _ = fs::remove_file(shared_dir.join("post_restore_file"));
     }
 
-    fn _test_live_migration_balloon(upgrade_test: bool, local: bool) {
+    fn _test_live_migration_balloon(upgrade_test: bool, memfds: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
@@ -10096,7 +10096,7 @@ mod common_sequential {
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
 
-        let memory_param: &[&str] = if local {
+        let memory_param: &[&str] = if memfds {
             &[
                 "--memory",
                 "size=4G,hotplug_method=virtio-mem,hotplug_size=8G,shared=on",
@@ -10209,7 +10209,7 @@ mod common_sequential {
                     &migration_socket,
                     &src_api_socket,
                     &dest_api_socket,
-                    local,
+                    memfds,
                     false
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
@@ -10277,7 +10277,7 @@ mod common_sequential {
         handle_child_output(r, &dest_output);
     }
 
-    fn _test_live_migration_numa(upgrade_test: bool, local: bool) {
+    fn _test_live_migration_numa(upgrade_test: bool, memfds: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
@@ -10288,7 +10288,7 @@ mod common_sequential {
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
 
-        let memory_param: &[&str] = if local {
+        let memory_param: &[&str] = if memfds {
             &[
                 "--memory",
                 "size=0,hotplug_method=virtio-mem,shared=on",
@@ -10425,7 +10425,7 @@ mod common_sequential {
                     &migration_socket,
                     &src_api_socket,
                     &dest_api_socket,
-                    local,
+                    memfds,
                     false
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
@@ -10523,7 +10523,7 @@ mod common_sequential {
     }
 
     #[cfg(not(feature = "mshv"))]
-    fn _test_live_migration_ovs_dpdk(upgrade_test: bool, local: bool) {
+    fn _test_live_migration_ovs_dpdk(upgrade_test: bool, memfds: bool) {
         let ovs_disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let ovs_guest = Guest::new(Box::new(ovs_disk_config));
 
@@ -10563,7 +10563,7 @@ mod common_sequential {
                     &migration_socket,
                     &src_api_socket,
                     &dest_api_socket,
-                    local,
+                    memfds,
                     false
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
@@ -10636,7 +10636,7 @@ mod common_sequential {
     }
 
     #[test]
-    fn test_live_migration_balloon_local() {
+    fn test_live_migration_balloon_memfds() {
         _test_live_migration_balloon(false, true);
     }
 
@@ -10646,7 +10646,7 @@ mod common_sequential {
     }
 
     #[test]
-    fn test_live_upgrade_balloon_local() {
+    fn test_live_upgrade_balloon_memfds() {
         _test_live_migration_balloon(true, true);
     }
 
@@ -10656,7 +10656,7 @@ mod common_sequential {
     }
 
     #[test]
-    fn test_live_migration_numa_local() {
+    fn test_live_migration_numa_memfds() {
         _test_live_migration_numa(false, true);
     }
 
@@ -10666,7 +10666,7 @@ mod common_sequential {
     }
 
     #[test]
-    fn test_live_upgrade_numa_local() {
+    fn test_live_upgrade_numa_memfds() {
         _test_live_migration_numa(true, true);
     }
 
@@ -10683,7 +10683,7 @@ mod common_sequential {
     #[ignore = "See #5532 and #7689"]
     #[cfg(target_arch = "x86_64")]
     #[cfg(not(feature = "mshv"))]
-    fn test_live_migration_ovs_dpdk_local() {
+    fn test_live_migration_ovs_dpdk_memfds() {
         _test_live_migration_ovs_dpdk(false, true);
     }
 
@@ -10699,11 +10699,11 @@ mod common_sequential {
     #[ignore = "See #5532"]
     #[cfg(target_arch = "x86_64")]
     #[cfg(not(feature = "mshv"))]
-    fn test_live_upgrade_ovs_dpdk_local() {
+    fn test_live_upgrade_ovs_dpdk_memfds() {
         _test_live_migration_ovs_dpdk(true, true);
     }
 
-    fn _test_live_migration_watchdog(upgrade_test: bool, local: bool) {
+    fn _test_live_migration_watchdog(upgrade_test: bool, memfds: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
@@ -10714,7 +10714,7 @@ mod common_sequential {
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
 
-        let memory_param: &[&str] = if local {
+        let memory_param: &[&str] = if memfds {
             &["--memory", "size=1500M,shared=on"]
         } else {
             &["--memory", "size=1500M"]
@@ -10818,7 +10818,7 @@ mod common_sequential {
                     &migration_socket,
                     &src_api_socket,
                     &dest_api_socket,
-                    local,
+                    memfds,
                     false
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6721,8 +6721,8 @@ mod common_parallel {
         handle_child_output(r, &output);
     }
 
-    // This test exercises the local live-migration between two Cloud Hypervisor VMs on the
-    // same host. It ensures the following behaviors:
+    // This helper exercises migration between two Cloud Hypervisor VMs on the
+    // same host:
     // 1. The source VM is up and functional (including various virtio-devices are working properly);
     // 2. The 'send-migration' and 'receive-migration' command finished successfully;
     // 3. The source VM terminated gracefully after live migration;

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -1,16 +1,27 @@
 # Live Migration
 
-This document gives examples of how to use the live migration support
-in Cloud Hypervisor:
+Cloud Hypervisor supports live migration over two transport channels:
 
-1. **Local Migration**: Migrating a VM from one Cloud Hypervisor instance to another on the same machine; also called
-  UNIX socket migration.
-1. **Remote Migration** (TCP Migration): migrating a VM between two TCP/IP hosts.
+| Transport          | When to use it                                                                  |
+|--------------------|---------------------------------------------------------------------------------|
+| TCP stream         | Migration between hosts. It also works on one host for development and testing. |
+| UNIX domain socket | Migration between VMMs on the same host.                                        |
 
-> :warning: These examples place sockets in /tmp. This is done for
+See [Migration Parameters](#migration-parameters) for the full definitions of
+these parameters.
+
+> :warning: The following examples place sockets in /tmp. This is done for
 > simplicity and should not be done in production.
 
-## Local Migration (Suitable for Live Upgrade of VMM)
+## UNIX Domain Socket Migration
+
+UNIX domain sockets are suited for same host migrations, especially when
+combined with `memory_mode=memfds`. This is particularly useful for VMM
+live upgrades with minimal VM downtime. We call this mode "local migration".
+
+If `memory_mode=memfds` is omitted, the migration defaults to copying guest
+memory instead. UNIX domain socket transport may be proxied via a socket proxy
+(e.g. `socat` fur advanced custom use cases).
 
 Launch the source VM (on the host machine):
 
@@ -46,13 +57,12 @@ When the above commands completed, the source VM should be successfully
 migrated to the destination VM. Now the destination VM is running while
 the source VM is terminated gracefully.
 
-## Remote Migration (TCP Migration)
+## TCP Migration
 
-_Hint: For developing purposes, same-host TCP migrations are also supported._
-
-In this example, we will migrate a VM from one machine (`src`) to
+TCP is intended for migration from one machine (`src`) to
 another (`dst`) across the network. To keep it simple, we will use a
-minimal VM setup without storage.
+minimal VM setup without storage. Same host TCP migration is also supported
+for development and testing.
 
 ### Preparation
 
@@ -76,65 +86,6 @@ src $ curl $DEBIAN/initrd.gz > /var/images/initrd
 
 Repeat the above steps on the destination host.
 
-### Unix Socket Migration
-
-If Unix socket is selected for migration, we can tunnel traffic through "socat".
-
-#### Starting the Receiver VM
-
-On the receiver side, we prepare an empty VM:
-
-```console
-dst $ cloud-hypervisor --api-socket /tmp/api
-```
-
-In a different terminal, configure the VM as a migration target:
-
-```console
-dst $ ch-remote --api-socket=/tmp/api receive-migration receiver_url=unix:/tmp/sock
-```
-
-In yet another terminal, forward TCP connections to the Unix domain socket:
-
-```console
-dst $ socat TCP-LISTEN:{port},reuseaddr UNIX-CLIENT:/tmp/sock
-```
-
-#### Starting the Sender VM
-
-Let's start the VM on the source machine:
-
-```console
-src $ cloud-hypervisor \
-        --serial tty --console off \
-        --cpus boot=2 --memory size=4G \
-        --kernel /var/images/linux \
-        --initramfs /var/images/initrd \
-        --cmdline "console=ttyS0" \
-        --api-socket /tmp/api
-```
-
-After a few seconds the VM should be up and you can interact with it.
-
-#### Performing the Migration
-
-First, we start `socat`:
-
-```console
-src $ socat UNIX-LISTEN:/tmp/sock,reuseaddr TCP:{dst}:{port}
-```
-
-> Replace {dst}:{port} with the actual IP address and port of your destination host.
-
-Then we kick-off the migration itself:
-
-```console
-src $ ch-remote --api-socket=/tmp/api send-migration destination_url=unix:/tmp/sock
-```
-
-When the above commands completed, the VM should be successfully
-migrated to the destination machine without interrupting the workload.
-
 ### Network Announcements After Resume
 
 After a VM resumes from migration, snapshot restore, or any other path
@@ -147,10 +98,10 @@ re-announcement therefore only happens when the guest negotiated
 `VIRTIO_NET_F_GUEST_ANNOUNCE`. For `vhost-user-net`, the current implementation
 only uses the guest announcement path.
 
-### TCP Socket Migration
+### Performing a TCP Migration
 
-If TCP socket is selected for migration, we need to consider migrating
-in a trusted network.
+Use TCP migration only in a trusted network or configure TLS as described
+below.
 
 #### Starting the Receiver VM
 
@@ -249,7 +200,7 @@ src $ ch-remote --api-socket=/tmp/api send-migration destination_url=tcp:{dst}:{
 ```
 
 TLS encryption is only supported with `tcp:<host>:<port>` migration
-URLs, not with local UNIX-socket migration.
+URLs, not with UNIX domain socket migration.
 
 The commands below describe how to create the encryption material necessary
 to perform a same-host TCP migration with TLS.
@@ -377,7 +328,7 @@ migration process. Via the API or `ch-remote`, you may specify:
 - `connections <amount>`: \
   The number of parallel TCP connections to use for migration.
   Must be between `1` and `128`. Defaults to `1`.
-  Multiple connections are not supported with local UNIX-socket migration.
+  Multiple connections are not supported with UNIX domain socket migration.
 - `memory_mode <memfds|precopy|postcopy>`: \
   Memory transfer mode. `memfds` passes the guest memory backing file
   descriptors over a UNIX socket. It requires every guest memory region to use

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -39,7 +39,7 @@ $ target/release/ch-remote --api-socket=/tmp/api2 receive-migration receiver_url
 Start to send migration for the source VM (on the host machine):
 
 ```console
-$ target/release/ch-remote --api-socket=/tmp/api1 send-migration destination_url=unix:/tmp/sock,local=on
+$ target/release/ch-remote --api-socket=/tmp/api1 send-migration destination_url=unix:/tmp/sock,memory_mode=memfds
 ```
 
 When the above commands completed, the source VM should be successfully
@@ -378,9 +378,11 @@ migration process. Via the API or `ch-remote`, you may specify:
   The number of parallel TCP connections to use for migration.
   Must be between `1` and `128`. Defaults to `1`.
   Multiple connections are not supported with local UNIX-socket migration.
-- `memory_mode <precopy|postcopy>`: \
-  Memory transfer mode. `postcopy` resumes the destination first and faults
-  guest pages in on demand over a dedicated connection. Defaults to `precopy`.
+- `memory_mode <memfds|precopy|postcopy>`: \
+  Memory transfer mode. `memfds` passes guest memory as file descriptors
+  over a UNIX socket (send side only). `postcopy` resumes the destination
+  first and faults guest pages in on demand over a dedicated connection.
+  Defaults to `precopy`.
 - `zone_updates <list of zone updates>`: \
   A list of updates to apply to memory zones on the receiver side. For example,
   this can be used to remap memory zones to another NUMA node. Each zone update

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -379,10 +379,14 @@ migration process. Via the API or `ch-remote`, you may specify:
   Must be between `1` and `128`. Defaults to `1`.
   Multiple connections are not supported with local UNIX-socket migration.
 - `memory_mode <memfds|precopy|postcopy>`: \
-  Memory transfer mode. `memfds` passes guest memory as file descriptors
-  over a UNIX socket (send side only). `postcopy` resumes the destination
-  first and faults guest pages in on demand over a dedicated connection.
-  Defaults to `precopy`.
+  Memory transfer mode. `memfds` passes the guest memory backing file
+  descriptors over a UNIX socket. It requires every guest memory region to use
+  shared memory or hugepage backing. `postcopy` resumes the destination first
+  and faults guest pages in on demand over a dedicated connection. Defaults to
+  `precopy`.
+- `preserve_source <on|off>`: \
+  Keep the source VM in a paused state after migration completes. This is only
+  supported with `memory_mode=memfds` and defaults to `off`.
 - `zone_updates <list of zone updates>`: \
   A list of updates to apply to memory zones on the receiver side. For example,
   this can be used to remap memory zones to another NUMA node. Each zone update

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -223,16 +223,17 @@ peer role:
   would for a local live migration. Passing `preserve_source=on` instead
   leaves the source VM paused and owned by the VMM once the snapshot
   completes, so it can be resumed afterwards. Memory is transferred via
-  `SCM_RIGHTS`, CH handing off the daemon one memfd per guest-memory slot.
+  `SCM_RIGHTS`, with CH handing the daemon one guest memory backing FD per
+  slot.
 - On restore, CH acts as the migration receiver and the daemon acts as the
-  sender. The daemon provides one memfd per slot, populated from its
-  storage, and CH uses those memfds directly as guest RAM backing.
+  sender. The daemon provides one populated guest memory backing FD per slot,
+  and CH uses those files directly as guest RAM backing.
 
 In practice, this means offload is driven through the existing
 `vm.send-migration` / `vm.receive-migration` endpoints (with
-`memory_mode=memfds` and a `unix:<path>` URL). The daemon is just another peer of these
-endpoints. This requires the VM to be configured with shared-memory
-backing, which is the same precondition that applies to local live
+`memory_mode=memfds` and a `unix:<path>` URL). The daemon is just another peer
+of these endpoints. Every guest memory region must use shared memory or
+hugepage backing, which is the same precondition that applies to local live
 migration today.
 
 ### Snapshot offload usage
@@ -333,9 +334,10 @@ The daemon implements the local live-migration wire protocol defined in
   `MemoryFd` command, receive a guest-memory fd via SCM_RIGHTS on the
   same UNIX socket.
 - Restore mode (migration sender): walk the same sequence in reverse,
-  emitting one `MemoryFd` per slot (with the memfd attached via SCM_RIGHTS)
-  before sending `Config` and `State`. Finish with either `CompletePaused`
-  (restored VM remains paused) or `Complete` (restored VM resumes).
+  emitting one `MemoryFd` per slot (with the guest memory backing FD attached
+  via SCM_RIGHTS) before sending `Config` and `State`. Finish with either
+  `CompletePaused` (restored VM remains paused) or `Complete` (restored VM
+  resumes).
 
 ### Critical invariant on snapshot
 
@@ -358,8 +360,8 @@ production backend.
 
 ### Limitations
 
-- The VM must use shared-memory backing (`shared=on` or file-backed).
-  Anonymous memory is rejected with the same error message that local
+- Every guest memory region must use shared memory (`shared=on`) or hugepage
+  backing. Anonymous memory is rejected with the same error message that local
   live migration produces.
 - Orchestrator-supplied network FDs (today carried by `vm.restore`'s
   `net_fds` field) are not plumbed through `vm.receive-migration`,

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -229,8 +229,8 @@ peer role:
   storage, and CH uses those memfds directly as guest RAM backing.
 
 In practice, this means offload is driven through the existing
-`vm.send-migration` / `vm.receive-migration` endpoints (with `local=on`
-and a `unix:<path>` URL). The daemon is just another peer of these
+`vm.send-migration` / `vm.receive-migration` endpoints (with
+`memory_mode=memfds` and a `unix:<path>` URL). The daemon is just another peer of these
 endpoints. This requires the VM to be configured with shared-memory
 backing, which is the same precondition that applies to local live
 migration today.
@@ -257,19 +257,19 @@ migration today.
 #    /tmp/offload.sock, streams the snapshot, and exits on success.
 ./ch-remote --api-socket /tmp/cloud-hypervisor.sock pause
 ./ch-remote --api-socket /tmp/cloud-hypervisor.sock \
-    send-migration destination_url=unix:/tmp/offload.sock,local=on
+    send-migration destination_url=unix:/tmp/offload.sock,memory_mode=memfds
 ```
 
 ### Preserve the source VM
 
 By default an offload snapshot destroys the source VM on success. If you want
 to preserve the source VM, add `preserve_source=on` (only valid together
-with `local=on`) to the `send-migration` command:
+with `memory_mode=memfds`) to the `send-migration` command:
 
 ```bash
 ./ch-remote --api-socket /tmp/cloud-hypervisor.sock pause
 ./ch-remote --api-socket /tmp/cloud-hypervisor.sock \
-    send-migration destination_url=unix:/tmp/offload.sock,local=on,preserve_source=on
+    send-migration destination_url=unix:/tmp/offload.sock,memory_mode=memfds,preserve_source=on
 # The source VMM keeps running, the VM is left paused. Resume it when ready:
 ./ch-remote --api-socket /tmp/cloud-hypervisor.sock resume
 ```

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -804,7 +804,7 @@ impl VhostUserCommon {
         let snapshot = Snapshot::new_from_state(state)?;
 
         if self.migration_started {
-            // Local migration does not enable dirty logging.
+            // Precopy migration may enable dirty logging.
             if self.dirty_logging {
                 self.saved_dirty_log = Some(self.dirty_log()?);
             }

--- a/vm-migration/src/context.rs
+++ b/vm-migration/src/context.rs
@@ -288,7 +288,8 @@ impl MemoryMigrationContext {
 
     /// Returns an empty finalized block.
     ///
-    /// This can be used if no memory was transferred (e.g., local migration).
+    /// This can be used if no memory was transferred eagerly (e.g., local or
+    /// postcopy migration).
     pub fn empty_finalized() -> Self {
         let mut this = Self::new();
         this.finalize();

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -5,16 +5,14 @@
 
 //! # Migration Protocol
 //!
-//! ## Cross-Host Migration
+//! ## TCP Migration
 //!
-//! A traditional network-based live migration where all resources are
-//! transmitted over the wire. Externally-provided FDs must be opened and
-//! managed by the management software on the destination side.
+//! TCP is the normal transport for cross-host migration. It can also be used
+//! between VMs on the same host for development and testing. Guest memory is
+//! copied over the stream. Externally provided FDs must be opened and managed
+//! by the management software on the destination side.
 //!
-//! **Supported migration modes**:
-//! - TCP (currently one single connection)
-//!
-//! The following mermaid sequence diagram shows a brief overview:
+//! The following sequence diagram shows precopy migration over a stream:
 //!
 //! <!-- Best viewed and edited here: https://mermaid.live/edit -->
 //! ```mermaid
@@ -44,13 +42,14 @@
 //!    Destination-->>Source: OK
 //! ```
 //!
-//! ## Local Migration
+//! ## UNIX Domain Socket Migration
 //!
-//! A simplified migration taking a few shortcuts and only working on the
-//! same host. The VM memory is not transferred over the wire but instead
-//! passed as memory FD.
+//! UNIX domain sockets connect two Cloud Hypervisor instances on the same
+//! host. They can transfer guest memory normally, as TCP does, or use
+//! `memory_mode=memfds` to pass the guest memory backing FDs instead of
+//! copying memory ("local migration").
 //!
-//! The following mermaid sequence diagram shows a brief overview:
+//! The following sequence diagram shows the MemFD mode:
 //!
 //! <!-- Best viewed and edited here: https://mermaid.live/edit -->
 //! ```mermaid

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -41,7 +41,7 @@ use std::str::FromStr;
 use std::sync::mpsc::{RecvError, SendError, Sender, channel};
 use std::time::Duration;
 
-use log::{debug, info};
+use log::{debug, info, warn};
 use micro_http::Body;
 use option_parser::{OptionParser, OptionParserError, Toggle, Tuple, TupleList};
 use serde::{Deserialize, Serialize};
@@ -288,6 +288,11 @@ pub struct VmCoredumpData {
 /// Memory transfer mode for a migration.
 #[derive(Copy, Clone, Default, Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub enum MigrationMode {
+    /// Transfer memory as memory FDs.
+    ///
+    /// Only works via a UNIX domain socket. All guest memory must be shared
+    /// memory or use hugepage backing.
+    MemFDs,
     /// Transfer all guest memory before the destination resumes.
     #[default]
     Precopy,
@@ -303,6 +308,7 @@ impl FromStr for MigrationMode {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
+            "memfds" => Ok(MigrationMode::MemFDs),
             "precopy" => Ok(MigrationMode::Precopy),
             "postcopy" => Ok(MigrationMode::Postcopy),
             _ => Err(format!("Invalid migration mode: {s}")),
@@ -589,11 +595,12 @@ pub enum VmSendMigrationConfigError {
 pub struct VmSendMigrationData {
     /// Migration destination, e.g. `tcp:<host>:<port>` or `unix:/path/to/socket`.
     pub destination_url: String,
-    /// Send memory across socket without copying
+    /// Send memory as memory FDs across socket without copying.
+    #[deprecated(note = "set `memory_mode` to `MigrationMode::MemFDs` instead")]
     #[serde(default)]
     pub local: bool,
     /// Keep the source VM alive in a paused state once the migration is
-    /// complete.
+    /// complete. Only valid with [`MigrationMode::MemFDs`].
     #[serde(default)]
     pub preserve_source: bool,
     /// The maximum downtime the migration aims for.
@@ -627,10 +634,11 @@ pub struct VmSendMigrationData {
 
 impl VmSendMigrationData {
     pub const SYNTAX: &'static str = "VM send migration parameters \
-        \"destination_url=<url>[,local=on|off,preserve_source=on|off,\
+        \"destination_url=<url>[,preserve_source=on|off,\
         downtime_ms=<milliseconds>,timeout_s=<seconds>,\
         timeout_strategy=cancel|ignore,connections=<amount>,\
-        tls_dir=<path>,memory_mode=precopy|postcopy]\"";
+        tls_dir=<path>,memory_mode=memfds|precopy|postcopy,\
+        local=on|off (deprecated; use memory_mode=memfds)]\"";
 
     // Same as QEMU.
     pub const DEFAULT_DOWNTIME: Duration = Duration::from_millis(300);
@@ -674,8 +682,10 @@ impl VmSendMigrationData {
         let local = parser
             .convert::<Toggle>("local")
             .map_err(VmSendMigrationConfigError::ParseError)?
-            .unwrap_or(Toggle(false))
-            .0;
+            .is_some_and(|Toggle(v)| {
+                warn!("The 'local' option is deprecated: use 'memory_mode=memfds' instead");
+                v
+            });
         let preserve_source = parser
             .convert::<Toggle>("preserve_source")
             .map_err(VmSendMigrationConfigError::ParseError)?
@@ -727,6 +737,7 @@ impl VmSendMigrationData {
             .map_err(VmSendMigrationConfigError::ParseError)?
             .unwrap_or_default();
 
+        #[expect(deprecated)]
         let data = Self {
             destination_url,
             local,
@@ -742,6 +753,12 @@ impl VmSendMigrationData {
         data.validate()?;
 
         Ok(data)
+    }
+
+    pub fn local(&self) -> bool {
+        #[allow(deprecated)]
+        let deprecated_local_flag = self.local;
+        matches!(self.memory_mode, MigrationMode::MemFDs) || deprecated_local_flag
     }
 
     pub fn downtime(&self) -> Duration {
@@ -784,24 +801,24 @@ impl VmSendMigrationData {
             )));
         }
 
-        if self.local {
+        if self.local() {
             if !self.destination_url.starts_with("unix:") {
                 return Err(VmSendMigrationConfigError::ValidationError(
-                    "local option is only supported with UNIX sockets.".to_string(),
+                    "Memory FD migration is only supported with UNIX sockets.".to_string(),
                 ));
             }
 
             if self.connections.get() > 1 {
                 return Err(VmSendMigrationConfigError::ValidationError(
-                    "local option and connections option cannot be used at the same time."
+                    "Memory FD migration and connections option cannot be used at the same time."
                         .to_string(),
                 ));
             }
         }
 
-        if self.preserve_source && !self.local {
+        if self.preserve_source && !self.local() {
             return Err(VmSendMigrationConfigError::ValidationError(
-                "preserve_source option is only supported with the local option.".to_string(),
+                "preserve_source option is only supported with local migration.".to_string(),
             ));
         }
 
@@ -813,19 +830,19 @@ impl VmSendMigrationData {
             })?;
         }
 
-        if matches!(self.memory_mode, MigrationMode::Postcopy) {
-            if self.local {
-                return Err(VmSendMigrationConfigError::ValidationError(
-                    "memory_mode=postcopy and local options are mutually exclusive.".to_string(),
-                ));
-            }
+        #[expect(deprecated)]
+        if self.local && matches!(self.memory_mode, MigrationMode::Postcopy) {
+            return Err(VmSendMigrationConfigError::ValidationError(
+                "memory_mode=postcopy and the deprecated local option are mutually exclusive."
+                    .to_string(),
+            ));
+        }
 
-            if self.connections.get() > 1 {
-                return Err(VmSendMigrationConfigError::ValidationError(
-                    "memory_mode=postcopy currently requires a single connection (connections=1)."
-                        .to_string(),
-                ));
-            }
+        if matches!(self.memory_mode, MigrationMode::Postcopy) && self.connections.get() > 1 {
+            return Err(VmSendMigrationConfigError::ValidationError(
+                "memory_mode=postcopy currently requires a single connection (connections=1)."
+                    .to_string(),
+            ));
         }
 
         Ok(())
@@ -2365,13 +2382,16 @@ mod tests {
     }
 
     #[test]
+    // The deprecated `local` flag is still constructed and compared here to
+    // cover the compatibility layer.
+    #[expect(deprecated)]
     fn test_vm_send_migration_data_parse() {
         // Fully specified
         let data = VmSendMigrationData::parse(
             "destination_url=unix:/tmp/migrate.sock,local=on,downtime_ms=200,timeout_s=3600,timeout_strategy=cancel"
         ).expect("valid migration string should parse");
         assert_eq!(data.destination_url, "unix:/tmp/migrate.sock");
-        assert!(data.local);
+        assert!(data.local());
         assert_eq!(data.downtime_ms.get(), 200);
         assert_eq!(data.timeout_s.get(), 3600);
         assert_eq!(data.timeout_strategy, TimeoutStrategy::Cancel);
@@ -2381,7 +2401,7 @@ mod tests {
         let data = VmSendMigrationData::parse("destination_url=tcp:192.168.1.1:8080")
             .expect("minimal migration string should parse");
         assert_eq!(data.destination_url, "tcp:192.168.1.1:8080");
-        assert!(!data.local);
+        assert!(!data.local());
         assert_eq!(data.downtime_ms, VmSendMigrationData::default_downtime_ms());
         assert_eq!(data.timeout_s, VmSendMigrationData::default_timeout_s());
         assert_eq!(data.timeout_strategy, TimeoutStrategy::default());
@@ -2512,7 +2532,7 @@ mod tests {
         )
         .unwrap();
         assert!(data.preserve_source);
-        assert!(data.local);
+        assert!(data.local());
 
         // preserve_source defaults to false when unspecified.
         let data = VmSendMigrationData::parse("destination_url=unix:/tmp/sock,local=on").unwrap();
@@ -2523,5 +2543,64 @@ mod tests {
             .unwrap_err();
         VmSendMigrationData::parse("destination_url=unix:/tmp/sock,preserve_source=on")
             .unwrap_err();
+    }
+
+    #[test]
+    fn test_vm_send_migration_data_memory_mode_memfds() {
+        let data = VmSendMigrationData::parse("destination_url=unix:/tmp/sock,memory_mode=memfds")
+            .unwrap();
+        assert_eq!(data.memory_mode, MigrationMode::MemFDs);
+        assert!(data.local());
+
+        // Without either setting, the migration is not local.
+        let data = VmSendMigrationData::parse("destination_url=unix:/tmp/sock").unwrap();
+        assert!(!data.local());
+
+        // The deprecated flag and the new mode may be combined.
+        let data = VmSendMigrationData::parse(
+            "destination_url=unix:/tmp/sock,local=on,memory_mode=memfds",
+        )
+        .unwrap();
+        assert!(data.local());
+
+        // Local migration requires a UNIX socket destination.
+        VmSendMigrationData::parse("destination_url=tcp:192.168.1.1:8080,memory_mode=memfds")
+            .unwrap_err();
+
+        // Local migration cannot use multiple connections.
+        VmSendMigrationData::parse(
+            "destination_url=unix:/tmp/sock,memory_mode=memfds,connections=2",
+        )
+        .unwrap_err();
+
+        // preserve_source is accepted together with memory_mode=memfds.
+        let data = VmSendMigrationData::parse(
+            "destination_url=unix:/tmp/sock,memory_mode=memfds,preserve_source=on",
+        )
+        .unwrap();
+        assert!(data.preserve_source);
+        assert!(data.local());
+    }
+
+    #[test]
+    fn test_vm_send_migration_data_local_flag_json_compatibility() {
+        // Old clients set the deprecated flag through the HTTP API; the
+        // compatibility layer must translate it without going through parse().
+        let data: VmSendMigrationData =
+            serde_json::from_str(r#"{"destination_url": "unix:/tmp/sock", "local": true}"#)
+                .unwrap();
+        assert_eq!(data.memory_mode, MigrationMode::Precopy);
+        assert!(data.local());
+        data.validate().unwrap();
+
+        let data: VmSendMigrationData =
+            serde_json::from_str(r#"{"destination_url": "unix:/tmp/sock"}"#).unwrap();
+        assert!(!data.local());
+
+        let data: VmSendMigrationData = serde_json::from_str(
+            r#"{"destination_url": "unix:/tmp/sock", "memory_mode": "MemFDs"}"#,
+        )
+        .unwrap();
+        assert!(data.local());
     }
 }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -600,7 +600,8 @@ pub struct VmSendMigrationData {
     #[serde(default)]
     pub local: bool,
     /// Keep the source VM alive in a paused state once the migration is
-    /// complete. Only valid with [`MigrationMode::MemFDs`].
+    /// complete. Only valid when [`Self::effective_memory_mode`] is
+    /// [`MigrationMode::MemFDs`].
     #[serde(default)]
     pub preserve_source: bool,
     /// The maximum downtime the migration aims for.
@@ -627,7 +628,7 @@ pub struct VmSendMigrationData {
     /// If this is `Some`, the migration is instructed to use mTLS.
     #[serde(default)]
     pub tls_dir: Option<PathBuf>,
-    /// Memory transfer mode.
+    /// Requested memory transfer mode.
     #[serde(default)]
     pub memory_mode: MigrationMode,
 }
@@ -755,10 +756,14 @@ impl VmSendMigrationData {
         Ok(data)
     }
 
-    pub fn local(&self) -> bool {
-        #[allow(deprecated)]
-        let deprecated_local_flag = self.local;
-        matches!(self.memory_mode, MigrationMode::MemFDs) || deprecated_local_flag
+    /// The memory transfer mode with the deprecated `local` flag folded in.
+    pub fn effective_memory_mode(&self) -> MigrationMode {
+        #[expect(deprecated)]
+        if self.local {
+            MigrationMode::MemFDs
+        } else {
+            self.memory_mode
+        }
     }
 
     pub fn downtime(&self) -> Duration {
@@ -801,7 +806,7 @@ impl VmSendMigrationData {
             )));
         }
 
-        if self.local() {
+        if self.effective_memory_mode() == MigrationMode::MemFDs {
             if !self.destination_url.starts_with("unix:") {
                 return Err(VmSendMigrationConfigError::ValidationError(
                     "Memory FD migration is only supported with UNIX sockets.".to_string(),
@@ -816,9 +821,9 @@ impl VmSendMigrationData {
             }
         }
 
-        if self.preserve_source && !self.local() {
+        if self.preserve_source && self.effective_memory_mode() != MigrationMode::MemFDs {
             return Err(VmSendMigrationConfigError::ValidationError(
-                "preserve_source option is only supported with local migration.".to_string(),
+                "preserve_source option is only supported with memory_mode=memfds.".to_string(),
             ));
         }
 
@@ -2391,7 +2396,7 @@ mod tests {
             "destination_url=unix:/tmp/migrate.sock,local=on,downtime_ms=200,timeout_s=3600,timeout_strategy=cancel"
         ).expect("valid migration string should parse");
         assert_eq!(data.destination_url, "unix:/tmp/migrate.sock");
-        assert!(data.local());
+        assert_eq!(data.effective_memory_mode(), MigrationMode::MemFDs);
         assert_eq!(data.downtime_ms.get(), 200);
         assert_eq!(data.timeout_s.get(), 3600);
         assert_eq!(data.timeout_strategy, TimeoutStrategy::Cancel);
@@ -2401,7 +2406,7 @@ mod tests {
         let data = VmSendMigrationData::parse("destination_url=tcp:192.168.1.1:8080")
             .expect("minimal migration string should parse");
         assert_eq!(data.destination_url, "tcp:192.168.1.1:8080");
-        assert!(!data.local());
+        assert_eq!(data.effective_memory_mode(), MigrationMode::Precopy);
         assert_eq!(data.downtime_ms, VmSendMigrationData::default_downtime_ms());
         assert_eq!(data.timeout_s, VmSendMigrationData::default_timeout_s());
         assert_eq!(data.timeout_strategy, TimeoutStrategy::default());
@@ -2532,7 +2537,7 @@ mod tests {
         )
         .unwrap();
         assert!(data.preserve_source);
-        assert!(data.local());
+        assert_eq!(data.effective_memory_mode(), MigrationMode::MemFDs);
 
         // preserve_source defaults to false when unspecified.
         let data = VmSendMigrationData::parse("destination_url=unix:/tmp/sock,local=on").unwrap();
@@ -2550,18 +2555,18 @@ mod tests {
         let data = VmSendMigrationData::parse("destination_url=unix:/tmp/sock,memory_mode=memfds")
             .unwrap();
         assert_eq!(data.memory_mode, MigrationMode::MemFDs);
-        assert!(data.local());
+        assert_eq!(data.effective_memory_mode(), MigrationMode::MemFDs);
 
         // Without either setting, the migration is not local.
         let data = VmSendMigrationData::parse("destination_url=unix:/tmp/sock").unwrap();
-        assert!(!data.local());
+        assert_eq!(data.effective_memory_mode(), MigrationMode::Precopy);
 
         // The deprecated flag and the new mode may be combined.
         let data = VmSendMigrationData::parse(
             "destination_url=unix:/tmp/sock,local=on,memory_mode=memfds",
         )
         .unwrap();
-        assert!(data.local());
+        assert_eq!(data.effective_memory_mode(), MigrationMode::MemFDs);
 
         // Local migration requires a UNIX socket destination.
         VmSendMigrationData::parse("destination_url=tcp:192.168.1.1:8080,memory_mode=memfds")
@@ -2579,7 +2584,7 @@ mod tests {
         )
         .unwrap();
         assert!(data.preserve_source);
-        assert!(data.local());
+        assert_eq!(data.effective_memory_mode(), MigrationMode::MemFDs);
     }
 
     #[test]
@@ -2590,17 +2595,17 @@ mod tests {
             serde_json::from_str(r#"{"destination_url": "unix:/tmp/sock", "local": true}"#)
                 .unwrap();
         assert_eq!(data.memory_mode, MigrationMode::Precopy);
-        assert!(data.local());
+        assert_eq!(data.effective_memory_mode(), MigrationMode::MemFDs);
         data.validate().unwrap();
 
         let data: VmSendMigrationData =
             serde_json::from_str(r#"{"destination_url": "unix:/tmp/sock"}"#).unwrap();
-        assert!(!data.local());
+        assert_eq!(data.effective_memory_mode(), MigrationMode::Precopy);
 
         let data: VmSendMigrationData = serde_json::from_str(
             r#"{"destination_url": "unix:/tmp/sock", "memory_mode": "MemFDs"}"#,
         )
         .unwrap();
-        assert!(data.local());
+        assert_eq!(data.effective_memory_mode(), MigrationMode::MemFDs);
     }
 }

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1687,12 +1687,14 @@ components:
 
     MigrationMode:
       type: string
-      enum: ["Precopy", "Postcopy"]
+      enum: ["MemFDs", "Precopy", "Postcopy"]
       default: "Precopy"
       description: >
-        Memory transfer mode. Precopy transfers all guest memory before the
-        destination resumes. Postcopy resumes the destination first and faults
-        guest pages in on demand.
+        Memory transfer mode. MemFDs passes the guest memory backing file
+        descriptors to the destination over a UNIX socket. MemFDs requires every
+        guest memory region to use shared memory or hugepage backing. Precopy
+        transfers all guest memory before the destination resumes. Postcopy
+        resumes the destination first and faults guest pages in on demand.
 
     VmMemoryZoneUpdateData:
       type: object
@@ -1724,6 +1726,18 @@ components:
           type: string
         local:
           type: boolean
+          default: false
+          deprecated: true
+          description: >
+            Deprecated: set memory_mode to "MemFDs" instead. If true, the
+            request is treated as if memory_mode were "MemFDs".
+        preserve_source:
+          type: boolean
+          default: false
+          description: >
+            Keep the source VM alive in a paused state after migration
+            completes. This is only supported when memory_mode is "MemFDs" or
+            the deprecated local property is true.
         downtime_ms:
           type: integer
           format: int64

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1765,7 +1765,7 @@ components:
           description: >
             The number of parallel TCP connections to use for migration.
             Must be between 1 and 128. Multiple connections are not supported
-            with local UNIX-socket migration.
+            with UNIX domain socket migration.
         tls_dir:
           type: string
           description: >

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1615,6 +1615,8 @@ impl Vmm {
         // State machine that is updated with more context as we progress.
         let mut ctx = OngoingMigrationContext::new();
 
+        let memory_mode = send_data_migration.effective_memory_mode();
+
         // Set up the socket connection
         let mut socket = transport::send_migration_socket(
             &send_data_migration.destination_url,
@@ -1667,7 +1669,7 @@ impl Vmm {
             .map_err(MigratableError::MigrateSend)?
         };
 
-        if send_data_migration.local() {
+        if matches!(memory_mode, MigrationMode::MemFDs) {
             match &mut socket {
                 SocketStream::Unix(unix_socket) => {
                     // Proceed with sending memory file descriptors over UNIX socket
@@ -1686,7 +1688,7 @@ impl Vmm {
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             common_cpuid,
             memory_manager_data: vm.memory_manager_data(),
-            memory_mode: send_data_migration.memory_mode,
+            memory_mode,
         };
         transport::send_config(&mut socket, &vm_migration_config)?;
 
@@ -1696,9 +1698,7 @@ impl Vmm {
             vm.start_migration()?;
         }
 
-        if send_data_migration.local()
-            || matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
-        {
+        if matches!(memory_mode, MigrationMode::MemFDs | MigrationMode::Postcopy) {
             // Now pause VM (skip if already paused, e.g. migrating a paused VM)
             let downtime_begin = Instant::now();
             if vm.get_state() != VmState::Paused {
@@ -1748,8 +1748,7 @@ impl Vmm {
 
         // For postcopy, serve faults before sending State so the destination
         // can fault pages in during restore.
-        let postcopy_handle = if matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
-        {
+        let postcopy_handle = if matches!(memory_mode, MigrationMode::Postcopy) {
             let fault_stream = transport::open_fault_connection(
                 &send_data_migration.destination_url,
                 send_data_migration.tls_dir.as_deref(),
@@ -1778,9 +1777,7 @@ impl Vmm {
             let snapshot = vm.snapshot()?;
 
             // One final memory iteration to handle side effects from snapshot.
-            if !send_data_migration.local()
-                && !matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
-            {
+            if matches!(memory_mode, MigrationMode::Precopy) {
                 let memory_ranges = vm.dirty_log()?;
                 transport::send_memory_ranges(&vm.guest_memory(), &memory_ranges, &mut socket)?;
             }
@@ -1820,9 +1817,7 @@ impl Vmm {
         debug!("Downtime breakdown: {}", ctx.downtime_ctx);
 
         // Stop logging dirty pages
-        if !send_data_migration.local()
-            && !matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
-        {
+        if matches!(memory_mode, MigrationMode::Precopy) {
             vm.stop_dirty_log()?;
         }
 
@@ -3324,10 +3319,9 @@ impl RequestHandler for Vmm {
             .map_err(MigratableError::MigrateSend)?;
 
         info!(
-            "Sending migration: destination_url={},memory_mode={:?},local={},tls={},downtime={}ms,timeout={}s,timeout_strategy={:?}",
+            "Sending migration: destination_url={},memory_mode={:?},tls={},downtime={}ms,timeout={}s,timeout_strategy={:?}",
             send_data_migration.destination_url,
-            send_data_migration.memory_mode,
-            send_data_migration.local(),
+            send_data_migration.effective_memory_mode(),
             send_data_migration.tls_dir.is_some(),
             send_data_migration.downtime().as_millis(),
             send_data_migration.timeout().as_secs(),
@@ -3341,7 +3335,7 @@ impl RequestHandler for Vmm {
             .lock()
             .unwrap()
             .backed_by_shared_memory()
-            && send_data_migration.local()
+            && send_data_migration.effective_memory_mode() == MigrationMode::MemFDs
         {
             return Err(MigratableError::MigrateSend(anyhow!(
                 "Memory FD migration requires shared memory or hugepages enabled"

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1667,7 +1667,7 @@ impl Vmm {
             .map_err(MigratableError::MigrateSend)?
         };
 
-        if send_data_migration.local {
+        if send_data_migration.local() {
             match &mut socket {
                 SocketStream::Unix(unix_socket) => {
                     // Proceed with sending memory file descriptors over UNIX socket
@@ -1675,7 +1675,7 @@ impl Vmm {
                 }
                 _ => {
                     return Err(MigratableError::MigrateSend(anyhow!(
-                        "--local option is only supported with UNIX sockets",
+                        "Memory FD migration is only supported with UNIX sockets",
                     )));
                 }
             }
@@ -1696,7 +1696,7 @@ impl Vmm {
             vm.start_migration()?;
         }
 
-        if send_data_migration.local
+        if send_data_migration.local()
             || matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
         {
             // Now pause VM (skip if already paused, e.g. migrating a paused VM)
@@ -1709,7 +1709,9 @@ impl Vmm {
                 // No memory was transferred
                 MemoryMigrationContext::empty_finalized(),
             )
-            .expect("migration context should transition to VmPaused for local/postcopy migration");
+            .expect(
+                "migration context should transition to VmPaused for memfds/postcopy migration",
+            );
         } else {
             let mut mem_send = transport::SendAdditionalConnections::new(
                 &send_data_migration.destination_url,
@@ -1776,7 +1778,7 @@ impl Vmm {
             let snapshot = vm.snapshot()?;
 
             // One final memory iteration to handle side effects from snapshot.
-            if !send_data_migration.local
+            if !send_data_migration.local()
                 && !matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
             {
                 let memory_ranges = vm.dirty_log()?;
@@ -1818,7 +1820,7 @@ impl Vmm {
         debug!("Downtime breakdown: {}", ctx.downtime_ctx);
 
         // Stop logging dirty pages
-        if !send_data_migration.local
+        if !send_data_migration.local()
             && !matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
         {
             vm.stop_dirty_log()?;
@@ -3322,9 +3324,10 @@ impl RequestHandler for Vmm {
             .map_err(MigratableError::MigrateSend)?;
 
         info!(
-            "Sending migration: destination_url={},local={},tls={},downtime={}ms,timeout={}s,timeout_strategy={:?}",
+            "Sending migration: destination_url={},memory_mode={:?},local={},tls={},downtime={}ms,timeout={}s,timeout_strategy={:?}",
             send_data_migration.destination_url,
-            send_data_migration.local,
+            send_data_migration.memory_mode,
+            send_data_migration.local(),
             send_data_migration.tls_dir.is_some(),
             send_data_migration.downtime().as_millis(),
             send_data_migration.timeout().as_secs(),
@@ -3338,10 +3341,10 @@ impl RequestHandler for Vmm {
             .lock()
             .unwrap()
             .backed_by_shared_memory()
-            && send_data_migration.local
+            && send_data_migration.local()
         {
             return Err(MigratableError::MigrateSend(anyhow!(
-                "Local migration requires shared memory or hugepages enabled"
+                "Memory FD migration requires shared memory or hugepages enabled"
             )));
         }
 


### PR DESCRIPTION
TL;DR: Future proof cleanup, remove technical debt, and improved code quality.

`local` was an unfortunate naming. It actually stands for "memory-FDs when migrating over a UNIX domain socket". Since we have `enum MigrationMode` describing the ways memory gets migrated from A to B, we should fold the `local` flag into this. It makes so much more sense to model it in code like this.
