### PR TITLE
Streamline Migration Events + Test and Document

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7119,6 +7119,32 @@ mod common_parallel {
         let send_success = wait_for_migration_command(send_migration, "send_migration");
         let receive_success = wait_for_migration_command(receive_migration, "receive_migration");
 
+        if send_success && receive_success {
+            let expected_events = [
+                &MetaEvent {
+                    event: "migration-receive-ready".to_string(),
+                    device_id: None,
+                },
+                &MetaEvent {
+                    event: "migration-receive-starting".to_string(),
+                    device_id: None,
+                },
+                &MetaEvent {
+                    event: "migration-receive-started".to_string(),
+                    device_id: None,
+                },
+                &MetaEvent {
+                    event: "migration-receive-finished".to_string(),
+                    device_id: None,
+                },
+            ];
+            assert!(wait_for_sequential_events(
+                Duration::from_secs(30),
+                &expected_events,
+                dest_event_path
+            ));
+        }
+
         send_success && receive_success
     }
 
@@ -7501,6 +7527,10 @@ mod common_parallel {
 
                     let expected_events = [
                         &MetaEvent {
+                            event: "migration-starting".to_string(),
+                            device_id: None,
+                        },
+                        &MetaEvent {
                             event: "migration-started".to_string(),
                             device_id: None,
                         },
@@ -7513,6 +7543,30 @@ mod common_parallel {
                         Duration::from_secs(30),
                         &expected_events,
                         &src_event_path
+                    ));
+
+                    let expected_events = [
+                        &MetaEvent {
+                            event: "migration-receive-ready".to_string(),
+                            device_id: None,
+                        },
+                        &MetaEvent {
+                            event: "migration-receive-starting".to_string(),
+                            device_id: None,
+                        },
+                        &MetaEvent {
+                            event: "migration-receive-started".to_string(),
+                            device_id: None,
+                        },
+                        &MetaEvent {
+                            event: "migration-receive-failed".to_string(),
+                            device_id: None,
+                        },
+                    ];
+                    assert!(wait_for_sequential_events(
+                        Duration::from_secs(30),
+                        &expected_events,
+                        &dest_event_path
                     ));
 
                     // Check that even after a few seconds, the VMM is still
@@ -7532,6 +7586,10 @@ mod common_parallel {
 
                     let expected_events = [
                         &MetaEvent {
+                            event: "migration-starting".to_string(),
+                            device_id: None,
+                        },
+                        &MetaEvent {
                             event: "migration-started".to_string(),
                             device_id: None,
                         },
@@ -7544,6 +7602,30 @@ mod common_parallel {
                         Duration::from_secs(30),
                         &expected_events,
                         &src_event_path
+                    ));
+
+                    let expected_events = [
+                        &MetaEvent {
+                            event: "migration-receive-ready".to_string(),
+                            device_id: None,
+                        },
+                        &MetaEvent {
+                            event: "migration-receive-starting".to_string(),
+                            device_id: None,
+                        },
+                        &MetaEvent {
+                            event: "migration-receive-started".to_string(),
+                            device_id: None,
+                        },
+                        &MetaEvent {
+                            event: "migration-receive-finished".to_string(),
+                            device_id: None,
+                        },
+                    ];
+                    assert!(wait_for_sequential_events(
+                        Duration::from_secs(30),
+                        &expected_events,
+                        &dest_event_path
                     ));
 
                     assert!(

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,37 +74,37 @@ The Cloud Hypervisor API exposes the following actions through its endpoints:
 
 | Action                                  | Endpoint                     | Request Body                      | Response Body                   | Prerequisites                                            |
 | --------------------------------------- | ---------------------------- | --------------------------------- | ------------------------------- | -------------------------------------------------------- |
-| Create the VM                           | `/vm.create`                 | `/schemas/VmConfig`               | N/A                             | The VM is not created yet                                |
-| Delete the VM                           | `/vm.delete`                 | N/A                               | N/A                             | N/A                                                      |
-| Boot the VM                             | `/vm.boot`                   | N/A                               | N/A                             | The VM is created but not booted                         |
-| Shut the VM down                        | `/vm.shutdown`               | N/A                               | N/A                             | The VM is booted                                         |
-| Reboot the VM                           | `/vm.reboot`                 | N/A                               | N/A                             | The VM is booted                                         |
-| Trigger power button of the VM          | `/vm.power-button`           | N/A                               | N/A                             | The VM is booted                                         |
-| Pause the VM                            | `/vm.pause`                  | N/A                               | N/A                             | The VM is booted                                         |
-| Resume the VM                           | `/vm.resume`                 | N/A                               | N/A                             | The VM is paused                                         |
-| Take a snapshot of the VM               | `/vm.snapshot`               | `/schemas/VmSnapshotConfig`       | N/A                             | The VM is paused                                         |
-| Perform a coredump of the VM*           | `/vm.coredump`               | `/schemas/VmCoredumpData`         | N/A                             | The VM is paused                                         |
-| Restore the VM from a snapshot          | `/vm.restore`                | `/schemas/RestoreConfig`          | N/A                             | The VM is created but not booted                         |
-| Add/remove CPUs to/from the VM          | `/vm.resize`                 | `/schemas/VmResize`               | N/A                             | The VM is booted                                         |
-| Add/remove memory from the VM           | `/vm.resize`                 | `/schemas/VmResize`               | N/A                             | The VM is booted                                         |
-| Resize a disk attached to the VM        | `/vm.resize-disk`            | `/schemas/VmResizeDisk`           | N/A                             | The VM is created                                        |
-| Add/remove memory from a zone           | `/vm.resize-zone`            | `/schemas/VmResizeZone`           | N/A                             | The VM is booted                                         |
-| Dump the VM information                 | `/vm.info`                   | N/A                               | `/schemas/VmInfo`               | The VM is created                                        |
-| Get virtio-balloon statistics           | `/vm.balloon-stats`          | N/A                               | `/schemas/BalloonStatsResponse` | The VM is running and balloon statistics were negotiated |
 | Add VFIO PCI device to the VM           | `/vm.add-device`             | `/schemas/VmAddDevice`            | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
 | Add disk device to the VM               | `/vm.add-disk`               | `/schemas/DiskConfig`             | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
 | Add fs device to the VM                 | `/vm.add-fs`                 | `/schemas/FsConfig`               | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
 | Add generic vhost-user device to the VM | `/vm.add-generic-vhost-user` | `/schemas/GenericVhostUserConfig` | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
-| Add pmem device to the VM               | `/vm.add-pmem`               | `/schemas/PmemConfig`             | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
 | Add network device to the VM            | `/vm.add-net`                | `/schemas/NetConfig`              | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
+| Add pmem device to the VM               | `/vm.add-pmem`               | `/schemas/PmemConfig`             | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
 | Add userspace PCI device to the VM      | `/vm.add-user-device`        | `/schemas/VmAddUserDevice`        | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
 | Add vdpa device to the VM               | `/vm.add-vdpa`               | `/schemas/VdpaConfig`             | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
 | Add vsock device to the VM              | `/vm.add-vsock`              | `/schemas/VsockConfig`            | `/schemas/PciDeviceInfo`        | The VM is booted                                         |
-| Remove device from the VM               | `/vm.remove-device`          | `/schemas/VmRemoveDevice`         | N/A                             | The VM is booted                                         |
+| Get virtio-balloon statistics           | `/vm.balloon-stats`          | N/A                               | `/schemas/BalloonStatsResponse` | The VM is running and balloon statistics were negotiated |
+| Boot the VM                             | `/vm.boot`                   | N/A                               | N/A                             | The VM is created but not booted                         |
+| Perform a coredump of the VM*           | `/vm.coredump`               | `/schemas/VmCoredumpData`         | N/A                             | The VM is paused                                         |
 | Dump the VM counters                    | `/vm.counters`               | N/A                               | `/schemas/VmCounters`           | The VM is booted                                         |
+| Create the VM                           | `/vm.create`                 | `/schemas/VmConfig`               | N/A                             | The VM is not created yet                                |
+| Delete the VM                           | `/vm.delete`                 | N/A                               | N/A                             | N/A                                                      |
+| Dump the VM information                 | `/vm.info`                   | N/A                               | `/schemas/VmInfo`               | The VM is created                                        |
 | Inject an NMI                           | `/vm.nmi`                    | N/A                               | N/A                             | The VM is booted                                         |
+| Pause the VM                            | `/vm.pause`                  | N/A                               | N/A                             | The VM is booted                                         |
+| Trigger power button of the VM          | `/vm.power-button`           | N/A                               | N/A                             | The VM is booted                                         |
+| Reboot the VM                           | `/vm.reboot`                 | N/A                               | N/A                             | The VM is booted                                         |
 | Prepare to receive a migration          | `/vm.receive-migration`      | `/schemas/ReceiveMigrationData`   | N/A                             | N/A                                                      |
+| Remove device from the VM               | `/vm.remove-device`          | `/schemas/VmRemoveDevice`         | N/A                             | The VM is booted                                         |
+| Add/remove CPUs to/from the VM          | `/vm.resize`                 | `/schemas/VmResize`               | N/A                             | The VM is booted                                         |
+| Add/remove memory from the VM           | `/vm.resize`                 | `/schemas/VmResize`               | N/A                             | The VM is booted                                         |
+| Resize a disk attached to the VM        | `/vm.resize-disk`            | `/schemas/VmResizeDisk`           | N/A                             | The VM is created                                        |
+| Add/remove memory from a zone           | `/vm.resize-zone`            | `/schemas/VmResizeZone`           | N/A                             | The VM is booted                                         |
+| Restore the VM from a snapshot          | `/vm.restore`                | `/schemas/RestoreConfig`          | N/A                             | The VM is created but not booted                         |
+| Resume the VM                           | `/vm.resume`                 | N/A                               | N/A                             | The VM is paused                                         |
 | Start to send migration to target       | `/vm.send-migration`         | `/schemas/SendMigrationData`      | N/A                             | The VM is booted and (shared mem or hugepages enabled)   |
+| Shut the VM down                        | `/vm.shutdown`               | N/A                               | N/A                             | The VM is booted                                         |
+| Take a snapshot of the VM               | `/vm.snapshot`               | `/schemas/VmSnapshotConfig`       | N/A                             | The VM is paused                                         |
 
 * The `vmcoredump` action is available exclusively for the `x86_64`
 architecture and can be executed only when the `guest_debug` feature is

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -410,3 +410,24 @@ features are added to existing device models or the VMM, the corresponding
 device-specific config falls back to safe false/disabled values. Hence, only
 newly spawned VMs will be able to use new functionality, while being able to run
 VMs first spawned in older versions of Cloud Hypervisor.
+
+## Events
+
+The following events are emitted by Cloud Hypervisor in the context of
+migration:
+
+- Sender
+  - `vm.migration-starting`: Migration worker is beginning the send attempt.
+  - `vm.migration-started`: Receiver acknowledged the migration start request.
+  - `vm.migration-finished`: Migration completed successfully.
+  - `vm.migration-failed`: Migration worker returned an error.
+- Receiver
+  - `vm.migration-receive-ready`: Migration listener is ready to accept a
+    connection.
+  - `vm.migration-receive-starting`: Migration connection was accepted.
+  - `vm.migration-receive-started`: Sender's migration start request was
+    acknowledged.
+  - `vm.migration-receive-finished`: Migration was received and the VM resumed
+    successfully.
+  - `vm.migration-receive-failed`: The migration failed or the sender aborted
+    the migration.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1113,6 +1113,71 @@ impl Vmm {
         }
     }
 
+    /// Runs the receiver side of the migration protocol.
+    fn vm_receive_migration_protocol(
+        &mut self,
+        mut listener: ReceiveListener,
+        receive_data_migration: &VmReceiveMigrationData,
+    ) -> result::Result<(), MigratableError> {
+        event!("vm", "migration-receive-ready");
+        // Accept the connection and get the socket
+        let mut socket = listener.accept()?;
+
+        event!("vm", "migration-receive-starting");
+        let mut state = ReceiveMigrationState::Established;
+
+        while !state.finished() {
+            let req = Request::read_from(&mut socket).inspect_err(|error| {
+                if matches!(
+                    error,
+                    MigratableError::MigrateSocket(io_error)
+                        if io_error.kind() == io::ErrorKind::UnexpectedEof
+                ) {
+                    error!("Failed to read migration request: sender likely failed, aborting");
+                }
+            })?;
+            debug!("Command '{:?}' received", req.command());
+
+            // If sender-side migration causes any error propagated here, the
+            // next loop iteration logs a helpful error when reading the next
+            // request (which will fail as the sender closed the socket).
+            let (response, new_state) = match self.vm_receive_migration_step(
+                &mut socket,
+                &listener,
+                state,
+                &req,
+                receive_data_migration,
+            ) {
+                Ok(next_state) => (Response::ok(), next_state),
+                Err(err) => {
+                    warn!(
+                        "Migration aborted as migration command {:?} failed: {}",
+                        req.command(),
+                        err
+                    );
+                    (Response::error(), ReceiveMigrationState::Aborted)
+                }
+            };
+
+            state = new_state;
+            assert_eq!(response.length(), 0);
+            response.write_to(&mut socket)?;
+
+            // Connection and handshake established
+            if matches!(state, ReceiveMigrationState::Started) {
+                event!("vm", "migration-receive-started");
+            }
+        }
+
+        match state {
+            ReceiveMigrationState::Aborted => Err(MigratableError::CompleteMigration(anyhow!(
+                "Migration was aborted"
+            ))),
+            ReceiveMigrationState::Completed => Ok(()),
+            _ => unreachable!("loop only exits in Completed or Aborted"),
+        }
+    }
+
     fn vm_receive_state_command(
         &mut self,
         req: &Request,
@@ -3201,7 +3266,7 @@ impl RequestHandler for Vmm {
             receive_data_migration.zone_updates,
         );
 
-        let mut listener = transport::receive_migration_listener(
+        let listener = transport::receive_migration_listener(
             &receive_data_migration.receiver_url,
             receive_data_migration.tls_dir.as_deref(),
         )?;
@@ -3210,73 +3275,16 @@ impl RequestHandler for Vmm {
             warn!("The existing VM config will be overwritten");
         }
 
-        event!("vm", "migration-receive-ready");
-        // Accept the connection and get the socket
-        let mut socket = listener.accept()?;
-
-        event!("vm", "migration-receive-starting");
-        let mut state = ReceiveMigrationState::Established;
-
-        while !state.finished() {
-            let req = Request::read_from(&mut socket).inspect_err(|error| {
-                if matches!(
-                    error,
-                    MigratableError::MigrateSocket(io_error)
-                        if io_error.kind() == io::ErrorKind::UnexpectedEof
-                ) {
-                    error!("Failed to read migration request: sender likely failed, aborting");
-                }
-            })?;
-            debug!("Command '{:?}' received", req.command());
-
-            // If sender-side migration causes any error propagated here, the
-            // next loop iteration logs a helpful error when reading the next
-            // request (which will fail as the sender closed the socket).
-            let (response, new_state) = match self.vm_receive_migration_step(
-                &mut socket,
-                &listener,
-                state,
-                &req,
-                &receive_data_migration,
-            ) {
-                Ok(next_state) => (Response::ok(), next_state),
-                Err(err) => {
-                    warn!(
-                        "Migration aborted as migration command {:?} failed: {}",
-                        req.command(),
-                        err
-                    );
-                    (Response::error(), ReceiveMigrationState::Aborted)
-                }
-            };
-
-            state = new_state;
-            assert_eq!(response.length(), 0);
-            response.write_to(&mut socket)?;
-
-            // Connection and handshake established
-            if matches!(state, ReceiveMigrationState::Started) {
-                event!("vm", "migration-receive-started");
-            }
-        }
-
-        match state {
-            ReceiveMigrationState::Aborted => {
+        self.vm_receive_migration_protocol(listener, &receive_data_migration)
+            .inspect(|_| {
+                // Serving and resume already happened in the protocol loop.
+                event!("vm", "migration-receive-finished");
+            })
+            .inspect_err(|_| {
                 event!("vm", "migration-receive-failed");
                 self.vm = VmOwnership::None;
                 self.vm_config = None;
-                return Err(MigratableError::CompleteMigration(anyhow!(
-                    "Migration was aborted"
-                )));
-            }
-            ReceiveMigrationState::Completed => {
-                // Serving and resume already happened in the protocol loop.
-                event!("vm", "migration-receive-finished");
-            }
-            _ => unreachable!("loop only exits in Completed or Aborted"),
-        }
-
-        Ok(())
+            })
     }
 
     /// Dispatches a migration.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1610,6 +1610,10 @@ impl Vmm {
             Request::start(),
             MigratableError::MigrateSend(anyhow!("Error starting migration")),
         )?;
+
+        // Connection and handshake established
+        event!("vm", "migration-started");
+
         debug!("Using migration protocol {CURRENT_PROTOCOL_VERSION}");
 
         // Send config
@@ -3210,8 +3214,7 @@ impl RequestHandler for Vmm {
         // Accept the connection and get the socket
         let mut socket = listener.accept()?;
 
-        event!("vm", "migration-receive-started");
-
+        event!("vm", "migration-receive-starting");
         let mut state = ReceiveMigrationState::Established;
 
         while !state.finished() {
@@ -3250,6 +3253,11 @@ impl RequestHandler for Vmm {
             state = new_state;
             assert_eq!(response.length(), 0);
             response.write_to(&mut socket)?;
+
+            // Connection and handshake established
+            if matches!(state, ReceiveMigrationState::Started) {
+                event!("vm", "migration-receive-started");
+            }
         }
 
         match state {

--- a/vmm/src/migration/worker.rs
+++ b/vmm/src/migration/worker.rs
@@ -107,7 +107,7 @@ impl MigrationWorker {
         // therefore we chain the results together.
         let migration_result = seccomp_res
             .and_then(|()| {
-                event!("vm", "migration-started");
+                event!("vm", "migration-starting");
                 Vmm::send_migration(
                     &mut vm,
                     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]


### PR DESCRIPTION
Let's streamline the migration related events and set them into stone (tests + documentation). Especially the differentiation between `-starting` and `-started` turned out to be very useful in our management layer.

Split-out from #8455 