### PR TITLE
treewide: Fix naming inconsistencies in error messages

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -145,7 +145,7 @@ pub enum ExecuteError {
     AsyncRead(#[source] AsyncIoError),
     #[error("Failed to async write")]
     AsyncWrite(#[source] AsyncIoError),
-    #[error("failed to async flush")]
+    #[error("Failed to async flush")]
     AsyncFlush(#[source] AsyncIoError),
     #[error("Failed to async punch hole")]
     AsyncPunchHole(#[source] AsyncIoError),

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -35,10 +35,10 @@ type ApiResult = Result<(), Error>;
 
 #[derive(Error, Debug)]
 enum Error {
-    #[error("http client error")]
+    #[error("HTTP Client Error")]
     HttpApiClient(#[source] ApiClientError),
     #[cfg(feature = "dbus_api")]
-    #[error("dbus api client error")]
+    #[error("D-Bus API Client Error")]
     DBusApiClient(#[source] zbus::Error),
     #[error("Error parsing CPU count")]
     InvalidCpuCount(#[source] num::ParseIntError),

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -51,9 +51,9 @@ const AMBA_ID_HIGH: u64 = 0x401;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("pl011_write: Bad Write Offset: {0}")]
+    #[error("PL011 write: Bad write offset: {0}")]
     BadWriteOffset(u64),
-    #[error("pl011: DMA not implemented")]
+    #[error("PL011: DMA not implemented")]
     DmaNotImplemented,
     #[error("Failed to trigger interrupt")]
     InterruptFailure(#[source] io::Error),

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -494,39 +494,39 @@ pub struct PciBarConfiguration {
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("address {0} size {1} too big")]
+    #[error("Address {0} size {1} too big")]
     BarAddressInvalid(u64, u64),
-    #[error("bar {0} already used")]
+    #[error("BAR {0} already used")]
     BarInUse(usize),
-    #[error("64bit bar {0} already used (requires two regs)")]
+    #[error("64-bit BAR {0} already used (requires two regs)")]
     BarInUse64(usize),
-    #[error("bar {0} invalid, max {max}", max = NUM_BAR_REGS - 1)]
+    #[error("BAR {0} invalid, max {max}", max = NUM_BAR_REGS - 1)]
     BarInvalid(usize),
-    #[error("64bitbar {0} invalid, requires two regs, max {max}", max = NUM_BAR_REGS - 1)]
+    #[error("64-bit BAR {0} invalid, requires two regs, max {max}", max = NUM_BAR_REGS - 1)]
     BarInvalid64(usize),
-    #[error("bar address {0} not a power of two")]
+    #[error("BAR address {0} not a power of two")]
     BarSizeInvalid(u64),
-    #[error("empty capabilities are invalid")]
+    #[error("Empty capabilities are invalid")]
     CapabilityEmpty,
     #[error("Invalid capability length {0}")]
     CapabilityLengthInvalid(usize),
-    #[error("capability of size {0} doesn't fit")]
+    #[error("Capability of size {0} doesn't fit")]
     CapabilitySpaceFull(usize),
-    #[error("failed to decode 32 bits BAR size")]
+    #[error("Failed to decode 32-bit BAR size")]
     Decode32BarSize,
-    #[error("failed to decode 64 bits BAR size")]
+    #[error("Failed to decode 64-bit BAR size")]
     Decode64BarSize,
-    #[error("failed to encode 32 bits BAR size")]
+    #[error("Failed to encode 32-bit BAR size")]
     Encode32BarSize,
-    #[error("failed to encode 64 bits BAR size")]
+    #[error("Failed to encode 64-bit BAR size")]
     Encode64BarSize,
-    #[error("address {0} size {1} too big")]
+    #[error("Address {0} size {1} too big")]
     RomBarAddressInvalid(u64, u64),
-    #[error("rom bar {0} already used")]
+    #[error("ROM BAR {0} already used")]
     RomBarInUse(usize),
-    #[error("rom bar {0} invalid, max {max}", max = NUM_BAR_REGS - 1)]
+    #[error("ROM BAR {0} invalid, max {max}", max = NUM_BAR_REGS - 1)]
     RomBarInvalid(usize),
-    #[error("rom bar address {0} not a power of two")]
+    #[error("ROM BAR address {0} not a power of two")]
     RomBarSizeInvalid(u64),
 }
 pub type Result<T> = result::Result<T, Error>;

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -15,11 +15,11 @@ use crate::{ImageFormat, PerformanceTestControl, PerformanceTestOverrides, mean}
 
 #[derive(Error, Debug)]
 enum Error {
-    #[error("boot time could not be parsed")]
+    #[error("Boot time could not be parsed")]
     BootTimeParse,
-    #[error("infrastructure failure")]
+    #[error("Infrastructure failure")]
     Infra(#[from] InfraError),
-    #[error("restore time could not be parsed")]
+    #[error("Restore time could not be parsed")]
     RestoreTimeParse,
 }
 

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -166,11 +166,11 @@ impl ProcessRegistry {
 
 #[derive(Error, Debug)]
 pub enum WaitTimeoutError {
-    #[error("timeout")]
+    #[error("Timeout")]
     Timedout,
-    #[error("exit status indicates failure")]
+    #[error("Exit status indicates failure")]
     ExitStatus,
-    #[error("general failure")]
+    #[error("General failure")]
     General(#[source] io::Error),
 }
 
@@ -178,21 +178,21 @@ pub enum WaitTimeoutError {
 pub enum Error {
     #[error("Failed to parse")]
     Parsing(#[source] num::ParseIntError),
-    #[error("ssh command failed")]
+    #[error("SSH command failed")]
     SshCommand(#[from] SshCommandError),
-    #[error("waiting for boot failed")]
+    #[error("Waiting for boot failed")]
     WaitForBoot(#[source] WaitForBootError),
-    #[error("reading log file failed")]
+    #[error("Reading log file failed")]
     EthrLogFile(#[source] io::Error),
-    #[error("parsing log file failed")]
+    #[error("Parsing log file failed")]
     EthrLogParse,
-    #[error("parsing fio output failed")]
+    #[error("Parsing fio output failed")]
     FioOutputParse,
-    #[error("parsing iperf3 output failed")]
+    #[error("Parsing iperf3 output failed")]
     Iperf3Parse,
-    #[error("spawning process failed")]
+    #[error("Spawning process failed")]
     Spawn(#[source] io::Error),
-    #[error("waiting for timeout failed")]
+    #[error("Waiting for timeout failed")]
     WaitTimeout(#[source] WaitTimeoutError),
 }
 
@@ -266,7 +266,7 @@ pub enum WaitForBootError {
     Listen(#[source] io::Error),
     #[error("Epoll wait timeout")]
     EpollWaitTimeout,
-    #[error("wrong guest address")]
+    #[error("Wrong guest address")]
     WrongGuestAddr,
     #[error("Failed to accept a TCP request")]
     Accept(#[source] io::Error),
@@ -816,37 +816,37 @@ pub const DEFAULT_SSH_TIMEOUT: u8 = 10;
 
 #[derive(Error, Debug)]
 pub enum SshCommandError {
-    #[error("ssh connection failed")]
+    #[error("SSH connection failed")]
     Connection(#[source] io::Error),
-    #[error("ssh handshake failed")]
+    #[error("SSH handshake failed")]
     Handshake(#[source] ssh2::Error),
-    #[error("ssh authentication failed")]
+    #[error("SSH authentication failed")]
     Authentication(#[source] ssh2::Error),
-    #[error("ssh channel session failed")]
+    #[error("SSH channel session failed")]
     ChannelSession(#[source] ssh2::Error),
-    #[error("ssh command failed")]
+    #[error("SSH command failed")]
     Command(#[source] ssh2::Error),
-    #[error("retrieving exit status from ssh command failed")]
+    #[error("Retrieving exit status from SSH command failed")]
     ExitStatus(#[source] ssh2::Error),
-    #[error("the exit code indicates failure: {0}")]
+    #[error("The exit code indicates failure: {0}")]
     NonZeroExitStatus(i32),
-    #[error("failed to read file")]
+    #[error("Failed to read file")]
     FileRead(#[source] io::Error),
-    #[error("failed to read metadata")]
+    #[error("Failed to read metadata")]
     FileMetadata(#[source] io::Error),
-    #[error("scp send failed")]
+    #[error("SCP send failed")]
     ScpSend(#[source] ssh2::Error),
-    #[error("scp write failed")]
+    #[error("SCP write failed")]
     WriteAll(#[source] io::Error),
-    #[error("scp send EOF failed")]
+    #[error("SCP send EOF failed")]
     SendEof(#[source] ssh2::Error),
-    #[error("scp wait EOF failed")]
+    #[error("SCP wait EOF failed")]
     WaitEof(#[source] ssh2::Error),
 }
 
 #[derive(Error, Debug)]
 pub enum WaitForSshError {
-    #[error("timed out after {timeout:?} waiting for ssh command {command:?} on {ip}: {source}")]
+    #[error("Timed out after {timeout:?} waiting for SSH command {command:?} on {ip}: {source}")]
     Timeout {
         command: String,
         ip: String,

--- a/vm-migration/src/context.rs
+++ b/vm-migration/src/context.rs
@@ -101,13 +101,13 @@ impl CompletedMigrationContext {
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum MigrationContextError {
     /// The memory migration context was not finalized before transition.
-    #[error("memory migration context should be finalized before pausing the VM")]
+    #[error("Memory migration context should be finalized before pausing the VM")]
     MemoryContextNotFinalized,
     /// The transition to `VmPaused` was attempted from an invalid state.
-    #[error("memory migration should only advance from the Begin state")]
+    #[error("Memory migration should only advance from the Begin state")]
     InvalidVmPausedTransition,
     /// Finalization was attempted before memory migration completed.
-    #[error("migration should only finalize after memory migration completed")]
+    #[error("Migration should only finalize after memory migration completed")]
     InvalidFinalizeTransition,
 }
 

--- a/vmm/src/coredump.rs
+++ b/vmm/src/coredump.rs
@@ -37,9 +37,9 @@ pub struct DumpState {
 
 #[derive(Error, Debug)]
 pub enum GuestDebuggableError {
-    #[error("coredump")]
+    #[error("Coredump")]
     Coredump(#[source] anyhow::Error),
-    #[error("coredump file")]
+    #[error("Coredump file")]
     CoredumpFile(#[source] io::Error),
     #[error("Failed to pause")]
     Pause(#[source] vm_migration::MigratableError),

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -88,19 +88,19 @@ pub struct SnpCpuidInfo {
 }
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("command line is not a valid C string")]
+    #[error("Command line is not a valid C string")]
     InvalidCommandLine(#[source] ffi::NulError),
-    #[error("failed to read igvm file")]
+    #[error("Failed to read IGVM file")]
     Igvm(#[source] io::Error),
-    #[error("invalid igvm file")]
+    #[error("Invalid IGVM file")]
     InvalidIgvmFile(#[source] igvm::Error),
-    #[error("multiple SNP ID blocks in IGVM file")]
+    #[error("Multiple SNP ID blocks in IGVM file")]
     DuplicateSnpIdBlock,
-    #[error("invalid guest memory map")]
+    #[error("Invalid guest memory map")]
     InvalidGuestMemmap(#[source] arch::Error),
-    #[error("loader error")]
+    #[error("Loader error")]
     Loader(#[source] loader::Error),
-    #[error("parameter too large for parameter area")]
+    #[error("Parameter too large for parameter area")]
     ParameterTooLarge,
     #[error("Error importing isolated pages")]
     ImportIsolatedPages(#[source] hypervisor::HypervisorVmError),

--- a/vmm/src/igvm/loader.rs
+++ b/vmm/src/igvm/loader.rs
@@ -31,13 +31,13 @@ pub struct ImportRegion {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("overlaps with existing import region {0:?}")]
+    #[error("Overlaps with existing import region {0:?}")]
     OverlapsExistingRegion(ImportRegion),
-    #[error("memory unavailable")]
+    #[error("Memory unavailable")]
     MemoryUnavailable,
-    #[error("failed to import pages")]
+    #[error("Failed to import pages")]
     ImportPagesFailed,
-    #[error("data larger than imported region")]
+    #[error("Data larger than imported region")]
     DataTooLarge,
 }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -207,7 +207,7 @@ pub enum Error {
     #[error("Cannot clone EventFd")]
     EventFdClone(#[source] io::Error),
 
-    #[error("invalid VM state transition: {0:?} to {1:?}")]
+    #[error("Invalid VM state transition: {0:?} to {1:?}")]
     InvalidStateTransition(VmState, VmState),
 
     #[error("Error from CPU manager")]
@@ -345,7 +345,7 @@ pub enum Error {
     #[error("Error spawning kernel loading thread")]
     KernelLoadThreadSpawn(#[source] io::Error),
 
-    #[error("Error joining kernel loading thread")]
+    #[error("Error joining kernel loading thread: {0:?}")]
     KernelLoadThreadJoin(Box<dyn any::Any + Send>),
 
     #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]


### PR DESCRIPTION
Trivial treewide fixing of inconsistencies in error messages. I found one while working on #8455 and LLM assistence helper me to identify the others easily.

