### PR TITLE
vmm: Reuse seccomp filter across vCPU threads

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -68,7 +68,7 @@ use libc::{c_void, siginfo_t};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use linux_loader::elf::Elf64_Nhdr;
 use log::{debug, error, info, warn};
-use seccompiler::{SeccompAction, apply_filter};
+use seccompiler::{BpfProgram, SeccompAction, apply_filter};
 use thiserror::Error;
 use tracer::trace_scoped;
 use vm_device::BusDevice;
@@ -1189,6 +1189,7 @@ impl CpuManager {
         vcpu: Arc<Mutex<Vcpu>>,
         vcpu_id: u32,
         vcpu_thread_barrier: Arc<Barrier>,
+        vcpu_seccomp_filter: Arc<BpfProgram>,
         inserting: bool,
     ) -> Result<()> {
         let reset_evt = self.reset_evt.try_clone().map_err(Error::EventFdClone)?;
@@ -1233,14 +1234,6 @@ impl CpuManager {
 
         let core_scheduling = self.config.core_scheduling;
         let core_scheduling_group_leader = self.core_scheduling_group_leader.clone();
-
-        // Retrieve seccomp filter for vcpu thread
-        let vcpu_seccomp_filter = get_seccomp_filter(
-            &self.seccomp_action,
-            Thread::Vcpu,
-            Some(self.hypervisor.hypervisor_type()),
-        )
-        .map_err(Error::CreateSeccompFilter)?;
 
         #[cfg(target_arch = "x86_64")]
         let interrupt_controller_clone = self.interrupt_controller.as_ref().cloned();
@@ -1519,9 +1512,9 @@ impl CpuManager {
             return Err(Error::DesiredVCpuCountExceedsMax);
         }
 
-        let vcpu_thread_barrier = Arc::new(Barrier::new(
-            (desired_vcpus - self.present_vcpus() + 1) as usize,
-        ));
+        let present_vcpus = self.present_vcpus();
+        let vcpu_thread_barrier =
+            Arc::new(Barrier::new((desired_vcpus - present_vcpus + 1) as usize));
 
         if let Some(paused) = paused {
             self.vcpus_pause_signalled.store(paused, Ordering::SeqCst);
@@ -1531,14 +1524,31 @@ impl CpuManager {
             "Starting vCPUs: desired = {}, allocated = {}, present = {}, paused = {}",
             desired_vcpus,
             self.vcpus.len(),
-            self.present_vcpus(),
+            present_vcpus,
             self.vcpus_pause_signalled.load(Ordering::SeqCst)
         );
 
-        // This reuses any inactive vCPUs as well as any that were newly created
-        for vcpu_id in self.present_vcpus()..desired_vcpus {
-            let vcpu = Arc::clone(&self.vcpus[vcpu_id as usize]);
-            self.start_vcpu(vcpu, vcpu_id, vcpu_thread_barrier.clone(), inserting)?;
+        if present_vcpus < desired_vcpus {
+            let vcpu_seccomp_filter = Arc::new(
+                get_seccomp_filter(
+                    &self.seccomp_action,
+                    Thread::Vcpu,
+                    Some(self.hypervisor.hypervisor_type()),
+                )
+                .map_err(Error::CreateSeccompFilter)?,
+            );
+
+            // This reuses any inactive vCPUs as well as any that were newly created
+            for vcpu_id in present_vcpus..desired_vcpus {
+                let vcpu = self.vcpus[vcpu_id as usize].clone();
+                self.start_vcpu(
+                    vcpu,
+                    vcpu_id,
+                    vcpu_thread_barrier.clone(),
+                    vcpu_seccomp_filter.clone(),
+                    inserting,
+                )?;
+            }
         }
 
         // Unblock all CPU threads.


### PR DESCRIPTION
Compile the vCPU seccomp filter once per activation batch and share the immutable BPF program through `Arc<BpfProgram>`. Each vCPU thread still installs the filter independently. Boot, restore, and hotplug use the same activation path; batches that start no vCPUs skip compilation.

The measurements in #8845 reduced vCPU-specific `get_seccomp_filter()` calls from 16 to 1 for a 16-vCPU boot, and process-wide calls from 18 to 3, saving roughly 300 microseconds of control-thread work. There are no API or CLI changes, and the installed filter and its security semantics are unchanged.

Validation on this branch:

- `cargo +nightly fmt --all -- --check`
- `cargo check --locked -p vmm --features kvm --all-targets`
- `cargo clippy --locked -p vmm --features kvm --all-targets -- -D warnings`
- Clean merge with current upstream `main`.

Benchmarks

  | vCPUs | Paired runs | Baseline (ms) | Patched (ms) | Speedup (ms) | 95% CI (ms) |
  | ---: | ---: | ---: | ---: | ---: | ---: |
  | 4 | 150 | 98.908 | 98.834 | +0.074 | −0.730 to +0.881 |
  | 8 | 150 | 109.706 | 109.180 | +0.527 | −0.388 to +1.413 |
  | 16 | 250 | 128.812 | 128.239 | +0.573 | −0.251 to +1.403 |
  | 64 | 500 | 273.416 | 273.790 | −0.374 | −2.076 to +1.380 |
  | 128 | 450 | 545.801 | 547.670 | −1.870 | −3.338 to −0.375 |

Prior validation recorded in #8845 includes workspace checks and Clippy, vMM CPU/KVM unit tests, and 16-vCPU smoke boots with seccomp enabled and disabled. The KVM-dependent tests were not rerun during initial PR preparation.

LLM assistance: OpenAI Codex:GPT-5, as disclosed in the existing commit trailer. Codex also assisted with review and PR preparation.

Fixes #8845
