### PR TITLE
vmm: migration: remove special case for single connection

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1002,11 +1002,7 @@ impl Vmm {
                 let (memory_manager, memory_mode) =
                     self.vm_receive_config(req, socket, memory_files, receive_data_migration)?;
                 let guest_memory = memory_manager.lock().unwrap().guest_memory();
-                // Create the additional-connection receiver even in the single-connection case.
-                // At this point the receiver does not know whether the sender will use extra TCP
-                // connections. If it does not, no worker connections are accepted and memory
-                // requests continue to arrive on the main connection.
-                // The accept thread hands the page fault connection back via this channel.
+
                 let (fault_tx, fault_rx) = channel();
                 let connections = listener.try_clone().and_then(|l| {
                     ReceiveAdditionalConnections::new(
@@ -1063,9 +1059,9 @@ impl Vmm {
                 c => invalid_command(state_name, c),
             },
             Configured(mut config_data) => match req.command() {
-                // Memory commands use the main connection only in the single-connection case.
-                // When multiple TCP connections are configured, the worker connections carry
-                // all memory commands and the main connection is used only for control traffic.
+                // In v53 and before, in case of single connections memory was
+                // received here via the main connection. Since v54, this is
+                // only needed for the post snapshot flush of memory pages.
                 Command::Memory => {
                     transport::receive_memory_ranges(&config_data.guest_memory, req, socket)
                     .inspect_err(|_| {
@@ -1467,7 +1463,6 @@ impl Vmm {
     /// (e.g., reasonably small downtime) is reached.
     fn do_memory_iterations(
         vm: &mut Vm,
-        socket: &mut SocketStream,
         ctx: &mut MemoryMigrationContext,
         is_converged: impl Fn(&MemoryMigrationContext) -> result::Result<bool, MigratableError>,
         mem_send: &mut SendAdditionalConnections,
@@ -1490,7 +1485,7 @@ impl Vmm {
 
             // Send the current dirty pages
             let transfer_begin = Instant::now();
-            mem_send.send_memory(iteration_table, socket)?;
+            mem_send.send_memory(iteration_table)?;
             let transfer_duration = transfer_begin.elapsed();
             ctx.update_metrics_after_transfer(transfer_begin, transfer_duration);
 
@@ -1613,7 +1608,6 @@ impl Vmm {
     /// [finalized]: MemoryMigrationContext::finalize
     fn do_memory_migration(
         vm: &mut Vm,
-        socket: &mut SocketStream,
         send_data_migration: &VmSendMigrationData,
         mem_send: &mut SendAdditionalConnections,
         ctx: &mut OngoingMigrationContext,
@@ -1623,7 +1617,6 @@ impl Vmm {
         vm.start_dirty_log()?;
         let remaining = Self::do_memory_iterations(
             vm,
-            socket,
             &mut mem_ctx,
             // We bind send_data_migration to the callback
             |ctx| Self::is_precopy_converged(ctx, send_data_migration),
@@ -1643,7 +1636,7 @@ impl Vmm {
 
             mem_ctx.update_metrics_before_transfer(iteration_begin, &final_table);
             let transfer_begin = Instant::now();
-            mem_send.send_memory(final_table, socket)?;
+            mem_send.send_memory(final_table)?;
             let transfer_duration = transfer_begin.elapsed();
             mem_ctx.update_metrics_after_transfer(transfer_begin, transfer_duration);
             mem_ctx.iteration += 1;
@@ -1773,7 +1766,7 @@ impl Vmm {
                 "migration context should transition to VmPaused for memfds/postcopy migration",
             );
         } else {
-            let mut mem_send = transport::SendAdditionalConnections::new(
+            let mut mem_send = SendAdditionalConnections::new(
                 &send_data_migration.destination_url,
                 send_data_migration.connections,
                 send_data_migration.tls_dir.as_deref(),
@@ -1781,19 +1774,13 @@ impl Vmm {
                 &seccomp_filters.tcp_worker,
             )?;
 
-            Self::do_memory_migration(
-                vm,
-                &mut socket,
-                send_data_migration,
-                &mut mem_send,
-                &mut ctx,
-            )
-            .inspect_err(|_| {
-                if let Err(e) = mem_send.cleanup_workers() {
-                    let msg = flatten_error_chain_to_string(&e);
-                    warn!("Error cleaning up migration connections: {msg}");
-                }
-            })?;
+            Self::do_memory_migration(vm, send_data_migration, &mut mem_send, &mut ctx)
+                .inspect_err(|_| {
+                    if let Err(e) = mem_send.cleanup_workers() {
+                        let msg = flatten_error_chain_to_string(&e);
+                        warn!("Error cleaning up migration connections: {msg}");
+                    }
+                })?;
 
             mem_send.cleanup_workers()?;
         }

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -292,7 +292,7 @@ fn wait_for_readable(fd: &impl AsFd, abort_event: &impl AsRawFd) -> Result<bool,
 /// [`Self::cleanup`] is called.
 #[derive(Debug)]
 pub(crate) struct ReceiveAdditionalConnections {
-    accept_thread: Option<thread::JoinHandle<Result<(), MigratableError>>>,
+    accept_thread: Option<JoinHandle<Result<(), MigratableError>>>,
 
     /// Shared kill eventfd for the accept thread and memory workers.
     kill_evt: EventFd,
@@ -637,10 +637,9 @@ enum SendMemoryThreadNotify {
     Error,
 }
 
-/// This struct keeps track of additional threads we use to send VM memory.
+/// This struct keeps track of all workers sending VM memory.
 pub(crate) struct SendAdditionalConnections {
-    guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
-    threads: Vec<thread::JoinHandle<Result<(), MigratableError>>>,
+    threads: Vec<JoinHandle<Result<(), MigratableError>>>,
     /// Sender to all workers. The receiver is shared by all workers.
     message_tx: SyncSender<SendMemoryThreadMessage>,
     /// If an error occurs in one of the memory sending threads, the main thread signals
@@ -692,22 +691,8 @@ impl SendAdditionalConnections {
         let worker_error = Arc::new(AtomicBool::new(false));
         let (notify_tx, notify_rx) = channel::<SendMemoryThreadNotify>();
 
-        // If one connection is configured, we don't have to create any additional threads.
-        // In this case the main thread does the sending.
-        if configured_connections == 1 {
-            return Ok(Self {
-                guest_memory: guest_memory.clone(),
-                threads,
-                message_tx,
-                worker_error,
-                notify_rx,
-            });
-        }
-
         let message_rx = Arc::new(Mutex::new(message_rx));
-        // If we use multiple threads to send memory, the main thread only distributes
-        // the memory chunks to the workers, but does not send memory anymore. Thus in
-        // this case we create one additional thread for each connection.
+        // Main thread distributes writes, and workers take requests from it.
         for n in 0..configured_connections {
             let mut socket = send_migration_socket(destination, tls_dir)?;
             ConnectionRole::PrecopyMemory.write_to(&mut socket)?;
@@ -743,7 +728,6 @@ impl SendAdditionalConnections {
         }
 
         Ok(Self {
-            guest_memory: guest_memory.clone(),
             threads,
             message_tx,
             worker_error,
@@ -811,24 +795,13 @@ impl SendAdditionalConnections {
         }
     }
 
-    /// Send memory via all connections that we have. `socket` is the original socket
-    /// that was used to connect to the destination. Returns Ok(true) if memory was
-    /// sent, Ok(false) if the given table was empty.
+    /// Send memory via all connections that we have.
     ///
+    /// Returns Ok(true) if memory was sent, Ok(false) if the given table was empty.
     /// When this function returns, all memory has been sent and acknowledged.
-    pub(crate) fn send_memory(
-        &mut self,
-        table: MemoryRangeTable,
-        socket: &mut SocketStream,
-    ) -> Result<bool, MigratableError> {
+    pub(crate) fn send_memory(&mut self, table: MemoryRangeTable) -> Result<bool, MigratableError> {
         if table.regions().is_empty() {
             return Ok(false);
-        }
-
-        // If we use only one connection, we send the memory directly.
-        if self.threads.is_empty() {
-            send_memory_ranges(&self.guest_memory, &table, socket)?;
-            return Ok(true);
         }
 
         // The chunk size is chosen to be big enough so that even very fast links need some


### PR DESCRIPTION
First of all, using a single connection is not the default case in a typical setup. Further, the special case of saving one thread buys us nothing in reality but code complexity. Let's remove the special case and handle all memory always via the connection pool (SendAdditionalConnections).
