### PR TITLE
seccomp: allow newfstatat syscall

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -1080,6 +1080,7 @@ fn migration_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError
         (libc::SYS_mremap, vec![]),
         (libc::SYS_munmap, vec![]),
         (libc::SYS_nanosleep, vec![]),
+        (libc::SYS_newfstatat, vec![]),
         (libc::SYS_openat, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_poll, vec![]),


### PR DESCRIPTION
Some libc implementation uses newfstatat when calling libc::fstat. Such implementation would trigger seccomp since newfstatat is not whitelisted.