### PR TITLE
build: Fix cargo unused dependency warning

### DIFF
--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -21,7 +21,7 @@ linux-loader = { workspace = true, features = [
   "pe",
 ], optional = true }
 log = { workspace = true }
-num_enum = "0.7.6"
+num_enum = { version = "0.7.6", optional = true }
 pci = { path = "../pci" }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
@@ -48,7 +48,7 @@ default = []
 fw_cfg = ["arch/fw_cfg", "bitfield-struct", "linux-loader", "zerocopy"]
 ivshmem = []
 kvm = ["arch/kvm"]
-pvmemcontrol = []
+pvmemcontrol = ["dep:num_enum"]
 
 [lints]
 workspace = true

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -10,15 +10,13 @@ version = "0.1.0"
 kvm = ["kvm-bindings", "kvm-ioctls", "vfio-ioctls/kvm"]
 mshv = ["mshv-bindings", "mshv-ioctls", "mshv_emulator", "vfio-ioctls/mshv"]
 mshv_emulator = ["iced-x86", "mshv-bindings"]
-sev_snp = ["igvm", "igvm_defs"]
+sev_snp = ["dep:bitfield-struct", "igvm", "igvm_defs"]
 tdx = []
 
 [dependencies]
 anyhow = { workspace = true }
 arc-swap = "1.9.1"
-bitfield-struct = "0.13.0"
 byteorder = { workspace = true }
-cfg-if = { workspace = true }
 concat-idents = "1.1.5"
 igvm = { workspace = true, optional = true }
 igvm_defs = { workspace = true, optional = true }
@@ -31,9 +29,7 @@ mshv-bindings = { workspace = true, features = [
   "with-serde",
 ], optional = true }
 mshv-ioctls = { workspace = true, optional = true }
-open-enum = "0.5.2"
 serde = { workspace = true, features = ["derive", "rc"] }
-serde_json = { workspace = true }
 serde_with = { workspace = true, default-features = false, features = [
   "macros",
 ] }
@@ -62,7 +58,16 @@ features = [
 optional = true
 version = "1.21.0"
 
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+bitfield-struct = "0.13.0"
+open-enum = "0.5.2"
+serde_json = { workspace = true }
+
+[target.'cfg(not(target_arch = "aarch64"))'.dependencies]
+bitfield-struct = { version = "0.13.0", optional = true }
+
 [dev-dependencies]
+cfg-if = { workspace = true }
 env_logger = { workspace = true }
 
 [lints]

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -6,13 +6,13 @@ rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]
-libc = { workspace = true }
-log = { workspace = true }
-serde = { workspace = true, features = ["derive", "rc"] }
-serde_json = { workspace = true }
+libc = { workspace = true, optional = true }
+log = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
+serde_json = { workspace = true, optional = true }
 
 [features]
-tracing = []
+tracing = ["dep:libc", "dep:log", "dep:serde", "dep:serde_json"]
 
 [lints]
 workspace = true

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -34,6 +34,7 @@ mshv = [
 pvmemcontrol = ["devices/pvmemcontrol"]
 sev_snp = [
   "arch/sev_snp",
+  "dep:sha2",
   "hypervisor/sev_snp",
   "igvm",
   "virtio-devices/sev_snp",
@@ -82,7 +83,7 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["macros"] }
 serial_buffer = { path = "../serial_buffer" }
-sha2 = { workspace = true }
+sha2 = { workspace = true, optional = true }
 signal-hook = { workspace = true }
 socket2 = { version = "0.6.5", features = ["all"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
Cargo now has an unused dependency warning for when a dependency is
specified and is not needed. None of the dependencies were strictly
unused but merely used by specific build configurations (features and
architectures). Adjust the Cargo.toml files to only include dependencies
in the specific configurations that require them.

Signed-off-by: Rob Bradford <rbradford@meta.com>
