### PR TITLE
tests: Use direct watchdog keepalives

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -3427,19 +3427,10 @@ pub(crate) fn _test_watchdog(guest: &Guest) {
 
         let mut expected_reboot_count = 1;
 
-        // Enable the watchdog with a 15s timeout
-        enable_guest_watchdog(guest, 15);
+        // Ping frequently enough to remain below the device's fixed timeout.
+        enable_guest_watchdog(guest, 5);
 
         assert_eq!(get_reboot_count(guest), expected_reboot_count);
-        assert_eq!(
-            guest
-                .ssh_command("sudo journalctl | grep -c -- \"Watchdog started\"")
-                .unwrap()
-                .trim()
-                .parse::<u32>()
-                .unwrap_or_default(),
-            1
-        );
 
         // Allow some normal time to elapse to check we don't get spurious reboots
         thread::sleep(Duration::new(40, 0));

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -1048,7 +1048,7 @@ pub(crate) fn get_reboot_count(guest: &Guest) -> u32 {
         .unwrap_or_default()
 }
 
-pub(crate) fn enable_guest_watchdog(guest: &Guest, watchdog_sec: u32) {
+pub(crate) fn enable_guest_watchdog(guest: &Guest, keepalive_sec: u32) {
     // Check for PCI device
     assert!(
         guest
@@ -1056,13 +1056,32 @@ pub(crate) fn enable_guest_watchdog(guest: &Guest, watchdog_sec: u32) {
             .unwrap_or_default()
     );
 
+    let service = format!(
+        r#"[Unit]
+Description=Cloud Hypervisor watchdog keepalive
+
+[Service]
+ExecStart=/bin/sh -c 'exec 3>/dev/watchdog; while :; do printf . >&3; sleep {keepalive_sec}; done'
+Restart=on-failure
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target
+"#
+    );
     guest
         .ssh_command(&format!(
-            "echo RuntimeWatchdogSec={watchdog_sec}s | sudo tee -a /etc/systemd/system.conf"
+            "cat <<'EOF' | sudo tee /etc/systemd/system/watchdog-keepalive.service >/dev/null\n{service}EOF"
         ))
         .unwrap();
 
-    guest.ssh_command("sudo systemctl daemon-reexec").unwrap();
+    guest
+        .ssh_command(
+            "sudo systemctl daemon-reload && \
+             sudo systemctl enable --now watchdog-keepalive.service && \
+             sudo systemctl is-active --quiet watchdog-keepalive.service",
+        )
+        .unwrap();
 }
 
 pub(crate) fn make_guest_panic(guest: &Guest) {

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10869,19 +10869,10 @@ mod common_sequential {
 
             // Enable watchdog and ensure its functional
             let expected_reboot_count = 1;
-            // Enable the watchdog with a 15s timeout
-            enable_guest_watchdog(&guest, 15);
+            // Ping frequently enough to remain below the device's fixed timeout.
+            enable_guest_watchdog(&guest, 5);
 
             assert_eq!(get_reboot_count(&guest), expected_reboot_count);
-            assert_eq!(
-                guest
-                    .ssh_command("sudo journalctl | grep -c -- \"Watchdog started\"")
-                    .unwrap()
-                    .trim()
-                    .parse::<u32>()
-                    .unwrap_or_default(),
-                1
-            );
             // Allow some normal time to elapse to check we don't get spurious reboots
             thread::sleep(Duration::new(40, 0));
             // Check no reboot


### PR DESCRIPTION
## Summary

- Replace `RuntimeWatchdogSec` setup with a persistent systemd service that writes keepalives directly to `/dev/watchdog`.
- Use a 5-second keepalive interval to remain below the device's fixed watchdog timeout.
- Keep the existing no-spurious-reboot, panic/reboot, and pause/resume coverage while removing a journal assertion that did not prove the watchdog was armed.

## Background

The virtio watchdog uses a fixed timeout. On kernels that do not support the timeout reprogramming requested by systemd, `WDIOC_SETTIMEOUT` fails and no keepalives are sent, so the watchdog never becomes armed.

Opening `/dev/watchdog` and writing keepalives directly avoids depending on guest support for timeout reprogramming. If guest userspace stops after a panic, the keepalives stop and the watchdog resets the VM.

## Testing

- `common_sequential::test_watchdog` passed with the standard Ubuntu Jammy guest.
- Verified normal keepalives do not trigger a spurious reboot.
- Verified a sysrq panic is followed by a watchdog-triggered reboot.
- Verified pause/resume does not cause an unexpected reboot.
- `git diff --check upstream/main...HEAD`

The upstream pull request CI will run the complete x86_64 integration suite, including the watchdog and live-migration watchdog paths.

## AI/LLM assistance

GitHub Copilot assisted with investigation and implementation; the client did not expose a model version.