### PR TITLE
vm-migration: deprecate Command::Abandon in v54, prepare remove in v55

### DIFF
--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -382,6 +382,8 @@ migration:
 - Sender
   - `vm.migration-starting`: Migration worker is beginning the send attempt.
   - `vm.migration-started`: Receiver acknowledged the migration start request.
+  - `vm.migration-memory-iteration`: A precopy iteration finished. Can appear
+    multiple times and solely signals forward progress.
   - `vm.migration-finished`: Migration completed successfully.
   - `vm.migration-failed`: Migration worker returned an error.
 - Receiver

--- a/offload_daemon/src/main.rs
+++ b/offload_daemon/src/main.rs
@@ -283,6 +283,7 @@ fn run_snapshot(socket_path: &Path, output_dir: &Path) -> Result<()> {
                 info!("Snapshot persisted to {output_dir:?}");
                 break;
             }
+            #[expect(deprecated)] // last sent in v52
             Command::Abandon => {
                 // ACK before bailing so CH's ok_or_fatal_error() read returns
                 // cleanly instead of hitting EOF.
@@ -560,6 +561,7 @@ fn serve_page_faults(stream: &mut UnixStream, slots: &[OnDemandSlot]) -> Result<
                     .map_err(Error::WriteGuestMemory)?;
                 Response::ok().write_to(stream).map_err(Error::Protocol)?;
             }
+            #[expect(deprecated)] // last sent in v52
             Command::Abandon => {
                 info!("Serve loop: received Abandon, exiting");
                 Response::ok().write_to(stream).ok();

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -145,6 +145,7 @@ pub enum Command {
     /// Finalizes the migration and resumes the VM on the destination.
     /// Sent when the source VM was running at migration time.
     Complete = 5,
+    #[deprecated = "v52 was the last version to send this command: we now rely on proper timeout and EOF handling on the destination"]
     Abandon = 6,
     MemoryFd = 7,
     /// Finalizes the migration without resuming the VM on the destination.
@@ -262,10 +263,6 @@ impl Request {
     /// Finalizes the migration without resuming the VM on the destination.
     pub fn complete_paused() -> Self {
         Self::new(Command::CompletePaused, 0)
-    }
-
-    pub fn abandon() -> Self {
-        Self::new(Command::Abandon, 0)
     }
 
     /// PageFault request always carries a single `MemoryRange`.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1035,6 +1035,7 @@ impl Vmm {
             Ok(memory_files)
         };
 
+        #[expect(deprecated)] // last sent in v52
         if req.command() == Command::Abandon {
             info!("Abandon Command Received");
             return Ok(Aborted);
@@ -1977,11 +1978,6 @@ impl Vmm {
                     socket
                         .write_all(&buf[..len])
                         .map_err(MigratableError::MigrateSocket)?;
-                }
-                Command::Abandon => {
-                    Response::ok().write_to(&mut socket)?;
-                    info!("Postcopy: received Abandon, exiting serve loop");
-                    return Ok(());
                 }
                 c => {
                     return Err(MigratableError::MigrateSend(anyhow!(


### PR DESCRIPTION
TL;DR: not sent since v52, can be safely deprecated in v54 and safely be removed in v55. Not needed and there are better alternatives: EOF handling plus timeouts (which we already have).

Also includes an docs fix.