### PR TITLE
vmm: fix restore of a fully file backed VM

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -847,10 +847,6 @@ impl MemoryManager {
         file_path: PathBuf,
         saved_regions: &MemoryRangeTable,
     ) -> Result<(), Error> {
-        if saved_regions.is_empty() {
-            return Ok(());
-        }
-
         // Open (read only) the snapshot file.
         let mut memory_file = OpenOptions::new()
             .read(true)
@@ -935,9 +931,6 @@ impl MemoryManager {
         file_path: PathBuf,
         saved_regions: &MemoryRangeTable,
     ) -> Result<(), Error> {
-        if saved_regions.is_empty() {
-            return Ok(());
-        }
         let guest_memory = self.guest_memory.memory();
         if !is_restore_cow_compatible(&guest_memory, saved_regions) {
             info!("Restore (mode=copyonwrite): guest RAM unsuitable, falling back to copy");
@@ -1986,20 +1979,22 @@ impl MemoryManager {
                 Default::default(),
             )?;
 
-            match memory_restore_mode {
-                MemoryRestoreMode::OnDemand => mm.lock().unwrap().restore_by_uffd(
-                    &memory_file_path,
-                    &mem_snapshot.memory_ranges,
-                    exit_evt,
-                )?,
-                MemoryRestoreMode::CopyOnWrite => mm
-                    .lock()
-                    .unwrap()
-                    .mmap_cow_saved_regions(memory_file_path, &mem_snapshot.memory_ranges)?,
-                MemoryRestoreMode::Copy => mm
-                    .lock()
-                    .unwrap()
-                    .fill_saved_regions(memory_file_path, &mem_snapshot.memory_ranges)?,
+            if !mem_snapshot.memory_ranges.is_empty() {
+                match memory_restore_mode {
+                    MemoryRestoreMode::OnDemand => mm.lock().unwrap().restore_by_uffd(
+                        &memory_file_path,
+                        &mem_snapshot.memory_ranges,
+                        exit_evt,
+                    )?,
+                    MemoryRestoreMode::CopyOnWrite => mm
+                        .lock()
+                        .unwrap()
+                        .mmap_cow_saved_regions(memory_file_path, &mem_snapshot.memory_ranges)?,
+                    MemoryRestoreMode::Copy => mm
+                        .lock()
+                        .unwrap()
+                        .fill_saved_regions(memory_file_path, &mem_snapshot.memory_ranges)?,
+                }
             }
 
             Ok(mm)


### PR DESCRIPTION
```
vmm: fix restore of a fully file backed VM

Snapshotting a VM whose every memory zone uses a named file with
shared=on produces no saved ranges and no memory range file, since
that content already lives in the backing files.

Restoring such a snapshot failed with ENOENT in ondemand mode, which
opened the memory range file before consulting the saved ranges. The
copy and copyonwrite paths each carried their own guard.

Check the saved ranges once in new_from_snapshot rather than in each
of the three restore paths.
```
Fixes: #8848
