### PR TITLE
scripts: Bump OVMF firmware tag to ch-811ce5ea35

### DIFF
--- a/scripts/sha1sums-aarch64-common
+++ b/scripts/sha1sums-aarch64-common
@@ -1,4 +1,4 @@
 e4addb6e212a298144f9eb0eb6e36019d013f0e7  alpine-minirootfs-aarch64.tar.gz
 7118f4d4cad18c8357bc2ad9824a50f9a82a860a  jammy-server-cloudimg-arm64-custom-20220329-0.qcow2
 1f2b71be43b8f748f01306c4454e5c921343faa4  jammy-server-cloudimg-arm64-custom-20220329-0.raw
-ce3656987f9e4238ef8afbd65fca219460c1f767  CLOUDHV_EFI.fd
+b42e6879e22d44b4757d0fbb6f2dc2814bbc0f69  CLOUDHV_EFI.fd

--- a/scripts/sha1sums-x86_64
+++ b/scripts/sha1sums-x86_64
@@ -1,3 +1,3 @@
 d4a44acc6014d5f83dea1c625c43d677a95fa75f alpine-minirootfs-x86_64.tar.gz
 540ac358429305d7aa94e15363665d1c9d845982 hypervisor-fw
-fb2e6834cc482c80a45766f6dcf12474f4fcb74e CLOUDHV.fd
+07cfe6d8e0c9772a257a6aad1df092f6bf2c47cc CLOUDHV.fd

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -245,7 +245,7 @@ prepare_linux() {
 }
 
 download_amd64_ovmf() {
-    OVMF_FW_TAG="ch-1e1b96f126"
+    OVMF_FW_TAG="ch-811ce5ea35"
     OVMF_FW_URL="https://github.com/cloud-hypervisor/edk2/releases/download/$OVMF_FW_TAG/CLOUDHV.fd"
     OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
     pushd "$WORKLOADS_DIR" || exit
@@ -255,7 +255,7 @@ download_amd64_ovmf() {
 }
 
 download_aarch64_ovmf() {
-    OVMF_FW_TAG="ch-1e1b96f126"
+    OVMF_FW_TAG="ch-811ce5ea35"
     OVMF_FW_URL="https://github.com/cloud-hypervisor/edk2/releases/download/$OVMF_FW_TAG/CLOUDHV_EFI.fd"
     OVMF_FW="$WORKLOADS_DIR/CLOUDHV_EFI.fd"
     pushd "$WORKLOADS_DIR" || exit


### PR DESCRIPTION
```
cloud-hypervisor/edk2 fork made a new
release based on upstream edk2-stable202608

Update the download tag for both architectures
in test-util.sh and refresh the sha1sums to
match ch-811ce5ea35 artifacts.

Signed-off-by: Saravanan D <saravanand@crusoe.ai>
```