### PR TITLE
ci: Check Rust formatting per commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,12 +240,25 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           components: rustfmt
+      - name: Bisectability Check (rustfmt)
+        if: ${{ github.event_name == 'pull_request' && matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: |
+          set -eufo pipefail
+          commits=$(git rev-list origin/${{ github.base_ref }}..${{ github.sha }})
+          for commit in $commits; do
+            git checkout $commit
+            cargo fmt --all -- --check
+            cargo fmt --all --manifest-path fuzz/Cargo.toml -- --check
+          done
+          git checkout ${{ github.sha }}
       - name: Formatting (rustfmt)
         run: cargo fmt --all -- --check
       - name: Formatting (fuzz) (rustfmt)


### PR DESCRIPTION
## Summary

The formatting CI job currently checks only the final pull request merge
result. This allows intermediate commits with formatting errors to pass,
leaving a multi-commit series non-bisectable.

Fetch the full Git history and run the existing formatting checks for
each commit in the pull request range. Both the root and fuzz workspaces
are checked, while the existing final-tree checks remain in place for
pull requests and merge queue events.

Fixes #7513

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly fmt --all --manifest-path fuzz/Cargo.toml -- --check`
- `git diff --check origin/main...HEAD`
- Parsed the workflow YAML and checked the embedded Bash syntax locally