### PR TITLE
State component cpuid checks

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -475,6 +475,12 @@ impl CpuidFeatureEntry {
                 compatible_check: CpuidCompatibleCheck::BitwiseSubset,
             },
             CpuidFeatureEntry {
+                function: 0xd,
+                index: 0,
+                feature_reg: CpuidReg::EDX,
+                compatible_check: CpuidCompatibleCheck::BitwiseSubset,
+            },
+            CpuidFeatureEntry {
                 function: 0x1d,
                 index: 0,
                 feature_reg: CpuidReg::EAX,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -481,6 +481,12 @@ impl CpuidFeatureEntry {
                 compatible_check: CpuidCompatibleCheck::BitwiseSubset,
             },
             CpuidFeatureEntry {
+                function: 0xd,
+                index: 1,
+                feature_reg: CpuidReg::EAX,
+                compatible_check: CpuidCompatibleCheck::BitwiseSubset,
+            },
+            CpuidFeatureEntry {
                 function: 0x1d,
                 index: 0,
                 feature_reg: CpuidReg::EAX,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -487,6 +487,12 @@ impl CpuidFeatureEntry {
                 compatible_check: CpuidCompatibleCheck::BitwiseSubset,
             },
             CpuidFeatureEntry {
+                function: 0xd,
+                index: 1,
+                feature_reg: CpuidReg::ECX,
+                compatible_check: CpuidCompatibleCheck::BitwiseSubset,
+            },
+            CpuidFeatureEntry {
                 function: 0x1d,
                 index: 0,
                 feature_reg: CpuidReg::EAX,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -469,6 +469,12 @@ impl CpuidFeatureEntry {
                 compatible_check: CpuidCompatibleCheck::BitwiseSubset,
             },
             CpuidFeatureEntry {
+                function: 0xd,
+                index: 0,
+                feature_reg: CpuidReg::EAX,
+                compatible_check: CpuidCompatibleCheck::BitwiseSubset,
+            },
+            CpuidFeatureEntry {
                 function: 0x1d,
                 index: 0,
                 feature_reg: CpuidReg::EAX,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -493,6 +493,12 @@ impl CpuidFeatureEntry {
                 compatible_check: CpuidCompatibleCheck::BitwiseSubset,
             },
             CpuidFeatureEntry {
+                function: 0xd,
+                index: 1,
+                feature_reg: CpuidReg::EDX,
+                compatible_check: CpuidCompatibleCheck::BitwiseSubset,
+            },
+            CpuidFeatureEntry {
                 function: 0x1d,
                 index: 0,
                 feature_reg: CpuidReg::EAX,


### PR DESCRIPTION
We add missing CPUID compatibility checks for CPUID leaf 0xd.

More concretely this adds compatibility checks for registers that are related to features (which state components are supported, is XSAVEOPT available, etc).

We are going to assume that sizes and offsets of state components are de-facto architecturally defined per CPU vendor (e.g. if Intel processors A and B both support component n, then they both report the same size and offset for that component). 

We also consider cross vendor live migration out of scope for this PR because that should not be possible due to several other CPUID compatibility checks failing.

Should our de-facto architecturally defined state components assumption turn out not to hold in the future, then we can add checks requiring somewhat more complex logic to accommodate for that case.

Our assumption means that we can avoid checking certain registers and/or sub-leaves which would otherwise require more code:
- Sub-leaf 0, register ECX: Maximum size of all supported features.
- Sub-leaves n, for n > 1. These have arguably different definitions in the case of Intel and AMD and it doesn't necessarily make sense to have the same checks for both vendors.

Register EBX of sub-leaves 0 and 1 depend on the current (runtime) state of XCR0 and it does thus not make sense to check compatibility in those cases.

We also do not introduce any checks for the upper 32 bits of IA32_XSS that Intel advertises in EDX of sub-leaf 1. They are currently all reserved and AMD has not advertised that they will also use this register for that purpose. Checks can be added in the future should it become necessary and CPU profiles generated before that will all define this value to be 0 (so not an issue when running on future hardware).

I will close https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8494 once this is merged as CPUID compatibility checks will then be arguably good enough to proceed with upstreaming the remaining parts of the CPU profile feature.