### PR TITLE
Enable `unreachable_pub` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,3 +139,4 @@ unnecessary_semicolon = "deny"
 [workspace.lints.rust]
 # `level = warn` is irrelevant here but mandatory for rustc/cargo
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(devcli_testenv)'] }
+unreachable_pub = "deny"

--- a/arch/src/x86_64/hyperv_msrs.rs
+++ b/arch/src/x86_64/hyperv_msrs.rs
@@ -64,7 +64,7 @@ const HV_X64_MSR_SYNDBG_PENDING_BUFFER: u32 = 0x400000F5;
 const HV_X64_MSR_SYNDBG_OPTIONS: u32 = 0x400000FF;
 
 // All Hyper-V MSRs extracted from https://elixir.bootlin.com/linux/v7.1.1/source/tools/testing/selftests/kvm/include/x86/hyperv.h#L23
-pub const HYPERV_MSRS: [u32; 59] = [
+pub(super) const HYPERV_MSRS: [u32; 59] = [
     HV_X64_MSR_GUEST_OS_ID,
     HV_X64_MSR_HYPERCALL,
     HV_X64_MSR_VP_INDEX,

--- a/arch/src/x86_64/mpspec.rs
+++ b/arch/src/x86_64/mpspec.rs
@@ -7,19 +7,19 @@ use std::os::raw;
 
 use vm_memory::ByteValued;
 
-pub const MP_PROCESSOR: raw::c_uint = 0;
-pub const MP_BUS: raw::c_uint = 1;
-pub const MP_IOAPIC: raw::c_uint = 2;
-pub const MP_INTSRC: raw::c_uint = 3;
-pub const MP_LINTSRC: raw::c_uint = 4;
-pub const CPU_ENABLED: raw::c_uint = 1;
-pub const CPU_BOOTPROCESSOR: raw::c_uint = 2;
-pub const MPC_APIC_USABLE: raw::c_uint = 1;
-pub const MP_IRQDIR_DEFAULT: raw::c_uint = 0;
+pub(super) const MP_PROCESSOR: raw::c_uint = 0;
+pub(super) const MP_BUS: raw::c_uint = 1;
+pub(super) const MP_IOAPIC: raw::c_uint = 2;
+pub(super) const MP_INTSRC: raw::c_uint = 3;
+pub(super) const MP_LINTSRC: raw::c_uint = 4;
+pub(super) const CPU_ENABLED: raw::c_uint = 1;
+pub(super) const CPU_BOOTPROCESSOR: raw::c_uint = 2;
+pub(super) const MPC_APIC_USABLE: raw::c_uint = 1;
+pub(super) const MP_IRQDIR_DEFAULT: raw::c_uint = 0;
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct mpf_intel {
+pub(super) struct mpf_intel {
     pub signature: [raw::c_uchar; 4usize],
     pub physptr: raw::c_uint,
     pub length: raw::c_uchar,
@@ -41,7 +41,7 @@ unsafe impl ByteValued for mpf_intel {}
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct mpc_table {
+pub(super) struct mpc_table {
     pub signature: [raw::c_uchar; 4usize],
     pub length: raw::c_ushort,
     pub spec: raw::c_uchar,
@@ -70,7 +70,7 @@ unsafe impl ByteValued for mpc_table {}
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct mpc_cpu {
+pub(super) struct mpc_cpu {
     pub type_: raw::c_uchar,
     pub apicid: raw::c_uchar,
     pub apicver: raw::c_uchar,
@@ -89,7 +89,7 @@ unsafe impl ByteValued for mpc_cpu {}
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct mpc_bus {
+pub(super) struct mpc_bus {
     pub type_: raw::c_uchar,
     pub busid: raw::c_uchar,
     pub bustype: [raw::c_uchar; 6usize],
@@ -104,7 +104,7 @@ unsafe impl ByteValued for mpc_bus {}
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct mpc_ioapic {
+pub(super) struct mpc_ioapic {
     pub type_: raw::c_uchar,
     pub apicid: raw::c_uchar,
     pub apicver: raw::c_uchar,
@@ -121,7 +121,7 @@ unsafe impl ByteValued for mpc_ioapic {}
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct mpc_intsrc {
+pub(super) struct mpc_intsrc {
     pub type_: raw::c_uchar,
     pub irqtype: raw::c_uchar,
     pub irqflag: raw::c_ushort,
@@ -138,13 +138,13 @@ const _: () = assert!(size_of::<mpc_intsrc>() == 8);
 // would be nowhere for them to exist.
 unsafe impl ByteValued for mpc_intsrc {}
 
-pub const MP_IRQ_SOURCE_TYPES_MP_INT: raw::c_uint = 0;
-pub const MP_IRQ_SOURCE_TYPES_MP_NMI: raw::c_uint = 1;
-pub const MP_IRQ_SOURCE_TYPES_MP_EXT_INT: raw::c_uint = 3;
+pub(super) const MP_IRQ_SOURCE_TYPES_MP_INT: raw::c_uint = 0;
+pub(super) const MP_IRQ_SOURCE_TYPES_MP_NMI: raw::c_uint = 1;
+pub(super) const MP_IRQ_SOURCE_TYPES_MP_EXT_INT: raw::c_uint = 3;
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct mpc_lintsrc {
+pub(super) struct mpc_lintsrc {
     pub type_: raw::c_uchar,
     pub irqtype: raw::c_uchar,
     pub irqflag: raw::c_ushort,
@@ -163,7 +163,7 @@ unsafe impl ByteValued for mpc_lintsrc {}
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct mpc_oemtable {
+struct mpc_oemtable {
     pub signature: [raw::c_uchar; 4usize],
     pub length: raw::c_ushort,
     pub rev: raw::c_uchar,

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -86,7 +86,7 @@ pub enum Error {
     WriteMpcTable(#[source] GuestMemoryError),
 }
 
-pub type Result<T> = result::Result<T, Error>;
+pub(super) type Result<T> = result::Result<T, Error>;
 
 // Most of these variables are sourced from the Intel MP Spec 1.4.
 const SMP_MAGIC_IDENT: &[c_uchar; 4] = b"_MP_";
@@ -124,7 +124,7 @@ fn compute_mp_size(num_cpus: u32) -> usize {
 }
 
 /// Performs setup of the MP table for the given `num_cpus`.
-pub fn setup_mptable(
+pub(super) fn setup_mptable(
     offset: GuestAddress,
     mem: &GuestMemoryMmap,
     num_cpus: u32,

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -40,7 +40,7 @@ pub enum Error {
     TooManyStrings,
 }
 
-pub type Result<T> = result::Result<T, Error>;
+type Result<T> = result::Result<T, Error>;
 
 // Constants sourced from SMBIOS Spec 3.9.0.
 const SM3_MAGIC_IDENT: &[u8; 5usize] = b"_SM3_";
@@ -55,8 +55,8 @@ const CHASSIS_STATE_UNKNOWN: u8 = 0x02;
 const CHASSIS_SECURITY_STATUS_NONE: u8 = 0x03;
 const PCI_SUPPORTED: u64 = 1 << 7;
 const IS_VIRTUAL_MACHINE: u8 = 1 << 4;
-pub const DEFAULT_SYSTEM_MANUFACTURER: &str = "Cloud Hypervisor";
-pub const DEFAULT_SYSTEM_PRODUCT_NAME: &str = "cloud-hypervisor";
+const DEFAULT_SYSTEM_MANUFACTURER: &str = "Cloud Hypervisor";
+const DEFAULT_SYSTEM_PRODUCT_NAME: &str = "cloud-hypervisor";
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SmbiosConfig {
@@ -366,7 +366,7 @@ fn write_type3_chassis(
     Ok(())
 }
 
-pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Result<u64> {
+pub(crate) fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Result<u64> {
     let system = smbios.and_then(|cfg| cfg.system.as_ref());
     let chassis = smbios.and_then(|cfg| cfg.chassis.as_ref());
     let oem_strings: &[String] = smbios.map_or(&[], |cfg| &cfg.oem_strings);

--- a/block/src/aligned_buffer.rs
+++ b/block/src/aligned_buffer.rs
@@ -28,7 +28,7 @@ impl AlignedBuffer {
     ///
     /// When offset and length are already aligned, `head_pad == 0` and the
     /// full buffer equals the user's logical portion (no overhead).
-    pub fn new(offset: u64, len: usize, alignment: usize) -> io::Result<Self> {
+    pub(crate) fn new(offset: u64, len: usize, alignment: usize) -> io::Result<Self> {
         if alignment == 0 || !alignment.is_power_of_two() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -80,13 +80,13 @@ impl AlignedBuffer {
     }
 
     /// The caller's logical portion of the buffer (read-only).
-    pub fn as_slice(&self) -> &[u8] {
+    pub(crate) fn as_slice(&self) -> &[u8] {
         // SAFETY: ptr is valid for layout.size() bytes; head_pad + user_len <= layout.size().
         unsafe { slice::from_raw_parts(self.ptr.add(self.head_pad), self.user_len) }
     }
 
     /// The caller's logical portion of the buffer (mutable).
-    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [u8] {
         // SAFETY: ptr is valid for layout.size() bytes; head_pad + user_len <= layout.size().
         unsafe { slice::from_raw_parts_mut(self.ptr.add(self.head_pad), self.user_len) }
     }
@@ -105,7 +105,7 @@ impl AlignedBuffer {
     ///
     /// Returns the number of caller-logical bytes now valid in `as_slice()`,
     /// accounting for head padding and any short read.
-    pub fn read_from(&mut self, f: &impl FileExt) -> io::Result<usize> {
+    pub(crate) fn read_from(&mut self, f: &impl FileExt) -> io::Result<usize> {
         let mut total = 0usize;
         while total < self.aligned_len {
             let offset = self
@@ -123,7 +123,7 @@ impl AlignedBuffer {
     }
 
     /// Write the full aligned region from this buffer to `f`.
-    pub fn write_to(&self, f: &impl FileExt) -> io::Result<()> {
+    pub(crate) fn write_to(&self, f: &impl FileExt) -> io::Result<()> {
         f.write_all_at(self.full_slice(), self.aligned_offset)
     }
 }

--- a/block/src/formats/qcow/backing.rs
+++ b/block/src/formats/qcow/backing.rs
@@ -18,7 +18,7 @@ use crate::error::{BlockError, BlockErrorKind, BlockResult};
 use crate::formats::qcow::common::decompress_cluster;
 
 /// Raw backing file using position-independent reads.
-pub(crate) struct RawBacking {
+struct RawBacking {
     pub(crate) file: AlignedFile,
     pub(crate) virtual_size: u64,
 }

--- a/block/src/formats/qcow/common.rs
+++ b/block/src/formats/qcow/common.rs
@@ -282,7 +282,7 @@ pub(crate) mod tests {
     }
 
     /// Compress every allocated cluster in a QCOW2 image file in place.
-    pub fn compress_allocated_clusters(file: &mut File) {
+    pub(crate) fn compress_allocated_clusters(file: &mut File) {
         let mut buf4 = [0u8; 4];
         file.read_exact_at(&mut buf4, HEADER_CLUSTER_BITS_OFFSET)
             .unwrap();

--- a/block/src/formats/qcow/metadata.rs
+++ b/block/src/formats/qcow/metadata.rs
@@ -365,18 +365,18 @@ impl QcowMetadata {
     }
 
     #[cfg(test)]
-    pub fn header(&self) -> QcowHeader {
+    pub(super) fn header(&self) -> QcowHeader {
         self.inner.read().unwrap().header.clone()
     }
 
     #[cfg(test)]
-    pub fn free_list_len(&self) -> usize {
+    pub(super) fn free_list_len(&self) -> usize {
         let inner = self.inner.read().unwrap();
         inner.avail_clusters.len() + inner.unref_clusters.len()
     }
 
     #[cfg(test)]
-    pub fn cluster_refcount(&self, address: u64) -> io::Result<u64> {
+    pub(super) fn cluster_refcount(&self, address: u64) -> io::Result<u64> {
         let mut inner = self.inner.write().unwrap();
         let QcowState {
             refcounts,
@@ -858,7 +858,7 @@ impl QcowState {
     /// logical-zero entries so reads do not fall through to backing data.
     ///
     /// Returns None if no host punch_hole is needed.
-    pub(super) fn deallocate_cluster(
+    fn deallocate_cluster(
         &mut self,
         address: u64,
         sparse: bool,
@@ -1017,7 +1017,7 @@ impl QcowState {
     }
 
     /// Flushes all dirty metadata to disk.
-    pub(super) fn sync_caches(&mut self) -> io::Result<()> {
+    fn sync_caches(&mut self) -> io::Result<()> {
         // Write out all dirty L2 tables.
         for (l1_index, l2_table) in self.l2_cache.iter_mut().filter(|(_k, v)| v.dirty()) {
             let addr = self.l1_table[*l1_index];

--- a/block/src/formats/qcow/parser.rs
+++ b/block/src/formats/qcow/parser.rs
@@ -858,7 +858,7 @@ fn rebuild_refcounts(raw_file: &mut QcowRawFile, header: QcowHeader) -> BlockRes
 }
 
 /// Detect the type of an image file by checking for a valid qcow2 header.
-pub(super) fn detect_image_type(file: &mut AlignedFile) -> BlockResult<ImageType> {
+fn detect_image_type(file: &mut AlignedFile) -> BlockResult<ImageType> {
     let mut magic_bytes = [0u8; 4];
     file.read_exact_at(&mut magic_bytes, 0)
         .map_err(|e| BlockError::new(BlockErrorKind::Io, Error::ReadingHeader(e)))?;

--- a/block/src/formats/raw/test_helpers.rs
+++ b/block/src/formats/raw/test_helpers.rs
@@ -22,7 +22,7 @@ fn next_completion(async_io: &mut dyn AsyncIo) -> (u64, i32) {
 
 /// Tests punching a hole in the middle of a 4 MB file and verifying data
 /// integrity around the hole.
-pub fn test_punch_hole(async_io: &mut dyn AsyncIo, file: &mut File) {
+pub(crate) fn test_punch_hole(async_io: &mut dyn AsyncIo, file: &mut File) {
     // Write 4MB of data
     let data = vec![0xAA; 4 * 1024 * 1024];
     file.write_all(&data).unwrap();
@@ -68,7 +68,7 @@ pub fn test_punch_hole(async_io: &mut dyn AsyncIo, file: &mut File) {
 
 /// Tests writing zeroes to a 512 KB region inside a 4 MB file and verifying
 /// surrounding data is preserved.
-pub fn test_write_zeroes(async_io: &mut dyn AsyncIo, file: &mut File) {
+pub(crate) fn test_write_zeroes(async_io: &mut dyn AsyncIo, file: &mut File) {
     // Write 4MB of data
     let data = vec![0xBB; 4 * 1024 * 1024];
     file.write_all(&data).unwrap();
@@ -114,7 +114,7 @@ pub fn test_write_zeroes(async_io: &mut dyn AsyncIo, file: &mut File) {
 
 /// Tests punching multiple holes in an 8 MB file and verifying each hole
 /// independently reads as zeroes.
-pub fn test_punch_hole_multiple_operations(async_io: &mut dyn AsyncIo, file: &mut File) {
+pub(crate) fn test_punch_hole_multiple_operations(async_io: &mut dyn AsyncIo, file: &mut File) {
     // Write 8MB of data
     let data = vec![0xCC; 8 * 1024 * 1024];
     file.write_all(&data).unwrap();

--- a/block/src/formats/vhd/footer.rs
+++ b/block/src/formats/vhd/footer.rs
@@ -107,50 +107,50 @@ impl VhdFooter {
     }
 
     #[cfg(test)]
-    pub fn cookie(&self) -> u64 {
+    pub(super) fn cookie(&self) -> u64 {
         self.cookie
     }
     #[cfg(test)]
-    pub fn features(&self) -> u32 {
+    pub(super) fn features(&self) -> u32 {
         self.features
     }
     #[cfg(test)]
-    pub fn file_format_version(&self) -> u32 {
+    fn file_format_version(&self) -> u32 {
         self.file_format_version
     }
     #[cfg(test)]
-    pub fn data_offset(&self) -> u64 {
+    pub(super) fn data_offset(&self) -> u64 {
         self.data_offset
     }
     #[cfg(test)]
-    pub fn time_stamp(&self) -> u32 {
+    fn time_stamp(&self) -> u32 {
         self.time_stamp
     }
     #[cfg(test)]
-    pub fn creator_application(&self) -> u32 {
+    fn creator_application(&self) -> u32 {
         self.creator_application
     }
     #[cfg(test)]
-    pub fn creator_version(&self) -> u32 {
+    fn creator_version(&self) -> u32 {
         self.creator_version
     }
     #[cfg(test)]
-    pub fn creator_host_os(&self) -> u32 {
+    fn creator_host_os(&self) -> u32 {
         self.creator_host_os
     }
     #[cfg(test)]
-    pub fn original_size(&self) -> u64 {
+    pub(super) fn original_size(&self) -> u64 {
         self.original_size
     }
     pub(super) fn current_size(&self) -> u64 {
         self.current_size
     }
     #[cfg(test)]
-    pub fn disk_geometry(&self) -> u32 {
+    fn disk_geometry(&self) -> u32 {
         self.disk_geometry
     }
     #[cfg(test)]
-    pub fn disk_type(&self) -> u32 {
+    pub(super) fn disk_type(&self) -> u32 {
         self.disk_type
     }
 
@@ -194,15 +194,15 @@ impl VhdFooter {
     }
 
     #[cfg(test)]
-    pub fn checksum(&self) -> u32 {
+    pub(super) fn checksum(&self) -> u32 {
         self.checksum
     }
     #[cfg(test)]
-    pub fn unique_id(&self) -> u128 {
+    fn unique_id(&self) -> u128 {
         self.unique_id
     }
     #[cfg(test)]
-    pub fn saved_state(&self) -> u8 {
+    pub(super) fn saved_state(&self) -> u8 {
         self.saved_state
     }
 }

--- a/block/src/formats/vmdk/descriptor.rs
+++ b/block/src/formats/vmdk/descriptor.rs
@@ -23,7 +23,7 @@ const VMDK_DESCRIPTOR_DDB_2: &str = "#DDB";
 
 /// Flat VMDK create types.
 #[derive(Debug, Default)]
-pub enum VMDKDiskType {
+enum VMDKDiskType {
     #[default]
     CreateTypeUnsupported,
     MonolithicFlat,
@@ -61,7 +61,7 @@ impl FromStr for ExtentAccess {
 /// Format of each extent line:
 /// `<access> <sectors> <type> "<file>" [offset]`.
 #[derive(Debug)]
-pub struct VmdkExtentHeader {
+pub(super) struct VmdkExtentHeader {
     pub access: ExtentAccess,
     pub size_in_sectors: u64,
     pub extent_type: String,
@@ -71,13 +71,13 @@ pub struct VmdkExtentHeader {
 
 /// Descriptor header fields.
 #[derive(Debug, Default)]
-pub struct VmdkDescriptorHeader {
+struct VmdkDescriptorHeader {
     pub create_type: VMDKDiskType,
 }
 
 /// Ordered list of extents.
 #[derive(Debug, Default)]
-pub struct VmdkDescriptorExtents {
+pub(super) struct VmdkDescriptorExtents {
     pub extents: Vec<VmdkExtentHeader>,
 }
 
@@ -86,13 +86,13 @@ pub struct VmdkDescriptorExtents {
 /// extents_list: ordered extent list
 /// base_path: descriptor file's parent directory
 #[derive(Debug, Default)]
-pub struct VmdkDescriptor {
+pub(super) struct VmdkDescriptor {
     pub base_path: String,
     pub extents_list: VmdkDescriptorExtents,
 }
 
 impl VmdkDescriptor {
-    pub fn new(file: &File, path: &Path) -> io::Result<Self> {
+    pub(super) fn new(file: &File, path: &Path) -> io::Result<Self> {
         // The descriptor's directory anchors the relative extent filenames.
         let base_path = path
             .parent()
@@ -150,9 +150,7 @@ fn read_descriptor(file: &File) -> io::Result<String> {
     })
 }
 
-pub(crate) fn parse_header<'a>(
-    lines: &mut Lines<'a>,
-) -> io::Result<(VmdkDescriptorHeader, &'a str)> {
+fn parse_header<'a>(lines: &mut Lines<'a>) -> io::Result<(VmdkDescriptorHeader, &'a str)> {
     let header_line = lines.next().unwrap_or_default();
 
     // Reject actual disk data (or an embedded descriptor, which is
@@ -187,7 +185,7 @@ pub(crate) fn parse_header<'a>(
     Ok((header, last_comment_line))
 }
 
-pub(crate) fn parse_extents(
+fn parse_extents(
     lines: &mut Lines<'_>,
     last_comment_line: &str,
 ) -> io::Result<VmdkDescriptorExtents> {

--- a/block/src/formats/vmdk/engine_sync.rs
+++ b/block/src/formats/vmdk/engine_sync.rs
@@ -27,7 +27,7 @@ pub(crate) struct FlatVmdkSync {
 }
 
 impl FlatVmdkSync {
-    pub fn new(extents: Arc<Vec<VmdkExtent>>, size: u64) -> Self {
+    pub(super) fn new(extents: Arc<Vec<VmdkExtent>>, size: u64) -> Self {
         FlatVmdkSync {
             extents,
             size,

--- a/block/src/formats/vmdk/flat.rs
+++ b/block/src/formats/vmdk/flat.rs
@@ -46,7 +46,7 @@ pub(crate) struct VmdkExtent {
 }
 
 #[derive(Debug)]
-pub struct FlatVmdk {
+pub(super) struct FlatVmdk {
     descriptor: Arc<VmdkDescriptor>,
     // Open handle to the VMDK descriptor file.
     descriptor_file: Arc<File>,
@@ -240,7 +240,7 @@ fn overflow_error(what: &str) -> io::Error {
 
 impl FlatVmdk {
     /// Opens a flat VMDK image from its already-open descriptor file.
-    pub fn new(file: File, path: &Path, readonly: bool, direct: bool) -> io::Result<Self> {
+    pub(super) fn new(file: File, path: &Path, readonly: bool, direct: bool) -> io::Result<Self> {
         let descriptor = VmdkDescriptor::new(&file, path)?;
 
         if descriptor.extents_list.extents.is_empty() {
@@ -325,12 +325,12 @@ impl FlatVmdk {
         })
     }
 
-    pub fn virtual_block_size(&self) -> u64 {
+    pub(super) fn virtual_block_size(&self) -> u64 {
         self.size
     }
 
     /// Shared handle to the opened data extents, used to build the I/O worker.
-    pub fn extents(&self) -> Arc<Vec<VmdkExtent>> {
+    pub(super) fn extents(&self) -> Arc<Vec<VmdkExtent>> {
         Arc::clone(&self.extents)
     }
 
@@ -339,7 +339,7 @@ impl FlatVmdk {
     /// block devices), so sparse extents are reported correctly. `NoAccess`
     /// extents (no open file) contribute 0, as does any extent whose size
     /// cannot be queried.
-    pub fn physical_block_size(&self) -> u64 {
+    pub(super) fn physical_block_size(&self) -> u64 {
         self.extents
             .iter()
             .filter_map(|extent| extent.file.as_ref())
@@ -348,7 +348,7 @@ impl FlatVmdk {
     }
 
     /// Sector/cluster geometry reported to the guest.
-    pub fn topology(&self) -> DiskTopology {
+    pub(super) fn topology(&self) -> DiskTopology {
         self.extents
             .iter()
             .find_map(|extent| extent.file.as_ref())

--- a/cloud-hypervisor/src/logger.rs
+++ b/cloud-hypervisor/src/logger.rs
@@ -14,7 +14,7 @@ use jiff::tz::TimeZone;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum Error {
+pub(crate) enum Error {
     #[error("Unterminated '{{' in format string")]
     UnterminatedBrace,
     #[error("Unmatched '}}' in format string")]
@@ -180,10 +180,10 @@ fn parse_format(fmt: &str) -> Result<Vec<Token>, Error> {
     Ok(tokens)
 }
 
-pub const DEFAULT_FORMAT: &str =
+pub(crate) const DEFAULT_FORMAT: &str =
     "cloud-hypervisor: {boottime}s: <{thread}> {level}:{location} -- {msg}";
 
-pub struct Logger {
+pub(crate) struct Logger {
     output: Mutex<Box<dyn Write + Send>>,
     start: Instant,
     pid: u32,
@@ -194,7 +194,7 @@ pub struct Logger {
 }
 
 impl Logger {
-    pub fn new(output: Box<dyn Write + Send>, format: &str) -> Result<Self, Error> {
+    pub(crate) fn new(output: Box<dyn Write + Send>, format: &str) -> Result<Self, Error> {
         Ok(Self {
             output: Mutex::new(output),
             start: Instant::now(),

--- a/cloud-hypervisor/src/test_util.rs
+++ b/cloud-hypervisor/src/test_util.rs
@@ -10,7 +10,7 @@ use std::cmp::Ordering;
 use clap::Arg;
 
 /// Ensures that all [`Arg`]s are sorted alphabetically.
-pub fn assert_args_sorted<'a, F: Fn() -> R, R: Iterator<Item = &'a Arg>>(get_base_iter: F) {
+pub(crate) fn assert_args_sorted<'a, F: Fn() -> R, R: Iterator<Item = &'a Arg>>(get_base_iter: F) {
     let iter = get_base_iter().zip(get_base_iter().skip(1));
     for (arg, next) in iter {
         assert_ne!(

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -2117,7 +2117,7 @@ pub(crate) fn _test_virtio_block(
     }
 }
 
-pub fn _test_virtio_block_dynamic_vhdx_expand(guest: &Guest) {
+pub(crate) fn _test_virtio_block_dynamic_vhdx_expand(guest: &Guest) {
     const VIRTUAL_DISK_SIZE: u64 = 100 << 20;
     const EMPTY_VHDX_FILE_SIZE: u64 = 8 << 20;
     const FULL_VHDX_FILE_SIZE: u64 = 112 << 20;
@@ -2463,7 +2463,7 @@ fn vhdx_image_size(disk_name: &str) -> u64 {
 }
 
 #[cfg(target_arch = "x86_64")]
-pub fn _test_split_irqchip(guest: &Guest) {
+pub(crate) fn _test_split_irqchip(guest: &Guest) {
     let mut child = GuestCommand::new(guest)
         .default_cpus()
         .default_memory()

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -482,7 +482,7 @@ pub(crate) fn setup_ovs_dpdk_guests(
     (child1, child2)
 }
 
-pub enum FwType {
+pub(crate) enum FwType {
     Ovmf,
     RustHypervisorFirmware,
 }
@@ -724,7 +724,7 @@ pub(crate) fn process_rss_kib(pid: u32) -> usize {
 }
 
 #[derive(PartialEq, Eq, PartialOrd)]
-pub struct Counters {
+pub(crate) struct Counters {
     rx_bytes: u64,
     rx_frames: u64,
     tx_bytes: u64,

--- a/devices/src/legacy/debug_port.rs
+++ b/devices/src/legacy/debug_port.rs
@@ -11,7 +11,7 @@ use log::{error, warn};
 use vm_device::BusDevice;
 
 /// Debug I/O port, see:
-/// https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html
+/// https://web.archive.org/web/20211028033025/https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html
 ///
 /// Since we're not a physical platform, we can freely assign code ranges for
 /// debugging specific parts of our virtual platform.

--- a/devices/src/legacy/debug_port.rs
+++ b/devices/src/legacy/debug_port.rs
@@ -15,7 +15,7 @@ use vm_device::BusDevice;
 ///
 /// Since we're not a physical platform, we can freely assign code ranges for
 /// debugging specific parts of our virtual platform.
-pub enum DebugIoPortRange {
+pub(super) enum DebugIoPortRange {
     Firmware,
     Bootloader,
     Kernel,

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -42,10 +42,10 @@ const PL031_ID: [u8; 8] = [0x31, 0x10, 0x14, 0x00, 0x0d, 0xf0, 0x05, 0xb1];
 const AMBA_ID_LOW: u64 = 0xFE0;
 const AMBA_ID_HIGH: u64 = 0x1000;
 /// Constant to convert seconds to nanoseconds.
-pub const NANOS_PER_SECOND: u64 = 1_000_000_000;
+pub(super) const NANOS_PER_SECOND: u64 = 1_000_000_000;
 
 #[derive(Debug, Error)]
-pub enum Error {
+pub(super) enum Error {
     #[error("Bad Write Offset: {0}")]
     BadWriteOffset(u64),
 }
@@ -80,7 +80,7 @@ impl From<ClockType> for libc::clockid_t {
 /// # Arguments
 ///
 /// * `clock_type` - Identifier of the Linux Kernel clock on which to act.
-pub fn get_time(clock_type: ClockType) -> u64 {
+pub(super) fn get_time(clock_type: ClockType) -> u64 {
     let mut time_struct = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
@@ -96,7 +96,7 @@ pub fn get_time(clock_type: ClockType) -> u64 {
 /// # Arguments
 ///
 /// * `value` - Timestamp in seconds.
-pub fn seconds_to_nanoseconds(value: i64) -> Option<i64> {
+pub(super) fn seconds_to_nanoseconds(value: i64) -> Option<i64> {
     value.checked_mul(NANOS_PER_SECOND as i64)
 }
 

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -50,7 +50,7 @@ const AMBA_ID_LOW: u64 = 0x3f8;
 const AMBA_ID_HIGH: u64 = 0x401;
 
 #[derive(Debug, Error)]
-pub enum Error {
+pub(super) enum Error {
     #[error("PL011 write: Bad write offset: {0}")]
     BadWriteOffset(u64),
     #[error("PL011: DMA not implemented")]

--- a/hypervisor/src/arch/aarch64/gic.rs
+++ b/hypervisor/src/arch/aarch64/gic.rs
@@ -59,7 +59,7 @@ impl<'de> Deserialize<'de> for GicState {
         // GicStateDefaultDeserialize is a helper enum that mirrors GicState but also derives the Deserialize trait.
         // This enables backward-compatible deserialization of GicState, facilitating live-upgrade scenarios.
         #[derive(Deserialize)]
-        pub enum GicStateDefaultDeserialize {
+        enum GicStateDefaultDeserialize {
             #[cfg(feature = "kvm")]
             Kvm(Gicv3ItsState),
             #[cfg(feature = "mshv")]

--- a/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
@@ -112,97 +112,97 @@ macro_rules! cmp_rm_imm {
     };
 }
 
-pub struct Cmp_rm64_r64;
+pub(crate) struct Cmp_rm64_r64;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm64_r64 {
     cmp_rm_r!(u64);
 }
 
-pub struct Cmp_rm32_r32;
+pub(crate) struct Cmp_rm32_r32;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm32_r32 {
     cmp_rm_r!(u32);
 }
 
-pub struct Cmp_rm16_r16;
+struct Cmp_rm16_r16;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm16_r16 {
     cmp_rm_r!(u16);
 }
 
-pub struct Cmp_rm8_r8;
+pub(crate) struct Cmp_rm8_r8;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm8_r8 {
     cmp_rm_r!(u8);
 }
 
-pub struct Cmp_r64_rm64;
+struct Cmp_r64_rm64;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_r64_rm64 {
     cmp_r_rm!(u64);
 }
 
-pub struct Cmp_r32_rm32;
+struct Cmp_r32_rm32;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_r32_rm32 {
     cmp_r_rm!(u32);
 }
 
-pub struct Cmp_r16_rm16;
+struct Cmp_r16_rm16;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_r16_rm16 {
     cmp_r_rm!(u16);
 }
 
-pub struct Cmp_r8_rm8;
+struct Cmp_r8_rm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_r8_rm8 {
     cmp_r_rm!(u8);
 }
 
-pub struct Cmp_AL_imm8;
+struct Cmp_AL_imm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_AL_imm8 {
     cmp_rm_imm!(u8, u8);
 }
 
-pub struct Cmp_AX_imm16;
+struct Cmp_AX_imm16;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_AX_imm16 {
     cmp_rm_imm!(u16, u16);
 }
 
-pub struct Cmp_EAX_imm32;
+struct Cmp_EAX_imm32;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_EAX_imm32 {
     cmp_rm_imm!(u32, u32);
 }
 
-pub struct Cmp_RAX_imm32;
+struct Cmp_RAX_imm32;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_RAX_imm32 {
     cmp_rm_imm!(u32, u64);
 }
 
-pub struct Cmp_rm8_imm8;
+struct Cmp_rm8_imm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm8_imm8 {
     cmp_rm_imm!(u8, u8);
 }
 
-pub struct Cmp_rm16_imm16;
+struct Cmp_rm16_imm16;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm16_imm16 {
     cmp_rm_imm!(u16, u16);
 }
 
-pub struct Cmp_rm32_imm32;
+struct Cmp_rm32_imm32;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm32_imm32 {
     cmp_rm_imm!(u32, u32);
 }
 
-pub struct Cmp_rm64_imm32;
+struct Cmp_rm64_imm32;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm64_imm32 {
     cmp_rm_imm!(u32, u64);
 }
 
-pub struct Cmp_rm16_imm8;
+struct Cmp_rm16_imm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm16_imm8 {
     cmp_rm_imm!(u8, u16);
 }
 
-pub struct Cmp_rm32_imm8;
+pub(crate) struct Cmp_rm32_imm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm32_imm8 {
     cmp_rm_imm!(u8, u32);
 }
 
-pub struct Cmp_rm64_imm8;
+struct Cmp_rm64_imm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm64_imm8 {
     cmp_rm_imm!(u8, u64);
 }

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -12,11 +12,11 @@ use crate::arch::x86::Exception;
 use crate::arch::x86::emulator::CpuStateManager;
 use crate::arch::x86::regs::DF;
 
-pub mod cmp;
-pub mod mov;
-pub mod movs;
-pub mod or;
-pub mod stos;
+pub(super) mod cmp;
+pub(super) mod mov;
+pub(super) mod movs;
+pub(super) mod or;
+pub(super) mod stos;
 
 pub fn string_op_repeat_count(has_rep_prefix: bool, rcx: u64) -> u64 {
     if has_rep_prefix { rcx } else { 1 }
@@ -146,7 +146,7 @@ fn memory_operand_address<T: CpuStateManager>(
     state.linearize(insn.memory_segment(), address, write)
 }
 
-pub trait InstructionHandler<T: CpuStateManager> {
+pub(super) trait InstructionHandler<T: CpuStateManager> {
     fn emulate(
         &self,
         insn: &Instruction,

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -111,138 +111,138 @@ macro_rules! mov_r_imm {
     };
 }
 
-pub struct Mov_r8_rm8;
+pub(crate) struct Mov_r8_rm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_r8_rm8 {
     mov_r_rm!(u8);
 }
 
-pub struct Mov_r8_imm8;
+pub(crate) struct Mov_r8_imm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_r8_imm8 {
     mov_r_imm!(u8);
 }
 
-pub struct Mov_r16_rm16;
+pub(crate) struct Mov_r16_rm16;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_r16_rm16 {
     mov_r_rm!(u16);
 }
 
-pub struct Mov_r16_imm16;
+pub(crate) struct Mov_r16_imm16;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_r16_imm16 {
     mov_r_imm!(u16);
 }
 
-pub struct Mov_r32_rm32;
+pub(crate) struct Mov_r32_rm32;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_r32_rm32 {
     mov_r_rm!(u32);
 }
 
-pub struct Mov_r32_imm32;
+pub(crate) struct Mov_r32_imm32;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_r32_imm32 {
     mov_r_imm!(u32);
 }
 
-pub struct Mov_r64_rm64;
+pub(crate) struct Mov_r64_rm64;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_r64_rm64 {
     mov_r_rm!(u64);
 }
 
-pub struct Mov_r64_imm64;
+pub(crate) struct Mov_r64_imm64;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_r64_imm64 {
     mov_r_imm!(u64);
 }
 
-pub struct Mov_rm8_imm8;
+pub(crate) struct Mov_rm8_imm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm8_imm8 {
     mov_rm_imm!(u8);
 }
 
-pub struct Mov_rm8_r8;
+pub(crate) struct Mov_rm8_r8;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm8_r8 {
     mov_rm_r!(u8);
 }
 
-pub struct Mov_rm16_imm16;
+pub(crate) struct Mov_rm16_imm16;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm16_imm16 {
     mov_rm_imm!(u16);
 }
 
-pub struct Mov_rm16_r16;
+pub(crate) struct Mov_rm16_r16;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm16_r16 {
     mov_rm_r!(u16);
 }
 
-pub struct Mov_rm32_imm32;
+pub(crate) struct Mov_rm32_imm32;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm32_imm32 {
     mov_rm_imm!(u32);
 }
 
-pub struct Mov_rm32_r32;
+pub(crate) struct Mov_rm32_r32;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm32_r32 {
     mov_rm_r!(u32);
 }
 
-pub struct Mov_rm64_imm32;
+pub(crate) struct Mov_rm64_imm32;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm64_imm32 {
     mov_rm_imm!(u32);
 }
 
-pub struct Mov_rm64_r64;
+pub(crate) struct Mov_rm64_r64;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm64_r64 {
     mov_rm_r!(u64);
 }
 
 // MOVZX
-pub struct Movzx_r16_rm8;
+pub(crate) struct Movzx_r16_rm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Movzx_r16_rm8 {
     movzx!(u16, u8);
 }
 
-pub struct Movzx_r32_rm8;
+pub(crate) struct Movzx_r32_rm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Movzx_r32_rm8 {
     movzx!(u32, u8);
 }
 
-pub struct Movzx_r64_rm8;
+pub(crate) struct Movzx_r64_rm8;
 impl<T: CpuStateManager> InstructionHandler<T> for Movzx_r64_rm8 {
     movzx!(u64, u8);
 }
 
-pub struct Movzx_r32_rm16;
+pub(crate) struct Movzx_r32_rm16;
 impl<T: CpuStateManager> InstructionHandler<T> for Movzx_r32_rm16 {
     movzx!(u32, u16);
 }
 
-pub struct Movzx_r64_rm16;
+pub(crate) struct Movzx_r64_rm16;
 impl<T: CpuStateManager> InstructionHandler<T> for Movzx_r64_rm16 {
     movzx!(u64, u16);
 }
 
-pub struct Mov_moffs16_AX;
+pub(crate) struct Mov_moffs16_AX;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_moffs16_AX {
     movzx!(u16, u16);
 }
 
-pub struct Mov_AX_moffs16;
+pub(crate) struct Mov_AX_moffs16;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_AX_moffs16 {
     movzx!(u16, u16);
 }
 
-pub struct Mov_moffs32_EAX;
+pub(crate) struct Mov_moffs32_EAX;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_moffs32_EAX {
     movzx!(u32, u32);
 }
 
-pub struct Mov_EAX_moffs32;
+pub(crate) struct Mov_EAX_moffs32;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_EAX_moffs32 {
     movzx!(u32, u32);
 }
 
-pub struct Mov_moffs64_RAX;
+pub(crate) struct Mov_moffs64_RAX;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_moffs64_RAX {
     movzx!(u64, u64);
 }
 
-pub struct Mov_RAX_moffs64;
+pub(crate) struct Mov_RAX_moffs64;
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_RAX_moffs64 {
     movzx!(u64, u64);
 }

--- a/hypervisor/src/arch/x86/emulator/instructions/movs.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/movs.rs
@@ -80,22 +80,22 @@ macro_rules! movs {
     };
 }
 
-pub struct Movsq_m64_m64;
+pub(crate) struct Movsq_m64_m64;
 impl<T: CpuStateManager> InstructionHandler<T> for Movsq_m64_m64 {
     movs!(u64);
 }
 
-pub struct Movsd_m32_m32;
+pub(crate) struct Movsd_m32_m32;
 impl<T: CpuStateManager> InstructionHandler<T> for Movsd_m32_m32 {
     movs!(u32);
 }
 
-pub struct Movsw_m16_m16;
+pub(crate) struct Movsw_m16_m16;
 impl<T: CpuStateManager> InstructionHandler<T> for Movsw_m16_m16 {
     movs!(u16);
 }
 
-pub struct Movsb_m8_m8;
+pub(crate) struct Movsb_m8_m8;
 impl<T: CpuStateManager> InstructionHandler<T> for Movsb_m8_m8 {
     movs!(u8);
 }

--- a/hypervisor/src/arch/x86/emulator/instructions/or.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/or.rs
@@ -36,7 +36,7 @@ macro_rules! or_rm_r {
     };
 }
 
-pub struct Or_rm8_r8;
+pub(crate) struct Or_rm8_r8;
 impl<T: CpuStateManager> InstructionHandler<T> for Or_rm8_r8 {
     or_rm_r!(u8);
 }

--- a/hypervisor/src/arch/x86/emulator/instructions/stos.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/stos.rs
@@ -67,22 +67,22 @@ macro_rules! stos {
     };
 }
 
-pub struct Stosq_m64_RAX;
+pub(crate) struct Stosq_m64_RAX;
 impl<T: CpuStateManager> InstructionHandler<T> for Stosq_m64_RAX {
     stos!(u64);
 }
 
-pub struct Stosd_m32_EAX;
+pub(crate) struct Stosd_m32_EAX;
 impl<T: CpuStateManager> InstructionHandler<T> for Stosd_m32_EAX {
     stos!(u32);
 }
 
-pub struct Stosw_m16_AX;
+pub(crate) struct Stosw_m16_AX;
 impl<T: CpuStateManager> InstructionHandler<T> for Stosw_m16_AX {
     stos!(u16);
 }
 
-pub struct Stosb_m8_AL;
+pub(crate) struct Stosb_m8_AL;
 impl<T: CpuStateManager> InstructionHandler<T> for Stosb_m8_AL {
     stos!(u8);
 }

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -660,15 +660,19 @@ mod mock_vmm {
     use crate::arch::x86::gdt::{gdt_entry, segment_from_gdt};
 
     #[derive(Debug, Clone)]
-    pub struct MockVmm {
+    pub(super) struct MockVmm {
         memory: Vec<u8>,
         state: Arc<Mutex<CpuState>>,
     }
 
-    pub type MockResult = Result<(), EmulationError<Exception>>;
+    pub(super) type MockResult = Result<(), EmulationError<Exception>>;
 
     impl MockVmm {
-        pub fn new(ip: u64, regs: Vec<(Register, u64)>, memory: Option<(u64, &[u8])>) -> MockVmm {
+        pub(super) fn new(
+            ip: u64,
+            regs: Vec<(Register, u64)>,
+            memory: Option<(u64, &[u8])>,
+        ) -> MockVmm {
             let _ = env_logger::try_init();
             let cs_reg = segment_from_gdt(gdt_entry(0xc09b, 0, 0xffffffff), 1);
             let ds_reg = segment_from_gdt(gdt_entry(0xc093, 0, 0xffffffff), 2);
@@ -706,7 +710,7 @@ mod mock_vmm {
             vmm
         }
 
-        pub fn emulate_insn(
+        pub(super) fn emulate_insn(
             &mut self,
             cpu_id: usize,
             insn: &[u8],
@@ -728,7 +732,7 @@ mod mock_vmm {
             Ok(())
         }
 
-        pub fn emulate_first_insn(&mut self, cpu_id: usize, insn: &[u8]) -> MockResult {
+        pub(super) fn emulate_first_insn(&mut self, cpu_id: usize, insn: &[u8]) -> MockResult {
             self.emulate_insn(cpu_id, insn, Some(1))
         }
     }

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -362,7 +362,7 @@ pub enum VmExit {
 ///
 /// Result type for returning from a function
 ///
-pub type Result<T> = anyhow::Result<T, HypervisorCpuError>;
+pub(crate) type Result<T> = anyhow::Result<T, HypervisorCpuError>;
 ///
 /// Trait to represent a generic Vcpu
 ///

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -99,7 +99,7 @@ pub enum HypervisorError {
 ///
 /// Result type for returning from a function
 ///
-pub type Result<T> = result::Result<T, HypervisorError>;
+pub(crate) type Result<T> = result::Result<T, HypervisorError>;
 
 ///
 /// Trait to represent a Hypervisor

--- a/hypervisor/src/kvm/aarch64/gic/dist_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/dist_regs.rs
@@ -112,12 +112,12 @@ fn dist_attr_get(gic: &DeviceFd, offset: u32) -> Result<u32> {
 }
 
 /// Get the distributor control register.
-pub fn read_ctlr(gic: &DeviceFd) -> Result<u32> {
+pub(super) fn read_ctlr(gic: &DeviceFd) -> Result<u32> {
     dist_attr_get(gic, GICD_CTLR)
 }
 
 /// Set the distributor control register.
-pub fn write_ctlr(gic: &DeviceFd, val: u32) -> Result<()> {
+pub(super) fn write_ctlr(gic: &DeviceFd, val: u32) -> Result<()> {
     dist_attr_set(gic, GICD_CTLR, val)
 }
 
@@ -164,7 +164,7 @@ fn compute_reg_len(gic: &DeviceFd, reg: &DistReg, base: u32) -> Result<u32> {
 }
 
 /// Set distributor registers of the GIC.
-pub fn set_dist_regs(gic: &DeviceFd, state: &[u32]) -> Result<()> {
+pub(super) fn set_dist_regs(gic: &DeviceFd, state: &[u32]) -> Result<()> {
     let mut idx = 0;
 
     for dreg in VGIC_DIST_REGS {
@@ -180,7 +180,7 @@ pub fn set_dist_regs(gic: &DeviceFd, state: &[u32]) -> Result<()> {
     Ok(())
 }
 /// Get distributor registers of the GIC.
-pub fn get_dist_regs(gic: &DeviceFd) -> Result<Vec<u32>> {
+pub(super) fn get_dist_regs(gic: &DeviceFd) -> Result<Vec<u32>> {
     let mut state = Vec::new();
 
     for dreg in VGIC_DIST_REGS {

--- a/hypervisor/src/kvm/aarch64/gic/icc_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/icc_regs.rs
@@ -115,7 +115,7 @@ fn icc_attr_get(gic: &DeviceFd, offset: u64, typer: u64) -> Result<u32> {
 }
 
 /// Get ICC registers.
-pub fn get_icc_regs(gic: &DeviceFd, gicr_typer: &[u64]) -> Result<Vec<u32>> {
+pub(super) fn get_icc_regs(gic: &DeviceFd, gicr_typer: &[u64]) -> Result<Vec<u32>> {
     let mut state: Vec<u32> = Vec::new();
     // We need this for the ICC_AP<m>R<n>_EL1 registers.
     let mut num_priority_bits = 0;
@@ -164,7 +164,7 @@ pub fn get_icc_regs(gic: &DeviceFd, gicr_typer: &[u64]) -> Result<Vec<u32>> {
 }
 
 /// Set ICC registers.
-pub fn set_icc_regs(gic: &DeviceFd, gicr_typer: &[u64], state: &[u32]) -> Result<()> {
+pub(super) fn set_icc_regs(gic: &DeviceFd, gicr_typer: &[u64], state: &[u32]) -> Result<()> {
     let mut num_priority_bits = 0;
     let mut idx = 0;
     for ix in gicr_typer {

--- a/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
@@ -146,7 +146,7 @@ fn access_redists_aux(
 }
 
 /// Get redistributor registers.
-pub fn get_redist_regs(gic: &DeviceFd, gicr_typer: &[u64]) -> Result<Vec<u32>> {
+pub(super) fn get_redist_regs(gic: &DeviceFd, gicr_typer: &[u64]) -> Result<Vec<u32>> {
     let mut state = Vec::new();
     let mut idx: usize = 0;
     access_redists_aux(
@@ -163,7 +163,7 @@ pub fn get_redist_regs(gic: &DeviceFd, gicr_typer: &[u64]) -> Result<Vec<u32>> {
 }
 
 /// Set redistributor registers.
-pub fn set_redist_regs(gic: &DeviceFd, gicr_typer: &[u64], state: &[u32]) -> Result<()> {
+pub(super) fn set_redist_regs(gic: &DeviceFd, gicr_typer: &[u64], state: &[u32]) -> Result<()> {
     let mut idx: usize = 0;
     let mut mut_state = state.to_owned();
     access_redists_aux(
@@ -184,7 +184,7 @@ pub fn set_redist_regs(gic: &DeviceFd, gicr_typer: &[u64], state: &[u32]) -> Res
     )
 }
 
-pub fn get_gicr_typers(vcpu_count: u64) -> Vec<u64> {
+pub(super) fn get_gicr_typers(vcpu_count: u64) -> Vec<u64> {
     /* Return a GICR_TYPER from the vCPU MPIDR affinities:
      * For our implementation:
      *  Top 32 bits are the affinity value of the associated CPU

--- a/hypervisor/src/kvm/x86_64/sev.rs
+++ b/hypervisor/src/kvm/x86_64/sev.rs
@@ -24,7 +24,7 @@ pub(crate) type Result<T> = result::Result<T, errno::Error>;
 // See AMD Spec Section 8.18 — SNP_LAUNCH_UPDATE
 // The last 12 bits are metadata about the guest context
 // https://docs.amd.com/v/u/en-US/56860_PUB_SEV_SNP
-pub const GPA_METADATA_SHIFT_OFFSET: u32 = 12;
+pub(crate) const GPA_METADATA_SHIFT_OFFSET: u32 = 12;
 
 // SNP in VMSA - linux/arch/x86/include/asm/svm.h
 const SVM_SEV_FEAT_SNP_ACTIVE: u64 = 1 << 0;
@@ -38,7 +38,7 @@ fn sev_op(vm: &VmFd, sev_cmd: &mut kvm_sev_cmd, name: &str) -> Result<()> {
 }
 
 #[derive(Debug)]
-pub struct SevFd {
+pub(crate) struct SevFd {
     pub fd: OwnedFd,
 }
 
@@ -47,7 +47,7 @@ pub struct SevFd {
 
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone, Default)]
-pub(crate) struct KvmSevInit {
+struct KvmSevInit {
     pub vmsa_features: u64,
     pub flags: u32,
     pub ghcb_version: u16,
@@ -57,7 +57,7 @@ pub(crate) struct KvmSevInit {
 
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone, Default)]
-pub(crate) struct KvmSevSnpLaunchStart {
+struct KvmSevSnpLaunchStart {
     pub policy: u64,
     pub gosvw: [u8; 16],
     pub flags: u16,
@@ -67,7 +67,7 @@ pub(crate) struct KvmSevSnpLaunchStart {
 
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone, Default)]
-pub(crate) struct KvmSevSnpLaunchUpdate {
+struct KvmSevSnpLaunchUpdate {
     pub gfn_start: u64,
     pub uaddr: u64,
     pub len: u64,
@@ -80,7 +80,7 @@ pub(crate) struct KvmSevSnpLaunchUpdate {
 
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone, Default)]
-pub(crate) struct KvmSevSnpLaunchFinish {
+struct KvmSevSnpLaunchFinish {
     pub id_block_uaddr: u64,
     pub id_auth_uaddr: u64,
     pub id_block_en: u8,
@@ -97,7 +97,7 @@ pub(crate) struct KvmSevSnpLaunchFinish {
 // https://docs.amd.com/v/u/en-US/56860_PUB_SEV_SNP
 #[repr(C)]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable)]
-pub(crate) struct KvmSevSnpIdBlock {
+struct KvmSevSnpIdBlock {
     pub ld: [u8; 48],
     pub family_id: [u8; 16],
     pub image_id: [u8; 16],
@@ -110,7 +110,7 @@ pub(crate) struct KvmSevSnpIdBlock {
 // https://docs.amd.com/v/u/en-US/56860_PUB_SEV_SNP
 #[repr(C)]
 #[derive(Clone, FromZeros, IntoBytes, Immutable)]
-pub(crate) struct KvmSevSnpIdAuth {
+struct KvmSevSnpIdAuth {
     pub id_key_alg: u32,
     pub auth_key_algo: u32,
     pub reserved: [u8; 56],

--- a/hypervisor/src/mshv/snp_constants.rs
+++ b/hypervisor/src/mshv/snp_constants.rs
@@ -5,14 +5,14 @@
 
 // Reference: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56860.pdf
 // Chapter 10
-pub const SIG_R_COMPONENT_SIZE_IN_BYTES: usize = 72;
-pub const SIG_R_AND_S_COMPONENT_SIZE_IN_BYTES: usize = 144;
-pub const ECDSA_CURVE_ID_SIZE_IN_BYTES: usize = 4;
-pub const ECDSA_SIG_X_COMPONENT_SIZE_IN_BYTES: usize = 72;
-pub const ECDSA_SIG_Y_COMPONENT_SIZE_IN_BYTES: usize = 72;
-pub const ECDSA_SIG_X_COMPONENT_START: usize = ECDSA_CURVE_ID_SIZE_IN_BYTES;
-pub const ECDSA_SIG_X_COMPONENT_END: usize =
+pub(crate) const SIG_R_COMPONENT_SIZE_IN_BYTES: usize = 72;
+pub(crate) const SIG_R_AND_S_COMPONENT_SIZE_IN_BYTES: usize = 144;
+pub(crate) const ECDSA_CURVE_ID_SIZE_IN_BYTES: usize = 4;
+pub(crate) const ECDSA_SIG_X_COMPONENT_SIZE_IN_BYTES: usize = 72;
+pub(crate) const ECDSA_SIG_Y_COMPONENT_SIZE_IN_BYTES: usize = 72;
+pub(crate) const ECDSA_SIG_X_COMPONENT_START: usize = ECDSA_CURVE_ID_SIZE_IN_BYTES;
+pub(crate) const ECDSA_SIG_X_COMPONENT_END: usize =
     ECDSA_SIG_X_COMPONENT_START + ECDSA_SIG_X_COMPONENT_SIZE_IN_BYTES;
-pub const ECDSA_SIG_Y_COMPONENT_START: usize = ECDSA_SIG_X_COMPONENT_END;
-pub const ECDSA_SIG_Y_COMPONENT_END: usize =
+pub(crate) const ECDSA_SIG_Y_COMPONENT_START: usize = ECDSA_SIG_X_COMPONENT_END;
+pub(crate) const ECDSA_SIG_Y_COMPONENT_END: usize =
     ECDSA_SIG_X_COMPONENT_END + ECDSA_SIG_Y_COMPONENT_SIZE_IN_BYTES;

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -264,7 +264,7 @@ pub enum HypervisorVmError {
 ///
 /// Result type for returning from a function
 ///
-pub type Result<T> = result::Result<T, HypervisorVmError>;
+pub(crate) type Result<T> = result::Result<T, HypervisorVmError>;
 
 /// Configuration data for legacy interrupts.
 ///

--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -53,7 +53,7 @@ type Result<T> = result::Result<T, Error>;
 
 #[repr(C, packed)]
 #[derive(Debug, Clone, Copy, Default)]
-pub struct ControlHeader {
+struct ControlHeader {
     pub class: u8,
     pub cmd: u8,
 }

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -49,7 +49,7 @@ pub enum Error {
     InvalidNetmask,
 }
 
-pub type Result<T> = result::Result<T, Error>;
+pub(crate) type Result<T> = result::Result<T, Error>;
 
 /// Handle for a network tap interface.
 ///

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -39,7 +39,7 @@ pub enum PciRootError {
     #[error("Valid PCI device identifier but already used: {0}")]
     AlreadyInUsePciDeviceSlot(usize),
 }
-pub type Result<T> = result::Result<T, PciRootError>;
+pub(crate) type Result<T> = result::Result<T, PciRootError>;
 
 /// Emulates the PCI Root bridge device.
 pub struct PciRoot {

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -86,7 +86,7 @@ pub trait PciSubclass {
 /// Subclasses of the MultimediaController class.
 #[expect(dead_code)]
 #[derive(Copy, Clone)]
-pub enum PciMultimediaSubclass {
+enum PciMultimediaSubclass {
     VideoController = 0x00,
     AudioController = 0x01,
     TelephonyDevice = 0x02,
@@ -103,7 +103,7 @@ impl PciSubclass for PciMultimediaSubclass {
 /// Subclasses of the BridgeDevice
 #[expect(dead_code)]
 #[derive(Copy, Clone)]
-pub enum PciBridgeSubclass {
+pub(crate) enum PciBridgeSubclass {
     HostBridge = 0x00,
     IsaBridge = 0x01,
     EisaBridge = 0x02,
@@ -525,7 +525,7 @@ pub enum Error {
     #[error("ROM BAR address {0} not a power of two")]
     RomBarSizeInvalid(u64),
 }
-pub type Result<T> = result::Result<T, Error>;
+pub(crate) type Result<T> = result::Result<T, Error>;
 
 impl PciConfiguration {
     #[expect(clippy::too_many_arguments)]

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -34,7 +34,7 @@ pub enum Error {
     #[error("Invalid resource: {0:?}")]
     InvalidResource(Resource),
 }
-pub type Result<T> = result::Result<T, Error>;
+pub(crate) type Result<T> = result::Result<T, Error>;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct BarReprogrammingParams {

--- a/pci/src/mmap.rs
+++ b/pci/src/mmap.rs
@@ -171,7 +171,7 @@ fn allocate_aligned_mapping(
 /// cause SIGSEGV or SIGBUS.  Non-atomic access will generally cause data
 /// races and thus Undefined Behavior.
 #[derive(Debug)]
-pub struct MmapRegion {
+pub(crate) struct MmapRegion {
     addr: *mut u8,
     len: size_t,
 }
@@ -191,7 +191,7 @@ unsafe impl Sync for MmapRegion {}
 
 impl MmapRegion {
     #[inline]
-    pub fn addr(&self) -> *mut u8 {
+    pub(crate) fn addr(&self) -> *mut u8 {
         self.addr
     }
 
@@ -199,12 +199,12 @@ impl MmapRegion {
     /// This function promises that the return value fits in [`libc::size_t`]
     /// and in [`isize`] and `unsafe` code can rely on this.
     #[inline]
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.len
     }
 
     /// Create an [`MmapRegion`] using `mmap` of a file descriptor.
-    pub fn mmap(
+    pub(crate) fn mmap(
         len: u64,
         prot: c_int,
         fd: BorrowedFd,

--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -46,7 +46,7 @@ pub enum Error {
     UpdateInterruptRoute(#[source] io::Error),
 }
 
-pub const MSI_CONFIG_ID: &str = "msi_config";
+pub(crate) const MSI_CONFIG_ID: &str = "msi_config";
 
 #[derive(Clone, Copy, Default, Serialize, Deserialize)]
 pub struct MsiCap {

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -294,7 +294,7 @@ impl Interrupt {
 }
 
 #[derive(Clone)]
-pub struct UserMemoryRegion {
+pub(crate) struct UserMemoryRegion {
     pub slot: u32,
     pub start: u64,
     pub mapping: Arc<MmapRegion>,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -285,7 +285,7 @@ struct PerformanceTest {
 }
 
 impl PerformanceTest {
-    pub fn run(&self, overrides: &PerformanceTestOverrides) -> PerformanceTestResult {
+    pub(crate) fn run(&self, overrides: &PerformanceTestOverrides) -> PerformanceTestResult {
         if self.control.num_ops.is_some() && !self.name.starts_with("micro_") {
             eprintln!(
                 "Warning: num_ops is set on '{}' but has no effect on non micro benchmarks",
@@ -329,7 +329,7 @@ impl PerformanceTest {
     // Calculate the timeout for each test
     // Note: To cover the setup/cleanup time, 20s is added for each iteration of the test
     // Confidential VMS can take up to DEFAULT_CVM_TCP_LISTENER_TIMEOUT
-    pub fn calc_timeout(
+    fn calc_timeout(
         &self,
         test_iterations: &Option<u32>,
         test_timeout: &Option<u32>,
@@ -377,24 +377,24 @@ fn std_deviation(data: &[f64]) -> Option<f64> {
 }
 
 mod adjuster {
-    pub fn identity(v: f64) -> f64 {
+    pub(crate) fn identity(v: f64) -> f64 {
         v
     }
 
-    pub fn s_to_ms(v: f64) -> f64 {
+    pub(crate) fn s_to_ms(v: f64) -> f64 {
         v * 1000.0
     }
 
-    pub fn s_to_us(v: f64) -> f64 {
+    pub(crate) fn s_to_us(v: f64) -> f64 {
         v * 1_000_000.0
     }
 
-    pub fn bps_to_gbps(v: f64) -> f64 {
+    pub(crate) fn bps_to_gbps(v: f64) -> f64 {
         v / (1_000_000_000_f64)
     }
 
     #[expect(non_snake_case)]
-    pub fn Bps_to_MiBps(v: f64) -> f64 {
+    pub(crate) fn Bps_to_MiBps(v: f64) -> f64 {
         v / (1 << 20) as f64
     }
 }

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -25,7 +25,7 @@ use crate::util::{
 /// how long it takes to drain every completion via next_completed_request().
 ///
 /// Returns the drain wall clock time in seconds.
-pub fn micro_bench_aio_drain(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_aio_drain(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let tmp = util::sized_tempfile(num_ops);
     let disk = RawDisk::new(tmp.as_file().try_clone().unwrap(), RawBackend::Aio, false);
@@ -64,7 +64,7 @@ pub fn micro_bench_aio_drain(control: &PerformanceTestControl) -> f64 {
 /// pread64 for allocated data, and iovec scatter.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_tempfile(num_ops);
     let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
@@ -93,7 +93,7 @@ pub fn micro_bench_qcow_read(control: &PerformanceTestControl) -> f64 {
 /// under random access patterns.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_random_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_random_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_tempfile(num_ops);
     let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
@@ -127,7 +127,7 @@ pub fn micro_bench_qcow_random_read(control: &PerformanceTestControl) -> f64 {
 /// the data.
 ///
 /// Returns the total write wall clock time in seconds.
-pub fn micro_bench_qcow_write(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_write(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::empty_qcow_tempfile(num_ops);
     let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
@@ -157,7 +157,7 @@ pub fn micro_bench_qcow_write(control: &PerformanceTestControl) -> f64 {
 /// frees clusters and issues fallocate punch_hole on the host file.
 ///
 /// Returns the total punch_hole wall clock time in seconds.
-pub fn micro_bench_qcow_punch_hole(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_punch_hole(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_tempfile(num_ops);
     let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
@@ -184,7 +184,7 @@ pub fn micro_bench_qcow_punch_hole(control: &PerformanceTestControl) -> f64 {
 /// of dirty L2 table entries and refcount blocks.
 ///
 /// Returns the fsync wall clock time in seconds.
-pub fn micro_bench_qcow_fsync(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_fsync(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::empty_qcow_tempfile(num_ops);
     let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
@@ -220,7 +220,7 @@ pub fn micro_bench_qcow_fsync(control: &PerformanceTestControl) -> f64 {
 /// read.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_backing_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_backing_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_backing, _overlay, disk) = util::qcow_overlay_tempfile(num_ops);
     let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
@@ -250,7 +250,7 @@ pub fn micro_bench_qcow_backing_read(control: &PerformanceTestControl) -> f64 {
 /// cluster).
 ///
 /// Returns the total write wall clock time in seconds.
-pub fn micro_bench_qcow_cow_write(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_cow_write(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_backing, _overlay, disk) = util::qcow_overlay_tempfile(num_ops);
     let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
@@ -279,7 +279,7 @@ pub fn micro_bench_qcow_cow_write(control: &PerformanceTestControl) -> f64 {
 /// the normal allocated-cluster read path.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_compressed_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_compressed_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::compressed_qcow_tempfile(num_ops);
     let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
@@ -309,7 +309,7 @@ pub fn micro_bench_qcow_compressed_read(control: &PerformanceTestControl) -> f64
 /// chunks of CLUSTERS_PER_READ.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_multi_cluster_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_multi_cluster_read(control: &PerformanceTestControl) -> f64 {
     const CLUSTERS_PER_READ: usize = 8;
 
     let num_ops = control.num_ops.expect("num_ops required") as usize;
@@ -344,7 +344,7 @@ pub fn micro_bench_qcow_multi_cluster_read(control: &PerformanceTestControl) -> 
 /// and measures the cold L2 cache miss overhead.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_l2_cache_miss(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_l2_cache_miss(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::sparse_qcow_tempfile(num_ops);
     let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
@@ -374,7 +374,7 @@ pub fn micro_bench_qcow_l2_cache_miss(control: &PerformanceTestControl) -> f64 {
 /// through io_uring for true asynchronous completion.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_async_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_async_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
     let mut async_io = disk
@@ -401,7 +401,7 @@ pub fn micro_bench_qcow_async_read(control: &PerformanceTestControl) -> f64 {
 /// Builds a batch of `num_ops` read requests and submits them all at once
 /// through `submit_batch_requests`, which packs multiple SQEs into a single
 /// io_uring submission. Returns the total wall clock time in seconds.
-pub fn micro_bench_qcow_batch_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_batch_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
     let mut async_io = disk
@@ -433,7 +433,7 @@ pub fn micro_bench_qcow_batch_read(control: &PerformanceTestControl) -> f64 {
 /// through the QcowAsync io_uring path.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_async_random_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_async_random_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
     let mut async_io = disk
@@ -466,7 +466,7 @@ pub fn micro_bench_qcow_async_random_read(control: &PerformanceTestControl) -> f
 /// mappings, this can hit the io_uring fast path for a single Readv.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_async_multi_cluster_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_async_multi_cluster_read(control: &PerformanceTestControl) -> f64 {
     const CLUSTERS_PER_READ: usize = 8;
 
     let num_ops = control.num_ops.expect("num_ops required") as usize;
@@ -499,7 +499,7 @@ pub fn micro_bench_qcow_async_multi_cluster_read(control: &PerformanceTestContro
 /// QcowAsync since the mapping is not a single allocated cluster).
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_async_backing_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_async_backing_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_backing, _overlay, disk) = util::qcow_async_overlay_tempfile(num_ops);
     let mut async_io = disk
@@ -525,7 +525,7 @@ pub fn micro_bench_qcow_async_backing_read(control: &PerformanceTestControl) -> 
 /// the async code path.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_async_compressed_read(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_async_compressed_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::compressed_qcow_async_tempfile(num_ops);
     let mut async_io = disk
@@ -554,7 +554,7 @@ pub fn micro_bench_qcow_async_compressed_read(control: &PerformanceTestControl) 
 /// write path overhead through the async code path.
 ///
 /// Returns the total write wall clock time in seconds.
-pub fn micro_bench_qcow_async_write(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_async_write(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::empty_qcow_async_tempfile(num_ops);
     let mut async_io = disk
@@ -580,7 +580,7 @@ pub fn micro_bench_qcow_async_write(control: &PerformanceTestControl) -> f64 {
 /// QCOW2 image through the QcowAsync io_uring path.
 ///
 /// Returns the total read wall clock time in seconds.
-pub fn micro_bench_qcow_async_l2_cache_miss(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_async_l2_cache_miss(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::sparse_qcow_async_tempfile(num_ops);
     let mut async_io = disk
@@ -610,7 +610,7 @@ pub fn micro_bench_qcow_async_l2_cache_miss(control: &PerformanceTestControl) ->
 /// overhead compared to individual write calls.
 ///
 /// Returns the total wall clock time in seconds.
-pub fn micro_bench_qcow_batch_write(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn micro_bench_qcow_batch_write(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::empty_qcow_async_tempfile(num_ops);
     let mut async_io = disk

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -25,16 +25,16 @@ enum Error {
 
 // The test image cannot be created on tmpfs (e.g. /tmp) filesystem,
 // as tmpfs does not support O_DIRECT
-pub const BLK_IO_TEST_IMG: &str = "/var/tmp/ch-blk-io-test.img";
+pub(crate) const BLK_IO_TEST_IMG: &str = "/var/tmp/ch-blk-io-test.img";
 const QCOW2_BACKING_FILE: &str = "/var/tmp/ch-blk-io-test-qcow2-backing.qcow2";
-pub const OVERLAY_WITH_QCOW2_BACKING: &str = "/var/tmp/ch-blk-io-test-overlay-qcow2.qcow2";
+pub(crate) const OVERLAY_WITH_QCOW2_BACKING: &str = "/var/tmp/ch-blk-io-test-overlay-qcow2.qcow2";
 const RAW_BACKING_FILE: &str = "/var/tmp/ch-blk-io-test-raw-backing.raw";
-pub const OVERLAY_WITH_RAW_BACKING: &str = "/var/tmp/ch-blk-io-test-overlay-raw.qcow2";
-pub const QCOW2_UNCOMPRESSED_IMG: &str = "/var/tmp/ch-blk-io-test-uncompressed.qcow2";
-pub const QCOW2_ZLIB_IMG: &str = "/var/tmp/ch-blk-io-test-zlib.qcow2";
-pub const QCOW2_ZSTD_IMG: &str = "/var/tmp/ch-blk-io-test-zstd.qcow2";
+pub(crate) const OVERLAY_WITH_RAW_BACKING: &str = "/var/tmp/ch-blk-io-test-overlay-raw.qcow2";
+pub(crate) const QCOW2_UNCOMPRESSED_IMG: &str = "/var/tmp/ch-blk-io-test-uncompressed.qcow2";
+pub(crate) const QCOW2_ZLIB_IMG: &str = "/var/tmp/ch-blk-io-test-zlib.qcow2";
+pub(crate) const QCOW2_ZSTD_IMG: &str = "/var/tmp/ch-blk-io-test-zstd.qcow2";
 
-pub fn init_tests(overrides: &PerformanceTestOverrides) {
+pub(crate) fn init_tests(overrides: &PerformanceTestOverrides) {
     let mut cmd = format!("dd if=/dev/zero of={BLK_IO_TEST_IMG} bs=1M count=4096");
 
     if let Some(o) = overrides.test_image_format {
@@ -92,7 +92,7 @@ pub fn init_tests(overrides: &PerformanceTestOverrides) {
     assert!(exec_host_command_output(&cmd).status.success());
 }
 
-pub fn cleanup_tests() {
+pub(crate) fn cleanup_tests() {
     fs::remove_file(BLK_IO_TEST_IMG)
         .unwrap_or_else(|_| panic!("Failed to remove file '{BLK_IO_TEST_IMG}'."));
     fs::remove_file(QCOW2_BACKING_FILE)
@@ -130,7 +130,7 @@ fn performance_test_new_guest(
     guest
 }
 
-pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     let test_timeout = control.test_timeout;
     let (rx, bandwidth) = control.net_control.unwrap();
 
@@ -173,7 +173,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     }
 }
 
-pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
     let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
     let mut guest = performance_test_new_guest(Box::new(jammy), control);
 
@@ -320,7 +320,7 @@ fn measure_boot_time(cmd: &mut GuestCommand, guest: &Guest) -> Result<f64, Error
     })
 }
 
-pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
     let r = panic::catch_unwind(|| {
         let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = performance_test_new_guest(Box::new(jammy), control);
@@ -345,7 +345,7 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
     }
 }
 
-pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
     let r = panic::catch_unwind(|| {
         let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = performance_test_new_guest(Box::new(jammy), control);
@@ -378,7 +378,7 @@ pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
     }
 }
 
-pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn performance_block_io(control: &PerformanceTestControl) -> f64 {
     let test_timeout = control.test_timeout;
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -516,7 +516,7 @@ fn measure_restore_time(
     })
 }
 
-pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
+pub(crate) fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
     let r = panic::catch_unwind(|| {
         let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = performance_test_new_guest(Box::new(jammy), control);

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -20,11 +20,11 @@ use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::tempfile::TempFile;
 
-pub const BLOCK_SIZE: u64 = 4096;
-pub const QCOW_CLUSTER_SIZE: u64 = 65536;
+pub(crate) const BLOCK_SIZE: u64 = 4096;
+pub(crate) const QCOW_CLUSTER_SIZE: u64 = 65536;
 
 /// Create a temporary file pre sized to hold `num_blocks` blocks.
-pub fn sized_tempfile(num_blocks: usize) -> TempFile {
+pub(crate) fn sized_tempfile(num_blocks: usize) -> TempFile {
     let tmp = TempFile::new().expect("failed to create tempfile");
     tmp.as_file()
         .set_len(BLOCK_SIZE * num_blocks as u64)
@@ -52,7 +52,7 @@ fn create_qcow_tempfile(num_clusters: usize) -> TempFile {
 
 /// Create a QCOW2 image with `num_clusters` allocated clusters opened
 /// via QcowDisk with synchronous backend.
-pub fn qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
+pub(crate) fn qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_qcow_tempfile(num_clusters);
     let disk = QcowDisk::new(
         tmp.as_file().try_clone().unwrap(),
@@ -67,7 +67,7 @@ pub fn qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
 
 /// Create a QCOW2 image with `num_clusters` allocated clusters opened
 /// via QcowDisk with io_uring backend.
-pub fn qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
+pub(crate) fn qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_qcow_tempfile(num_clusters);
     let disk = QcowDisk::new(tmp.as_file().try_clone().unwrap(), false, false, true, true)
         .expect("failed to open QCOW2 via QcowDisk");
@@ -75,7 +75,7 @@ pub fn qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
 }
 
 /// Drain `count` completions from a synchronous async_io backend.
-pub fn drain_completions(async_io: &mut dyn AsyncIo, count: usize) {
+pub(crate) fn drain_completions(async_io: &mut dyn AsyncIo, count: usize) {
     for _ in 0..count {
         async_io.next_completed_request();
     }
@@ -85,7 +85,7 @@ pub fn drain_completions(async_io: &mut dyn AsyncIo, count: usize) {
 ///
 /// Uses a Fisher-Yates shuffle seeded by `DefaultHasher` so the
 /// permutation is identical across runs.
-pub fn deterministic_permutation(n: usize) -> Vec<usize> {
+pub(crate) fn deterministic_permutation(n: usize) -> Vec<usize> {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
@@ -103,7 +103,7 @@ pub fn deterministic_permutation(n: usize) -> Vec<usize> {
 ///
 /// The block microbenchmarks intentionally use this as a hot buffer to keep
 /// cache behavior close to the borrowed-iovec benchmarks they replaced.
-pub fn guest_memory_buffer(len: usize) -> Arc<GuestMemoryMmap> {
+pub(crate) fn guest_memory_buffer(len: usize) -> Arc<GuestMemoryMmap> {
     assert!(
         len <= u32::MAX as usize,
         "GuestMemoryTarget ranges are limited to u32 lengths"
@@ -128,7 +128,7 @@ fn prefault_guest_memory(mem: &Arc<GuestMemoryMmap>, total_len: usize) {
 }
 
 /// Create a target for the reusable benchmark guest-memory range.
-pub fn guest_memory_target(mem: &Arc<GuestMemoryMmap>, len: usize) -> GuestMemoryTarget {
+pub(crate) fn guest_memory_target(mem: &Arc<GuestMemoryMmap>, len: usize) -> GuestMemoryTarget {
     assert!(
         len <= u32::MAX as usize,
         "GuestMemoryTarget ranges are limited to u32 lengths"
@@ -139,14 +139,14 @@ pub fn guest_memory_target(mem: &Arc<GuestMemoryMmap>, len: usize) -> GuestMemor
 }
 
 /// Fill the reusable benchmark guest-memory range with one byte pattern.
-pub fn fill_guest_memory(mem: &Arc<GuestMemoryMmap>, len: usize, value: u8) {
+pub(crate) fn fill_guest_memory(mem: &Arc<GuestMemoryMmap>, len: usize, value: u8) {
     let buf = vec![value; len];
     mem.write_slice(&buf, GuestAddress(0))
         .expect("failed to initialize benchmark guest memory");
 }
 
 /// Submit `count` sequential read calls at `stride`-byte intervals.
-pub fn submit_reads(
+pub(crate) fn submit_reads(
     async_io: &mut dyn AsyncIo,
     mem: &Arc<GuestMemoryMmap>,
     count: usize,
@@ -162,7 +162,7 @@ pub fn submit_reads(
 }
 
 /// Submit `count` sequential write calls at `stride`-byte intervals.
-pub fn submit_writes(
+pub(crate) fn submit_writes(
     async_io: &mut dyn AsyncIo,
     mem: &Arc<GuestMemoryMmap>,
     count: usize,
@@ -179,7 +179,7 @@ pub fn submit_writes(
 
 /// Drain `count` completions from an asynchronous I/O backend that delivers
 /// results via eventfd notification (e.g. io_uring).
-pub fn drain_async_completions(async_io: &mut dyn AsyncIo, count: usize) {
+pub(crate) fn drain_async_completions(async_io: &mut dyn AsyncIo, count: usize) {
     let mut drained = 0usize;
     while drained < count {
         wait_for_eventfd(async_io.notifier());
@@ -199,7 +199,7 @@ fn create_empty_qcow_tempfile(num_clusters: usize) -> TempFile {
 }
 
 /// Empty QCOW2 opened via QcowDisk with synchronous backend.
-pub fn empty_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
+pub(crate) fn empty_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_empty_qcow_tempfile(num_clusters);
     let disk = QcowDisk::new(
         tmp.as_file().try_clone().unwrap(),
@@ -213,7 +213,7 @@ pub fn empty_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
 }
 
 /// Empty QCOW2 opened via QcowDisk with io_uring backend.
-pub fn empty_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
+pub(crate) fn empty_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_empty_qcow_tempfile(num_clusters);
     let disk = QcowDisk::new(tmp.as_file().try_clone().unwrap(), false, false, true, true)
         .expect("failed to open QCOW2 via QcowDisk");
@@ -248,7 +248,7 @@ fn create_overlay_tempfiles(num_clusters: usize) -> (TempFile, TempFile) {
 }
 
 /// QCOW2 overlay with raw backing opened via QcowDisk with synchronous backend.
-pub fn qcow_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDisk) {
+pub(crate) fn qcow_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDisk) {
     let (backing, overlay) = create_overlay_tempfiles(num_clusters);
     let disk = QcowDisk::new(
         overlay.as_file().try_clone().unwrap(),
@@ -262,7 +262,7 @@ pub fn qcow_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDi
 }
 
 /// QCOW2 overlay with raw backing opened via QcowDisk with io_uring backend.
-pub fn qcow_async_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDisk) {
+pub(crate) fn qcow_async_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDisk) {
     let (backing, overlay) = create_overlay_tempfiles(num_clusters);
     let disk = QcowDisk::new(
         overlay.as_file().try_clone().unwrap(),
@@ -315,7 +315,7 @@ fn create_compressed_qcow_tempfile(num_clusters: usize) -> TempFile {
 }
 
 /// Compressed QCOW2 opened via QcowDisk with synchronous backend.
-pub fn compressed_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
+pub(crate) fn compressed_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_compressed_qcow_tempfile(num_clusters);
     let path = tmp.as_path().to_str().unwrap().to_string();
     let disk = QcowDisk::new(
@@ -330,7 +330,7 @@ pub fn compressed_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
 }
 
 /// Compressed QCOW2 opened via QcowDisk with io_uring backend.
-pub fn compressed_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
+pub(crate) fn compressed_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_compressed_qcow_tempfile(num_clusters);
     let path = tmp.as_path().to_str().unwrap().to_string();
     let disk = QcowDisk::new(
@@ -346,7 +346,7 @@ pub fn compressed_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDis
 
 /// Number of data clusters covered by a single L2 table (64 KiB cluster,
 /// 8-byte entries -> 8192 entries per L2 table).
-pub const L2_ENTRIES_PER_TABLE: usize = QCOW_CLUSTER_SIZE as usize / 8;
+pub(crate) const L2_ENTRIES_PER_TABLE: usize = QCOW_CLUSTER_SIZE as usize / 8;
 
 /// Create a sparse QCOW2 image with one allocated cluster per L2 table,
 /// spanning `num_l2_tables` L2 tables.
@@ -363,7 +363,7 @@ fn create_sparse_qcow_tempfile(num_l2_tables: usize) -> TempFile {
 }
 
 /// Sparse QCOW2 opened via QcowDisk with synchronous backend.
-pub fn sparse_qcow_tempfile(num_l2_tables: usize) -> (TempFile, QcowDisk) {
+pub(crate) fn sparse_qcow_tempfile(num_l2_tables: usize) -> (TempFile, QcowDisk) {
     let tmp = create_sparse_qcow_tempfile(num_l2_tables);
     let disk = QcowDisk::new(
         tmp.as_file().try_clone().unwrap(),
@@ -377,7 +377,7 @@ pub fn sparse_qcow_tempfile(num_l2_tables: usize) -> (TempFile, QcowDisk) {
 }
 
 /// Sparse QCOW2 opened via QcowDisk with io_uring backend.
-pub fn sparse_qcow_async_tempfile(num_l2_tables: usize) -> (TempFile, QcowDisk) {
+pub(crate) fn sparse_qcow_async_tempfile(num_l2_tables: usize) -> (TempFile, QcowDisk) {
     let tmp = create_sparse_qcow_tempfile(num_l2_tables);
     let disk = QcowDisk::new(tmp.as_file().try_clone().unwrap(), false, false, true, true)
         .expect("failed to open QCOW2 via QcowDisk");
@@ -385,7 +385,7 @@ pub fn sparse_qcow_async_tempfile(num_l2_tables: usize) -> (TempFile, QcowDisk) 
 }
 
 /// Spin and wait until the given eventfd becomes readable.
-pub fn wait_for_eventfd(notifier: &EventFd) {
+pub(crate) fn wait_for_eventfd(notifier: &EventFd) {
     loop {
         match notifier.read() {
             Ok(_) => return,

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -107,7 +107,7 @@ impl VhostUserNetThread {
         })
     }
 
-    pub fn set_epoll_fd(&mut self, fd: RawFd) {
+    fn set_epoll_fd(&mut self, fd: RawFd) {
         self.net.epoll_fd = Some(fd);
     }
 }

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -59,7 +59,7 @@ enum Error {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 #[repr(C, packed)]
-pub struct VirtioConsoleConfig {
+struct VirtioConsoleConfig {
     cols: u16,
     rows: u16,
     max_nr_ports: u32,
@@ -559,7 +559,7 @@ impl ConsoleResizer {
 }
 
 impl VirtioConsoleConfig {
-    pub fn update_console_size(&mut self, cols: u16, rows: u16) {
+    pub(crate) fn update_console_size(&mut self, cols: u16, rows: u16) {
         self.cols = cols;
         self.rows = rows;
     }

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -1147,7 +1147,7 @@ pub(crate) struct VirtioNetGuestAnnounceOps {
 }
 
 impl VirtioNetGuestAnnounceOps {
-    pub fn new(
+    pub(crate) fn new(
         interrupt_cb: Arc<dyn VirtioInterrupt>,
         guest_announce_negotiated: bool,
         announce: &AnnouncementState,
@@ -1189,7 +1189,7 @@ struct VirtioNetHostAnnounceOps {
 }
 
 impl VirtioNetHostAnnounceOps {
-    pub fn new(rarp_announce: Option<[u8; ETH_FRAME_LEN]>, taps: Box<[Tap]>) -> Self {
+    pub(crate) fn new(rarp_announce: Option<[u8; ETH_FRAME_LEN]>, taps: Box<[Tap]>) -> Self {
         Self {
             rarp_announce,
             taps,

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -85,13 +85,13 @@ const VRING_AVAIL_ELEMENT_SIZE: usize = 2;
 const VRING_USED_ELEMENT_SIZE: usize = 8;
 
 #[derive(Copy, Clone)]
-pub enum VringType {
+pub(super) enum VringType {
     Desc,
     Avail,
     Used,
 }
 
-pub fn get_vring_size(t: VringType, queue_size: u16) -> u64 {
+pub(super) fn get_vring_size(t: VringType, queue_size: u16) -> u64 {
     let (length_except_ring, element_size) = match t {
         VringType::Desc => (0, VRING_DESC_ELEMENT_SIZE),
         VringType::Avail => (6, VRING_AVAIL_ELEMENT_SIZE),

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -88,7 +88,7 @@ impl PciCapability for VirtioPciCap {
 const VIRTIO_PCI_CAP_LEN_OFFSET: u8 = 2;
 
 impl VirtioPciCap {
-    pub fn new(cfg_type: PciCapabilityType, pci_bar: u8, offset: u32, length: u32) -> Self {
+    pub(crate) fn new(cfg_type: PciCapabilityType, pci_bar: u8, offset: u32, length: u32) -> Self {
         VirtioPciCap {
             cap_len: (size_of::<VirtioPciCap>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET,
             cfg_type: cfg_type as u8,
@@ -121,7 +121,7 @@ impl PciCapability for VirtioPciNotifyCap {
 }
 
 impl VirtioPciNotifyCap {
-    pub fn new(
+    pub(crate) fn new(
         cfg_type: PciCapabilityType,
         pci_bar: u8,
         offset: u32,
@@ -164,7 +164,13 @@ impl PciCapability for VirtioPciCap64 {
 }
 
 impl VirtioPciCap64 {
-    pub fn new(cfg_type: PciCapabilityType, pci_bar: u8, id: u8, offset: u64, length: u64) -> Self {
+    pub(crate) fn new(
+        cfg_type: PciCapabilityType,
+        pci_bar: u8,
+        id: u8,
+        offset: u64,
+        length: u64,
+    ) -> Self {
         VirtioPciCap64 {
             cap: VirtioPciCap {
                 cap_len: (size_of::<VirtioPciCap64>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET,
@@ -232,7 +238,7 @@ struct VirtioPciCfgCapInfo {
 }
 
 #[derive(Copy, Clone)]
-pub enum PciVirtioSubclass {
+pub(super) enum PciVirtioSubclass {
     NonTransitionalBase = 0xff,
 }
 
@@ -303,7 +309,7 @@ struct QueueState {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct VirtioPciDeviceState {
+pub(super) struct VirtioPciDeviceState {
     device_activated: bool,
     queues: Vec<QueueState>,
     interrupt_status: usize,
@@ -358,7 +364,7 @@ pub enum VirtioPciDeviceError {
     #[error("Failed creating VirtioPciDevice")]
     CreateVirtioPciDevice(#[source] anyhow::Error),
 }
-pub type Result<T> = result::Result<T, VirtioPciDeviceError>;
+pub(super) type Result<T> = result::Result<T, VirtioPciDeviceError>;
 
 pub struct VirtioPciDevice {
     id: String,
@@ -875,7 +881,7 @@ impl VirtioTransport for VirtioPciDevice {
     }
 }
 
-pub struct VirtioInterruptMsix {
+pub(super) struct VirtioInterruptMsix {
     msix_config: Arc<Mutex<MsixConfig>>,
     config_vector: Arc<AtomicU16>,
     config_changed: Arc<AtomicBool>,
@@ -885,7 +891,7 @@ pub struct VirtioInterruptMsix {
 }
 
 impl VirtioInterruptMsix {
-    pub fn new(
+    pub(super) fn new(
         msix_config: Arc<Mutex<MsixConfig>>,
         config_vector: Arc<AtomicU16>,
         config_changed: Arc<AtomicBool>,

--- a/virtio-devices/src/vsock/csm/connection.rs
+++ b/virtio-devices/src/vsock/csm/connection.rs
@@ -105,7 +105,7 @@ impl TxBufSource for VsockPacket {
 /// A self-managing connection object, that handles communication between a guest-side AF_VSOCK
 /// socket and a host-side `Read + Write + AsRawFd` stream.
 ///
-pub struct VsockConnection<S: Read + ReadVolatile + Write + WriteVolatile + AsRawFd> {
+pub(crate) struct VsockConnection<S: Read + ReadVolatile + Write + WriteVolatile + AsRawFd> {
     /// The current connection state.
     state: ConnState,
     /// The local CID. Most of the time this will be the constant `2` (the vsock host CID).
@@ -572,7 +572,7 @@ where
 {
     /// Create a new guest-initiated connection object.
     ///
-    pub fn new_peer_init(
+    pub(crate) fn new_peer_init(
         stream: S,
         local_cid: u64,
         peer_cid: u64,
@@ -602,7 +602,7 @@ where
 
     /// Create a new host-initiated connection object.
     ///
-    pub fn new_local_init(
+    pub(crate) fn new_local_init(
         stream: S,
         local_cid: u64,
         peer_cid: u64,
@@ -632,7 +632,7 @@ where
     /// Check if there is an expiry (kill) timer set for this connection, sometime in the
     /// future.
     ///
-    pub fn will_expire(&self) -> bool {
+    pub(crate) fn will_expire(&self) -> bool {
         match self.expiry {
             None => false,
             Some(t) => t > Instant::now(),
@@ -642,7 +642,7 @@ where
     /// Check if this connection needs to be scheduled for forceful termination, due to its
     /// kill timer having expired.
     ///
-    pub fn has_expired(&self) -> bool {
+    pub(crate) fn has_expired(&self) -> bool {
         match self.expiry {
             None => false,
             Some(t) => t <= Instant::now(),
@@ -651,21 +651,21 @@ where
 
     /// Get the kill timer value, if one is set.
     ///
-    pub fn expiry(&self) -> Option<Instant> {
+    pub(crate) fn expiry(&self) -> Option<Instant> {
         self.expiry
     }
 
     /// Schedule the connection to be forcefully terminated ASAP (i.e. the next time the
     /// connection is asked to yield a packet, via `recv_pkt()`).
     ///
-    pub fn kill(&mut self) {
+    pub(crate) fn kill(&mut self) {
         self.state = ConnState::Killed;
         self.pending_rx.insert(PendingRx::Rst);
     }
 
     /// Return the connections state.
     ///
-    pub fn state(&self) -> ConnState {
+    pub(crate) fn state(&self) -> ConnState {
         self.state
     }
 
@@ -676,7 +676,7 @@ where
     /// underlying stream. No account of this write is kept, which includes bypassing
     /// vsock flow control.
     ///
-    pub fn send_bytes_raw(&mut self, buf: &[u8]) -> Result<usize> {
+    pub(crate) fn send_bytes_raw(&mut self, buf: &[u8]) -> Result<usize> {
         self.stream.write(buf).map_err(Error::StreamWrite)
     }
 

--- a/virtio-devices/src/vsock/csm/mod.rs
+++ b/virtio-devices/src/vsock/csm/mod.rs
@@ -11,25 +11,25 @@ use thiserror::Error;
 mod connection;
 mod txbuf;
 
-pub use connection::VsockConnection;
+pub(super) use connection::VsockConnection;
 
-pub mod defs {
+pub(super) mod defs {
     /// Vsock connection TX buffer capacity.
-    pub const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
+    pub(crate) const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
 
     /// When the guest thinks we have less than this amount of free buffer space,
     /// we will send them a credit update packet.
-    pub const CONN_CREDIT_UPDATE_THRESHOLD: u32 = 4 * 1024;
+    pub(crate) const CONN_CREDIT_UPDATE_THRESHOLD: u32 = 4 * 1024;
 
     /// Connection request timeout, in millis.
-    pub const CONN_REQUEST_TIMEOUT_MS: u64 = 2000;
+    pub(crate) const CONN_REQUEST_TIMEOUT_MS: u64 = 2000;
 
     /// Connection graceful shutdown timeout, in millis.
-    pub const CONN_SHUTDOWN_TIMEOUT_MS: u64 = 2000;
+    pub(crate) const CONN_SHUTDOWN_TIMEOUT_MS: u64 = 2000;
 }
 
 #[derive(Debug, Error)]
-pub enum Error {
+pub(super) enum Error {
     /// Attempted to push data to a full TX buffer.
     #[error("TX buffer full")]
     TxBufFull,
@@ -49,7 +49,7 @@ type Result<T> = result::Result<T, Error>;
 /// A vsock connection state.
 ///
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ConnState {
+pub(super) enum ConnState {
     /// The connection has been initiated by the host end, but is yet to be confirmed by the guest.
     LocalInit,
     /// The connection has been initiated by the guest, but we are yet to confirm it, by sending

--- a/virtio-devices/src/vsock/csm/txbuf.rs
+++ b/virtio-devices/src/vsock/csm/txbuf.rs
@@ -25,7 +25,7 @@ impl TxBufSource for [u8] {
 /// data.  Memory for this buffer is allocated lazily, since buffering will only be needed when
 /// the host can't read fast enough.
 ///
-pub struct TxBuf {
+pub(crate) struct TxBuf {
     /// The actual u8 buffer - only allocated after the first push.
     data: Option<Box<[u8]>>,
     /// Ring-buffer head offset - where new data is pushed to.
@@ -41,7 +41,7 @@ impl TxBuf {
 
     /// Ring-buffer constructor.
     ///
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             data: None,
             head: Wrapping(0),
@@ -52,7 +52,7 @@ impl TxBuf {
     /// Get the used length of this buffer - number of bytes that have been pushed in, but not
     /// yet flushed out.
     ///
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         (self.head - self.tail).0 as usize
     }
 
@@ -108,7 +108,7 @@ impl TxBuf {
     /// Return the number of bytes that have been transferred out of the ring-buffer and into
     /// the writable stream.
     ///
-    pub fn flush_to<W>(&mut self, sink: &mut W) -> Result<usize>
+    pub(crate) fn flush_to<W>(&mut self, sink: &mut W) -> Result<usize>
     where
         W: Write,
     {
@@ -158,7 +158,7 @@ impl TxBuf {
 
     /// Check if the buffer holds any data that hasn't yet been flushed out.
     ///
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -169,7 +169,7 @@ impl TxBuf {
     /// directly from a packet buffer via `push_from`.
     ///
     #[cfg(test)]
-    pub fn push(&mut self, src: &[u8]) -> Result<()> {
+    pub(crate) fn push(&mut self, src: &[u8]) -> Result<()> {
         self.push_from(src, 0, src.len())
     }
 }

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -61,13 +61,13 @@ const NUM_QUEUES: usize = 3;
 const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE; NUM_QUEUES];
 
 // New descriptors are pending on the rx queue.
-pub const RX_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
+pub(super) const RX_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
 // New descriptors are pending on the tx queue.
-pub const TX_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
+pub(super) const TX_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
 // New descriptors are pending on the event queue.
-pub const EVT_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 3;
+pub(super) const EVT_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 3;
 // Notification coming from the backend.
-pub const BACKEND_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 4;
+pub(super) const BACKEND_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 4;
 
 #[derive(Error, Debug)]
 enum Error {
@@ -93,7 +93,7 @@ enum Error {
 ///   - forward the event to the backend; then
 ///   - again, attempt to fetch any incoming packets queued by the backend into virtio RX buffers.
 ///
-pub struct VsockEpollHandler<B: VsockBackend> {
+pub(crate) struct VsockEpollHandler<B: VsockBackend> {
     pub mem: GuestMemoryAtomic<GuestMemoryMmap>,
     pub queues: Vec<Queue>,
     pub queue_evts: Vec<EventFd>,

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -25,43 +25,43 @@ pub use self::unix::{VsockUnixBackend, VsockUnixError};
 mod defs {
 
     /// Max vsock packet data/buffer size.
-    pub const MAX_PKT_BUF_SIZE: usize = 64 * 1024;
+    pub(super) const MAX_PKT_BUF_SIZE: usize = 64 * 1024;
 
-    pub mod uapi {
+    pub(super) mod uapi {
 
         /// Vsock packet operation IDs.
         /// Defined in `/include/uapi/linux/virtio_vsock.h`.
         ///
         /// Connection request.
-        pub const VSOCK_OP_REQUEST: u16 = 1;
+        pub(crate) const VSOCK_OP_REQUEST: u16 = 1;
         /// Connection response.
-        pub const VSOCK_OP_RESPONSE: u16 = 2;
+        pub(crate) const VSOCK_OP_RESPONSE: u16 = 2;
         /// Connection reset.
-        pub const VSOCK_OP_RST: u16 = 3;
+        pub(crate) const VSOCK_OP_RST: u16 = 3;
         /// Connection clean shutdown.
-        pub const VSOCK_OP_SHUTDOWN: u16 = 4;
+        pub(crate) const VSOCK_OP_SHUTDOWN: u16 = 4;
         /// Connection data (read/write).
-        pub const VSOCK_OP_RW: u16 = 5;
+        pub(crate) const VSOCK_OP_RW: u16 = 5;
         /// Flow control credit update.
-        pub const VSOCK_OP_CREDIT_UPDATE: u16 = 6;
+        pub(crate) const VSOCK_OP_CREDIT_UPDATE: u16 = 6;
         /// Flow control credit update request.
-        pub const VSOCK_OP_CREDIT_REQUEST: u16 = 7;
+        pub(crate) const VSOCK_OP_CREDIT_REQUEST: u16 = 7;
 
         /// Vsock packet flags.
         /// Defined in `/include/uapi/linux/virtio_vsock.h`.
         ///
         /// Valid with a VSOCK_OP_SHUTDOWN packet: the packet sender will receive no more data.
-        pub const VSOCK_FLAGS_SHUTDOWN_RCV: u32 = 1;
+        pub(crate) const VSOCK_FLAGS_SHUTDOWN_RCV: u32 = 1;
         /// Valid with a VSOCK_OP_SHUTDOWN packet: the packet sender will send no more data.
-        pub const VSOCK_FLAGS_SHUTDOWN_SEND: u32 = 2;
+        pub(crate) const VSOCK_FLAGS_SHUTDOWN_SEND: u32 = 2;
 
         /// Vsock packet type.
         /// Defined in `/include/uapi/linux/virtio_vsock.h`.
         ///
         /// Stream / connection-oriented packet (the only currently valid type).
-        pub const VSOCK_TYPE_STREAM: u16 = 1;
+        pub(crate) const VSOCK_TYPE_STREAM: u16 = 1;
 
-        pub const VSOCK_HOST_CID: u64 = 2;
+        pub(crate) const VSOCK_HOST_CID: u64 = 2;
     }
 }
 
@@ -346,7 +346,7 @@ pub mod tests {
     }
 
     pub struct EpollHandlerContext<'a> {
-        pub handler: VsockEpollHandler<TestBackend>,
+        pub(crate) handler: VsockEpollHandler<TestBackend>,
         pub guest_rxvq: GuestQ<'a>,
         pub guest_txvq: GuestQ<'a>,
         pub guest_evvq: GuestQ<'a>,

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -56,7 +56,7 @@ use crate::GuestMemoryMmap;
 // endianness.
 
 /// The vsock packet header struct size (when packed).
-pub const VSOCK_PKT_HDR_SIZE: usize = 44;
+pub(super) const VSOCK_PKT_HDR_SIZE: usize = 44;
 
 // Source CID.
 const HDROFF_SRC_CID: usize = 0;

--- a/virtio-devices/src/vsock/unix/mod.rs
+++ b/virtio-devices/src/vsock/unix/mod.rs
@@ -22,13 +22,13 @@ use thiserror::Error;
 
 mod defs {
     /// Maximum number of established connections that we can handle.
-    pub const MAX_CONNECTIONS: usize = 1023;
+    pub(super) const MAX_CONNECTIONS: usize = 1023;
 
     /// Size of the muxer RX packet queue.
-    pub const MUXER_RXQ_SIZE: usize = 256;
+    pub(super) const MUXER_RXQ_SIZE: usize = 256;
 
     /// Size of the muxer connection kill queue.
-    pub const MUXER_KILLQ_SIZE: usize = 128;
+    pub(super) const MUXER_KILLQ_SIZE: usize = 128;
 }
 
 #[derive(Error, Debug)]

--- a/virtio-devices/src/vsock/unix/muxer.rs
+++ b/virtio-devices/src/vsock/unix/muxer.rs
@@ -63,7 +63,7 @@ use super::{Error, MuxerConnection, Result, defs};
 /// keyed by a `ConnMapKey` object.
 ///
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct ConnMapKey {
+pub(super) struct ConnMapKey {
     local_port: u32,
     peer_port: u32,
 }
@@ -71,7 +71,7 @@ pub struct ConnMapKey {
 /// A muxer RX queue item.
 ///
 #[derive(Clone, Copy, Debug)]
-pub enum MuxerRx {
+pub(super) enum MuxerRx {
     /// The packet must be fetched from the connection identified by `ConnMapKey`.
     ConnRx(ConnMapKey),
     /// The muxer must produce an RST packet.

--- a/virtio-devices/src/vsock/unix/muxer_killq.rs
+++ b/virtio-devices/src/vsock/unix/muxer_killq.rs
@@ -42,7 +42,7 @@ struct MuxerKillQItem {
 /// The connection kill queue: a FIFO structure, storing the connections that are scheduled for
 /// termination.
 ///
-pub struct MuxerKillQ {
+pub(super) struct MuxerKillQ {
     /// The kill queue contents.
     q: VecDeque<MuxerKillQItem>,
 
@@ -59,7 +59,7 @@ impl MuxerKillQ {
 
     /// Trivial kill queue constructor.
     ///
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             q: VecDeque::with_capacity(Self::SIZE),
             synced: true,
@@ -71,7 +71,7 @@ impl MuxerKillQ {
     /// Note: if more than `Self::SIZE` connections are found, the queue will be created in an
     ///       out-of-sync state, and will be discarded after it is emptied.
     ///
-    pub fn from_conn_map(conn_map: &HashMap<ConnMapKey, MuxerConnection>) -> Self {
+    pub(super) fn from_conn_map(conn_map: &HashMap<ConnMapKey, MuxerConnection>) -> Self {
         let mut q_buf: Vec<MuxerKillQItem> = Vec::with_capacity(Self::SIZE);
         let mut synced = true;
         for (key, conn) in conn_map.iter() {
@@ -97,7 +97,7 @@ impl MuxerKillQ {
     /// Push a connection key to the queue, scheduling it for termination at
     /// `CONN_SHUTDOWN_TIMEOUT_MS` from now (the push time).
     ///
-    pub fn push(&mut self, key: ConnMapKey, kill_time: Instant) {
+    pub(super) fn push(&mut self, key: ConnMapKey, kill_time: Instant) {
         if !self.is_synced() || self.is_full() {
             self.synced = false;
             return;
@@ -110,7 +110,7 @@ impl MuxerKillQ {
     /// This will succeed and return a connection key, only if the connection at the front of
     /// the queue has expired. Otherwise, `None` is returned.
     ///
-    pub fn pop(&mut self) -> Option<ConnMapKey> {
+    pub(super) fn pop(&mut self) -> Option<ConnMapKey> {
         if let Some(item) = self.q.front()
             && Instant::now() > item.kill_time
         {
@@ -122,19 +122,19 @@ impl MuxerKillQ {
 
     /// Check if the kill queue is synchronized with the connection pool.
     ///
-    pub fn is_synced(&self) -> bool {
+    pub(super) fn is_synced(&self) -> bool {
         self.synced
     }
 
     /// Check if the kill queue is empty, obviously.
     ///
-    pub fn is_empty(&self) -> bool {
+    pub(super) fn is_empty(&self) -> bool {
         self.q.len() == 0
     }
 
     /// Check if the kill queue is full.
     ///
-    pub fn is_full(&self) -> bool {
+    pub(super) fn is_full(&self) -> bool {
         self.q.len() == Self::SIZE
     }
 }

--- a/virtio-devices/src/vsock/unix/muxer_rxq.rs
+++ b/virtio-devices/src/vsock/unix/muxer_rxq.rs
@@ -24,7 +24,7 @@ use super::{MuxerConnection, defs};
 
 /// The muxer RX queue.
 ///
-pub struct MuxerRxQ {
+pub(super) struct MuxerRxQ {
     /// The RX queue data.
     q: VecDeque<MuxerRx>,
     /// The RX queue sync status.
@@ -36,7 +36,7 @@ impl MuxerRxQ {
 
     /// Trivial RX queue constructor.
     ///
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             q: VecDeque::with_capacity(Self::SIZE),
             synced: true,
@@ -48,7 +48,7 @@ impl MuxerRxQ {
     ///       that have pending RX data. In that case, the muxer will first drain this queue, and
     ///       then try again to build a synchronized one.
     ///
-    pub fn from_conn_map(conn_map: &HashMap<ConnMapKey, MuxerConnection>) -> Self {
+    pub(super) fn from_conn_map(conn_map: &HashMap<ConnMapKey, MuxerConnection>) -> Self {
         let mut q = VecDeque::new();
         let mut synced = true;
 
@@ -79,7 +79,7 @@ impl MuxerRxQ {
     /// - `true` if the new item has been successfully queued; or
     /// - `false` if there was no room left in the queue.
     ///
-    pub fn push(&mut self, rx: MuxerRx) -> bool {
+    pub(super) fn push(&mut self, rx: MuxerRx) -> bool {
         // Pushing to a non-full, synchronized queue will always succeed.
         if self.is_synced() && !self.is_full() {
             self.q.push_back(rx);
@@ -109,37 +109,37 @@ impl MuxerRxQ {
 
     /// Peek into the front of the queue.
     ///
-    pub fn peek(&self) -> Option<MuxerRx> {
+    pub(super) fn peek(&self) -> Option<MuxerRx> {
         self.q.front().copied()
     }
 
     /// Pop an RX item from the front of the queue.
     ///
-    pub fn pop(&mut self) -> Option<MuxerRx> {
+    pub(super) fn pop(&mut self) -> Option<MuxerRx> {
         self.q.pop_front()
     }
 
     /// Check if the RX queue is synchronized with the connection pool.
     ///
-    pub fn is_synced(&self) -> bool {
+    pub(super) fn is_synced(&self) -> bool {
         self.synced
     }
 
     /// Get the total number of items in the queue.
     ///
-    pub fn len(&self) -> usize {
+    pub(super) fn len(&self) -> usize {
         self.q.len()
     }
 
     /// Check if the queue is empty.
     ///
-    pub fn is_empty(&self) -> bool {
+    pub(super) fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Check if the queue is full.
     ///
-    pub fn is_full(&self) -> bool {
+    pub(super) fn is_full(&self) -> bool {
         self.len() == Self::SIZE
     }
 }

--- a/vm-allocator/src/address.rs
+++ b/vm-allocator/src/address.rs
@@ -13,13 +13,13 @@ use std::result;
 use vm_memory::{Address, GuestAddress, GuestUsize};
 
 #[derive(Debug)]
-pub enum Error {
+pub(crate) enum Error {
     Overflow,
     Overlap,
     UnalignedAddress,
 }
 
-pub type Result<T> = result::Result<T, Error>;
+pub(crate) type Result<T> = result::Result<T, Error>;
 
 /// Manages allocating address ranges.
 /// Use `AddressAllocator` whenever an address range needs to be allocated to different users.

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -14,7 +14,7 @@ use std::result;
 
 use thiserror::Error;
 
-pub type Result<T> = result::Result<T, InterruptAllocError>;
+pub(crate) type Result<T> = result::Result<T, InterruptAllocError>;
 
 /// Describes one APIC interrupt input range in the global system interrupt
 /// namespace.

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -66,7 +66,7 @@ pub enum Error {
     MissingAddressRange,
 }
 
-pub type Result<T> = result::Result<T, Error>;
+pub(crate) type Result<T> = result::Result<T, Error>;
 
 impl convert::From<Error> for io::Error {
     fn from(e: Error) -> Self {
@@ -79,14 +79,14 @@ impl convert::From<Error> for io::Error {
 /// * base - The address at which the range start.
 /// * len - The length of the range in bytes.
 #[derive(Debug, Copy, Clone)]
-pub struct BusRange {
+struct BusRange {
     pub base: u64,
     pub len: u64,
 }
 
 impl BusRange {
     /// Returns true if there is overlap with the given range.
-    pub fn overlaps(&self, base: u64, len: u64) -> bool {
+    pub(crate) fn overlaps(&self, base: u64, len: u64) -> bool {
         self.base < (base + len) && base < self.base + self.len
     }
 }

--- a/vm-migration/src/bitpos_iterator.rs
+++ b/vm-migration/src/bitpos_iterator.rs
@@ -58,7 +58,7 @@ where
     }
 }
 
-pub trait BitposIteratorExt: Iterator<Item = u64> + Sized {
+pub(crate) trait BitposIteratorExt: Iterator<Item = u64> + Sized {
     /// Turn an iterator over `u64` into an iterator over the bit positions of
     /// all 1s. We basically treat the incoming `u64` as one gigantic integer
     /// and just spit out which bits are set.

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -453,7 +453,7 @@ struct MemoryRangeTableIterator {
 impl MemoryRangeTableIterator {
     /// Create an iterator that partitions `table` into chunks of at most
     /// `chunk_size` bytes.
-    pub fn new(table: MemoryRangeTable, chunk_size: u64) -> Self {
+    pub(crate) fn new(table: MemoryRangeTable, chunk_size: u64) -> Self {
         MemoryRangeTableIterator {
             chunk_size,
             data: table.data,

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -45,7 +45,7 @@ pub enum Error {
     FwCfg(#[source] io::Error),
 }
 
-pub type Result<T> = result::Result<T, Error>;
+pub(crate) type Result<T> = result::Result<T, Error>;
 
 fn next_table_address(address: GuestAddress, length: u64) -> Result<GuestAddress> {
     address.checked_add(length).ok_or(Error::AddressOverflow)
@@ -53,25 +53,25 @@ fn next_table_address(address: GuestAddress, length: u64) -> Result<GuestAddress
 
 /* Values for Type in APIC sub-headers */
 #[cfg(target_arch = "x86_64")]
-pub const ACPI_X2APIC_PROCESSOR: u8 = 9;
+pub(crate) const ACPI_X2APIC_PROCESSOR: u8 = 9;
 #[cfg(target_arch = "x86_64")]
-pub const ACPI_APIC_IO: u8 = 1;
+pub(crate) const ACPI_APIC_IO: u8 = 1;
 #[cfg(target_arch = "x86_64")]
-pub const ACPI_APIC_XRUPT_OVERRIDE: u8 = 2;
+pub(crate) const ACPI_APIC_XRUPT_OVERRIDE: u8 = 2;
 #[cfg(target_arch = "aarch64")]
-pub const ACPI_APIC_GENERIC_CPU_INTERFACE: u8 = 11;
+pub(crate) const ACPI_APIC_GENERIC_CPU_INTERFACE: u8 = 11;
 #[cfg(target_arch = "aarch64")]
-pub const ACPI_APIC_GENERIC_DISTRIBUTOR: u8 = 12;
+pub(crate) const ACPI_APIC_GENERIC_DISTRIBUTOR: u8 = 12;
 #[cfg(target_arch = "aarch64")]
-pub const ACPI_APIC_GIC_MSI_FRAME: u8 = 13;
+pub(crate) const ACPI_APIC_GIC_MSI_FRAME: u8 = 13;
 #[cfg(target_arch = "aarch64")]
-pub const ACPI_APIC_GENERIC_REDISTRIBUTOR: u8 = 14;
+pub(crate) const ACPI_APIC_GENERIC_REDISTRIBUTOR: u8 = 14;
 #[cfg(target_arch = "aarch64")]
-pub const ACPI_APIC_GENERIC_TRANSLATOR: u8 = 15;
+pub(crate) const ACPI_APIC_GENERIC_TRANSLATOR: u8 = 15;
 #[cfg(target_arch = "riscv64")]
-pub const ACPI_RISC_V_IMSIC: u8 = 0x19;
+pub(crate) const ACPI_RISC_V_IMSIC: u8 = 0x19;
 #[cfg(target_arch = "riscv64")]
-pub const ACPI_RISC_V_APLIC: u8 = 0x1A;
+pub(crate) const ACPI_RISC_V_APLIC: u8 = 0x1A;
 
 #[repr(C, packed)]
 #[derive(Default, IntoBytes, Immutable, FromBytes)]
@@ -291,7 +291,7 @@ struct ViotPciRangeNode {
     _reserved2: [u8; 6],
 }
 
-pub fn create_dsdt_table(
+pub(crate) fn create_dsdt_table(
     device_manager: &DeviceManager,
     cpu_manager: &CpuManager,
     memory_manager: &MemoryManager,
@@ -1108,7 +1108,7 @@ fn create_acpi_tables_internal(
 }
 
 #[cfg(feature = "fw_cfg")]
-pub fn create_acpi_tables_for_fw_cfg(
+pub(crate) fn create_acpi_tables_for_fw_cfg(
     device_manager: &DeviceManager,
     cpu_manager: &CpuManager,
     memory_manager: &MemoryManager,
@@ -1164,7 +1164,7 @@ pub fn create_acpi_tables_for_fw_cfg(
         .map_err(Error::FwCfg)
 }
 
-pub fn create_acpi_tables(
+pub(crate) fn create_acpi_tables(
     guest_mem: &GuestMemoryMmap,
     device_manager: &DeviceManager,
     cpu_manager: &CpuManager,
@@ -1205,7 +1205,7 @@ pub fn create_acpi_tables(
 }
 
 #[cfg(feature = "tdx")]
-pub fn create_acpi_tables_tdx(
+pub(crate) fn create_acpi_tables_tdx(
     device_manager: &DeviceManager,
     cpu_manager: &CpuManager,
     memory_manager: &MemoryManager,

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -84,7 +84,7 @@ mod fds_helper {
 
     /// Abstraction over configuration types received via the HTTP API that
     /// have associated externally opened FDs.
-    pub trait ConfigWithFDs {
+    pub(super) trait ConfigWithFDs {
         /// Returns the ID of the device.
         ///
         /// Used for logging.
@@ -111,7 +111,7 @@ mod fds_helper {
     /// Extension of [`ConfigWithFDs`] for config objects that know how many
     /// FDs they want (e.g., a restore configuration that is aware of the
     /// previous state).
-    pub trait ConfigWithVariableFDs: ConfigWithFDs {
+    pub(super) trait ConfigWithVariableFDs: ConfigWithFDs {
         /// Returns how many FDs this type wants to have from the pool of
         /// available FDs.
         fn expected_num_fds(&self) -> usize;
@@ -239,7 +239,7 @@ mod fds_helper {
     /// - `cfgs`: List of network configurations where each network can have up to `n` FDs.
     ///
     /// [module description]: self
-    pub fn attach_fds_to_cfgs<T: ConfigWithVariableFDs>(
+    pub(super) fn attach_fds_to_cfgs<T: ConfigWithVariableFDs>(
         device_fds: Vec<File>,
         cfgs: &mut [&mut T],
     ) -> Result<(), HttpError> {
@@ -283,7 +283,7 @@ mod fds_helper {
     /// - `cfg`: The config object that wants to take ownership of all available FDs.
     ///
     /// [module description]: self
-    pub fn attach_fds_to_cfg<T: ConfigWithFDs>(
+    pub(super) fn attach_fds_to_cfg<T: ConfigWithFDs>(
         device_fds: Vec<File>,
         cfg: &mut T,
     ) -> Result<(), HttpError> {

--- a/vmm/src/clone3.rs
+++ b/vmm/src/clone3.rs
@@ -3,11 +3,11 @@
 
 use libc::{SYS_clone3, c_long, size_t, syscall};
 
-pub const CLONE_CLEAR_SIGHAND: u64 = 0x100000000;
+pub(crate) const CLONE_CLEAR_SIGHAND: u64 = 0x100000000;
 
 #[repr(C)]
 #[derive(Default)]
-pub struct clone_args {
+pub(crate) struct clone_args {
     pub flags: u64,
     pub pidfd: u64,
     pub child_tid: u64,
@@ -31,7 +31,7 @@ pub struct clone_args {
 ///   - Child: `0`
 /// - On error: `-1` and `errno` is set
 #[must_use]
-pub unsafe fn clone3(args: &mut clone_args, size: size_t) -> c_long {
+pub(crate) unsafe fn clone3(args: &mut clone_args, size: size_t) -> c_long {
     // SAFETY: parameters are assumed to be valid
     unsafe { syscall(SYS_clone3, args, size) }
 }

--- a/vmm/src/coredump.rs
+++ b/vmm/src/coredump.rs
@@ -47,7 +47,7 @@ pub enum GuestDebuggableError {
     Resume(#[source] vm_migration::MigratableError),
 }
 
-pub trait GuestDebuggable: vm_migration::Pausable {
+pub(crate) trait GuestDebuggable: vm_migration::Pausable {
     fn coredump(&mut self, _destination_url: &str) -> result::Result<(), GuestDebuggableError> {
         Ok(())
     }
@@ -55,7 +55,7 @@ pub trait GuestDebuggable: vm_migration::Pausable {
 
 #[repr(C)]
 #[derive(Default, Copy, Clone)]
-pub struct X86_64UserRegs {
+pub(crate) struct X86_64UserRegs {
     /// r15, r14, r13, r12, rbp, rbx, r11, r10;
     pub regs1: [u64; 8],
     /// r9, r8, rax, rcx, rdx, rsi, rdi, orig_rax;
@@ -77,7 +77,7 @@ pub struct X86_64UserRegs {
 unsafe impl ByteValued for X86_64UserRegs {}
 
 #[repr(C)]
-pub struct X86_64ElfPrStatus {
+pub(crate) struct X86_64ElfPrStatus {
     pub pad1: [u8; 32],
     pub pid: u32,
     pub pads2: [u8; 76],
@@ -87,7 +87,7 @@ pub struct X86_64ElfPrStatus {
 
 #[repr(C)]
 #[derive(Default, Copy, Clone)]
-pub struct CpuSegment {
+pub(crate) struct CpuSegment {
     pub selector: u32,
     pub limit: u32,
     pub flags: u32,
@@ -109,7 +109,7 @@ const DESC_G_SHIFT: u32 = 23;
 const DESC_G_MASK: u32 = 1 << DESC_G_SHIFT;
 
 impl CpuSegment {
-    pub fn new(reg: SegmentRegister) -> Self {
+    pub(crate) fn new(reg: SegmentRegister) -> Self {
         let p_mask = if (reg.present > 0) && (reg.unusable == 0) {
             DESC_P_MASK
         } else {
@@ -133,7 +133,7 @@ impl CpuSegment {
         }
     }
 
-    pub fn new_from_table(reg: DescriptorTable) -> Self {
+    pub(crate) fn new_from_table(reg: DescriptorTable) -> Self {
         CpuSegment {
             selector: 0,
             limit: reg.limit as u32,
@@ -146,7 +146,7 @@ impl CpuSegment {
 
 #[repr(C)]
 #[derive(Default, Copy, Clone)]
-pub struct CpuState {
+pub(crate) struct CpuState {
     pub version: u32,
     pub size: u32,
     /// rax, rbx, rcx, rdx, rsi, rdi, rsp, rbp
@@ -172,15 +172,15 @@ pub struct CpuState {
 // SAFETY: This is just a series of bytes
 unsafe impl ByteValued for CpuState {}
 
-pub enum NoteDescType {
+pub(crate) enum NoteDescType {
     Elf = 0,
     Vmm = 1,
     ElfAndVmm = 2,
 }
 
 // "CORE" or "QEMU"
-pub const COREDUMP_NAME_SIZE: u32 = 5;
-pub const NT_PRSTATUS: u32 = 1;
+pub(crate) const COREDUMP_NAME_SIZE: u32 = 5;
+pub(crate) const NT_PRSTATUS: u32 = 1;
 
 /// Core file.
 const ET_CORE: u16 = 4;
@@ -191,7 +191,7 @@ const EV_CURRENT: u8 = 1;
 /// AMD x86-64 architecture
 const EM_X86_64: u16 = 62;
 
-pub trait Elf64Writable {
+pub(crate) trait Elf64Writable {
     fn write_header(&mut self, dump_state: &DumpState) -> result::Result<(), GuestDebuggableError> {
         let e_ident = [
             elf::ELFMAG0, // magic
@@ -321,7 +321,7 @@ pub trait Elf64Writable {
     }
 }
 
-pub trait CpuElf64Writable {
+pub(crate) trait CpuElf64Writable {
     fn cpu_write_elf64_note(
         &mut self,
         _dump_state: &DumpState,

--- a/vmm/src/gdb.rs
+++ b/vmm/src/gdb.rs
@@ -59,7 +59,7 @@ pub enum DebuggableError {
     TranslateGva(#[source] cpu::Error),
 }
 
-pub trait Debuggable: vm_migration::Pausable {
+pub(crate) trait Debuggable: vm_migration::Pausable {
     fn set_guest_debug(
         &self,
         cpu_id: usize,
@@ -101,7 +101,7 @@ pub enum Error {
 type GdbResult<T> = result::Result<T, Error>;
 
 #[derive(Debug)]
-pub struct GdbRequest {
+pub(crate) struct GdbRequest {
     pub sender: mpsc::Sender<GdbResponse>,
     pub payload: GdbRequestPayload,
     pub cpu_id: usize,
@@ -120,7 +120,7 @@ pub enum GdbRequestPayload {
     ActiveVcpus,
 }
 
-pub type GdbResponse = result::Result<GdbResponsePayload, Error>;
+pub(crate) type GdbResponse = result::Result<GdbResponsePayload, Error>;
 
 #[derive(Debug)]
 pub enum GdbResponsePayload {
@@ -130,7 +130,7 @@ pub enum GdbResponsePayload {
     ActiveVcpus(usize),
 }
 
-pub struct GdbStub {
+pub(crate) struct GdbStub {
     gdb_sender: mpsc::Sender<GdbRequest>,
     gdb_event: eventfd::EventFd,
     vm_event: eventfd::EventFd,
@@ -139,7 +139,7 @@ pub struct GdbStub {
 }
 
 impl GdbStub {
-    pub fn new(
+    pub(crate) fn new(
         gdb_sender: mpsc::Sender<GdbRequest>,
         gdb_event: eventfd::EventFd,
         vm_event: eventfd::EventFd,
@@ -202,7 +202,7 @@ fn cpuid_to_tid(cpu_id: usize) -> Tid {
     Tid::new(get_raw_tid(cpu_id)).unwrap()
 }
 
-pub fn get_raw_tid(cpu_id: usize) -> usize {
+pub(crate) fn get_raw_tid(cpu_id: usize) -> usize {
     cpu_id + 1
 }
 
@@ -500,7 +500,7 @@ impl run_blocking::BlockingEventLoop for GdbEventLoop {
     }
 }
 
-pub fn gdb_thread(mut gdbstub: GdbStub, path: &path::Path) {
+pub(crate) fn gdb_thread(mut gdbstub: GdbStub, path: &path::Path) {
     let listener = match UnixListener::bind(path) {
         Ok(s) => s,
         Err(e) => {

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -65,7 +65,7 @@ const SNP_CPUID_LIMIT: u32 = 64;
 #[cfg(all(feature = "kvm", feature = "sev_snp"))]
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Eq, IntoBytes, FromBytes)]
-pub struct SnpCpuidFunc {
+struct SnpCpuidFunc {
     pub eax_in: u32,
     pub ecx_in: u32,
     pub xcr0_in: u64,
@@ -80,7 +80,7 @@ pub struct SnpCpuidFunc {
 #[cfg(all(feature = "kvm", feature = "sev_snp"))]
 #[repr(C)]
 #[derive(Debug, Clone, FromBytes, IntoBytes)]
-pub struct SnpCpuidInfo {
+struct SnpCpuidInfo {
     pub count: u32,
     pub _reserved1: u32,
     pub _reserved2: u64,
@@ -221,7 +221,7 @@ fn import_parameter(
 ///
 /// Extract guest policy from the IGVM initialization headers.
 #[cfg(feature = "sev_snp")]
-pub fn extract_guest_policy(igvm_file: &IgvmFile) -> Option<igvm_defs::SnpPolicy> {
+pub(crate) fn extract_guest_policy(igvm_file: &IgvmFile) -> Option<igvm_defs::SnpPolicy> {
     for header in igvm_file.initializations() {
         if let IgvmInitializationHeader::GuestPolicy { policy, .. } = header
             && *policy != 0
@@ -236,7 +236,7 @@ pub fn extract_guest_policy(igvm_file: &IgvmFile) -> Option<igvm_defs::SnpPolicy
 /// Extract sev_features from the boot CPU (vp_index 0) VMSA.
 ///
 #[cfg(feature = "sev_snp")]
-pub fn extract_sev_features(igvm_file: &IgvmFile) -> u64 {
+pub(crate) fn extract_sev_features(igvm_file: &IgvmFile) -> u64 {
     for header in igvm_file.directives() {
         if let IgvmDirectiveHeader::SnpVpContext { vp_index, vmsa, .. } = header
             && *vp_index == 0
@@ -257,7 +257,7 @@ pub fn extract_sev_features(igvm_file: &IgvmFile) -> u64 {
 /// Hypervisor-specific code paths are gated by runtime type checks. A future
 /// refactor could split these into separate KVM/MSHV loader implementations.
 #[expect(clippy::needless_pass_by_value)]
-pub fn load_igvm(
+pub(crate) fn load_igvm(
     igvm_file: IgvmFile,
     memory_manager: Arc<Mutex<MemoryManager>>,
     cpu_manager: Arc<Mutex<CpuManager>>,

--- a/vmm/src/igvm/loader.rs
+++ b/vmm/src/igvm/loader.rs
@@ -16,7 +16,7 @@ use crate::igvm::{BootPageAcceptance, HV_PAGE_SIZE, StartupMemoryType};
 /// Structure to hold the guest memory info/layout to check
 /// the if the memory is accepted within the layout.
 /// Adds up the total bytes written to the guest memory
-pub struct Loader {
+pub(super) struct Loader {
     memory: GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>,
     accepted_ranges: RangeMap<u64, BootPageAcceptance>,
     bytes_written: u64,
@@ -42,7 +42,7 @@ pub enum Error {
 }
 
 impl Loader {
-    pub fn new(memory: GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>) -> Loader {
+    pub(super) fn new(memory: GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>) -> Loader {
         Loader {
             memory,
             accepted_ranges: RangeMap::new(),
@@ -51,7 +51,7 @@ impl Loader {
     }
 
     /// Accept a new page range with a given acceptance into the map of accepted ranges.
-    pub fn accept_new_range(
+    pub(super) fn accept_new_range(
         &mut self,
         page_base: u64,
         page_count: u64,
@@ -75,7 +75,7 @@ impl Loader {
         }
     }
 
-    pub fn import_pages(
+    pub(super) fn import_pages(
         &mut self,
         page_base: u64,
         page_count: u64,
@@ -120,7 +120,7 @@ impl Loader {
         Ok(())
     }
 
-    pub fn verify_startup_memory_available(
+    pub(super) fn verify_startup_memory_available(
         &mut self,
         page_base: u64,
         page_count: u64,

--- a/vmm/src/igvm/mod.rs
+++ b/vmm/src/igvm/mod.rs
@@ -25,7 +25,7 @@
  *  booting a legacy VM, as well as SNP based isolated VM.
  */
 
-pub mod igvm_loader;
+pub(crate) mod igvm_loader;
 mod loader;
 use std::fs;
 use std::path::Path;
@@ -35,14 +35,14 @@ use igvm::{IgvmFile, IsolationType};
 use igvm_defs::IGVM_VHS_SNP_ID_BLOCK;
 use zerocopy::FromZeros;
 
-pub fn parse_igvm(igvm_path: &Path) -> Result<IgvmFile, igvm_loader::Error> {
+pub(crate) fn parse_igvm(igvm_path: &Path) -> Result<IgvmFile, igvm_loader::Error> {
     let file_contents = fs::read(igvm_path).map_err(igvm_loader::Error::Igvm)?;
     IgvmFile::new_from_binary(&file_contents, Some(IsolationType::Snp))
         .map_err(igvm_loader::Error::InvalidIgvmFile)
 }
 
 #[derive(Debug, Clone)]
-pub struct IgvmLoadedInfo {
+pub(crate) struct IgvmLoadedInfo {
     pub gpas: Vec<u64>,
     pub vmsa_gpa: u64,
     pub snp_id_block: IGVM_VHS_SNP_ID_BLOCK,
@@ -62,7 +62,7 @@ impl Default for IgvmLoadedInfo {
     }
 }
 
-pub const HV_PAGE_SIZE: u64 = 4096;
+pub(crate) const HV_PAGE_SIZE: u64 = 4096;
 
 /// The page acceptance used for importing pages into the initial launch context of the guest.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -86,7 +86,7 @@ pub enum BootPageAcceptance {
 /// The startup memory type used to notify a well behaved host that memory should be present before attempting to
 /// start the guest.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum StartupMemoryType {
+pub(crate) enum StartupMemoryType {
     /// The range is normal memory.
     Ram,
 }

--- a/vmm/src/landlock.rs
+++ b/vmm/src/landlock.rs
@@ -87,11 +87,7 @@ impl Landlock {
         Ok(Landlock { ruleset })
     }
 
-    pub(crate) fn add_rule(
-        &mut self,
-        path: &Path,
-        access: BitFlags<AccessFs>,
-    ) -> Result<(), LandlockError> {
+    fn add_rule(&mut self, path: &Path, access: BitFlags<AccessFs>) -> Result<(), LandlockError> {
         // path_beneath_rules in landlock crate handles file and directory access rules.
         // Incoming path/s are passed to path_beneath_rules, so that we don't
         // have to worry about the type of the path.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3445,7 +3445,7 @@ mod util {
     ///
     /// This mimics the error chain that we print on exit in CH or ch-remote for
     /// situations where we do not exit the program.
-    pub fn error_chain_messages(top_error: &dyn StdError) -> Vec<String> {
+    pub(crate) fn error_chain_messages(top_error: &dyn StdError) -> Vec<String> {
         iter::successors(Some(top_error), |sub_error| {
             // Dereference necessary to mitigate rustc compiler bug.
             // See <https://github.com/rust-lang/rust/issues/141673>
@@ -3459,7 +3459,7 @@ mod util {
 
     /// Flattens the chain of errors of a [`StdError`] into a single printable
     /// line.
-    pub fn flatten_error_chain_to_string(top_error: &dyn StdError) -> String {
+    pub(crate) fn flatten_error_chain_to_string(top_error: &dyn StdError) -> String {
         // Separator discussed here: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8510
         error_chain_messages(top_error).join(": ")
     }

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -1006,7 +1006,7 @@ pub enum TcpAddressParseError {
 /// The expected format is `<host>:<port>` for hostnames and IPv4 addresses, or
 /// `[<ipv6-address>]:<port>` for IPv6 addresses. The host and port must both be
 /// present, and the port must parse as a `u16`.
-pub fn tcp_address_to_server_name(address: &str) -> Result<&str, TcpAddressParseError> {
+pub(crate) fn tcp_address_to_server_name(address: &str) -> Result<&str, TcpAddressParseError> {
     let (host, port) = if let Some(rest) = address.strip_prefix('[') {
         let (host, rest) = rest
             .split_once(']')

--- a/vmm/src/migration/worker.rs
+++ b/vmm/src/migration/worker.rs
@@ -32,7 +32,7 @@ use crate::vm::{Vm, VmState};
 
 #[derive(thiserror::Error)]
 #[error("Migration worker could not be spawned: {spawn_error}")]
-pub struct MigrationWorkerSpawnError {
+pub(crate) struct MigrationWorkerSpawnError {
     pub spawn_error: io::Error,
     pub vm: Vm,
 }
@@ -46,12 +46,12 @@ impl Debug for MigrationWorkerSpawnError {
     }
 }
 
-pub struct MigrationWorkerHandle {
+pub(crate) struct MigrationWorkerHandle {
     handle: Option<JoinHandle<MigrationWorkerResult>>,
 }
 
 impl MigrationWorkerHandle {
-    pub fn join(mut self) -> MigrationWorkerResult {
+    pub(crate) fn join(mut self) -> MigrationWorkerResult {
         self.handle
             .take()
             .expect("should have thread")
@@ -70,13 +70,13 @@ impl Drop for MigrationWorkerHandle {
 }
 
 #[derive(Clone, Debug)]
-pub struct MigrationSeccompFilters {
+pub(crate) struct MigrationSeccompFilters {
     pub worker: BpfProgram,
     pub tcp_worker: BpfProgram,
     pub postcopy_server: BpfProgram,
 }
 
-pub struct MigrationWorker {
+pub(crate) struct MigrationWorker {
     // Keep the VM out of the thread closure until spawning succeeds.
     vm_receiver: Receiver<Vm>,
     check_migration_evt: EventFd,
@@ -135,7 +135,7 @@ impl MigrationWorker {
     // All code paths need special care to prevent any panic and thus losing the
     // VM in case of failure.
     #[expect(clippy::result_large_err)]
-    pub fn spawn(
+    pub(crate) fn spawn(
         vm: Vm,
         check_migration_evt: EventFd,
         config: VmSendMigrationData,
@@ -178,7 +178,7 @@ impl MigrationWorker {
 }
 
 /// Return value of [`MigrationWorker`].
-pub struct MigrationWorkerResult {
+pub(crate) struct MigrationWorkerResult {
     /// The VM that was migrated.
     ///
     /// If `migration_result` is `Ok`, the VM is paused and can be deleted

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -195,7 +195,7 @@ impl PciSegment {
         ))
     }
 
-    pub fn reserve_legacy_interrupts_for_pci_devices(
+    pub(crate) fn reserve_legacy_interrupts_for_pci_devices(
         address_manager: &Arc<AddressManager>,
         pci_irq_slots: &mut [u8; 32],
     ) -> DeviceManagerResult<()> {
@@ -228,7 +228,7 @@ impl PciSegment {
     /// An [`AddressManager`] would otherwise be required to create
     /// [`PciBus`] instances. Instead, we use any struct that implements
     /// [`DeviceRelocation`] to instantiate a [`PciBus`].
-    pub(crate) fn new_without_address_manager(
+    fn new_without_address_manager(
         id: u16,
         numa_node: u32,
         mem32_allocator: Arc<Mutex<AddressAllocator>>,

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -89,56 +89,56 @@ const VFIO_DEVICE_FEATURE: u64 = 0x3b75;
 // See include/uapi/linux/kvm.h in the kernel code.
 #[cfg(feature = "kvm")]
 mod kvm {
-    pub const KVM_GET_API_VERSION: u64 = 0xae00;
-    pub const KVM_CREATE_VM: u64 = 0xae01;
-    pub const KVM_CHECK_EXTENSION: u64 = 0xae03;
-    pub const KVM_GET_VCPU_MMAP_SIZE: u64 = 0xae04;
-    pub const KVM_CREATE_VCPU: u64 = 0xae41;
-    pub const KVM_CREATE_IRQCHIP: u64 = 0xae60;
-    pub const KVM_RUN: u64 = 0xae80;
-    pub const KVM_SET_MP_STATE: u64 = 0x4004_ae99;
-    pub const KVM_SET_GSI_ROUTING: u64 = 0x4008_ae6a;
-    pub const KVM_SET_DEVICE_ATTR: u64 = 0x4018_aee1;
-    pub const KVM_HAS_DEVICE_ATTR: u64 = 0x4018_aee3;
-    pub const KVM_SET_ONE_REG: u64 = 0x4010_aeac;
-    pub const KVM_SET_USER_MEMORY_REGION: u64 = 0x4020_ae46;
-    pub const KVM_SET_USER_MEMORY_REGION2: u64 = 0x40a0_ae49;
-    pub const KVM_SET_MEMORY_ATTRIBUTES: u64 = 0x4020_aed2;
-    pub const KVM_CREATE_GUEST_MEMFD: u64 = 0xc040_aed4;
-    pub const KVM_IRQFD: u64 = 0x4020_ae76;
-    pub const KVM_IOEVENTFD: u64 = 0x4040_ae79;
-    pub const KVM_SET_VCPU_EVENTS: u64 = 0x4040_aea0;
-    pub const KVM_ENABLE_CAP: u64 = 0x4068_aea3;
-    pub const KVM_SET_REGS: u64 = 0x4090_ae82;
-    pub const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
-    pub const KVM_GET_DEVICE_ATTR: u64 = 0x4018_aee2;
-    pub const KVM_GET_DIRTY_LOG: u64 = 0x4010_ae42;
-    pub const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
-    pub const KVM_GET_ONE_REG: u64 = 0x4010_aeab;
-    pub const KVM_GET_REGS: u64 = 0x8090_ae81;
-    pub const KVM_GET_SUPPORTED_CPUID: u64 = 0xc008_ae05;
-    pub const KVM_CREATE_DEVICE: u64 = 0xc00c_aee0;
-    pub const KVM_GET_REG_LIST: u64 = 0xc008_aeb0;
-    pub const KVM_MEMORY_ENCRYPT_OP: u64 = 0xc008_aeba;
-    pub const KVM_NMI: u64 = 0xae9a;
-    pub const KVM_GET_NESTED_STATE: u64 = 3229658814;
-    pub const KVM_SET_NESTED_STATE: u64 = 1082175167;
-    pub const KVM_SEV_SNP_LAUNCH_START: u64 = 0x4018_aeb4;
-    pub const KVM_SEV_SNP_LAUNCH_UPDATE: u64 = 0x8018_aeb5;
-    pub const KVM_SEV_SNP_LAUNCH_FINISH: u64 = 0x4008_aeb7;
+    pub(super) const KVM_GET_API_VERSION: u64 = 0xae00;
+    pub(super) const KVM_CREATE_VM: u64 = 0xae01;
+    pub(super) const KVM_CHECK_EXTENSION: u64 = 0xae03;
+    pub(super) const KVM_GET_VCPU_MMAP_SIZE: u64 = 0xae04;
+    pub(super) const KVM_CREATE_VCPU: u64 = 0xae41;
+    pub(super) const KVM_CREATE_IRQCHIP: u64 = 0xae60;
+    pub(super) const KVM_RUN: u64 = 0xae80;
+    pub(super) const KVM_SET_MP_STATE: u64 = 0x4004_ae99;
+    pub(super) const KVM_SET_GSI_ROUTING: u64 = 0x4008_ae6a;
+    pub(super) const KVM_SET_DEVICE_ATTR: u64 = 0x4018_aee1;
+    pub(super) const KVM_HAS_DEVICE_ATTR: u64 = 0x4018_aee3;
+    pub(super) const KVM_SET_ONE_REG: u64 = 0x4010_aeac;
+    pub(super) const KVM_SET_USER_MEMORY_REGION: u64 = 0x4020_ae46;
+    pub(super) const KVM_SET_USER_MEMORY_REGION2: u64 = 0x40a0_ae49;
+    pub(super) const KVM_SET_MEMORY_ATTRIBUTES: u64 = 0x4020_aed2;
+    pub(super) const KVM_CREATE_GUEST_MEMFD: u64 = 0xc040_aed4;
+    pub(super) const KVM_IRQFD: u64 = 0x4020_ae76;
+    pub(super) const KVM_IOEVENTFD: u64 = 0x4040_ae79;
+    pub(super) const KVM_SET_VCPU_EVENTS: u64 = 0x4040_aea0;
+    pub(super) const KVM_ENABLE_CAP: u64 = 0x4068_aea3;
+    pub(super) const KVM_SET_REGS: u64 = 0x4090_ae82;
+    pub(super) const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
+    pub(super) const KVM_GET_DEVICE_ATTR: u64 = 0x4018_aee2;
+    pub(super) const KVM_GET_DIRTY_LOG: u64 = 0x4010_ae42;
+    pub(super) const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
+    pub(super) const KVM_GET_ONE_REG: u64 = 0x4010_aeab;
+    pub(super) const KVM_GET_REGS: u64 = 0x8090_ae81;
+    pub(super) const KVM_GET_SUPPORTED_CPUID: u64 = 0xc008_ae05;
+    pub(super) const KVM_CREATE_DEVICE: u64 = 0xc00c_aee0;
+    pub(super) const KVM_GET_REG_LIST: u64 = 0xc008_aeb0;
+    pub(super) const KVM_MEMORY_ENCRYPT_OP: u64 = 0xc008_aeba;
+    pub(super) const KVM_NMI: u64 = 0xae9a;
+    pub(super) const KVM_GET_NESTED_STATE: u64 = 3229658814;
+    pub(super) const KVM_SET_NESTED_STATE: u64 = 1082175167;
+    pub(super) const KVM_SEV_SNP_LAUNCH_START: u64 = 0x4018_aeb4;
+    pub(super) const KVM_SEV_SNP_LAUNCH_UPDATE: u64 = 0x8018_aeb5;
+    pub(super) const KVM_SEV_SNP_LAUNCH_FINISH: u64 = 0x4008_aeb7;
 }
 
 mod iommufd {
     // See include/uapi/linux/iommufd.h in the kernel code.
-    pub const IOMMU_DESTROY: u64 = 0x3b80;
-    pub const IOMMU_IOAS_ALLOC: u64 = 0x3b81;
-    pub const IOMMU_IOAS_MAP: u64 = 0x3b85;
-    pub const IOMMU_IOAS_UNMAP: u64 = 0x3b86;
+    pub(super) const IOMMU_DESTROY: u64 = 0x3b80;
+    pub(super) const IOMMU_IOAS_ALLOC: u64 = 0x3b81;
+    pub(super) const IOMMU_IOAS_MAP: u64 = 0x3b85;
+    pub(super) const IOMMU_IOAS_UNMAP: u64 = 0x3b86;
 
     // See include/uapi/linux/vfio.h in the kernel code.
-    pub const VFIO_DEVICE_BIND_IOMMUFD: u64 = 0x3b76;
-    pub const VFIO_DEVICE_ATTACH_IOMMUFD_PT: u64 = 0x3b77;
-    pub const VFIO_DEVICE_DETACH_IOMMUFD_PT: u64 = 0x3b78;
+    pub(super) const VFIO_DEVICE_BIND_IOMMUFD: u64 = 0x3b76;
+    pub(super) const VFIO_DEVICE_ATTACH_IOMMUFD_PT: u64 = 0x3b77;
+    pub(super) const VFIO_DEVICE_DETACH_IOMMUFD_PT: u64 = 0x3b78;
 }
 
 // Block device ioctls (not exported by libc)

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -88,11 +88,11 @@ pub enum Error {
     #[error("Error applying seccomp filter")]
     ApplySeccompFilter(#[source] seccompiler::Error),
 }
-pub type Result<T> = result::Result<T, Error>;
+pub(crate) type Result<T> = result::Result<T, Error>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u64)]
-pub enum EpollDispatch {
+pub(crate) enum EpollDispatch {
     File = 0,
     Kill = 1,
     Socket = 2,
@@ -112,7 +112,7 @@ impl From<u64> for EpollDispatch {
     }
 }
 
-pub struct SerialManager {
+pub(crate) struct SerialManager {
     #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
     serial: Arc<Mutex<Serial>>,
     #[cfg(target_arch = "aarch64")]
@@ -162,7 +162,7 @@ impl SocketConsole {
 }
 
 impl SerialManager {
-    pub fn new(
+    pub(crate) fn new(
         #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))] serial: Arc<Mutex<Serial>>,
         #[cfg(target_arch = "aarch64")] serial: Arc<Mutex<Pl011>>,
         mut transport: ConsoleTransport,
@@ -308,7 +308,7 @@ impl SerialManager {
         Ok(())
     }
 
-    pub fn start_thread(
+    pub(crate) fn start_thread(
         &mut self,
         exit_evt: EventFd,
         seccomp_action: &SeccompAction,

--- a/vmm/src/sev.rs
+++ b/vmm/src/sev.rs
@@ -23,8 +23,8 @@ use zerocopy::{Immutable, IntoBytes};
 pub(crate) type Result<T> = result::Result<T, errno::Error>;
 
 // https://github.com/tianocore/edk2/blob/f98662c5e35b6ab60f46ee4350fa0e6eab0497cf/OvmfPkg/Include/Fdf/MemFd.fdf.inc#L89-L93
-pub const SEV_HASH_BLOCK_ADDRESS: u64 = 0x10c00;
-pub const SEV_HASH_BLOCK_SIZE: usize = 0x400;
+pub(crate) const SEV_HASH_BLOCK_ADDRESS: u64 = 0x10c00;
+pub(crate) const SEV_HASH_BLOCK_SIZE: usize = 0x400;
 const SHA256_HASH_SIZE: usize = 32;
 
 // Measured hashes table definitions. These match the definitions found in
@@ -51,7 +51,7 @@ const SEV_HASH_TABLE_PADDING: usize =
     size_of::<SevHashTable>().next_multiple_of(16) - size_of::<SevHashTable>();
 
 #[derive(IntoBytes, Immutable)]
-pub struct PaddedSevHashTable {
+struct PaddedSevHashTable {
     #[expect(dead_code)]
     hash_table: SevHashTable,
     #[expect(dead_code)]
@@ -66,7 +66,7 @@ const SEV_KERNEL_HASH_GUID: Uuid = uuid!("4de79437-abd2-427f-b835-d5b172d2045b")
 const SEV_INITRD_HASH_GUID: Uuid = uuid!("44baf731-3a2f-4bd7-9af1-41e29169781d");
 const SEV_CMDLINE_HASH_GUID: Uuid = uuid!("97d02dd8-bd20-4c94-aa78-e7714d36ab2a");
 
-pub struct MeasuredBootInfo {
+pub(crate) struct MeasuredBootInfo {
     pub kernel: File,
     // QEMU also makes initrd optional in the hash table
     pub initramfs: Option<File>,
@@ -94,7 +94,7 @@ impl MeasuredBootInfo {
         Ok(hasher.finalize().into())
     }
 
-    pub fn build_hash_block(&self) -> Result<[u8; SEV_HASH_BLOCK_SIZE]> {
+    pub(crate) fn build_hash_block(&self) -> Result<[u8; SEV_HASH_BLOCK_SIZE]> {
         // Current tooling appends a NUL byte at the end of cmdlines:
         // https://github.com/virtee/sev-snp-measure/blob/main/sevsnpmeasure/sev_hashes.py#L71-L74
         let cmdline_digest: [u8; 32] = Sha256::digest(self.cmdline.as_bytes_with_nul()).into();
@@ -231,17 +231,17 @@ struct Inner {
 /// Tracks which confidential guest pages are shared and keeps the device
 /// IOMMU mapping exactly those pages.
 #[derive(Default)]
-pub struct SevSnpSharedPageTracker {
+pub(crate) struct SevSnpSharedPageTracker {
     inner: Mutex<Inner>,
 }
 
 impl SevSnpSharedPageTracker {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
     /// Register a confidential RAM region `[base, base + size)`.
-    pub fn register_region(&self, base: u64, size: u64) {
+    pub(crate) fn register_region(&self, base: u64, size: u64) {
         self.inner
             .lock()
             .unwrap()
@@ -252,7 +252,7 @@ impl SevSnpSharedPageTracker {
     /// Register a VFIO DMA handler, replaying the currently shared pages into it.
     /// A partial replay is rolled back, so a failed registration leaves nothing
     /// mapped in the IOMMU.
-    pub fn add_dma_mapping_handler(
+    pub(crate) fn add_dma_mapping_handler(
         &self,
         handler: Arc<dyn ExternalDmaMapping>,
     ) -> anyhow::Result<()> {
@@ -286,7 +286,7 @@ impl SevSnpSharedPageTracker {
     }
 
     /// Drop the registered DMA handler.
-    pub fn clear_dma_mapping_handler(&self) {
+    pub(crate) fn clear_dma_mapping_handler(&self) {
         self.inner.lock().unwrap().handler = None;
     }
 

--- a/vmm/src/sigwinch_listener.rs
+++ b/vmm/src/sigwinch_listener.rs
@@ -241,7 +241,7 @@ unsafe fn clone_clear_sighand() -> io::Result<u64> {
     Ok(r.try_into().unwrap())
 }
 
-pub fn start_sigwinch_listener(seccomp_filter: BpfProgramRef, tty_sub: File) -> io::Result<File> {
+fn start_sigwinch_listener(seccomp_filter: BpfProgramRef, tty_sub: File) -> io::Result<File> {
     let mut pipe = [-1; 2];
     // SAFETY: FFI call with valid arguments
     if unsafe { pipe2(pipe.as_mut_ptr(), O_CLOEXEC) } == -1 {
@@ -266,7 +266,7 @@ pub fn start_sigwinch_listener(seccomp_filter: BpfProgramRef, tty_sub: File) -> 
     Ok(rx)
 }
 
-pub fn listen_for_sigwinch_on_tty(
+pub(crate) fn listen_for_sigwinch_on_tty(
     pty_sub: File,
     seccomp_action: &SeccompAction,
 ) -> io::Result<File> {

--- a/vmm/src/sync_utils.rs
+++ b/vmm/src/sync_utils.rs
@@ -11,7 +11,7 @@ use std::sync::{Condvar, Mutex};
 /// there, e.g. if one worker signals that an error occurred and thus cannot
 /// continue.
 #[derive(Debug)]
-pub struct Gate {
+pub(crate) struct Gate {
     /// True if the gate is open, false otherwise.
     open: Mutex<bool>,
     /// Used to notify waiting threads.
@@ -19,7 +19,7 @@ pub struct Gate {
 }
 
 impl Gate {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             open: Mutex::new(false),
             cv: Condvar::new(),
@@ -27,7 +27,7 @@ impl Gate {
     }
 
     /// Wait at the gate. Only blocks if the gate is not opened.
-    pub fn wait(&self) {
+    pub(crate) fn wait(&self) {
         let mut open = self.open.lock().unwrap();
         while !*open {
             open = self.cv.wait(open).unwrap();
@@ -35,7 +35,7 @@ impl Gate {
     }
 
     /// Open the gate, releasing all waiting threads.
-    pub fn open(&self) {
+    pub(crate) fn open(&self) {
         let mut open = self.open.lock().unwrap();
         *open = true;
         self.cv.notify_all();

--- a/vmm/src/uffd.rs
+++ b/vmm/src/uffd.rs
@@ -25,14 +25,14 @@ use crate::migration::transport::SocketStream;
 use crate::userfaultfd;
 
 #[repr(C)]
-pub(crate) struct UffdioApi {
+struct UffdioApi {
     pub api: u64,
     pub features: u64,
     pub ioctls: u64,
 }
 
 #[repr(C)]
-pub(crate) struct UffdioRegister {
+struct UffdioRegister {
     pub range_start: u64,
     pub range_len: u64,
     pub mode: u64,
@@ -40,7 +40,7 @@ pub(crate) struct UffdioRegister {
 }
 
 #[repr(C)]
-pub(crate) struct UffdioCopy {
+struct UffdioCopy {
     pub dst: u64,
     pub src: u64,
     pub len: u64,
@@ -49,7 +49,7 @@ pub(crate) struct UffdioCopy {
 }
 
 #[repr(C)]
-pub(crate) struct UffdioContinue {
+struct UffdioContinue {
     pub range_start: u64,
     pub range_len: u64,
     pub mode: u64,
@@ -234,19 +234,19 @@ pub(crate) struct UffdRange {
 }
 
 impl UffdRange {
-    pub fn num_pages(&self) -> u64 {
+    pub(crate) fn num_pages(&self) -> u64 {
         self.length.div_ceil(self.page_size)
     }
 
-    pub fn page_addr(&self, page_idx: u64) -> u64 {
+    pub(crate) fn page_addr(&self, page_idx: u64) -> u64 {
         self.host_addr + page_idx * self.page_size
     }
 
-    pub fn page_source_offset(&self, page_idx: u64) -> u64 {
+    pub(crate) fn page_source_offset(&self, page_idx: u64) -> u64 {
         self.source_offset + page_idx * self.page_size
     }
 
-    pub fn page_index_of(&self, addr: u64) -> Option<u64> {
+    pub(crate) fn page_index_of(&self, addr: u64) -> Option<u64> {
         let page_addr = addr & !(self.page_size - 1);
         (page_addr >= self.host_addr && page_addr < self.host_addr + self.length)
             .then(|| (page_addr - self.host_addr) / self.page_size)
@@ -280,7 +280,7 @@ pub(crate) struct FileUffdMemorySource {
 }
 
 impl FileUffdMemorySource {
-    pub fn new(file: File) -> Self {
+    pub(crate) fn new(file: File) -> Self {
         Self {
             file,
             buf: Vec::new(),
@@ -332,7 +332,7 @@ pub(crate) struct SocketUffdMemorySource {
 }
 
 impl SocketUffdMemorySource {
-    pub fn new(stream: SocketStream, shared_backing: bool) -> Self {
+    pub(crate) fn new(stream: SocketStream, shared_backing: bool) -> Self {
         Self {
             stream,
             shared_backing,

--- a/vmm/src/userfaultfd.rs
+++ b/vmm/src/userfaultfd.rs
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // See include/uapi/linux/userfaultfd.h in the kernel code.
-pub const UFFDIO_API: u64 = 0xc018_aa3f; // _IOWR(0xAA, 0x3F, struct uffdio_api)
-pub const UFFDIO_REGISTER: u64 = 0xc020_aa00; // _IOWR(0xAA, 0x00, struct uffdio_register)
-pub const UFFDIO_COPY: u64 = 0xc028_aa03; // _IOWR(0xAA, 0x03, struct uffdio_copy)
-pub const UFFDIO_WAKE: u64 = 0x8010_aa02; // _IOR(0xAA, 0x02, struct uffdio_range)
-pub const UFFDIO_CONTINUE: u64 = 0xc020_aa07; // _IOWR(0xAA, 0x07, struct uffdio_continue)
+pub(crate) const UFFDIO_API: u64 = 0xc018_aa3f; // _IOWR(0xAA, 0x3F, struct uffdio_api)
+pub(crate) const UFFDIO_REGISTER: u64 = 0xc020_aa00; // _IOWR(0xAA, 0x00, struct uffdio_register)
+pub(crate) const UFFDIO_COPY: u64 = 0xc028_aa03; // _IOWR(0xAA, 0x03, struct uffdio_copy)
+pub(crate) const UFFDIO_WAKE: u64 = 0x8010_aa02; // _IOR(0xAA, 0x02, struct uffdio_range)
+pub(crate) const UFFDIO_CONTINUE: u64 = 0xc020_aa07; // _IOWR(0xAA, 0x07, struct uffdio_continue)
 
 // Validate ioctl encoding against the _IO{R,W,WR}(type, nr, size) formula so
 // transposed direction bits or sizes are caught at compile time.
@@ -30,21 +30,22 @@ const _: () = assert!(UFFDIO_WAKE <= u32::MAX as u64);
 const _: () = assert!(UFFDIO_CONTINUE <= u32::MAX as u64);
 
 // /dev/userfaultfd ioctl: _IO(0xAA, 0x00)
-pub const USERFAULTFD_IOC_NEW: u64 = 0x0000_AA00;
+pub(crate) const USERFAULTFD_IOC_NEW: u64 = 0x0000_AA00;
 const _: () = assert!(USERFAULTFD_IOC_NEW == ioctl_ioc(0, 0xAA, 0x00, 0));
 const _: () = assert!(USERFAULTFD_IOC_NEW <= u32::MAX as u64);
 
-pub const UFFD_API: u64 = 0xAA;
-pub const UFFDIO_REGISTER_MODE_MISSING: u64 = 1;
-pub const UFFDIO_REGISTER_MODE_MINOR: u64 = 1 << 2;
-pub const UFFD_EVENT_PAGEFAULT: u8 = 0x12;
-pub const UFFD_FEATURE_MISSING_HUGETLBFS: u64 = 1 << 4;
-pub const UFFD_FEATURE_MISSING_SHMEM: u64 = 1 << 5;
-pub const UFFD_FEATURE_MINOR_HUGETLBFS: u64 = 1 << 9;
-pub const UFFD_FEATURE_MINOR_SHMEM: u64 = 1 << 10;
+pub(crate) const UFFD_API: u64 = 0xAA;
+pub(crate) const UFFDIO_REGISTER_MODE_MISSING: u64 = 1;
+pub(crate) const UFFDIO_REGISTER_MODE_MINOR: u64 = 1 << 2;
+pub(crate) const UFFD_EVENT_PAGEFAULT: u8 = 0x12;
+pub(crate) const UFFD_FEATURE_MISSING_HUGETLBFS: u64 = 1 << 4;
+pub(crate) const UFFD_FEATURE_MISSING_SHMEM: u64 = 1 << 5;
+pub(crate) const UFFD_FEATURE_MINOR_HUGETLBFS: u64 = 1 << 9;
+pub(crate) const UFFD_FEATURE_MINOR_SHMEM: u64 = 1 << 10;
 
 const _UFFDIO_COPY: u64 = 0x03;
 const _UFFDIO_WAKE: u64 = 0x02;
 const _UFFDIO_CONTINUE: u64 = 0x07;
-pub const UFFD_API_RANGE_IOCTLS_BASIC: u64 = (1 << _UFFDIO_WAKE) | (1 << _UFFDIO_COPY);
-pub const UFFD_API_RANGE_IOCTLS_MINOR: u64 = UFFD_API_RANGE_IOCTLS_BASIC | (1 << _UFFDIO_CONTINUE);
+pub(crate) const UFFD_API_RANGE_IOCTLS_BASIC: u64 = (1 << _UFFDIO_WAKE) | (1 << _UFFDIO_COPY);
+pub(crate) const UFFD_API_RANGE_IOCTLS_MINOR: u64 =
+    UFFD_API_RANGE_IOCTLS_BASIC | (1 << _UFFDIO_CONTINUE);

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3915,7 +3915,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_vm() {
+    pub(crate) fn test_vm() {
         use hypervisor::VmExit;
         use vm_memory::{Address, GuestMemoryBackend, GuestMemoryRegion};
         // This example based on https://lwn.net/Articles/658511/


### PR DESCRIPTION
Cleans up unreachable usages of `pub` and enables [`unreachable_pub`](https://doc.rust-lang.org/beta/nightly-rustc/rustc_lint/builtin/static.UNREACHABLE_PUB.html) to prevent reintroducing unreachable `pub` again.

Description from the `unreachable_pub` doc since that explains is better than I can paraphrase:

> The pub keyword both expresses an intent for an item to be publicly available, and also signals to the compiler to make the item publicly accessible. The intent can only be satisfied, however, if all items which contain this item are also publicly accessible. Thus, this lint serves to identify situations where the intent does not match the reality.
>
> If you wish the item to be accessible elsewhere within the crate, but not outside it, the pub(crate) visibility is recommended to be used instead. This more clearly expresses the intent that the item is only visible within its own crate.
> 
> This lint is “allow” by default because it will trigger for a large amount of existing Rust code. Eventually it is desired for this to become warn-by-default.

Also fixes a broken link for CI.