### PR TITLE
aarch64: Support running integration tests on Graviton4

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -12832,6 +12832,23 @@ mod vfio {
 mod aarch64_acpi {
     use crate::*;
 
+    fn kvm_exposes_split_l1_cache() -> bool {
+        const CTR_EL0_IDC: u64 = 1 << 28;
+        const CTR_EL0_DIC: u64 = 1 << 29;
+
+        let ctr_el0: u64;
+        // SAFETY: CTR_EL0 is read-only and this touches no memory or stack.
+        unsafe {
+            std::arch::asm!(
+                "mrs {}, ctr_el0",
+                out(reg) ctr_el0,
+                options(nomem, nostack, preserves_flags),
+            );
+        }
+
+        ctr_el0 & (CTR_EL0_IDC | CTR_EL0_DIC) == 0
+    }
+
     #[test]
     fn test_simple_launch_acpi() {
         let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
@@ -12902,6 +12919,11 @@ mod aarch64_acpi {
 
     #[test]
     fn test_cache_topology() {
+        if !kvm_exposes_split_l1_cache() {
+            println!("SKIPPED: KVM does not expose a split L1 data and instruction cache");
+            return;
+        }
+
         let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
 
         vec![Box::new(jammy)].drain(..).for_each(|disk_config| {

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -141,6 +141,9 @@ if [ $RES -ne 0 ]; then
     exit 1
 fi
 
+# Set number of open descriptors high enough for VFIO tests to run
+ulimit -n 4096
+
 # Common configuration for every test run
 export RUST_BACKTRACE=1
 export RUSTFLAGS="$RUSTFLAGS"

--- a/scripts/test_assets.yaml
+++ b/scripts/test_assets.yaml
@@ -85,8 +85,8 @@ assets:
     test: [integration]
 
   - filename: cloud-hypervisor-static-aarch64
-    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v52.0/cloud-hypervisor-static-aarch64
-    sha256: bf004ddc1a148f47caa87ac49a783b8dbd6bf9bc27abe522ed197df7b982d3b1
+    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v53.0/cloud-hypervisor-static-aarch64
+    sha256: f192b510eea1c710cbc439d716bb0573c223fc463dbe3e6523788a2b7ef62850
     executable: true
     arch: [aarch64]
     test: [integration]


### PR DESCRIPTION
Set up the Cloud Hypervisor aarch64 integration tests to run on Graviton4 hosts.

```
./scripts/dev_cli.sh tests --integration --libc musl --hypervisor kvm
...
cargo nextest run -p cloud-hypervisor --profile common_tests --no-tests=pass --test-threads=24 '' --
Summary [ 772.574s] 176 tests run: 176 passed (8 slow), 87 skipped
...
cargo nextest run -p cloud-hypervisor --profile dbus --no-tests=pass --test-threads=24 '' --
Summary [  87.774s] 5 tests run: 5 passed (1 slow), 258 skipped
...
cargo nextest run -p cloud-hypervisor --profile fw_cfg --no-tests=pass --test-threads=24 '' --
Summary [   6.938s] 2 tests run: 2 passed, 261 skipped
...
cargo nextest run -p cloud-hypervisor --profile ivshmem --no-tests=pass --test-threads=24 '' --
Summary [  62.574s] 17 tests run: 17 passed (3 slow), 246 skipped
```