### PR TITLE
vm-migration: replace BitposIterator (~2x faster, trivial replacement)

### DIFF
--- a/vm-migration/src/bitpos_iterator.rs
+++ b/vm-migration/src/bitpos_iterator.rs
@@ -1,95 +1,131 @@
-// Copyright © 2025 Cyberus Technology GmbH
+// Copyright © 2026 Cyberus Technology GmbH
 //
 // SPDX-License-Identifier: Apache-2.0
+//
+// Code imported from https://github.com/phip1611/bit_ops/blob/7befc3998fac6c7bc0d9238f89b040da3f8c1b02/src/bitpos_iter.rs
+// but the generics were removed (only operates on u64).
 
-use std::ops::Mul;
+use std::fmt::Debug;
 
-/// An iterator that turns a sequence of u64s into a sequence of bit positions
-/// that are set.
+/// Iterator over set bits of an unsigned integer.
 ///
-/// This is useful to iterate over dirty memory bitmaps.
-struct BitposIterator<I> {
-    underlying_it: I,
-
-    /// How many `u64`'s we've already consumed.
-    ///
-    /// `u32` is sufficient.
-    word_pos: u32,
-
-    /// If we already started working on a u64, it's here. Together with the bit
-    /// position where we have to continue.
-    current_word: Option<(u64 /* cur word */, u32 /* cur pos */)>,
+/// The index / bit position starts at `0`, the last bit position is
+/// `n_bits - 1`.
+#[derive(Debug)]
+pub(crate) struct BitsIter {
+    value: u64,
 }
 
-impl<I> Iterator for BitposIterator<I>
-where
-    I: Iterator<Item = u64>,
-{
+impl BitsIter {
+    pub(crate) const fn new(value: u64) -> Self {
+        Self { value }
+    }
+}
+
+impl Iterator for BitsIter {
     type Item = u64;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
+        if self.value == 0 {
+            return None;
+        }
+        let tz = self.value.trailing_zeros() as u64;
+        self.value &= self.value - 1; // clear lowest set bit
+        Some(tz)
+    }
+}
+
+/// Iterator over set bits in (large) bitmaps, i.e., collection of unsigned
+/// integers.
+pub(crate) struct BitmapIter<I> {
+    bitmap_iter: I,
+    consumed_bits: u64,
+    current_element_it: BitsIter,
+}
+
+impl<I: Iterator<Item = u64>> BitmapIter<I> {
+    pub(crate) fn new<In: IntoIterator<IntoIter = I>>(bitmap_iter: In) -> Self {
+        let mut bitmap_iter = bitmap_iter.into_iter();
+        let current_element_it = BitsIter::new(bitmap_iter.next().unwrap_or(0));
+        Self {
+            bitmap_iter,
+            consumed_bits: 0,
+            current_element_it,
+        }
+    }
+}
+
+impl<I: Iterator<Item = u64>> Iterator for BitmapIter<I> {
+    type Item = u64;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        // Performance: Avoid `checked_add` in the hot path.
         loop {
-            if self.current_word.is_none() {
-                self.current_word = self.underlying_it.next().map(|w| (w, 0));
+            // We return here, if we currently have an element.
+            if let Some(bit) = self.current_element_it.next() {
+                return Some(self.consumed_bits + bit);
             }
 
-            let (word, word_bit) = self.current_word?;
-
-            // Continue early if there is no chance to find something.
-            if word != 0 && word_bit < 64 {
-                let shifted_word = word >> word_bit;
-                if shifted_word != 0 {
-                    let zeroes = shifted_word.trailing_zeros();
-
-                    self.current_word = Some((word, zeroes + word_bit + 1));
-                    let next_bitpos = (self.word_pos as u64)
-                        .mul(64)
-                        // the inner value can not overflow
-                        .checked_add(word_bit as u64 + zeroes as u64)
-                        .unwrap();
-
-                    return Some(next_bitpos);
-                }
-            }
-
-            self.current_word = None;
-            self.word_pos += 1;
+            // Current u64 exhausted: load next one or return `None` / exit.
+            let next_u64 = self.bitmap_iter.next()?;
+            // Unchecked add: see performance comment above
+            self.consumed_bits += u64::BITS as u64;
+            self.current_element_it = BitsIter::new(next_u64);
         }
     }
 }
 
+/// Extension for the Rust standard libraries [`Iterator`] for convenient
+/// integration of [`BitmapIter`].
 pub(crate) trait BitposIteratorExt: Iterator<Item = u64> + Sized {
-    /// Turn an iterator over `u64` into an iterator over the bit positions of
-    /// all 1s. We basically treat the incoming `u64` as one gigantic integer
-    /// and just spit out which bits are set.
-    fn bit_positions(self) -> impl Iterator<Item = u64> {
-        BitposIterator {
-            underlying_it: self,
-            word_pos: 0,
-            current_word: None,
-        }
+    fn bit_positions(self) -> BitmapIter<Self> {
+        BitmapIter::new(self)
     }
 }
 
+// Blanked implementation for all matching iterators.
 impl<I: Iterator<Item = u64> + Sized> BitposIteratorExt for I {}
 
 #[cfg(test)]
 mod tests {
+    use std::array;
+    use std::vec::Vec;
+
     use super::*;
 
-    fn bitpos_check(inp: &[u64], out: &[u64]) {
-        assert_eq!(inp.iter().copied().bit_positions().collect::<Vec<_>>(), out);
+    #[test]
+    fn bits_iter() {
+        let iter = BitsIter::new(0_u64);
+        assert_eq!(&iter.collect::<Vec<u64>>(), &[] as &[u64]);
+
+        let iter = BitsIter::new(1_u64);
+        assert_eq!(&iter.collect::<Vec<u64>>(), &[0]);
+
+        let iter = BitsIter::new(0b1010_1010_u64);
+        assert_eq!(&iter.collect::<Vec<u64>>(), &[1, 3, 5, 7]);
+
+        let iter = BitsIter::new(0b1111_1111_u64);
+        assert_eq!(&iter.collect::<Vec<u64>>(), &[0, 1, 2, 3, 4, 5, 6, 7]);
+
+        let iter = BitsIter::new(u64::MAX);
+        assert_eq!(
+            &iter.collect::<Vec<u64>>(),
+            // [0, 1, ..., 63]
+            &array::from_fn::<u64, 64, _>(|i| i as u64)
+        );
     }
 
     #[test]
-    fn bitpos_iterator_works() {
-        bitpos_check(&[], &[]);
-        bitpos_check(&[0], &[]);
-        bitpos_check(&[1], &[0]);
-        bitpos_check(&[5], &[0, 2]);
-        bitpos_check(&[3 + 32], &[0, 1, 5]);
-        bitpos_check(&[1 << 63], &[63]);
+    fn bitmap_iter() {
+        let iter = BitmapIter::<_>::new([0_u64]);
+        assert_eq!(&iter.collect::<Vec<u64>>(), &[] as &[u64]);
 
-        bitpos_check(&[1, 1 + 32], &[0, 64, 69]);
+        let iter = BitmapIter::<_>::new([0b1111_0010, 0b1000, 1]);
+        assert_eq!(&iter.collect::<Vec<u64>>(), &[1, 4, 5, 6, 7, 67, 128]);
+
+        let iter = BitmapIter::<_>::new([0b10, 0b10, 0b11]);
+        assert_eq!(&iter.collect::<Vec<u64>>(), &[1, 65, 128, 129]);
     }
 }


### PR DESCRIPTION
TL;DR: Replace the BitposIterator with another implementation that is ~2x faster in micro benchmarks and also has measureable savings on CPU time in macro benchmarks. New implementation is trivial.

I've done this already ~9months ago or so and just forgot to upstream. My colleague @olivereanderson and I nerd sniped into this and iterated multiple times. Oliver also created a SIMD optimized version. For now let's go with this easy drop in replacement which doesn't hinder future improvement but is nevertheless a nice improvement.

- Implementation (origin): https://docs.rs/bit_ops/0.2.4/bit_ops/struct.BitmapIter.html
- Micro Benchmark: https://github.com/phip1611/bit_ops/tree/7befc3998fac6c7bc0d9238f89b040da3f8c1b02#benchmarks