### PR TITLE
seccomp: Determine target architecture at compile time

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -4,8 +4,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-
 use block::{BLKDISCARD, BLKZEROOUT};
 use libc::{FIONBIO, TIOCGWINSZ, TUNSETOFFLOAD};
 use seccompiler::SeccompCmpOp::{Eq, MaskedEq};
@@ -406,13 +404,20 @@ pub fn get_seccomp_filter(
     seccomp_action: &SeccompAction,
     thread_type: Thread,
 ) -> Result<BpfProgram, Error> {
+    #[cfg(target_arch = "x86_64")]
+    let target_arch = seccompiler::TargetArch::x86_64;
+    #[cfg(target_arch = "aarch64")]
+    let target_arch = seccompiler::TargetArch::aarch64;
+    #[cfg(target_arch = "riscv64")]
+    let target_arch = seccompiler::TargetArch::riscv64;
+
     match seccomp_action {
         SeccompAction::Allow => Ok(vec![]),
         _ => SeccompFilter::new(
             get_seccomp_rules(thread_type).into_iter().collect(),
             seccomp_action.clone(),
             SeccompAction::Allow,
-            env::consts::ARCH.try_into().unwrap(),
+            target_arch,
         )
         .and_then(|filter| filter.try_into())
         .map_err(Error::Backend),

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -4,8 +4,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env::consts;
-
 use hypervisor::HypervisorType;
 use libc::{
     BLKIOMIN, BLKIOOPT, BLKPBSZGET, BLKSSZGET, FIOCLEX, FIONBIO, SIOCGIFFLAGS, SIOCGIFHWADDR,
@@ -1262,6 +1260,13 @@ pub fn get_seccomp_filter(
     thread_type: Thread,
     hypervisor_type: Option<HypervisorType>,
 ) -> Result<BpfProgram, Error> {
+    #[cfg(target_arch = "x86_64")]
+    let target_arch = seccompiler::TargetArch::x86_64;
+    #[cfg(target_arch = "aarch64")]
+    let target_arch = seccompiler::TargetArch::aarch64;
+    #[cfg(target_arch = "riscv64")]
+    let target_arch = seccompiler::TargetArch::riscv64;
+
     match seccomp_action {
         SeccompAction::Allow => Ok(vec![]),
         _ => SeccompFilter::new(
@@ -1271,7 +1276,7 @@ pub fn get_seccomp_filter(
                 .collect(),
             seccomp_action.clone(),
             SeccompAction::Allow,
-            consts::ARCH.try_into().unwrap(),
+            target_arch,
         )
         .and_then(|filter| filter.try_into())
         .map_err(Error::Backend),


### PR DESCRIPTION
Currently, get_seccomp_filter calls env::consts::ARCH.try_into().unwrap() to determine the target architecture for BPF filter construction.

In cross-compilation environments (e.g. building for aarch64 on an x86_64 build host), std::env::consts::ARCH may evaluate to the host architecture rather than the target architecture. This embeds an x86_64 architecture audit check in the BPF bytecode, causing all system calls to immediately trap with SIGSYS when run on an AArch64 host.

Replace runtime string parsing with compile-time cfg(target_arch) selection. This guarantees that the correct architecture is embedded in the filter, eliminates runtime string parsing, and removes the unwrap().

Assisted-by: Jetski:Gemini