### PR TITLE
vmm: Reuse serial socket listener across reboot

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -2796,8 +2796,7 @@ mod common_parallel {
         handle_child_output(r, &output);
     }
 
-    #[test]
-    fn test_serial_socket_stale_cleanup() {
+    fn _test_serial_socket_stale_cleanup(landlock_reboot: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let serial_socket = guest.tmp_dir.as_path().join("serial.socket");
@@ -2817,8 +2816,8 @@ mod common_parallel {
 
         // The VM must remove the stale socket under the lock and bind anew;
         // without the cleanup this would fail with EADDRINUSE.
-        let mut child = GuestCommand::new(&guest)
-            .default_cpus()
+        let mut cmd = GuestCommand::new(&guest);
+        cmd.default_cpus()
             .default_memory()
             .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
             .args(["--cmdline", &cmdline])
@@ -2828,12 +2827,18 @@ mod common_parallel {
             .args([
                 "--serial",
                 format!("socket={}", serial_socket.to_str().unwrap()).as_str(),
-            ])
-            .spawn()
-            .unwrap();
+            ]);
+        if landlock_reboot {
+            cmd.args(["--landlock"]);
+        }
+        let mut child = cmd.spawn().unwrap();
 
         let r = panic::catch_unwind(|| {
             guest.wait_vm_boot().unwrap();
+            if landlock_reboot {
+                // Reboot reuses the listener after Landlock has been applied.
+                guest.reboot_linux(0);
+            }
             guest.ssh_command("sudo shutdown -h now").unwrap();
         });
 
@@ -2852,6 +2857,17 @@ mod common_parallel {
             }
         });
         handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_serial_socket_stale_cleanup() {
+        _test_serial_socket_stale_cleanup(false);
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_serial_socket_landlock_reboot() {
+        _test_serial_socket_stale_cleanup(true);
     }
 
     #[test]

--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -14,7 +14,7 @@ use std::fs::{File, OpenOptions, read_link};
 use std::mem::zeroed;
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::fs::OpenOptionsExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{io, result};
 
@@ -180,9 +180,27 @@ fn dup_stdout() -> errno::Result<File> {
     Ok(unsafe { File::from_raw_fd(stdout) })
 }
 
+fn get_or_create_serial_socket(
+    existing_listener: Option<&Arc<LockedUnixListener>>,
+    socket_path: &Path,
+) -> ConsoleDeviceResult<Arc<LockedUnixListener>> {
+    if let Some(listener) = existing_listener
+        && listener.path() == socket_path
+    {
+        return Ok(Arc::clone(listener));
+    }
+
+    LockedUnixListener::bind(socket_path)
+        .map(Arc::new)
+        .map_err(|e| match e {
+            LockedUnixListenerError::InUse(path) => ConsoleDeviceError::SerialSocketInUse(path),
+            LockedUnixListenerError::Io(e) => ConsoleDeviceError::CreateConsoleDevice(e),
+        })
+}
+
 pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<ConsoleInfo> {
-    // Drop the previous VM's console devices so a reboot can rebind the serial
-    // socket (its OFD lock is held until they drop).
+    // Drop per-VM console handles. The VMM-owned serial socket listener remains
+    // available for reuse across reboot and shutdown followed by boot.
     vmm.console_info = None;
 
     let vm_config = vmm.vm_config.as_mut().unwrap().clone();
@@ -264,17 +282,11 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                 ConsoleTransport::Tty(Arc::new(stdout))
             }
             ConsoleOutputMode::Socket => {
-                let socket =
-                    LockedUnixListener::bind(vmconfig.serial.common.socket.as_ref().unwrap())
-                        .map_err(|e| match e {
-                            LockedUnixListenerError::InUse(path) => {
-                                ConsoleDeviceError::SerialSocketInUse(path)
-                            }
-                            LockedUnixListenerError::Io(e) => {
-                                ConsoleDeviceError::CreateConsoleDevice(e)
-                            }
-                        })?;
-                ConsoleTransport::Socket(Arc::new(socket))
+                let socket_path = vmconfig.serial.common.socket.as_ref().unwrap();
+                ConsoleTransport::Socket(get_or_create_serial_socket(
+                    vmm.serial_socket_listener.as_ref(),
+                    socket_path,
+                )?)
             }
             ConsoleOutputMode::Null => ConsoleTransport::Null,
             ConsoleOutputMode::Off => ConsoleTransport::Off,
@@ -307,5 +319,31 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
         },
     };
 
+    vmm.serial_socket_listener = match &console_info.serial {
+        ConsoleTransport::Socket(listener) => Some(Arc::clone(listener)),
+        _ => None,
+    };
+
     Ok(console_info)
+}
+
+#[cfg(test)]
+mod tests {
+    use vmm_sys_util::tempdir::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn test_reuse_serial_socket_listener() {
+        let temp_dir = TempDir::new_with_prefix("/tmp/vmm-serial-socket").unwrap();
+        let socket_path = temp_dir.as_path().join("serial.socket");
+        let listener = get_or_create_serial_socket(None, &socket_path).unwrap();
+
+        let reused = get_or_create_serial_socket(Some(&listener), &socket_path).unwrap();
+        assert!(Arc::ptr_eq(&listener, &reused));
+
+        let other_path = temp_dir.as_path().join("other.socket");
+        let other = get_or_create_serial_socket(Some(&listener), &other_path).unwrap();
+        assert!(!Arc::ptr_eq(&listener, &other));
+    }
 }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -56,6 +56,7 @@ use crate::config::{MemoryRestoreMode, RestoreConfig, VmMemoryZoneUpdateData, ad
 use crate::coredump::GuestDebuggable;
 use crate::device_manager::DeviceManager;
 use crate::landlock::Landlock;
+use crate::locked_unix_listener::LockedUnixListener;
 use crate::memory_manager::{MemoryManager, MemoryRangePolicy};
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 use crate::migration::get_vm_snapshot;
@@ -711,6 +712,7 @@ pub struct Vmm {
     original_termios_opt: Arc<Mutex<Option<termios>>>,
     console_resize_pipe: Option<Arc<File>>,
     console_info: Option<ConsoleInfo>,
+    serial_socket_listener: Option<Arc<LockedUnixListener>>,
     no_shutdown: bool,
     check_migration_evt: EventFd,
 }
@@ -940,6 +942,7 @@ impl Vmm {
             original_termios_opt: Arc::new(Mutex::new(None)),
             console_resize_pipe: None,
             console_info: None,
+            serial_socket_listener: None,
             no_shutdown,
             check_migration_evt,
         })
@@ -2750,6 +2753,8 @@ impl RequestHandler for Vmm {
             VmOwnership::None => {}
         }
 
+        self.console_info = None;
+        self.serial_socket_listener = None;
         self.vm_config = None;
         event!("vm", "deleted");
 

--- a/vmm/src/locked_unix_listener.rs
+++ b/vmm/src/locked_unix_listener.rs
@@ -89,6 +89,10 @@ impl LockedUnixListener {
     pub(crate) fn listener(&self) -> &UnixListener {
         &self.listener
     }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 impl AsFd for LockedUnixListener {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -666,9 +666,8 @@ impl ApplyLandlock for CommonConsoleConfig {
         if let Some(file) = &self.file {
             landlock.add_rule_with_access(file, "rw")?;
         }
-        if let Some(socket) = &self.socket {
-            landlock.add_rule_with_access(socket, "rw")?;
-        }
+        // Socket listeners are created before Landlock is applied and retained
+        // by the VMM, so serial I/O does not need path-based access.
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Keep the locked serial socket listener owned by the VMM.
- Reuse the listener across VM reboot and shutdown followed by boot.
- Release the persistent listener when the VM is deleted.
- Avoid granting broader Landlock directory permissions for socket rebinding.
- Preserve cross-architecture stale socket cleanup coverage and add an
  x86-64 Landlock reboot regression test.

## Background

Console devices are pre-created before Landlock is applied. During a VM
reboot, the serial socket listener was previously dropped and rebound.

Once Landlock had restricted the VMM, rebinding failed because removing
and creating Unix socket paths was no longer permitted. Granting the
required permissions on the parent directory would unnecessarily broaden
the VMM's filesystem access.

## Implementation

The locked serial socket listener is now retained by the VMM independently
of the per-VM console handles. When console devices are recreated, the
listener is reused if the configured socket path is unchanged.

The listener remains available across reboot and shutdown followed by
boot, while VM deletion explicitly releases it. Serial I/O continues to
use the already-open listener file descriptor, so the serial socket path
no longer needs an automatic Landlock rule.

The existing stale socket cleanup test remains architecture-independent.
A separate x86-64 test enables Landlock and verifies that the guest can
reboot successfully with a serial socket configured.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo check --locked --all-targets --tests`
- `cargo test -p vmm --features kvm`
  - 114 unit tests passed
  - 1 doctest passed