### PR TITLE
Remove Much Dead Code (147 enum variants, 22 functions, more)

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -206,15 +206,6 @@ pub fn simple_api_full_command<T: Read + Write + ScmSocket>(
     simple_api_full_command_with_fds(socket, method, full_command, request_body, &[])
 }
 
-pub fn simple_api_full_command_and_response<T: Read + Write + ScmSocket>(
-    socket: &mut T,
-    method: &str,
-    full_command: &str,
-    request_body: Option<&str>,
-) -> Result<Option<String>, Error> {
-    simple_api_full_command_with_fds_and_response(socket, method, full_command, request_body, &[])
-}
-
 pub fn simple_api_command_with_fds<T: Read + Write + ScmSocket>(
     socket: &mut T,
     method: &str,

--- a/arch/src/x86_64/cpu_profile/mod.rs
+++ b/arch/src/x86_64/cpu_profile/mod.rs
@@ -483,9 +483,9 @@ mod tests {
             let leaf2 = transform_leaf(leaf2);
 
             // The leaves should still be distinct
-            assert!(leaf0 != leaf1);
-            assert!(leaf0 != leaf2);
-            assert!(leaf1 != leaf2);
+            assert_ne!(leaf0, leaf1);
+            assert_ne!(leaf0, leaf2);
+            assert_ne!(leaf1, leaf2);
             // We have now setup leaves to be used in this test
 
             // Let's now construct some simple adjustments

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -38,7 +38,6 @@ use vm_memory::{
     Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend,
     GuestMemoryRegion,
 };
-use vmm_sys_util::fam;
 
 use crate::x86_64::cpu_profile::cpuid_adjustments::MissingCpuidEntriesError;
 use crate::{CpuProfile, GuestMemoryMmap, InitramfsConfig, RegionType};
@@ -151,14 +150,6 @@ pub enum Error {
     /// Error getting supported CPUID through the hypervisor (kvm/mshv) API
     #[error("Error getting supported CPUID through the hypervisor API")]
     CpuidGetSupported(#[source] HypervisorError),
-
-    /// Error populating CPUID with KVM HyperV emulation details
-    #[error("Error populating CPUID with KVM HyperV emulation details")]
-    CpuidKvmHyperV(#[source] fam::Error),
-
-    /// Error populating CPUID with CPU identification
-    #[error("Error populating CPUID with CPU identification")]
-    CpuidIdentification(#[source] fam::Error),
 
     /// Error checking CPUID compatibility
     #[error("Error checking CPUID compatibility")]

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -50,18 +50,6 @@ pub enum Error {
     /// Writing the IDT to RAM failed.
     #[error("Writing the IDT to RAM failed")]
     WriteIdt(#[source] GuestMemoryError),
-    /// Writing PDPTE to RAM failed.
-    #[error("Writing PDPTE to RAM failed")]
-    WritePdpteAddress(#[source] GuestMemoryError),
-    /// Writing PDE to RAM failed.
-    #[error("Writing PDE to RAM failed")]
-    WritePdeAddress(#[source] GuestMemoryError),
-    /// Writing PML4 to RAM failed.
-    #[error("Writing PML4 to RAM failed")]
-    WritePml4Address(#[source] GuestMemoryError),
-    /// Writing PML5 to RAM failed.
-    #[error("Writing PML5 to RAM failed")]
-    WritePml5Address(#[source] GuestMemoryError),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/block/src/error.rs
+++ b/block/src/error.rs
@@ -153,21 +153,6 @@ impl BlockError {
         }
     }
 
-    /// Attach or replace the source error (builder-style).
-    pub fn with_source<E>(mut self, source: E) -> Self
-    where
-        E: StdError + Send + Sync + 'static,
-    {
-        self.source = Some(Box::new(source));
-        self
-    }
-
-    /// Attach diagnostic context.
-    pub fn with_ctx(mut self, ctx: ErrorContext) -> Self {
-        self.ctx = Some(ctx);
-        self
-    }
-
     /// Replace the error classification (builder-style).
     pub fn with_kind(mut self, kind: BlockErrorKind) -> Self {
         self.kind = kind;
@@ -183,12 +168,6 @@ impl BlockError {
     /// Shorthand: attach a file path.
     pub fn with_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.ctx.get_or_insert_with(ErrorContext::default).path = Some(path.into());
-        self
-    }
-
-    /// Shorthand: attach a byte offset.
-    pub fn with_offset(mut self, offset: u64) -> Self {
-        self.ctx.get_or_insert_with(ErrorContext::default).offset = Some(offset);
         self
     }
 

--- a/block/src/error.rs
+++ b/block/src/error.rs
@@ -38,10 +38,6 @@ pub enum BlockErrorKind {
     UnsupportedFeature,
     /// The image is marked or detected as corrupt.
     CorruptImage,
-    /// An address, offset, or index is outside the valid range.
-    OutOfBounds,
-    /// A file or required internal structure could not be found.
-    NotFound,
     /// An internal counter or limit was exceeded.
     Overflow,
     /// Image type mismatch
@@ -55,8 +51,6 @@ impl Display for BlockErrorKind {
             Self::InvalidFormat => write!(f, "Invalid format"),
             Self::UnsupportedFeature => write!(f, "Unsupported feature"),
             Self::CorruptImage => write!(f, "Corrupt image"),
-            Self::OutOfBounds => write!(f, "Out of bounds"),
-            Self::NotFound => write!(f, "Not found"),
             Self::Overflow => write!(f, "Overflow"),
             Self::ImageTypeMismatch { specified } => {
                 write!(f, "Image type mismatch: specified = {specified}")

--- a/block/src/formats/qcow/parser.rs
+++ b/block/src/formats/qcow/parser.rs
@@ -52,16 +52,12 @@ pub enum Error {
     BackingFileOverlapsHeader(u64, u32, u32),
     #[error("Backing file size {0:#x} with zero offset")]
     BackingFileSizeWithoutOffset(u32),
-    #[error("Backing file support is disabled")]
-    BackingFilesDisabled,
     #[error("Backing file name is too long: {0} bytes over")]
     BackingFileTooLong(usize),
     #[error("Failed to clone backing file")]
     CloneBackingFile(#[source] io::Error),
     #[error("Image is marked corrupt and cannot be opened for writing")]
     CorruptImage,
-    #[error("Failed to evict cache")]
-    EvictingCache(#[source] io::Error),
     #[error("File larger than max of {MAX_QCOW_FILE_SIZE}: {0}")]
     FileTooBig(u64),
     #[error("Failed to get file size")]
@@ -94,44 +90,22 @@ pub enum Error {
     InvalidRefcountTableSize(u64),
     #[error("Maximum disk nesting depth exceeded")]
     MaxNestingDepthExceeded,
-    #[error("No free clusters")]
-    NoFreeClusters,
     #[error("No refcount clusters")]
     NoRefcountClusters,
     #[error("Not enough space for refcounts")]
     NotEnoughSpaceForRefcounts,
-    #[error("Failed to open file {0}")]
-    OpeningFile(#[source] io::Error),
-    #[error("Failed to read data")]
-    ReadingData(#[source] io::Error),
     #[error("Failed to read header")]
     ReadingHeader(#[source] io::Error),
     #[error("Failed to read pointers")]
     ReadingPointers(#[source] io::Error),
-    #[error("Failed to read ref count block")]
-    ReadingRefCountBlock(#[source] refcount::Error),
     #[error("Failed to read ref counts")]
     ReadingRefCounts(#[source] io::Error),
-    #[error("Failed to rebuild ref counts")]
-    RebuildingRefCounts(#[source] io::Error),
     #[error("Refcount overflow")]
     RefcountOverflow(#[source] refcount::Error),
     #[error("Refcount table offset past file end")]
     RefcountTableOffEnd,
     #[error("Too many clusters specified for refcount")]
     RefcountTableTooLarge,
-    #[error("Failed to resize")]
-    ResizeIo(#[source] io::Error),
-    #[error("Resize not supported with backing file")]
-    ResizeWithBackingFile,
-    #[error("Failed to set file size")]
-    SettingFileSize(#[source] io::Error),
-    #[error("Failed to set refcount refcount")]
-    SettingRefcountRefcount(#[source] io::Error),
-    #[error("Shrinking QCOW images is not supported")]
-    ShrinkNotSupported,
-    #[error("Size too small for number of clusters")]
-    SizeTooSmallForNumberOfClusters,
     #[error("Failed to sync header")]
     SyncingHeader(#[source] io::Error),
     #[error("L1 entry table too large: {0}")]
@@ -148,8 +122,6 @@ pub enum Error {
     UnsupportedRefcountOrder,
     #[error("Unsupported version: {0}")]
     UnsupportedVersion(u32),
-    #[error("Failed to write data")]
-    WritingData(#[source] io::Error),
     #[error("Failed to write header")]
     WritingHeader(#[source] io::Error),
 }

--- a/block/src/formats/vhdx/dynamic.rs
+++ b/block/src/formats/vhdx/dynamic.rs
@@ -19,8 +19,6 @@ use crate::aligned_file::AlignedFile;
 #[sorted]
 #[derive(Error, Debug)]
 pub enum VhdxError {
-    #[error("Not a VHDx file")]
-    NotVhdx(#[source] VhdxHeaderError),
     #[error("Failed to parse VHDx header")]
     ParseVhdxHeader(#[source] VhdxHeaderError),
     #[error("Failed to parse VHDx metadata")]

--- a/block/src/formats/vhdx/header.rs
+++ b/block/src/formats/vhdx/header.rs
@@ -40,8 +40,6 @@ const MDR_GUID: [u8; 16] = [
 #[sorted]
 #[derive(Error, Debug)]
 pub enum VhdxHeaderError {
-    #[error("Failed to calculate checksum")]
-    CalculateChecksum,
     #[error("BAT entry is not unique")]
     DuplicateBATEntry,
     #[error("Metadata region entry is not unique")]
@@ -58,14 +56,10 @@ pub enum VhdxHeaderError {
     InvalidVHDXSign,
     #[error("No valid header found")]
     NoValidHeader,
-    #[error("Cannot read checksum")]
-    ReadChecksum,
     #[error("Failed to read File Type Identifier {0}")]
     ReadFileTypeIdentifier(#[source] io::Error),
     #[error("Failed to read headers {0}")]
     ReadHeader(#[source] io::Error),
-    #[error("Failed to read metadata {0}")]
-    ReadMetadata(#[source] io::Error),
     #[error("Failed to read region table entries {0}")]
     ReadRegionTableEntries(#[source] io::Error),
     #[error("Failed to read region table header {0}")]

--- a/block/src/formats/vhdx/mod.rs
+++ b/block/src/formats/vhdx/mod.rs
@@ -48,8 +48,7 @@ impl VhdxDisk {
         Ok(VhdxDisk {
             vhdx_file: Arc::new(Mutex::new(Vhdx::new(f, direct_io).map_err(|e| {
                 let kind = match &e {
-                    VhdxError::NotVhdx(_)
-                    | VhdxError::ParseVhdxHeader(_)
+                    VhdxError::ParseVhdxHeader(_)
                     | VhdxError::ParseVhdxMetadata(_)
                     | VhdxError::ParseVhdxRegionEntry(_) => BlockErrorKind::InvalidFormat,
                     VhdxError::ReadBatEntry(_) => BlockErrorKind::CorruptImage,

--- a/block/src/io/async_io.rs
+++ b/block/src/io/async_io.rs
@@ -36,9 +36,6 @@ pub enum DiskFileError {
     /// Failed creating a new AsyncIo.
     #[error("Failed creating a new AsyncIo")]
     NewAsyncIo(#[source] io::Error),
-    /// Unsupported operation.
-    #[error("Unsupported operation")]
-    Unsupported,
     /// Resize failed
     #[error("Resize failed")]
     ResizeError(#[source] io::Error),

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -65,10 +65,6 @@ pub enum Error {
     DescriptorChainTooShort,
     #[error("Guest gave us a descriptor that was too short to use")]
     DescriptorLengthTooSmall,
-    #[error("Failed to validate image type")]
-    ValidateImageType(#[source] io::Error),
-    #[error("Failure in fixed vhd")]
-    FixedVhdError(#[source] io::Error),
     #[error("Getting a block's metadata failed")]
     GetFileMetadata(#[source] io::Error),
     #[error("The requested operation would cause a seek beyond disk end")]

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -133,8 +133,6 @@ pub enum ExecuteError {
     Unsupported(u32),
     #[error("Unsupported flags {flags:#x} for request type {request_type}")]
     UnsupportedFlags { request_type: u32, flags: u32 },
-    #[error("Failed to submit io uring")]
-    SubmitIoUring(#[source] io::Error),
     #[error("Failed to get guest address")]
     GetHostAddress(#[source] GuestMemoryError),
     #[error("Failed to async read")]
@@ -163,7 +161,6 @@ impl ExecuteError {
             ExecuteError::WriteAll(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::Unsupported(_) => VIRTIO_BLK_S_UNSUPP,
             ExecuteError::UnsupportedFlags { .. } => VIRTIO_BLK_S_UNSUPP,
-            ExecuteError::SubmitIoUring(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::GetHostAddress(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::AsyncRead(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::AsyncWrite(_) => VIRTIO_BLK_S_IOERR,

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -577,36 +577,6 @@ fn check_sequential_events_with_options(
     ret
 }
 
-// Return true if all events from the input 'expected_events' are matched exactly
-// with events from the 'event_file'
-pub(crate) fn check_sequential_events_exact(
-    expected_events: &[&MetaEvent],
-    event_file: &str,
-) -> bool {
-    if !Path::new(event_file).exists() {
-        return false;
-    }
-    let json_events = parse_event_file(event_file);
-    if expected_events.len() > json_events.len() {
-        return false;
-    }
-    let json_events = &json_events[..expected_events.len()];
-
-    for (idx, e) in json_events.iter().enumerate() {
-        if !expected_events[idx].match_with_json_event(e) {
-            eprintln!(
-                "\n\n==== Start 'check_sequential_events_exact' failed ==== \
-                 \n\nexpected_events={expected_events:?}\nactual_events={json_events:?} \
-                 \n\n==== End 'check_sequential_events_exact' failed ====",
-            );
-
-            return false;
-        }
-    }
-
-    true
-}
-
 /// Return true if events from the input 'latest_events' are matched exactly
 /// with the most recent events from the 'event_file'
 pub(crate) fn check_latest_events_exact(latest_events: &[&MetaEvent], event_file: &str) -> bool {

--- a/devices/src/aia.rs
+++ b/devices/src/aia.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, Mutex};
 
 use arch::layout;
 use hypervisor::arch::riscv64::aia::{Vaia, VaiaConfig};
-use hypervisor::{AiaState, CpuState};
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup,
     LegacyIrqSourceConfig, MsiIrqGroupConfig,
@@ -62,19 +61,6 @@ impl Aia {
         aia.enable()?;
 
         Ok(aia)
-    }
-
-    pub fn restore_vaia(
-        &mut self,
-        state: Option<AiaState>,
-        _saved_vcpu_states: &[CpuState],
-    ) -> Result<()> {
-        self.vaia
-            .clone()
-            .lock()
-            .unwrap()
-            .set_state(&state.unwrap())
-            .map_err(Error::RestoreAia)
     }
 
     fn enable(&self) -> Result<()> {

--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -42,10 +42,6 @@ pub enum Error {
     /// Failed creating AIA device.
     #[error("Failed creating AIA device")]
     CreateAia(#[source] hypervisor::HypervisorVmError),
-    #[cfg(target_arch = "riscv64")]
-    /// Failed restoring AIA device.
-    #[error("Failed restoring AIA device")]
-    RestoreAia(#[source] hypervisor::arch::riscv64::aia::Error),
 }
 
 type Result<T> = result::Result<T, Error>;

--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -24,12 +24,6 @@ pub enum Error {
     /// Failed triggering the interrupt.
     #[error("Failed triggering the interrupt")]
     TriggerInterrupt(#[source] io::Error),
-    /// Failed masking the interrupt.
-    #[error("Failed masking the interrupt")]
-    MaskInterrupt(#[source] io::Error),
-    /// Failed unmasking the interrupt.
-    #[error("Failed unmasking the interrupt")]
-    UnmaskInterrupt(#[source] io::Error),
     /// Failed updating the interrupt.
     #[error("Failed updating the interrupt")]
     UpdateInterrupt(#[source] io::Error),

--- a/devices/src/ivshmem.rs
+++ b/devices/src/ivshmem.rs
@@ -41,8 +41,6 @@ pub enum IvshmemError {
     RetrievePciConfigurationState(#[source] anyhow::Error),
     #[error("Failed to retrieve IvshmemDeviceState: {0}")]
     RetrieveIvshmemDeviceStateState(#[source] anyhow::Error),
-    #[error("Failed to remove user memory region")]
-    RemoveUserMemoryRegion,
     #[error("Failed to create user memory region.")]
     CreateUserMemoryRegion(#[source] anyhow::Error),
     #[error("Failed to create userspace mapping.")]

--- a/devices/src/pvmemcontrol.rs
+++ b/devices/src/pvmemcontrol.rs
@@ -42,9 +42,6 @@ pub enum Error {
     GuestMemory(#[source] GuestMemoryError),
     #[error("Guest sent us invalid request")]
     InvalidRequest,
-
-    #[error("Guest sent us invalid command: {0}")]
-    InvalidCommand(u32),
     #[error("Guest sent us invalid connection: {0}")]
     InvalidConnection(u32),
 

--- a/devices/src/pvmemcontrol.rs
+++ b/devices/src/pvmemcontrol.rs
@@ -46,8 +46,6 @@ pub enum Error {
     InvalidConnection(u32),
 
     // pvmemcontrol errors
-    #[error("Request contains invalid arguments: {0}")]
-    InvalidArgument(u64),
     #[error("Unknown function code: {0}")]
     UnknownFunctionCode(u64),
     #[error("Libc call fail")]
@@ -562,11 +560,6 @@ impl PvmemcontrolBusDevice {
         let resp = match resp_or_err {
             Ok(resp) => resp,
             Err(e) => match e {
-                Error::InvalidArgument(arg) => PvmemcontrolResp {
-                    ret_errno: (libc::EINVAL as u32).into(),
-                    ret_code: (arg as u32).into(),
-                    ..Default::default()
-                },
                 Error::LibcFail(err) => PvmemcontrolResp {
                     ret_errno: (err.raw_os_error().unwrap_or(libc::EFAULT) as u32).into(),
                     ret_code: 0u32.into(),

--- a/hypervisor/src/arch/emulator/mod.rs
+++ b/hypervisor/src/arch/emulator/mod.rs
@@ -73,14 +73,8 @@ pub enum EmulationError<T: Debug> {
     #[error("Unsupported instruction")]
     UnsupportedInstruction(#[source] anyhow::Error),
 
-    #[error("Unsupported memory size")]
-    UnsupportedMemorySize(#[source] anyhow::Error),
-
     #[error("Invalid operand")]
     InvalidOperand(#[source] anyhow::Error),
-
-    #[error("Wrong number of operands")]
-    WrongNumberOperands(#[source] anyhow::Error),
 
     #[error("Instruction Exception")]
     InstructionException(#[source] Exception<T>),

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -108,64 +108,33 @@ impl SegmentRegister {
     pub fn segment_type(&self) -> u8 {
         self.type_
     }
-    pub fn set_segment_type(&mut self, val: u8) {
-        self.type_ = val;
-    }
 
     pub fn dpl(&self) -> u8 {
         self.dpl
-    }
-
-    pub fn set_dpl(&mut self, val: u8) {
-        self.dpl = val;
     }
 
     pub fn present(&self) -> u8 {
         self.present
     }
 
-    pub fn set_present(&mut self, val: u8) {
-        self.present = val;
-    }
-
     pub fn long(&self) -> u8 {
         self.l
-    }
-
-    pub fn set_long(&mut self, val: u8) {
-        self.l = val;
     }
 
     pub fn avl(&self) -> u8 {
         self.avl
     }
 
-    pub fn set_avl(&mut self, val: u8) {
-        self.avl = val;
-    }
-
     pub fn desc_type(&self) -> u8 {
         self.s
-    }
-
-    pub fn set_desc_type(&mut self, val: u8) {
-        self.s = val;
     }
 
     pub fn granularity(&self) -> u8 {
         self.g
     }
 
-    pub fn set_granularity(&mut self, val: u8) {
-        self.g = val;
-    }
-
     pub fn db(&self) -> u8 {
         self.db
-    }
-
-    pub fn set_db(&mut self, val: u8) {
-        self.db = val;
     }
 }
 

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -214,11 +214,6 @@ pub enum HypervisorCpuError {
     ///
     #[error("Failed to get misc registers")]
     GetMiscRegs(#[source] anyhow::Error),
-    ///
-    /// Write to Guest Mem
-    ///
-    #[error("Failed to write to Guest Mem at")]
-    GuestMemWrite(#[source] anyhow::Error),
     /// Enabling HyperV SynIC error
     ///
     #[error("Failed to enable HyperV SynIC")]
@@ -274,25 +269,10 @@ pub enum HypervisorCpuError {
     #[error("Failed to get non-core register")]
     GetNonCoreRegister(#[source] anyhow::Error),
     ///
-    /// Setting RISC-V 64-bit non-core register error
-    ///
-    #[error("Failed to set non-core register")]
-    SetNonCoreRegister(#[source] anyhow::Error),
-    ///
     /// GVA translation error
     ///
     #[error("Failed to translate GVA")]
     TranslateVirtualAddress(#[source] anyhow::Error),
-    ///
-    /// Set cpu attribute error
-    ///
-    #[error("Failed to set vcpu attribute")]
-    SetVcpuAttribute(#[source] anyhow::Error),
-    ///
-    /// Check if cpu has a certain attribute error
-    ///
-    #[error("Failed to check if vcpu has attribute")]
-    HasVcpuAttribute(#[source] anyhow::Error),
     ///
     /// Failed to initialize TDX on CPU
     ///
@@ -335,11 +315,6 @@ pub enum HypervisorCpuError {
     #[error("Failed to set TSC offset")]
     SetTscOffset(#[source] anyhow::Error),
     ///
-    /// Error reading value at given GPA
-    ///
-    #[error("Failed to read from GPA")]
-    GpaRead(#[source] anyhow::Error),
-    ///
     /// Error writing value at given GPA
     ///
     #[error("Failed to write to GPA")]
@@ -368,8 +343,6 @@ pub enum HypervisorCpuError {
     Nmi(#[source] anyhow::Error),
     #[error("Failed to get nested guest state")]
     GetNestedState(#[source] anyhow::Error),
-    #[error("Failed to set nested guest state")]
-    SetNestedState(#[source] anyhow::Error),
 }
 
 #[derive(Debug)]

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -43,16 +43,6 @@ pub enum HypervisorError {
     #[error("Failed to create Vm")]
     VmCreate(#[source] anyhow::Error),
     ///
-    /// Vm setup failure
-    ///
-    #[error("Failed to setup Vm")]
-    VmSetup(#[source] anyhow::Error),
-    ///
-    /// API version error
-    ///
-    #[error("Failed to get API Version")]
-    GetApiVersion(#[source] anyhow::Error),
-    ///
     /// CpuId error
     ///
     #[error("Failed to get cpuid")]
@@ -82,16 +72,6 @@ pub enum HypervisorError {
     ///
     #[error("Failed to set partition property")]
     SetPartitionProperty(#[source] anyhow::Error),
-    ///
-    /// Running on an unsupported CPU
-    ///
-    #[error("Unsupported CPU")]
-    UnsupportedCpu(#[source] anyhow::Error),
-    ///
-    /// Launching a VM with unsupported VM Type
-    ///
-    #[error("Unsupported VmType")]
-    UnsupportedVmType(),
 
     ///
     /// The attempt to enable AMX tile state components failed

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -398,8 +398,9 @@ impl From<kvm_userspace_memory_region2> for UserMemoryRegion {
 
 impl From<UserMemoryRegion> for kvm_userspace_memory_region2 {
     fn from(region: UserMemoryRegion) -> Self {
-        assert!(
-            region.flags & USER_MEMORY_REGION_READ != 0,
+        assert_ne!(
+            region.flags & USER_MEMORY_REGION_READ,
+            0,
             "KVM mapped memory is always readable"
         );
 

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -438,17 +438,6 @@ get_aarch64_reg!(pc, u64);
 get_aarch64_reg!(pstate, u64);
 
 macro_rules! set_riscv64_reg {
-    (mode) => {
-        #[cfg(target_arch = "riscv64")]
-        impl StandardRegisters {
-            pub fn set_mode(&mut self, val: u64) {
-                match self {
-                    #[cfg(feature = "kvm")]
-                    StandardRegisters::Kvm(s) => s.mode = val,
-                }
-            }
-        }
-    };
     ($reg_name:ident) => {
         concat_idents!(method_name = "set_", $reg_name {
             #[cfg(target_arch = "riscv64")]
@@ -465,17 +454,6 @@ macro_rules! set_riscv64_reg {
 }
 
 macro_rules! get_riscv64_reg {
-    (mode) => {
-        #[cfg(target_arch = "riscv64")]
-        impl StandardRegisters {
-            pub fn get_mode(&self) -> u64 {
-                match self {
-                    #[cfg(feature = "kvm")]
-                    StandardRegisters::Kvm(s) => s.mode,
-                }
-            }
-        }
-    };
     ($reg_name:ident) => {
         concat_idents!(method_name = "get_", $reg_name {
             #[cfg(target_arch = "riscv64")]
@@ -523,7 +501,6 @@ set_riscv64_reg!(t3);
 set_riscv64_reg!(t4);
 set_riscv64_reg!(t5);
 set_riscv64_reg!(t6);
-set_riscv64_reg!(mode);
 
 get_riscv64_reg!(pc);
 get_riscv64_reg!(ra);
@@ -557,4 +534,3 @@ get_riscv64_reg!(t3);
 get_riscv64_reg!(t4);
 get_riscv64_reg!(t5);
 get_riscv64_reg!(t6);
-get_riscv64_reg!(mode);

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -179,45 +179,15 @@ pub enum HypervisorVmError {
     #[error("Failed to read guest memory")]
     GuestMemRead(#[source] anyhow::Error),
     ///
-    /// Read from MMIO Bus
-    ///
-    #[error("Failed to read from MMIO Bus")]
-    MmioBusRead(#[source] anyhow::Error),
-    ///
-    /// Write to MMIO Bus
-    ///
-    #[error("Failed to write to MMIO Bus")]
-    MmioBusWrite(#[source] anyhow::Error),
-    ///
-    /// Read from IO Bus
-    ///
-    #[error("Failed to read from IO Bus")]
-    IoBusRead(#[source] anyhow::Error),
-    ///
-    /// Write to IO Bus
-    ///
-    #[error("Failed to write to IO Bus")]
-    IoBusWrite(#[source] anyhow::Error),
-    ///
     /// Start dirty log error
     ///
     #[error("Failed to get dirty log")]
     StartDirtyLog(#[source] anyhow::Error),
     ///
-    /// Stop dirty log error
-    ///
-    #[error("Failed to get dirty log")]
-    StopDirtyLog(#[source] anyhow::Error),
-    ///
     /// Get dirty log error
     ///
     #[error("Failed to get dirty log")]
     GetDirtyLog(#[source] anyhow::Error),
-    ///
-    /// Assert virtual interrupt error
-    ///
-    #[error("Failed to assert virtual Interrupt")]
-    AssertVirtualInterrupt(#[source] anyhow::Error),
 
     #[cfg(feature = "sev_snp")]
     ///

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -440,8 +440,6 @@ pub struct NetCounters {
 
 #[derive(Error, Debug)]
 pub enum NetQueuePairError {
-    #[error("No memory configured")]
-    NoMemoryConfigured,
     #[error("Error registering listener")]
     RegisterListener(#[source] io::Error),
     #[error("Error unregistering listener")]

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 use vm_device::BusDevice;
 
 use crate::configuration::{PciBridgeSubclass, PciClassCode, PciConfiguration, PciHeaderType};
-use crate::device::{BarReprogrammingParams, DeviceRelocation, Error as PciDeviceError, PciDevice};
+use crate::device::{BarReprogrammingParams, DeviceRelocation, PciDevice};
 
 /// Denotes the PCI device ID of a bus' root bridge device.
 pub const PCI_ROOT_DEVICE_ID: u8 = 0;
@@ -29,12 +29,6 @@ const DEVICE_ID_INTEL_VIRT_PCIE_HOST: u16 = 0x0d57;
 /// Errors for device manager.
 #[derive(Error, Debug)]
 pub enum PciRootError {
-    /// Could not allocate device address space for the device.
-    #[error("Could not allocate device address space for the device")]
-    AllocateDeviceAddrs(#[source] PciDeviceError),
-    /// Could not allocate an IRQ number.
-    #[error("Could not allocate an IRQ number")]
-    AllocateIrq,
     /// Could not find an available device slot on the PCI bus.
     #[error("Could not find an available device slot on the PCI bus")]
     NoPciDeviceSlotAvailable,

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -14,8 +14,8 @@ use thiserror::Error;
 use vm_device::PciBarType;
 use vm_migration::{MigratableError, Pausable, Snapshot, Snapshottable};
 
+use crate::MsixConfig;
 use crate::device::BarReprogrammingParams;
-use crate::{MsixConfig, PciInterruptPin};
 
 // The number of 32bit registers in the config space, 4096 bytes.
 const NUM_CONFIGURATION_REGISTERS: usize = 1024;
@@ -37,8 +37,6 @@ const NUM_BAR_REGS: usize = 6;
 const CAPABILITY_LIST_HEAD_OFFSET: usize = 0x34;
 const FIRST_CAPABILITY_OFFSET: usize = 0x40;
 const CAPABILITY_MAX_OFFSET: usize = 192;
-
-const INTERRUPT_LINE_PIN_REG: usize = 15;
 
 pub const PCI_CONFIGURATION_ID: &str = "pci_configuration";
 
@@ -834,16 +832,6 @@ impl PciConfiguration {
         }
 
         addr
-    }
-
-    /// Configures the IRQ line and pin used by this device.
-    pub fn set_irq(&mut self, line: u8, pin: PciInterruptPin) {
-        // `pin` is 1-based in the pci config space.
-        let pin_idx = (pin as u32) + 1;
-        self.registers[INTERRUPT_LINE_PIN_REG] = (self.registers[INTERRUPT_LINE_PIN_REG]
-            & 0xffff_0000)
-            | (pin_idx << 8)
-            | u32::from(line);
     }
 
     /// Adds the capability `cap_data` to the list of capabilities.

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -508,8 +508,6 @@ pub enum Error {
     BarSizeInvalid(u64),
     #[error("Empty capabilities are invalid")]
     CapabilityEmpty,
-    #[error("Invalid capability length {0}")]
-    CapabilityLengthInvalid(usize),
     #[error("Capability of size {0} doesn't fit")]
     CapabilitySpaceFull(usize),
     #[error("Failed to decode 32-bit BAR size")]

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -50,12 +50,6 @@ pub enum PciInterruptPin {
     IntD,
 }
 
-impl PciInterruptPin {
-    pub fn to_mask(self) -> u32 {
-        self as u32
-    }
-}
-
 #[cfg(target_arch = "x86_64")]
 pub const PCI_CONFIG_IO_PORT: u64 = 0xcf8;
 #[cfg(target_arch = "x86_64")]

--- a/pci/src/mmap.rs
+++ b/pci/src/mmap.rs
@@ -227,8 +227,9 @@ in both isize and libc::size_t";
             return Err(Error::new(ErrorKind::InvalidInput, BAD_LENGTH));
         };
 
-        assert!(
-            (prot & !(libc::PROT_READ | libc::PROT_WRITE | libc::PROT_EXEC)) == 0,
+        assert_eq!(
+            (prot & !(libc::PROT_READ | libc::PROT_WRITE | libc::PROT_EXEC)),
+            0,
             "bad protection"
         );
 

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -54,8 +54,6 @@ pub enum VfioUserPciDeviceError {
     DmaMap(#[source] VfioUserError),
     #[error("Failed to DMA unmap")]
     DmaUnmap(#[source] VfioUserError),
-    #[error("Failed to initialize legacy interrupts")]
-    InitializeLegacyInterrupts(#[source] VfioPciError),
     #[error("Failed to create VfioCommon")]
     CreateVfioCommon(#[source] VfioPciError),
     #[error("Other OS error")]

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2627,30 +2627,6 @@ pub fn measure_virtio_net_latency(guest: &Guest, test_timeout: u32) -> Result<Ve
     parse_ethr_latency_output(&content)
 }
 
-// parse the bar address from the output of `lspci -vv`
-
-pub fn extract_bar_address(output: &str, device_desc: &str, bar_index: usize) -> Option<String> {
-    let devices: Vec<&str> = output.split("\n\n").collect();
-
-    for device in devices {
-        if device.contains(device_desc) {
-            for line in device.lines() {
-                let line = line.trim();
-                let line_start_str = format!("Region {bar_index}: Memory at");
-                // for example: Region 2: Memory at 200000000 (64-bit, non-prefetchable) [size=1M]
-                if line.starts_with(line_start_str.as_str()) {
-                    let parts: Vec<&str> = line.split_whitespace().collect();
-                    if parts.len() >= 4 {
-                        let addr_str = parts[4];
-                        return Some(String::from(addr_str));
-                    }
-                }
-            }
-        }
-    }
-    None
-}
-
 #[derive(PartialEq, Clone, Copy, Default)]
 pub enum GuestVmType {
     #[default]

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -72,16 +72,10 @@ pub const MINIMUM_BLOCK_QUEUE_SIZE: u16 = 2;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Failed to parse the request")]
-    RequestParsing(#[source] block::Error),
-    #[error("Failed to execute the request")]
-    RequestExecuting(#[source] block::ExecuteError),
     #[error("Failed to complete the request")]
     RequestCompleting(#[source] block::Error),
     #[error("Missing the expected entry in the list of requests")]
     MissingEntryRequestList,
-    #[error("The asynchronous request returned with failure")]
-    AsyncRequestFailure,
     #[error("Failed synchronizing the file")]
     Fsync(#[source] AsyncIoError),
     #[error("Failed adding used index")]

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -115,8 +115,6 @@ pub enum ActivateError {
     CreateEventFd(#[source] io::Error),
     #[error("Failed to spawn thread")]
     ThreadSpawn(#[source] io::Error),
-    #[error("Failed to setup vhost-user-fs daemon")]
-    VhostUserFsSetup(#[source] vhost_user::Error),
     #[error("Failed to setup vhost-user daemon")]
     VhostUserSetup(#[source] vhost_user::Error),
     #[error("Failed to create seccomp filter")]

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -222,8 +222,6 @@ pub enum Error {
     DuplicateTapFd(#[source] io::Error),
     #[error("Error creating EventFd")]
     CreateEventFd(#[source] io::Error),
-    #[error("Error cloning EventFd")]
-    CloneEventFd(#[source] io::Error),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -41,8 +41,6 @@ pub enum Error {
     DmaMap(#[source] vhost::Error),
     #[error("Failed to unmap DMA range")]
     DmaUnmap(#[source] vhost::Error),
-    #[error("Failed to get address range")]
-    GetAddressRange,
     #[error("Failed to get the available index from the virtio queue")]
     GetAvailableIndex(#[source] virtio_queue::Error),
     #[error("Get virtio configuration size")]
@@ -61,8 +59,6 @@ pub enum Error {
     InvalidIovaRange(u64, u64),
     #[error("Missing VIRTIO_F_ACCESS_PLATFORM feature")]
     MissingAccessPlatformVirtioFeature,
-    #[error("Failed to reset owner")]
-    ResetOwner(#[source] vhost::Error),
     #[error("Failed to set backend specific features")]
     SetBackendFeatures(#[source] vhost::Error),
     #[error("Failed to set backend configuration")]
@@ -71,8 +67,6 @@ pub enum Error {
     SetConfigCall(#[source] vhost::Error),
     #[error("Failed to set virtio features")]
     SetFeatures(#[source] vhost::Error),
-    #[error("Failed to set memory table")]
-    SetMemTable(#[source] vhost::Error),
     #[error("Failed to set owner")]
     SetOwner(#[source] vhost::Error),
     #[error("Failed to set virtio status")]

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -61,14 +61,10 @@ pub enum Error {
     BindSocket(#[source] io::Error),
     #[error("Creating eventfd failed")]
     CreateEventFd(#[source] io::Error),
-    #[error("Cloning kill eventfd failed")]
-    CloneKillEventFd(#[source] io::Error),
     #[error("Invalid descriptor table address")]
     DescriptorTableAddress,
     #[error("Signal used queue failed")]
     FailedSignalingUsedQueue(#[source] io::Error),
-    #[error("Failed to read vhost eventfd")]
-    MemoryRegions(#[source] MmapError),
     #[error("Failed removing socket path")]
     RemoveSocketPath(#[source] io::Error),
     #[error("Failed to create frontend")]
@@ -87,8 +83,6 @@ pub enum Error {
     VhostUserGetProtocolFeatures(#[source] VhostError),
     #[error("Get vring base failed")]
     VhostUserGetVringBase(#[source] VhostError),
-    #[error("Vhost-user Backend not support vhost-user protocol")]
-    VhostUserProtocolNotSupport,
     #[error("Set owner failed")]
     VhostUserSetOwner(#[source] VhostError),
     #[error("Reset owner failed")]
@@ -111,10 +105,6 @@ pub enum Error {
     VhostUserSetVringKick(#[source] VhostError),
     #[error("Set vring enable failed")]
     VhostUserSetVringEnable(#[source] VhostError),
-    #[error("Failed to create vhost eventfd")]
-    VhostIrqCreate(#[source] io::Error),
-    #[error("Failed to read vhost eventfd")]
-    VhostIrqRead(#[source] io::Error),
     #[error("Failed to read vhost eventfd")]
     VhostUserMemoryRegion(#[source] MmapError),
     #[error("Failed to create the frontend request handler from backend")]
@@ -135,12 +125,8 @@ pub enum Error {
     VhostUserSetLogBase(#[source] VhostError),
     #[error("Invalid used address")]
     UsedAddress,
-    #[error("Invalid features provided from vhost-user backend")]
-    InvalidFeatures,
     #[error("Missing file descriptor for the region")]
     MissingRegionFd,
-    #[error("Missing IrqFd")]
-    MissingIrqFd,
     #[error("Failed getting the available index")]
     GetAvailableIndex(#[source] QueueError),
     #[error("Failed getting the used index")]

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -67,14 +67,8 @@ pub enum Error {
     FailedSignalingUsedQueue(#[source] io::Error),
     #[error("Failed removing socket path")]
     RemoveSocketPath(#[source] io::Error),
-    #[error("Failed to create frontend")]
-    VhostUserCreateFrontend(#[source] VhostError),
-    #[error("Failed to open vhost device")]
-    VhostUserOpen(#[source] VhostError),
     #[error("Connection to socket failed")]
     VhostUserConnect(#[source] VhostError),
-    #[error("Backend disconnected for socket {0}")]
-    BackendDisconnected(String),
     #[error("Get features failed")]
     VhostUserGetFeatures(#[source] VhostError),
     #[error("Get queue max number failed")]
@@ -85,8 +79,6 @@ pub enum Error {
     VhostUserGetVringBase(#[source] VhostError),
     #[error("Set owner failed")]
     VhostUserSetOwner(#[source] VhostError),
-    #[error("Reset owner failed")]
-    VhostUserResetOwner(#[source] VhostError),
     #[error("Set features failed")]
     VhostUserSetFeatures(#[source] VhostError),
     #[error("Set protocol features failed")]
@@ -207,15 +199,12 @@ fn vhost_error_is_transport_lost(error: &VhostError) -> bool {
 impl Error {
     fn is_transport_lost(&self) -> bool {
         match self {
-            Error::VhostUserConnect(_) | Error::BackendDisconnected(_) => true,
-            Error::VhostUserCreateFrontend(e)
-            | Error::VhostUserOpen(e)
-            | Error::VhostUserGetFeatures(e)
+            Error::VhostUserConnect(_) => true,
+            Error::VhostUserGetFeatures(e)
             | Error::VhostUserGetQueueMaxNum(e)
             | Error::VhostUserGetProtocolFeatures(e)
             | Error::VhostUserGetVringBase(e)
             | Error::VhostUserSetOwner(e)
-            | Error::VhostUserResetOwner(e)
             | Error::VhostUserSetFeatures(e)
             | Error::VhostUserSetProtocolFeatures(e)
             | Error::VhostUserSetMemTable(e)

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -79,9 +79,6 @@ pub enum VsockError {
     /// Chained GuestMemory access error.
     #[error("Guest memory access error")]
     GuestMemoryAccess(#[source] vm_memory::GuestMemoryError),
-    /// Bounds check failed on guest memory pointer.
-    #[error("Bounds check failed on guest memory pointer")]
-    GuestMemoryBounds,
     /// The vsock header descriptor length is too small.
     #[error("The vsock header descriptor length is too small: {0}")]
     HdrDescTooSmall(u32),

--- a/virtio-devices/src/vsock/unix/mod.rs
+++ b/virtio-devices/src/vsock/unix/mod.rs
@@ -14,7 +14,7 @@ mod muxer_killq;
 mod muxer_rxq;
 
 use std::os::unix::net::UnixStream;
-use std::{io, num, result, str};
+use std::{io, result};
 
 pub use Error as VsockUnixError;
 pub use muxer::VsockMuxer as VsockUnixBackend;
@@ -33,9 +33,6 @@ mod defs {
 
 #[derive(Error, Debug)]
 pub enum Error {
-    /// Error converting from UTF-8
-    #[error("Error converting from UTF-8")]
-    ConvertFromUtf8(#[source] str::Utf8Error),
     /// Error registering a new epoll-listening FD.
     #[error("Error registering a new epoll-listening FD")]
     EpollAdd(#[source] io::Error),
@@ -45,12 +42,6 @@ pub enum Error {
     /// The host made an invalid vsock port connection request.
     #[error("The host made an invalid vsock port connection request")]
     InvalidPortRequest,
-    /// Error parsing integer.
-    #[error("Error parsing integer")]
-    ParseInteger(#[source] num::ParseIntError),
-    /// Error reading stream port.
-    #[error("Error reading stream port")]
-    ReadStreamPort(#[source] Box<Error>),
     /// Error accepting a new connection from the host-side Unix socket.
     #[error("Error accepting a new connection from the host-side Unix socket")]
     UnixAccept(#[source] io::Error),

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -126,10 +126,4 @@ impl SystemAllocator {
     pub fn free_io_addresses(&mut self, address: GuestAddress, size: GuestUsize) {
         self.io_address_space.free(address, size);
     }
-
-    /// Free a platform MMIO address range.
-    /// We can only free a range if it matches exactly an already allocated range.
-    pub fn free_platform_mmio_addresses(&mut self, address: GuestAddress, size: GuestUsize) {
-        self.platform_mmio_address_space.free(address, size);
-    }
 }

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -15,17 +15,6 @@ pub mod interrupt;
 
 pub use self::bus::{Bus, BusDevice, BusDeviceSync, Error as BusError};
 
-/// Type of Message Signalled Interrupt
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum MsiIrqType {
-    /// PCI MSI IRQ numbers.
-    PciMsi,
-    /// PCI MSIx IRQ numbers.
-    PciMsix,
-    /// Generic MSI IRQ numbers.
-    GenericMsi,
-}
-
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub enum PciBarType {
     Io,
@@ -37,8 +26,6 @@ pub enum PciBarType {
 #[expect(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Resource {
-    /// IO Port address range.
-    PioAddressRange { base: u16, size: u16 },
     /// Memory Mapped IO address range.
     MmioAddressRange { base: u64, size: u64 },
     /// PCI BAR
@@ -49,18 +36,6 @@ pub enum Resource {
         type_: PciBarType,
         prefetchable: bool,
     },
-    /// Legacy IRQ number.
-    LegacyIrq(u32),
-    /// Message Signaled Interrupt
-    MsiIrq {
-        ty: MsiIrqType,
-        base: u32,
-        size: u32,
-    },
-    /// Network Interface Card MAC address.
-    MacAddress(String),
-    /// KVM memslot index.
-    KvmMemSlot(u32),
 }
 
 #[derive(Clone)]

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -114,14 +114,6 @@ pub enum ApiError {
     #[error("The VM could not resume")]
     VmResume(#[source] VmError),
 
-    /// The VM is not booted.
-    #[error("The VM is not booted")]
-    VmNotBooted,
-
-    /// The VM is not created.
-    #[error("The VM is not created")]
-    VmNotCreated,
-
     /// The VM could not shutdown.
     #[error("The VM could not shutdown")]
     VmShutdown(#[source] VmError),
@@ -169,14 +161,6 @@ pub enum ApiError {
     /// The device could not be removed from the VM.
     #[error("The device could not be removed from the VM")]
     VmRemoveDevice(#[source] VmError),
-
-    /// Cannot create seccomp filter
-    #[error("Cannot create seccomp filter")]
-    CreateSeccompFilter(#[source] seccompiler::Error),
-
-    /// Cannot apply seccomp filter
-    #[error("Cannot apply seccomp filter")]
-    ApplySeccompFilter(#[source] seccompiler::Error),
 
     /// The disk could not be added to the VM.
     #[error("The disk could not be added to the VM")]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -66,15 +66,9 @@ pub enum Error {
     /// Generic vhost-user socket is missing
     #[error("Error parsing --generic-vhost-user: socket missing")]
     ParseGenericVhostUserSockMissing,
-    /// Generic vhost-user number of queues is missing
-    #[error("Error parsing --generic-vhost-user: number of queues missing")]
-    ParseGenericVhostUserNumResponseQueuesMissing,
     /// Generic vhost-user device type is missing
     #[error("Error parsing --generic-vhost-user: device_type missing")]
     ParseGenericVhostUserVirtioIdMissing,
-    /// Generic vhost-user available features is missing
-    #[error("Error parsing --generic-vhost-user: available features missing")]
-    ParseGenericVhostUserAvailFeaturesMissing,
     /// Generic vhost-user queue size missing
     #[error("Error parsing --generic-vhost-user: queue size missing")]
     ParseGenericVhostUserQueueSizeMissing,
@@ -138,10 +132,6 @@ pub enum Error {
     /// Failed parsing serial parameters
     #[error("Error parsing --serial")]
     ParseSerial(#[source] OptionParserError),
-    #[cfg(target_arch = "x86_64")]
-    /// Failed parsing debug-console
-    #[error("Error parsing --debug-console")]
-    ParseDebugConsole(#[source] OptionParserError),
     /// No mode given for console
     #[error("Error parsing --console: invalid console mode given")]
     ParseConsoleInvalidModeGiven,
@@ -160,18 +150,6 @@ pub enum Error {
     /// Failed validating configuration
     #[error("Error validating configuration")]
     Validation(#[source] ValidationError),
-    #[cfg(feature = "sev_snp")]
-    #[error("Error parsing --sev_snp")]
-    /// Failed parsing SEV-SNP config
-    ParseSevSnp(#[source] OptionParserError),
-    #[cfg(feature = "tdx")]
-    #[error("Error parsing --tdx")]
-    /// Failed parsing TDX config
-    ParseTdx(#[source] OptionParserError),
-    #[cfg(feature = "tdx")]
-    #[error("TDX firmware missing")]
-    /// No TDX firmware
-    FirmwarePathMissing,
     /// Failed parsing userspace device
     #[error("Error parsing --user-device")]
     ParseUserDevice(#[source] OptionParserError),
@@ -232,10 +210,6 @@ pub enum ValidationError {
     /// Too many CPUs.
     #[error("Too many CPUs: specified {0} but {MAX_SUPPORTED_CPUS} is the limit")]
     TooManyCpus(u32 /* specified CPUs */),
-    /// Missing file value for debug-console
-    #[cfg(target_arch = "x86_64")]
-    #[error("Path missing when using file mode for debug console")]
-    DebugconFileMissing,
     /// Both socket and path specified
     #[error("Disk path and vhost socket both provided")]
     DiskSocketAndPath,
@@ -248,12 +222,6 @@ pub enum ValidationError {
     /// No socket provided for vhost_use
     #[error("No socket provided when using vhost-user")]
     VhostUserMissingSocket,
-    /// Trying to use IOMMU without PCI
-    #[error("Using an IOMMU without PCI support is unsupported")]
-    IommuUnsupported,
-    /// Trying to use VFIO without PCI
-    #[error("Using VFIO without PCI support is unsupported")]
-    VfioUnsupported,
     /// CPU topology count doesn't match max
     #[error("Product of CPU topology parts does not match maximum vCPU")]
     CpuTopologyCount,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -192,12 +192,6 @@ pub enum Error {
     #[error("Error starting vCPU after restore")]
     StartRestoreVcpu(#[source] anyhow::Error),
 
-    #[error("Unexpected VmExit")]
-    UnexpectedVmExit,
-
-    #[error("Failed to allocate MMIO address for CpuManager")]
-    AllocateMmmioAddress,
-
     #[cfg(feature = "tdx")]
     #[error("Error initializing TDX")]
     InitializeTdx(#[source] hypervisor::HypervisorCpuError),
@@ -227,10 +221,6 @@ pub enum Error {
     #[cfg(feature = "sev_snp")]
     #[error("Failed to set up SEV-SNP vCPU registers")]
     SetupSevSnpRegs(#[source] hypervisor::HypervisorCpuError),
-
-    #[cfg(target_arch = "x86_64")]
-    #[error("Failed to inject NMI")]
-    NmiError(#[source] hypervisor::HypervisorCpuError),
 
     #[cfg(feature = "mshv")]
     #[error("Failed to set partition property")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -624,14 +624,6 @@ pub struct Console {
 }
 
 impl Console {
-    pub fn need_resize(&self) -> bool {
-        if let Some(_resizer) = self.console_resizer.as_ref() {
-            return true;
-        }
-
-        false
-    }
-
     pub fn update_console_size(&self) {
         if let Some(resizer) = self.console_resizer.as_ref() {
             resizer.update_console_size();

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -123,7 +123,7 @@ use vm_virtio::{AccessPlatform, VirtioDeviceType};
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::console_devices::{ConsoleDeviceError, ConsoleInfo, ConsoleTransport};
+use crate::console_devices::{ConsoleInfo, ConsoleTransport};
 use crate::cpu::{AcpiCpuHotplugController, CPU_MANAGER_ACPI_SIZE, CpuManager};
 use crate::device_tree::{DeviceNode, DeviceTree};
 use crate::interrupt::{LegacyUserspaceInterruptManager, MsiInterruptManager};
@@ -268,11 +268,6 @@ pub enum DeviceManagerError {
     #[error("Cannot create virtio-balloon device")]
     CreateVirtioBalloon(#[source] io::Error),
 
-    /// Cannot create pvmemcontrol device
-    #[cfg(feature = "pvmemcontrol")]
-    #[error("Cannot create pvmemcontrol device")]
-    CreatePvmemcontrol(#[source] io::Error),
-
     /// Cannot create virtio-watchdog device
     #[error("Cannot create virtio-watchdog device")]
     CreateVirtioWatchdog(#[source] io::Error),
@@ -285,17 +280,9 @@ pub enum DeviceManagerError {
     #[error("Cannot spawn serial manager thread")]
     SpawnSerialManager(#[source] SerialManagerError),
 
-    /// Cannot open tap interface
-    #[error("Cannot open tap interface")]
-    OpenTap(#[source] net_util::TapError),
-
     /// Cannot allocate IRQ.
     #[error("Cannot allocate IRQ")]
     AllocateIrq(#[from] InterruptAllocError),
-
-    /// Cannot configure the IRQ.
-    #[error("Cannot configure the IRQ")]
-    Irq(#[source] errno::Error),
 
     /// Cannot allocate PCI BARs
     #[error("Cannot allocate PCI BARs")]
@@ -341,43 +328,6 @@ pub enum DeviceManagerError {
     #[error("Cannot find a memory range for persistent memory")]
     PmemRangeAllocation,
 
-    /// Cannot find a memory range for virtio-fs
-    #[error("Cannot find a memory range for virtio-fs")]
-    FsRangeAllocation,
-
-    /// Error creating serial output file
-    #[error("Error creating serial output file")]
-    SerialOutputFileOpen(#[source] io::Error),
-
-    /// Error creating debug-console output file
-    #[cfg(target_arch = "x86_64")]
-    #[error("Error creating debug-console output file")]
-    DebugconOutputFileOpen(#[source] io::Error),
-
-    /// Error creating console output file
-    #[error("Error creating console output file")]
-    ConsoleOutputFileOpen(#[source] io::Error),
-
-    /// Error creating serial pty
-    #[error("Error creating serial pty")]
-    SerialPtyOpen(#[source] io::Error),
-
-    /// Error creating console pty
-    #[error("Error creating console pty")]
-    ConsolePtyOpen(#[source] io::Error),
-
-    /// Error creating debugcon pty
-    #[error("Error creating console pty")]
-    DebugconPtyOpen(#[source] io::Error),
-
-    /// Error setting pty raw mode
-    #[error("Error setting pty raw mode")]
-    SetPtyRaw(#[source] ConsoleDeviceError),
-
-    /// Error getting pty peer
-    #[error("Error getting pty peer")]
-    GetPtyPeer(#[source] errno::Error),
-
     /// Cannot create iommufd
     #[cfg(feature = "kvm")]
     #[error("Cannot create iommufd")]
@@ -407,17 +357,9 @@ pub enum DeviceManagerError {
     #[error("Failed to DMA map VFIO device")]
     VfioDmaMap(#[source] vfio_ioctls::VfioError),
 
-    /// Failed to DMA unmap VFIO device.
-    #[error("Failed to DMA unmap VFIO device")]
-    VfioDmaUnmap(#[source] pci::VfioPciError),
-
     /// Failed to create the passthrough device.
     #[error("Failed to create the passthrough device")]
     CreatePassthroughDevice(#[source] anyhow::Error),
-
-    /// Failed to memory map.
-    #[error("Failed to memory map")]
-    Mmap(#[source] io::Error),
 
     /// Cannot add legacy device to Bus.
     #[error("Cannot add legacy device to Bus")]
@@ -443,10 +385,6 @@ pub enum DeviceManagerError {
     #[error("Failed to create new interrupt source group")]
     CreateInterruptGroup(#[source] io::Error),
 
-    /// Failed to update interrupt source group.
-    #[error("Failed to update interrupt source group")]
-    UpdateInterruptGroup(#[source] io::Error),
-
     /// Failed to create interrupt controller.
     #[error("Failed to create interrupt controller")]
     CreateInterruptController(#[source] interrupt_controller::Error),
@@ -458,22 +396,6 @@ pub enum DeviceManagerError {
     /// Failed to clone a File.
     #[error("Failed to clone a File")]
     CloneFile(#[source] io::Error),
-
-    /// Failed to create socket file
-    #[error("Failed to create socket file")]
-    CreateSocketFile(#[source] io::Error),
-
-    /// Failed to spawn the network backend
-    #[error("Failed to spawn the network backend")]
-    SpawnNetBackend(#[source] io::Error),
-
-    /// Failed to spawn the block backend
-    #[error("Failed to spawn the block backend")]
-    SpawnBlockBackend(#[source] io::Error),
-
-    /// Missing PCI bus.
-    #[error("Missing PCI bus")]
-    NoPciBus,
 
     /// Could not find an available device name.
     #[error("Could not find an available device name")]
@@ -494,10 +416,6 @@ pub enum DeviceManagerError {
     /// Failed to remove a bus device from the MMIO bus.
     #[error("Failed to remove a bus device from the MMIO bus")]
     RemoveDeviceFromMmioBus(#[source] vm_device::BusError),
-
-    /// Failed to find the device corresponding to a specific PCI b/d/f.
-    #[error("Failed to find the device corresponding to a specific PCI b/d/f: {0:#x}")]
-    UnknownPciBdf(u32),
 
     /// Not allowed to remove this type of device from the VM.
     #[error("Not allowed to remove this type of device from the VM: {0}")]
@@ -530,10 +448,6 @@ pub enum DeviceManagerError {
     /// Cannot create virtio-mem device
     #[error("Cannot create virtio-mem device")]
     CreateVirtioMem(#[source] io::Error),
-
-    /// Cannot find a memory range for virtio-mem memory
-    #[error("Cannot find a memory range for virtio-mem memory")]
-    VirtioMemRangeAllocation,
 
     /// Failed to update guest memory for VFIO PCI device.
     #[error("Failed to update guest memory for VFIO PCI device")]
@@ -595,10 +509,6 @@ pub enum DeviceManagerError {
     #[cfg(target_arch = "aarch64")]
     #[error("Failed to do AArch64 GPIO power button notification")]
     AArch64PowerButtonNotification(#[source] legacy::GpioDeviceError),
-
-    /// Failed to set O_DIRECT flag to file descriptor
-    #[error("Failed to set O_DIRECT flag to file descriptor")]
-    SetDirectIo,
     /// Failed to add DMA mapping handler to virtio-mem device.
     #[error("Failed to add DMA mapping handler to virtio-mem device")]
     AddDmaMappingHandlerVirtioMem(#[source] mem::Error),
@@ -627,10 +537,6 @@ pub enum DeviceManagerError {
     /// Failed to DMA map VFIO user device.
     #[error("Failed to DMA map VFIO user device")]
     VfioUserDmaMap(#[source] VfioUserPciDeviceError),
-
-    /// Failed to DMA unmap VFIO user device.
-    #[error("Failed to DMA unmap VFIO user device")]
-    VfioUserDmaUnmap(#[source] VfioUserPciDeviceError),
 
     /// Failed to update memory mappings for VFIO user device
     #[error("Failed to update memory mappings for VFIO user device")]
@@ -690,17 +596,9 @@ pub enum DeviceManagerError {
     #[error("Cannot create a RateLimiterGroup")]
     RateLimiterGroupCreate(#[source] group::Error),
 
-    /// Cannot start sigwinch listener
-    #[error("Cannot start sigwinch listener")]
-    StartSigwinchListener(#[source] io::Error),
-
     // Invalid console info
     #[error("Invalid console info")]
     InvalidConsoleInfo,
-
-    // Invalid console fd
-    #[error("Invalid console fd")]
-    InvalidConsoleFd,
 
     /// Cannot lock images of all block devices.
     #[error("Cannot lock images of all block devices")]

--- a/vmm/src/gdb.rs
+++ b/vmm/src/gdb.rs
@@ -57,8 +57,6 @@ pub enum DebuggableError {
     WriteMem(#[source] GuestMemoryError),
     #[error("Translating GVA failed")]
     TranslateGva(#[source] cpu::Error),
-    #[error("The lock is poisened")]
-    PoisonedState,
 }
 
 pub trait Debuggable: vm_migration::Pausable {
@@ -99,8 +97,6 @@ pub enum Error {
     GdbResponseNotify(#[source] io::Error),
     #[error("GDB response failed")]
     GdbResponse(#[source] mpsc::RecvError),
-    #[error("GDB response timeout")]
-    GdbResponseTimeout(#[source] mpsc::RecvTimeoutError),
 }
 type GdbResult<T> = result::Result<T, Error>;
 

--- a/vmm/src/landlock.rs
+++ b/vmm/src/landlock.rs
@@ -145,13 +145,13 @@ fn test_try_from_access() {
         | Truncate
     });
     let landlock_access = LandlockAccess::try_from("rw").unwrap();
-    assert!(landlock_access.access == read_access | write_access);
+    assert_eq!(landlock_access.access, read_access | write_access);
 
     let landlock_access = LandlockAccess::try_from("r").unwrap();
-    assert!(landlock_access.access == read_access);
+    assert_eq!(landlock_access.access, read_access);
 
     let landlock_access = LandlockAccess::try_from("w").unwrap();
-    assert!(landlock_access.access == write_access);
+    assert_eq!(landlock_access.access, write_access);
 
     LandlockAccess::try_from("").unwrap_err();
 }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -120,10 +120,6 @@ pub enum Error {
     #[error("Error sending API request")]
     ApiResponseSend(#[source] SendError<ApiResponse>),
 
-    /// Cannot bind to the UNIX domain socket path
-    #[error("Error binding to UNIX domain socket")]
-    Bind(#[source] io::Error),
-
     /// Cannot clone EventFd.
     #[error("Error cloning EventFd")]
     EventFdClone(#[source] io::Error),
@@ -157,14 +153,6 @@ pub enum Error {
     /// Cannot create `event-monitor` thread
     #[error("Error spawning `event-monitor` thread")]
     EventMonitorThreadSpawn(#[source] io::Error),
-
-    /// Cannot handle the VM STDIN stream
-    #[error("Error handling VM stdin")]
-    Stdin(#[source] VmError),
-
-    /// Cannot handle the VM pty stream
-    #[error("Error handling VM pty")]
-    Pty(#[source] VmError),
 
     /// Cannot reboot the VM
     #[error("Error rebooting VM")]

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -3506,8 +3506,8 @@ impl Migratable for MemoryManager {
             let vmm_dirty_bitmap = match self.guest_memory.memory().find_region(GuestAddress(r.gpa))
             {
                 Some(region) => {
-                    assert!(region.start_addr().raw_value() == r.gpa);
-                    assert!(region.len() == r.size);
+                    assert_eq!(region.start_addr().raw_value(), r.gpa);
+                    assert_eq!(region.len(), r.size);
                     (**region).bitmap().get_and_reset()
                 }
                 None => {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -297,10 +297,6 @@ pub enum Error {
     #[error("Failed to EventFd")]
     EventFdFail(#[source] io::Error),
 
-    /// Eventfd write error
-    #[error("Eventfd write error")]
-    EventfdError(#[source] io::Error),
-
     /// Failed to virtio-mem resize
     #[error("Failed to virtio-mem resize")]
     VirtioMemResizeFail(#[source] VirtioMemError),

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -64,10 +64,6 @@ pub enum Error {
     #[error("Error spawning SerialManager thread")]
     SpawnSerialManager(#[source] io::Error),
 
-    /// Cannot bind to Unix socket
-    #[error("Error binding to socket")]
-    BindUnixSocket(#[source] io::Error),
-
     /// Cannot accept connection from Unix socket
     #[error("Error accepting connection")]
     AcceptConnection(#[source] io::Error),

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -33,8 +33,6 @@ use arch::layout::{KVM_IDENTITY_MAP_START, KVM_TSS_START};
 use arch::uefi;
 use arch::{EntryPoint, NumaNode, NumaNodes, get_host_cpu_phys_bits, layout};
 use devices::AcpiNotificationFlags;
-#[cfg(target_arch = "aarch64")]
-use devices::interrupt_controller;
 #[cfg(feature = "fw_cfg")]
 use devices::legacy::fw_cfg;
 #[cfg(feature = "fw_cfg")]
@@ -167,10 +165,6 @@ pub enum Error {
     #[error("Cannot configure system")]
     ConfigureSystem(#[source] arch::Error),
 
-    #[cfg(target_arch = "aarch64")]
-    #[error("Cannot enable interrupt controller")]
-    EnableInterruptController(#[source] interrupt_controller::Error),
-
     #[error("Error from device manager")]
     DeviceManager(#[source] DeviceManagerError),
 
@@ -213,18 +207,6 @@ pub enum Error {
     #[error("Error from CPU manager")]
     CpuManager(#[source] cpu::Error),
 
-    #[error("Cannot pause devices")]
-    PauseDevices(#[source] MigratableError),
-
-    #[error("Cannot resume devices")]
-    ResumeDevices(#[source] MigratableError),
-
-    #[error("Cannot pause CPUs")]
-    PauseCpus(#[source] MigratableError),
-
-    #[error("Cannot resume cpus")]
-    ResumeCpus(#[source] MigratableError),
-
     #[error("Cannot pause VM")]
     Pause(#[source] MigratableError),
 
@@ -233,9 +215,6 @@ pub enum Error {
 
     #[error("Memory manager error")]
     MemoryManager(#[source] MemoryManagerError),
-
-    #[error("Eventfd write error")]
-    EventfdError(#[source] io::Error),
 
     #[error("Cannot snapshot VM")]
     Snapshot(#[source] MigratableError),
@@ -282,17 +261,8 @@ pub enum Error {
     #[error("Kernel lacks PVH header")]
     KernelMissingPvhHeader,
 
-    #[error("Failed to allocate firmware RAM")]
-    AllocateFirmwareMemory(#[source] MemoryManagerError),
-
     #[error("Error manipulating firmware file")]
     FirmwareFile(#[source] io::Error),
-
-    #[error("Firmware too big")]
-    FirmwareTooLarge,
-
-    #[error("Failed to copy firmware to memory")]
-    FirmwareLoad(#[source] vm_memory::GuestMemoryError),
 
     #[cfg(feature = "sev_snp")]
     #[error("Error enabling SEV-SNP VM")]
@@ -379,10 +349,6 @@ pub enum Error {
     #[cfg(feature = "fw_cfg")]
     #[error("Fw Cfg missing kernel cmdline")]
     MissingFwCfgCmdline,
-
-    #[cfg(feature = "fw_cfg")]
-    #[error("Error creating e820 map")]
-    CreatingE820Map(#[source] io::Error),
 
     #[error("Error creating ACPI tables")]
     CreatingAcpiTables(#[source] acpi::Error),


### PR DESCRIPTION
With the help of my RustRover IDE and an LLM, I was able to identify a lot of dead enum variants. Less code is better, so let's remove them. In case one turns out to be useful, add it again. However, I think this is not necessary. Also none of the open PRs seem to use any of this functionality.

On top, while on it, in the same files I replace some `assert!()` with `assert_eq!()` - the commits are grouped together at the end.