### PR TITLE
Allow Guest Reboot and Shutdown During Migration

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7669,6 +7669,170 @@ mod common_parallel {
         _test_live_migration(false, true, true);
     }
 
+    #[derive(Clone, Copy)]
+    enum GuestEventDuringMigration {
+        RebootImmediately,
+        RebootDuringPrecopy,
+        ShutdownImmediately,
+        ShutdownDuringPrecopy,
+    }
+
+    fn _test_live_migration_guest_event(guest_event: GuestEventDuringMigration) {
+        fn wait_for_vm_event(event: &str, event_path: &str) {
+            let expected = MetaEvent {
+                event: event.to_string(),
+                device_id: None,
+            };
+            assert!(wait_for_sequential_events(
+                Duration::from_secs(30),
+                &[&expected],
+                event_path,
+            ));
+        }
+
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_memory("500M");
+        let src_api_socket = temp_api_path(&guest.tmp_dir);
+        let src_event_path = temp_event_monitor_path(&guest.tmp_dir);
+
+        let mut src_child = GuestCommand::new(&guest)
+            .default_cpus()
+            .default_memory()
+            .default_kernel_cmdline()
+            .default_disks()
+            .default_net()
+            .args(["--api-socket", &src_api_socket])
+            .args(["--event-monitor", format!("path={src_event_path}").as_str()])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let mut dest_api_socket = temp_api_path(&guest.tmp_dir);
+        dest_api_socket.push_str(".dest");
+        let dest_event_path = format!("{src_event_path}.dest");
+        let mut dest_child = GuestCommand::new(&guest)
+            .args(["--api-socket", &dest_api_socket])
+            .args(["--no-shutdown"])
+            .args([
+                "--event-monitor",
+                format!("path={dest_event_path}").as_str(),
+            ])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            guest.wait_vm_boot().unwrap();
+            let reboot_count = get_reboot_count(&guest);
+
+            // Ensure we have a longer time window to reboot/shutdown.
+            start_stress_in_vm(&guest);
+
+            let migration_port = get_available_port();
+            let receive_url = format!("receiver_url=tcp:0.0.0.0:{migration_port}");
+            let receive_api_socket = dest_api_socket.clone();
+            let receive_migration = thread::spawn(move || {
+                remote_command(&receive_api_socket, "receive-migration", Some(&receive_url))
+            });
+
+            wait_for_vm_event("migration-receive-ready", &dest_event_path);
+
+            assert!(remote_command(
+                &src_api_socket,
+                "send-migration",
+                Some(&format!(
+                    "destination_url=tcp:127.0.0.1:{migration_port},downtime_ms=1,timeout_s=30,timeout_strategy=cancel"
+                )),
+            ));
+
+            match guest_event {
+                GuestEventDuringMigration::RebootDuringPrecopy
+                | GuestEventDuringMigration::ShutdownDuringPrecopy => {
+                    wait_for_vm_event("migration-memory-iteration", &src_event_path);
+                }
+                _ => (),
+            }
+
+            match guest_event {
+                GuestEventDuringMigration::RebootImmediately
+                | GuestEventDuringMigration::RebootDuringPrecopy => {
+                    guest.ssh_command("sudo reboot").unwrap();
+                }
+                GuestEventDuringMigration::ShutdownImmediately
+                | GuestEventDuringMigration::ShutdownDuringPrecopy => {
+                    guest.ssh_command("sudo poweroff").unwrap();
+                }
+            }
+
+            wait_for_vm_event("migration-finished", &src_event_path);
+            assert!(receive_migration.join().unwrap());
+            assert!(wait_until(Duration::from_secs(30), || {
+                matches!(src_child.try_wait(), Ok(Some(status)) if status.success())
+            }));
+
+            // The event must be replayed after the migration was finished.
+            wait_for_vm_event("migration-receive-finished", &dest_event_path);
+
+            match guest_event {
+                GuestEventDuringMigration::RebootImmediately
+                | GuestEventDuringMigration::RebootDuringPrecopy => {
+                    // Wait for the VM to be reachable again
+                    guest.wait_vm_boot().unwrap();
+                    assert_eq!(get_reboot_count(&guest), reboot_count + 1);
+                    wait_for_vm_event("rebooting", &dest_event_path);
+                    wait_for_vm_event("rebooted", &dest_event_path);
+                }
+                GuestEventDuringMigration::ShutdownImmediately
+                | GuestEventDuringMigration::ShutdownDuringPrecopy => {
+                    wait_for_vm_event("shutdown", &dest_event_path);
+
+                    // check guest can be booted again
+                    assert!(remote_command(&dest_api_socket, "boot", None,));
+                    guest.wait_vm_boot().unwrap();
+                    assert_eq!(get_reboot_count(&guest), reboot_count + 1);
+                    wait_for_vm_event("booting", &dest_event_path);
+                    wait_for_vm_event("booted", &dest_event_path);
+                }
+            }
+        }));
+
+        if r.is_err() {
+            print_and_panic(
+                src_child,
+                dest_child,
+                None,
+                "Error handling a guest lifecycle event during live migration",
+            );
+        }
+
+        let _ = src_child.kill();
+        let src_output = src_child.wait_with_output().unwrap();
+        handle_child_output(Ok(()), &src_output);
+
+        let _ = dest_child.kill();
+        let dest_output = dest_child.wait_with_output().unwrap();
+        handle_child_output(Ok(()), &dest_output);
+    }
+
+    #[test]
+    fn test_live_migration_tcp_event_reboot_immediately() {
+        _test_live_migration_guest_event(GuestEventDuringMigration::RebootImmediately);
+    }
+
+    #[test]
+    fn test_live_migration_tcp_event_reboot_during_precopy() {
+        _test_live_migration_guest_event(GuestEventDuringMigration::RebootDuringPrecopy);
+    }
+
+    #[test]
+    fn test_live_migration_tcp_event_shutdown_immediately() {
+        _test_live_migration_guest_event(GuestEventDuringMigration::ShutdownImmediately);
+    }
+
+    #[test]
+    fn test_live_migration_tcp_event_shutdown_during_precopy() {
+        _test_live_migration_guest_event(GuestEventDuringMigration::ShutdownDuringPrecopy);
+    }
+
     #[test]
     fn test_live_migration_tcp() {
         _test_live_migration_tcp(NonZeroU32::new(1).unwrap());

--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -24,6 +24,7 @@ pub struct AcpiShutdownDevice {
     guest_exit_evt: EventFd,
     reset_evt: EventFd,
     vcpus_kill_signalled: Arc<AtomicBool>,
+    vcpus_pause_signalled: Arc<AtomicBool>,
 }
 
 impl AcpiShutdownDevice {
@@ -32,11 +33,13 @@ impl AcpiShutdownDevice {
         guest_exit_evt: EventFd,
         reset_evt: EventFd,
         vcpus_kill_signalled: Arc<AtomicBool>,
+        vcpus_pause_signalled: Arc<AtomicBool>,
     ) -> AcpiShutdownDevice {
         AcpiShutdownDevice {
             guest_exit_evt,
             reset_evt,
             vcpus_kill_signalled,
+            vcpus_pause_signalled,
         }
     }
 }
@@ -67,7 +70,9 @@ impl BusDevice for AcpiShutdownDevice {
             }
             // Spin until we are sure the reset_evt has been handled and that when
             // we return from the KVM_RUN we will exit rather than re-enter the guest.
-            while !self.vcpus_kill_signalled.load(Ordering::SeqCst) {
+            while !self.vcpus_kill_signalled.load(Ordering::SeqCst)
+                && !self.vcpus_pause_signalled.load(Ordering::SeqCst)
+            {
                 // This is more effective than thread::yield_now() at
                 // avoiding a priority inversion with the VMM thread
                 thread::sleep(Duration::from_millis(1));
@@ -84,7 +89,9 @@ impl BusDevice for AcpiShutdownDevice {
             }
             // Spin until we are sure the reset_evt has been handled and that when
             // we return from the KVM_RUN we will exit rather than re-enter the guest.
-            while !self.vcpus_kill_signalled.load(Ordering::SeqCst) {
+            while !self.vcpus_kill_signalled.load(Ordering::SeqCst)
+                && !self.vcpus_pause_signalled.load(Ordering::SeqCst)
+            {
                 // This is more effective than thread::yield_now() at
                 // avoiding a priority inversion with the VMM thread
                 thread::sleep(Duration::from_millis(1));

--- a/devices/src/legacy/cmos.rs
+++ b/devices/src/legacy/cmos.rs
@@ -28,8 +28,8 @@ pub struct Cmos {
     index: u8,
     data: [u8; DATA_LEN],
     reset_evt: EventFd,
-    vcpus_kill_signalled: Option<Arc<AtomicBool>>,
-    vcpus_pause_signalled: Option<Arc<AtomicBool>>,
+    vcpus_kill_signalled: Arc<AtomicBool>,
+    vcpus_pause_signalled: Arc<AtomicBool>,
 }
 
 impl Cmos {
@@ -40,8 +40,8 @@ impl Cmos {
         mem_below_4g: u64,
         mem_above_4g: u64,
         reset_evt: EventFd,
-        vcpus_kill_signalled: Option<Arc<AtomicBool>>,
-        vcpus_pause_signalled: Option<Arc<AtomicBool>>,
+        vcpus_kill_signalled: Arc<AtomicBool>,
+        vcpus_pause_signalled: Arc<AtomicBool>,
     ) -> Cmos {
         let mut data = [0u8; DATA_LEN];
 
@@ -82,19 +82,14 @@ impl BusDevice for Cmos {
                 if self.index == 0x8f && data[0] == 0 {
                     info!("CMOS reset");
                     self.reset_evt.write(1).unwrap();
-                    if let Some(vcpus_kill_signalled) = self.vcpus_kill_signalled.take() {
-                        let pause_signalled = self.vcpus_pause_signalled.clone();
-                        // Spin until we are sure the reset_evt has been handled and that when
-                        // we return from the KVM_RUN we will exit rather than re-enter the guest.
-                        while !vcpus_kill_signalled.load(Ordering::SeqCst)
-                            && !pause_signalled
-                                .as_ref()
-                                .is_some_and(|p| p.load(Ordering::SeqCst))
-                        {
-                            // This is more effective than thread::yield_now() at
-                            // avoiding a priority inversion with the VMM thread
-                            thread::sleep(Duration::from_millis(1));
-                        }
+                    // Spin until we are sure the reset_evt has been handled and that when
+                    // we return from the KVM_RUN we will exit rather than re-enter the guest.
+                    while !self.vcpus_kill_signalled.load(Ordering::SeqCst)
+                        && !self.vcpus_pause_signalled.load(Ordering::SeqCst)
+                    {
+                        // This is more effective than thread::yield_now() at
+                        // avoiding a priority inversion with the VMM thread
+                        thread::sleep(Duration::from_millis(1));
                     }
                 } else {
                     self.data[(self.index & INDEX_MASK) as usize] = data[0];

--- a/devices/src/legacy/cmos.rs
+++ b/devices/src/legacy/cmos.rs
@@ -29,6 +29,7 @@ pub struct Cmos {
     data: [u8; DATA_LEN],
     reset_evt: EventFd,
     vcpus_kill_signalled: Option<Arc<AtomicBool>>,
+    vcpus_pause_signalled: Option<Arc<AtomicBool>>,
 }
 
 impl Cmos {
@@ -40,6 +41,7 @@ impl Cmos {
         mem_above_4g: u64,
         reset_evt: EventFd,
         vcpus_kill_signalled: Option<Arc<AtomicBool>>,
+        vcpus_pause_signalled: Option<Arc<AtomicBool>>,
     ) -> Cmos {
         let mut data = [0u8; DATA_LEN];
 
@@ -62,6 +64,7 @@ impl Cmos {
             data,
             reset_evt,
             vcpus_kill_signalled,
+            vcpus_pause_signalled,
         }
     }
 }
@@ -80,9 +83,14 @@ impl BusDevice for Cmos {
                     info!("CMOS reset");
                     self.reset_evt.write(1).unwrap();
                     if let Some(vcpus_kill_signalled) = self.vcpus_kill_signalled.take() {
+                        let pause_signalled = self.vcpus_pause_signalled.clone();
                         // Spin until we are sure the reset_evt has been handled and that when
                         // we return from the KVM_RUN we will exit rather than re-enter the guest.
-                        while !vcpus_kill_signalled.load(Ordering::SeqCst) {
+                        while !vcpus_kill_signalled.load(Ordering::SeqCst)
+                            && !pause_signalled
+                                .as_ref()
+                                .is_some_and(|p| p.load(Ordering::SeqCst))
+                        {
                             // This is more effective than thread::yield_now() at
                             // avoiding a priority inversion with the VMM thread
                             thread::sleep(Duration::from_millis(1));

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -17,14 +17,20 @@ use vmm_sys_util::eventfd::EventFd;
 pub struct I8042Device {
     reset_evt: EventFd,
     vcpus_kill_signalled: Arc<AtomicBool>,
+    vcpus_pause_signalled: Arc<AtomicBool>,
 }
 
 impl I8042Device {
     /// Constructs a i8042 device that will signal the given event when the guest requests it.
-    pub fn new(reset_evt: EventFd, vcpus_kill_signalled: Arc<AtomicBool>) -> I8042Device {
+    pub fn new(
+        reset_evt: EventFd,
+        vcpus_kill_signalled: Arc<AtomicBool>,
+        vcpus_pause_signalled: Arc<AtomicBool>,
+    ) -> I8042Device {
         I8042Device {
             reset_evt,
             vcpus_kill_signalled,
+            vcpus_pause_signalled,
         }
     }
 }
@@ -51,7 +57,9 @@ impl BusDevice for I8042Device {
             }
             // Spin until we are sure the reset_evt has been handled and that when
             // we return from the KVM_RUN we will exit rather than re-enter the guest.
-            while !self.vcpus_kill_signalled.load(Ordering::SeqCst) {
+            while !self.vcpus_kill_signalled.load(Ordering::SeqCst)
+                && !self.vcpus_pause_signalled.load(Ordering::SeqCst)
+            {
                 // This is more effective than thread::yield_now() at
                 // avoiding a priority inversion with the VMM thread
                 thread::sleep(Duration::from_millis(1));

--- a/fuzz/fuzz_targets/cmos.rs
+++ b/fuzz/fuzz_targets/cmos.rs
@@ -26,6 +26,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
         u64::from_le_bytes(above_4g),
         EventFd::new(EFD_NONBLOCK).unwrap(),
         None,
+        None,
     );
 
     let mut i = 16;

--- a/fuzz/fuzz_targets/cmos.rs
+++ b/fuzz/fuzz_targets/cmos.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![no_main]
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
 use devices::legacy::Cmos;
 use libc::EFD_NONBLOCK;
 use libfuzzer_sys::{fuzz_target, Corpus};
@@ -25,8 +28,9 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
         u64::from_le_bytes(below_4g),
         u64::from_le_bytes(above_4g),
         EventFd::new(EFD_NONBLOCK).unwrap(),
-        None,
-        None,
+        // Set one to true: prevent endless loop
+        Arc::new(AtomicBool::new(true)),
+        Arc::new(AtomicBool::new(false)),
     );
 
     let mut i = 16;

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2349,6 +2349,11 @@ impl CpuManager {
         &self.vcpus_kill_signalled
     }
 
+    pub(crate) fn vcpus_pause_signalled(&self) -> &Arc<AtomicBool> {
+        &self.vcpus_pause_signalled
+    }
+
+    #[cfg(feature = "igvm")]
     #[cfg(all(feature = "igvm", feature = "mshv"))]
     pub(crate) fn get_cpuid_leaf(
         &self,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1864,10 +1864,17 @@ impl DeviceManager {
             .unwrap()
             .vcpus_kill_signalled()
             .clone();
+        let vcpus_pause_signalled = self
+            .cpu_manager
+            .lock()
+            .unwrap()
+            .vcpus_pause_signalled()
+            .clone();
         let shutdown_device = Arc::new(Mutex::new(devices::AcpiShutdownDevice::new(
             guest_exit_evt,
             reset_evt,
             vcpus_kill_signalled,
+            vcpus_pause_signalled,
         )));
 
         self.bus_devices
@@ -1968,10 +1975,17 @@ impl DeviceManager {
             .unwrap()
             .vcpus_kill_signalled()
             .clone();
+        let vcpus_pause_signalled = self
+            .cpu_manager
+            .lock()
+            .unwrap()
+            .vcpus_pause_signalled()
+            .clone();
         // Add a shutdown device (i8042)
         let i8042 = Arc::new(Mutex::new(legacy::I8042Device::new(
             reset_evt.try_clone().unwrap(),
             vcpus_kill_signalled.clone(),
+            vcpus_pause_signalled.clone(),
         )));
 
         self.bus_devices
@@ -2000,6 +2014,7 @@ impl DeviceManager {
                 mem_above_4g,
                 reset_evt,
                 Some(vcpus_kill_signalled),
+                Some(vcpus_pause_signalled.clone()),
             )));
 
             self.bus_devices

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2013,8 +2013,8 @@ impl DeviceManager {
                 mem_below_4g,
                 mem_above_4g,
                 reset_evt,
-                Some(vcpus_kill_signalled),
-                Some(vcpus_pause_signalled.clone()),
+                vcpus_kill_signalled,
+                vcpus_pause_signalled.clone(),
             )));
 
             self.bus_devices

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 #[cfg(feature = "guest_debug")]
 use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, RecvError, SendError, Sender, channel};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 use std::{any, io, mem, panic, path, process, result, thread};
 
@@ -69,7 +69,7 @@ use crate::migration::worker::{
 use crate::migration::{recv_vm_config, recv_vm_state};
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::util::flatten_error_chain_to_string;
-use crate::vm::{Error as VmError, Vm, VmState};
+use crate::vm::{Error as VmError, PostponedLifecycleEvent, Vm, VmState};
 use crate::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, NetConfig, PmemConfig,
     UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
@@ -668,11 +668,39 @@ enum VmOwnership {
         vm_info_response: VmInfoResponse,
         /// Access to VM state needed during migration.
         device_manager: Weak<Mutex<DeviceManager>>,
+        /// A guest induced lifecycle event (if any) for replay.
+        /// Shared between the VMM's event loop and the migration worker.
+        postponed_lifecycle_event: Arc<OnceLock<PostponedLifecycleEvent>>,
     },
     None,
 }
 
 impl VmOwnership {
+    /// Marks an event to be postponed and replayed on the destination when the
+    /// migration finishes.
+    ///
+    /// Returns whether a migration is ongoing.
+    fn postpone_lifecycle_event_if_needed(&self, event: PostponedLifecycleEvent) -> bool {
+        let VmOwnership::Migration {
+            postponed_lifecycle_event,
+            ..
+        } = self
+        else {
+            return false;
+        };
+
+        match postponed_lifecycle_event.set(event) {
+            Ok(_) => {
+                info!("Postponed lifecycle event: {event}");
+            }
+            Err(_) => {
+                warn!("Failed to postpone another (unexpected) lifecycle event: {event}");
+            }
+        }
+
+        true
+    }
+
     /// Returns a mutable reference to the underlying VM, if available.
     fn as_mut(&mut self) -> Option<&mut Vm> {
         match self {
@@ -1096,19 +1124,28 @@ impl Vmm {
                         .vm
                         .as_mut()
                         .expect("VM should have been created by now");
-                    let (_, resume_duration) = measure_ok(|| vm.resume())?;
-                    debug!(
-                        "Migration (incoming): resume:{}ms",
-                        resume_duration.as_millis()
-                    );
+
+                    let do_resume = !vm.has_postponed_lifecycle_event();
+                    if do_resume {
+                        let (_, resume_duration) = measure_ok(|| vm.resume())?;
+                        debug!(
+                            "Migration (incoming): resume:{}ms",
+                            resume_duration.as_millis()
+                        );
+                    } else {
+                        debug!(
+                            "Migration (incoming): skipping resume because of a postponed lifecycle event"
+                        );
+                    }
+
                     // This logs the downtime without the final memory delta, so
                     // it does not reflect the actual downtime. While we could
                     // pass along the timestamp from when the VM was paused,
                     // that would rely on both VM hosts having synchronized
-                    // clocks, which we cannot guarantee. For that reason, this
-                    // is logged as debug! rather than info!.
+                    // clocks, which we cannot guarantee.
                     debug!(
-                        "Migration (incoming): Receiving final state and resuming the VM took {}ms",
+                        "Migration (incoming): Receiving final state{}the VM took {}ms",
+                        if do_resume { " and resuming " } else { " " },
                         state_receive_begin.elapsed().as_millis()
                     );
                     Ok(Completed)
@@ -1629,7 +1666,7 @@ impl Vmm {
             vm,
             socket,
             &mut mem_ctx,
-            // We bind send_data_migration to the callback
+            // Bind parameters to not pass them to deeper levels.
             |ctx| Self::is_precopy_converged(ctx, send_data_migration),
             mem_send,
         )?;
@@ -1671,6 +1708,7 @@ impl Vmm {
         send_data_migration: &VmSendMigrationData,
         initial_vm_state: VmState,
         seccomp_filters: &MigrationSeccompFilters,
+        postponed_lifecycle_event: &OnceLock<PostponedLifecycleEvent>,
     ) -> result::Result<(), MigratableError> {
         // State machine that is updated with more context as we progress.
         let mut ctx = OngoingMigrationContext::new();
@@ -1850,7 +1888,13 @@ impl Vmm {
 
         let (vm_snapshot, snapshot_duration) = measure_ok(|| {
             // Capture snapshot. This may have side effects, e.g. vhost-user backend inflight drain
-            let snapshot = vm.snapshot()?;
+            let snapshot = {
+                // Make sure a possible event is baked into the VM snapshot.
+                if let Some(&lifecycle_event) = postponed_lifecycle_event.get() {
+                    vm.set_postponed_lifecycle_event(lifecycle_event);
+                }
+                vm.snapshot()?
+            };
 
             // One final memory iteration to handle side effects from snapshot.
             if matches!(memory_mode, MigrationMode::Precopy) {
@@ -2125,6 +2169,7 @@ impl Vmm {
     fn check_migration(&mut self) {
         let VmOwnership::Migration {
             migration_worker_handle,
+            postponed_lifecycle_event,
             ..
         } = mem::replace(&mut self.vm, VmOwnership::None)
         else {
@@ -2157,6 +2202,10 @@ impl Vmm {
             });
 
             self.vm = VmOwnership::Owned(vm);
+
+            if let Some(event) = postponed_lifecycle_event.get() {
+                self.replay_lifecycle_event(*event);
+            }
         };
 
         match migration_res {
@@ -2224,10 +2273,9 @@ impl Vmm {
                         warn!("Unknown VMM loop event: {event}");
                     }
                     EpollDispatch::Exit => {
-                        info!("VM exit event");
+                        info!("VMM exit event");
                         // Consume the event.
                         self.exit_evt.read().map_err(Error::EventFdRead)?;
-                        // TODO: Future follow-up must resolve lifecycle handling while migrating.
                         self.vmm_shutdown().map_err(Error::VmmShutdown)?;
 
                         break 'outer;
@@ -2236,13 +2284,23 @@ impl Vmm {
                         info!("VM reset event");
                         // Consume the event.
                         self.reset_evt.read().map_err(Error::EventFdRead)?;
-                        // TODO: Future follow-up must resolve lifecycle handling while migrating.
+                        if self
+                            .vm
+                            .postpone_lifecycle_event_if_needed(PostponedLifecycleEvent::Reboot)
+                        {
+                            continue;
+                        }
                         self.vm_reboot().map_err(Error::VmReboot)?;
                     }
                     EpollDispatch::GuestExit => {
                         info!("VM guest exit event");
                         self.guest_exit_evt.read().map_err(Error::EventFdRead)?;
-                        // TODO: Future follow-up must resolve lifecycle handling while migrating.
+                        if self
+                            .vm
+                            .postpone_lifecycle_event_if_needed(PostponedLifecycleEvent::Shutdown)
+                        {
+                            continue;
+                        }
                         if self.no_shutdown {
                             self.vm_shutdown().map_err(Error::VmShutdown)?;
                         } else {
@@ -2332,6 +2390,20 @@ impl Vmm {
         }
 
         Ok(())
+    }
+
+    /// Replays a lifecycle event by triggering again the VMM event loop.
+    ///
+    /// This requires that events are only caught in the VMMs event loop.
+    fn replay_lifecycle_event(&mut self, event: PostponedLifecycleEvent) {
+        info!("VM requested a {event:?} during the migration: replaying now");
+        let result = match event {
+            PostponedLifecycleEvent::Reboot => self.reset_evt.write(1),
+            PostponedLifecycleEvent::Shutdown => self.guest_exit_evt.write(1),
+        };
+        if let Err(e) = result {
+            error!("Failed replaying lifecycle event {event:?} after migration: {e}");
+        }
     }
 }
 
@@ -3303,6 +3375,17 @@ impl RequestHandler for Vmm {
             .inspect(|_| {
                 // Serving and resume already happened in the protocol loop.
                 event!("vm", "migration-receive-finished");
+
+                // now replay lifecycle event
+                let vm = self
+                    .vm
+                    .as_mut()
+                    .expect("VM should have been created by now");
+                let lifecycle_event = vm.take_postponed_lifecycle_event();
+
+                if let Some(event) = lifecycle_event {
+                    self.replay_lifecycle_event(event);
+                }
             })
             .inspect_err(|_| {
                 event!("vm", "migration-receive-failed");
@@ -3433,6 +3516,7 @@ impl RequestHandler for Vmm {
             .expect("should have VM ownership as we just checked it");
 
         let device_manager = Arc::downgrade(vm.device_manager());
+        let postponed_lifecycle_event = Arc::new(OnceLock::new());
 
         match MigrationWorker::spawn(
             vm,
@@ -3442,12 +3526,14 @@ impl RequestHandler for Vmm {
             self.hypervisor.clone(),
             initial_vm_state,
             seccomp_filters,
+            postponed_lifecycle_event.clone(),
         ) {
             Ok(handle) => {
                 self.vm = VmOwnership::Migration {
                     migration_worker_handle: handle,
                     vm_info_response: vm_info_snapshot,
                     device_manager,
+                    postponed_lifecycle_event,
                 };
                 Ok(())
             }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1561,10 +1561,11 @@ impl Vmm {
     ///
     /// 1. **No dirty pages remain** – the current iteration would transfer zero
     ///    bytes.
-    /// 2. **Downtime budget is met** – the estimated downtime for the final
+    /// 1. **Postponed lifecycle event** – no need to transfer memory anymore
+    /// 1. **Downtime budget is met** – the estimated downtime for the final
     ///    (paused) iteration is within the caller-specified
     ///    [`VmSendMigrationData::downtime`] budget.
-    /// 3. **Timeout** – the precopy phase has been running for at least
+    /// 1. **Timeout** – the precopy phase has been running for at least
     ///    [`VmSendMigrationData::timeout`]. The outcome depends on
     ///    [`VmSendMigrationData::timeout_strategy`]:
     ///    - [`TimeoutStrategy::Cancel`] – returns
@@ -1584,9 +1585,18 @@ impl Vmm {
     fn is_precopy_converged(
         ctx: &MemoryMigrationContext,
         send_data_migration: &VmSendMigrationData,
+        postponed_lifecycle_event: &OnceLock<PostponedLifecycleEvent>,
     ) -> result::Result<bool, MigratableError> {
         if ctx.current_iteration_total_bytes == 0 {
             debug!("Precopy: No more memory to transfer");
+            return Ok(true);
+        }
+
+        // Guest reboot or shutdown signaled? We do not need the memory anymore.
+        if let Some(event) = postponed_lifecycle_event.get() {
+            info!(
+                "Lifecycle event postponed during migration ({event:?}), switching to downtime phase early"
+            );
             return Ok(true);
         }
 
@@ -1658,21 +1668,28 @@ impl Vmm {
         send_data_migration: &VmSendMigrationData,
         mem_send: &mut SendAdditionalConnections,
         ctx: &mut OngoingMigrationContext,
+        postponed_lifecycle_event: &OnceLock<PostponedLifecycleEvent>,
     ) -> result::Result<(), MigratableError> {
         let mut mem_ctx = MemoryMigrationContext::new();
 
         vm.start_dirty_log()?;
-        let remaining = Self::do_memory_iterations(
+        let mut remaining = Self::do_memory_iterations(
             vm,
             socket,
             &mut mem_ctx,
             // Bind parameters to not pass them to deeper levels.
-            |ctx| Self::is_precopy_converged(ctx, send_data_migration),
+            |ctx| Self::is_precopy_converged(ctx, send_data_migration, postponed_lifecycle_event),
             mem_send,
         )?;
         let downtime_begin = Instant::now();
         if vm.get_state() != VmState::Paused {
             vm.pause()?;
+        }
+
+        // Performance shortcut: no need to send memory (drain dirty log)
+        if postponed_lifecycle_event.get().is_some() {
+            let _ = vm.dirty_log()?;
+            remaining = MemoryRangeTable::default();
         }
 
         // Send last batch of dirty pages: final iteration
@@ -1819,6 +1836,7 @@ impl Vmm {
                     send_data_migration,
                     &mut mem_send,
                     &mut ctx,
+                    postponed_lifecycle_event,
                 )
                 .inspect_err(|_| {
                     if let Err(e) = mem_send.cleanup_workers() {
@@ -1826,6 +1844,7 @@ impl Vmm {
                         warn!("Error cleaning up migration connections: {msg}");
                     }
                 })?;
+
                 mem_send.cleanup_workers()?;
             }
             // No need for precopy: just pause VM

--- a/vmm/src/migration/worker.rs
+++ b/vmm/src/migration/worker.rs
@@ -13,9 +13,8 @@
 //! [`MigrationWorkerSpawnError`].
 
 use std::fmt::{self, Debug, Formatter};
-#[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-use std::sync::Arc;
 use std::sync::mpsc::{self, Receiver};
+use std::sync::{Arc, OnceLock};
 use std::thread::JoinHandle;
 use std::{io, thread};
 
@@ -28,7 +27,7 @@ use vmm_sys_util::eventfd::EventFd;
 
 use crate::Vmm;
 use crate::api::VmSendMigrationData;
-use crate::vm::{Vm, VmState};
+use crate::vm::{PostponedLifecycleEvent, Vm, VmState};
 
 #[derive(thiserror::Error)]
 #[error("Migration worker could not be spawned: {spawn_error}")]
@@ -85,6 +84,9 @@ pub(crate) struct MigrationWorker {
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
     initial_vm_state: VmState,
     seccomp_filters: MigrationSeccompFilters,
+    /// A guest induced lifecycle event (if any) for replay.
+    /// Shared between the VMM's event loop and the migration worker.
+    postponed_lifecycle_event: Arc<OnceLock<PostponedLifecycleEvent>>,
 }
 
 impl MigrationWorker {
@@ -115,6 +117,7 @@ impl MigrationWorker {
                     &self.config,
                     self.initial_vm_state,
                     &self.seccomp_filters,
+                    self.postponed_lifecycle_event.as_ref(),
                 )
             })
             .inspect(|_| event!("vm", "migration-finished"))
@@ -144,6 +147,7 @@ impl MigrationWorker {
         >,
         initial_vm_state: VmState,
         seccomp_filters: MigrationSeccompFilters,
+        postponed_lifecycle_event: Arc<OnceLock<PostponedLifecycleEvent>>,
     ) -> Result<MigrationWorkerHandle, MigrationWorkerSpawnError> {
         let (vm_sender, vm_receiver) = mpsc::sync_channel(0);
         let worker = MigrationWorker {
@@ -154,6 +158,7 @@ impl MigrationWorker {
             hypervisor,
             initial_vm_state,
             seccomp_filters,
+            postponed_lifecycle_event,
         };
 
         let inner_handle = match thread::Builder::new()

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -14,6 +14,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 #[cfg(feature = "fw_cfg")]
 use std::ffi;
+use std::fmt::{Display, Formatter};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Seek, SeekFrom, Write};
 use std::num::Wrapping;
@@ -22,7 +23,7 @@ use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
 #[cfg(not(target_arch = "riscv64"))]
 use std::time::Instant;
-use std::{any, cmp, result, str, thread};
+use std::{any, cmp, fmt, result, str, thread};
 
 use anyhow::{Context, anyhow};
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
@@ -558,6 +559,26 @@ pub struct Vm {
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
     stop_on_boot: bool,
     load_payload_handle: Option<thread::JoinHandle<Result<EntryPoint>>>,
+    /// Lifecycle event to replay after a restore/migration.
+    postponed_lifecycle_event: Option<PostponedLifecycleEvent>,
+}
+
+/// Guest induced events that can/must be postponed, e.g., during migration.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PostponedLifecycleEvent {
+    /// VM reboot aka. [`crate::EpollDispatch::Reset`].
+    Reboot,
+    /// VM shutdown aka. [`crate::EpollDispatch::GuestExit`].
+    Shutdown,
+}
+
+impl Display for PostponedLifecycleEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            PostponedLifecycleEvent::Reboot => write!(f, "Reboot (Reset)"),
+            PostponedLifecycleEvent::Shutdown => write!(f, "Shutdown (GuestExit)"),
+        }
+    }
 }
 
 impl Vm {
@@ -721,6 +742,15 @@ impl Vm {
         } else {
             VmState::Created
         };
+        let postponed_lifecycle_event = snapshot
+            .as_ref()
+            .map(|snapshot| {
+                get_vm_snapshot(snapshot)
+                    .map(|vm_snapshot| vm_snapshot.postponed_lifecycle_event)
+                    .map_err(Error::Restore)
+            })
+            .transpose()?
+            .flatten();
 
         Ok(Vm {
             #[cfg(feature = "tdx")]
@@ -740,6 +770,7 @@ impl Vm {
             hypervisor,
             stop_on_boot,
             load_payload_handle,
+            postponed_lifecycle_event,
         })
     }
 
@@ -1333,6 +1364,18 @@ impl Vm {
         }
 
         Ok(numa_nodes)
+    }
+
+    pub fn set_postponed_lifecycle_event(&mut self, event: PostponedLifecycleEvent) {
+        self.postponed_lifecycle_event = Some(event);
+    }
+
+    pub fn take_postponed_lifecycle_event(&mut self) -> Option<PostponedLifecycleEvent> {
+        self.postponed_lifecycle_event.take()
+    }
+
+    pub fn has_postponed_lifecycle_event(&self) -> bool {
+        self.postponed_lifecycle_event.is_some()
     }
 
     #[expect(clippy::too_many_arguments)]
@@ -3318,6 +3361,8 @@ impl Pausable for Vm {
 
 #[derive(Serialize, Deserialize)]
 pub struct VmSnapshot {
+    #[serde(default)]
+    pub postponed_lifecycle_event: Option<PostponedLifecycleEvent>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clock: Option<hypervisor::ClockState>,
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
@@ -3379,6 +3424,7 @@ impl Snapshottable for Vm {
         };
 
         let vm_snapshot_state = VmSnapshot {
+            postponed_lifecycle_event: self.take_postponed_lifecycle_event(),
             clock: self.saved_clock.map(|saved| saved.state),
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             common_cpuid,


### PR DESCRIPTION
CH never supported guest induced reboot or shutdown during a migration. We figured the right and also simplest approach is to catch the lifecycle event, shortcut the migration (stop memory migration) and to replay the lifecycle event on the destination.

We use this with success on scale via OpenStack and libvirt/ch. Our internal tests and the CH integration tests give us confidence.

I didn't do it for postcopy here as postcopy is officially still **experimental**. We need to build postcopy first right and then can fix it. However, a PoC showed me that it technically works as well with postcopy.

This is work done mainly by @Coffeeri but I had to adjust some things for upstream.

The observable behavior from the outside is similar to QEMU. The VM migrates, even on shutdown or reboot.

Related to #7111 