### PR TITLE
vmm: Reuse serial socket listener across reboot

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -2796,8 +2796,7 @@ mod common_parallel {
         handle_child_output(r, &output);
     }
 
-    #[test]
-    fn test_serial_socket_stale_cleanup() {
+    fn _test_serial_socket_stale_cleanup(reboot: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let serial_socket = guest.tmp_dir.as_path().join("serial.socket");
@@ -2817,13 +2816,17 @@ mod common_parallel {
 
         // The VM must remove the stale socket under the lock and bind anew;
         // without the cleanup this would fail with EADDRINUSE.
-        let mut child = GuestCommand::new(&guest)
-            .default_cpus()
+        let mut cmd = GuestCommand::new(&guest);
+        cmd.default_cpus()
             .default_memory()
             .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
             .args(["--cmdline", &cmdline])
             .default_disks()
-            .default_net()
+            .default_net();
+        // The arm64 runner does not support the required Landlock ABI V3 yet.
+        #[cfg(not(target_arch = "aarch64"))]
+        cmd.args(["--landlock"]);
+        let mut child = cmd
             .args(["--console", "null"])
             .args([
                 "--serial",
@@ -2834,6 +2837,9 @@ mod common_parallel {
 
         let r = panic::catch_unwind(|| {
             guest.wait_vm_boot().unwrap();
+            if reboot {
+                guest.reboot_linux(0);
+            }
             guest.ssh_command("sudo shutdown -h now").unwrap();
         });
 
@@ -2852,6 +2858,16 @@ mod common_parallel {
             }
         });
         handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_serial_socket_stale_cleanup() {
+        _test_serial_socket_stale_cleanup(false);
+    }
+
+    #[test]
+    fn test_serial_socket_landlock_reboot() {
+        _test_serial_socket_stale_cleanup(true);
     }
 
     #[test]

--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -181,8 +181,8 @@ fn dup_stdout() -> errno::Result<File> {
 }
 
 pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<ConsoleInfo> {
-    // Drop the previous VM's console devices so a reboot can rebind the serial
-    // socket (its OFD lock is held until they drop).
+    // Drop the previous VM's console handles. The VMM serial socket listener
+    // remains available for reuse across reboot and shutdown followed by boot.
     vmm.console_info = None;
 
     let vm_config = vmm.vm_config.as_mut().unwrap().clone();
@@ -264,17 +264,22 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                 ConsoleTransport::Tty(Arc::new(stdout))
             }
             ConsoleOutputMode::Socket => {
-                let socket =
-                    LockedUnixListener::bind(vmconfig.serial.common.socket.as_ref().unwrap())
-                        .map_err(|e| match e {
-                            LockedUnixListenerError::InUse(path) => {
-                                ConsoleDeviceError::SerialSocketInUse(path)
-                            }
-                            LockedUnixListenerError::Io(e) => {
-                                ConsoleDeviceError::CreateConsoleDevice(e)
-                            }
-                        })?;
-                ConsoleTransport::Socket(Arc::new(socket))
+                let socket_path = vmconfig.serial.common.socket.as_ref().unwrap();
+                if let Some(listener) = vmm.serial_socket_listener.as_ref()
+                    && listener.path() == socket_path
+                {
+                    ConsoleTransport::Socket(Arc::clone(listener))
+                } else {
+                    let listener = LockedUnixListener::bind(socket_path).map_err(|e| match e {
+                        LockedUnixListenerError::InUse(path) => {
+                            ConsoleDeviceError::SerialSocketInUse(path)
+                        }
+                        LockedUnixListenerError::Io(e) => {
+                            ConsoleDeviceError::CreateConsoleDevice(e)
+                        }
+                    })?;
+                    ConsoleTransport::Socket(Arc::new(listener))
+                }
             }
             ConsoleOutputMode::Null => ConsoleTransport::Null,
             ConsoleOutputMode::Off => ConsoleTransport::Off,
@@ -305,6 +310,11 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
             ConsoleOutputMode::Null => ConsoleTransport::Null,
             ConsoleOutputMode::Off => ConsoleTransport::Off,
         },
+    };
+
+    vmm.serial_socket_listener = match &console_info.serial {
+        ConsoleTransport::Socket(listener) => Some(Arc::clone(listener)),
+        _ => None,
     };
 
     Ok(console_info)

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -56,6 +56,7 @@ use crate::config::{MemoryRestoreMode, RestoreConfig, VmMemoryZoneUpdateData, ad
 use crate::coredump::GuestDebuggable;
 use crate::device_manager::DeviceManager;
 use crate::landlock::Landlock;
+use crate::locked_unix_listener::LockedUnixListener;
 use crate::memory_manager::{MemoryManager, MemoryRangePolicy};
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 use crate::migration::get_vm_snapshot;
@@ -711,6 +712,7 @@ pub struct Vmm {
     original_termios_opt: Arc<Mutex<Option<termios>>>,
     console_resize_pipe: Option<Arc<File>>,
     console_info: Option<ConsoleInfo>,
+    serial_socket_listener: Option<Arc<LockedUnixListener>>,
     no_shutdown: bool,
     check_migration_evt: EventFd,
 }
@@ -940,6 +942,7 @@ impl Vmm {
             original_termios_opt: Arc::new(Mutex::new(None)),
             console_resize_pipe: None,
             console_info: None,
+            serial_socket_listener: None,
             no_shutdown,
             check_migration_evt,
         })
@@ -2750,6 +2753,8 @@ impl RequestHandler for Vmm {
             VmOwnership::None => {}
         }
 
+        self.console_info = None;
+        self.serial_socket_listener = None;
         self.vm_config = None;
         event!("vm", "deleted");
 

--- a/vmm/src/locked_unix_listener.rs
+++ b/vmm/src/locked_unix_listener.rs
@@ -89,6 +89,10 @@ impl LockedUnixListener {
     pub(crate) fn listener(&self) -> &UnixListener {
         &self.listener
     }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 impl AsFd for LockedUnixListener {


### PR DESCRIPTION
## Summary

- Keep the locked serial socket listener owned by the VMM.
- Reuse the listener across VM reboot and shutdown followed by boot.
- Release the persistent listener when the VM is deleted.
- Avoid granting broader Landlock directory permissions for socket rebinding.
- Preserve cross-architecture stale socket cleanup coverage and add an
  x86-64 Landlock reboot regression test.

## Background

Console devices are pre-created before Landlock is applied. During a VM
reboot, the serial socket listener was previously dropped and rebound.

Once Landlock had restricted the VMM, rebinding failed because removing
and creating Unix socket paths was no longer permitted. Granting the
required permissions on the parent directory would unnecessarily broaden
the VMM's filesystem access.

## Implementation

The locked serial socket listener is now retained by the VMM independently
of the per-VM console handles. When console devices are recreated, the
listener is reused if the configured socket path is unchanged.

The listener remains available across reboot and shutdown followed by
boot, while VM deletion explicitly releases it. Serial I/O continues to
use the already-open listener file descriptor, so the serial socket path
no longer needs an automatic Landlock rule.

The existing stale socket cleanup test remains architecture-independent.
A separate x86-64 test enables Landlock and verifies that the guest can
reboot successfully with a serial socket configured.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo check --locked --all-targets --tests`
- `cargo test -p vmm --features kvm`
  - 114 unit tests passed
  - 1 doctest passed

Fixes #8793