### PR TITLE
block: Serialize the direct I/O inline read-modify-write

### DIFF
--- a/block/src/formats/raw/engine_aio.rs
+++ b/block/src/formats/raw/engine_aio.rs
@@ -56,15 +56,15 @@ impl AsyncIo for RawAio {
 
         if operation_is_aligned(&op, self.alignment) {
             let fd = self.raw_file.as_raw_fd();
-            return self.data_io.submit_operation(fd, op).map_err(|e| {
-                if is_read {
-                    AsyncIoError::ReadVectored(e)
-                } else {
-                    AsyncIoError::WriteVectored(e)
-                }
-            });
+            return self
+                .data_io
+                .submit_operation(fd, op)
+                .map_err(|e| AsyncIoError::vectored(is_read, e));
         }
 
+        self.data_io
+            .wait_all_in_flight()
+            .map_err(|e| AsyncIoError::vectored(is_read, e))?;
         let result = run_unaligned_operation(&self.raw_file, &op)?;
         self.data_io
             .inject_completion(AsyncIoCompletion::from_operation(op, result));

--- a/block/src/formats/raw/engine_uring.rs
+++ b/block/src/formats/raw/engine_uring.rs
@@ -53,15 +53,15 @@ impl AsyncIo for RawAsync {
 
         if operation_is_aligned(&op, self.alignment) {
             let fd = self.raw_file.as_raw_fd();
-            return self.data_io.submit_operation(fd, op).map_err(|e| {
-                if is_read {
-                    AsyncIoError::ReadVectored(e)
-                } else {
-                    AsyncIoError::WriteVectored(e)
-                }
-            });
+            return self
+                .data_io
+                .submit_operation(fd, op)
+                .map_err(|e| AsyncIoError::vectored(is_read, e));
         }
 
+        self.data_io
+            .wait_all_in_flight()
+            .map_err(|e| AsyncIoError::vectored(is_read, e))?;
         let result = run_unaligned_operation(&self.raw_file, &op)?;
         self.data_io
             .inject_completion(AsyncIoCompletion::from_operation(op, result));
@@ -98,6 +98,10 @@ impl AsyncIo for RawAsync {
                 if operation_is_aligned(&op, self.alignment) {
                     aligned_batch.push(op);
                 } else {
+                    let is_read = op.is_read();
+                    self.data_io
+                        .wait_all_in_flight()
+                        .map_err(|e| AsyncIoError::vectored(is_read, e))?;
                     let result = run_unaligned_operation(&self.raw_file, &op)?;
                     self.data_io
                         .inject_completion(AsyncIoCompletion::from_operation(op, result));

--- a/block/src/formats/raw/engine_uring.rs
+++ b/block/src/formats/raw/engine_uring.rs
@@ -142,3 +142,69 @@ impl AsyncIo for RawAsync {
             .map_err(AsyncIoError::WriteZeroes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::FileExt;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+    use crate::async_io::OwnedIoBuffer;
+
+    // A sub block write under direct I/O must not drop a concurrent aligned write.
+    #[test]
+    fn sub_block_direct_write_preserves_concurrent_aligned_write() {
+        const BLK: usize = 4096;
+
+        let file = TempFile::new().unwrap().into_file();
+        file.set_len(BLK as u64).unwrap();
+
+        let aligned = AlignedFile::with_alignment(file.try_clone().unwrap(), BLK);
+        let mut eng = RawAsync::new(aligned, 128).unwrap();
+
+        let iters = 4000u64;
+        let mut lost = 0u64;
+        for i in 0..iters {
+            file.write_all_at(&[0xAA; BLK], 0).unwrap();
+
+            let mut w1buf = OwnedIoBuffer::new(BLK, BLK).unwrap();
+            w1buf.as_mut_slice().fill(0xBB);
+            eng.submit_data_operation(AsyncIoOperation::write_from_vec(0, w1buf, i * 2 + 1))
+                .unwrap();
+
+            eng.submit_data_operation(AsyncIoOperation::write_from_vec(
+                512,
+                OwnedIoBuffer::from_vec(vec![0xCC; 512]),
+                i * 2 + 2,
+            ))
+            .unwrap();
+
+            let mut done = 0;
+            let mut spins = 0;
+            while done < 2 {
+                if eng.next_completed_request().is_some() {
+                    done += 1;
+                } else {
+                    spins += 1;
+                    assert!(spins < 1_000_000, "timed out draining completions");
+                    sleep(Duration::from_micros(5));
+                }
+            }
+
+            let mut out = [0u8; BLK];
+            file.read_at(&mut out, 0).unwrap();
+            // 0xAA here means the whole block write was dropped.
+            if out[100] != 0xBB {
+                lost += 1;
+            }
+        }
+
+        assert_eq!(
+            lost, 0,
+            "sub block write dropped a concurrent aligned write"
+        );
+    }
+}

--- a/block/src/io/async_io.rs
+++ b/block/src/io/async_io.rs
@@ -98,6 +98,16 @@ pub enum AsyncIoError {
     SubmitBatchRequests(#[source] io::Error),
 }
 
+impl AsyncIoError {
+    pub(crate) fn vectored(is_read: bool, e: io::Error) -> Self {
+        if is_read {
+            Self::ReadVectored(e)
+        } else {
+            Self::WriteVectored(e)
+        }
+    }
+}
+
 pub type AsyncIoResult<T> = result::Result<T, AsyncIoError>;
 
 pub trait AsyncIo: Send {

--- a/block/src/io/async_io/aio_data_io.rs
+++ b/block/src/io/async_io/aio_data_io.rs
@@ -14,8 +14,14 @@ use log::warn;
 use vmm_sys_util::aio;
 use vmm_sys_util::eventfd::EventFd;
 
-use super::common::{duplicate_user_data_error, errno_result, validate_batch};
+use super::common::{
+    KernelDataIo, drain_all_in_flight, duplicate_user_data_error, errno_result,
+    record_kernel_completion, validate_batch,
+};
 use super::{AsyncIoCompletion, AsyncIoOperation, CompletionCommon};
+
+/// Completion events reaped per `get_events` call.
+const EVENT_BATCH: usize = 32;
 
 /// Retained Linux AIO queue for owned async data I/O operations.
 pub struct AioDataIo {
@@ -133,7 +139,7 @@ impl AioDataIo {
             return Some(completion);
         }
 
-        let mut events = [aio::IoEvent::default(); 32];
+        let mut events = [aio::IoEvent::default(); EVENT_BATCH];
         let rc = match self.ctx.get_events(0, &mut events, None) {
             Ok(rc) => rc,
             Err(e) => {
@@ -153,6 +159,31 @@ impl AioDataIo {
         }
 
         self.completions.next_completed()
+    }
+
+    pub fn wait_all_in_flight(&mut self) -> io::Result<()> {
+        drain_all_in_flight(self)
+    }
+}
+
+impl KernelDataIo for AioDataIo {
+    fn in_flight_is_empty(&self) -> bool {
+        self.in_flight.is_empty()
+    }
+
+    fn reap_blocking(&mut self) -> io::Result<()> {
+        let mut events = [aio::IoEvent::default(); EVENT_BATCH];
+        let rc = self.ctx.get_events(1, &mut events, None)?;
+        for event in &events[..rc] {
+            record_kernel_completion(
+                &mut self.in_flight,
+                &mut self.completions,
+                event.data,
+                event.res as i32,
+            );
+        }
+
+        Ok(())
     }
 }
 

--- a/block/src/io/async_io/common.rs
+++ b/block/src/io/async_io/common.rs
@@ -4,10 +4,10 @@
 
 //! Helpers used by both aio and uring async io.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io;
 
-use super::AsyncIoOperation;
+use super::{AsyncIoCompletion, AsyncIoOperation, CompletionCommon};
 
 /// Converts an I/O error into the negative errno form used in completions.
 pub(super) fn errno_result(error: &io::Error) -> i32 {
@@ -34,6 +34,36 @@ where
         if is_in_flight(user_data) || !seen.insert(user_data) {
             return Err(duplicate_user_data_error(user_data));
         }
+    }
+
+    Ok(())
+}
+
+/// Records the completion for `user_data` and releases its retained buffer.
+pub(super) fn record_kernel_completion(
+    in_flight: &mut HashMap<u64, Option<AsyncIoOperation>>,
+    completions: &mut CompletionCommon,
+    user_data: u64,
+    result: i32,
+) {
+    let buffer = in_flight
+        .remove(&user_data)
+        .flatten()
+        .and_then(AsyncIoOperation::into_completion_buffer);
+    completions.complete(AsyncIoCompletion::new(user_data, result, buffer));
+}
+
+pub(super) trait KernelDataIo {
+    fn in_flight_is_empty(&self) -> bool;
+
+    /// Reaps at least one completion, blocking if none is ready.
+    fn reap_blocking(&mut self) -> io::Result<()>;
+}
+
+/// Blocks until no operation is pending, keeping their completions.
+pub(super) fn drain_all_in_flight<D: KernelDataIo>(data_io: &mut D) -> io::Result<()> {
+    while !data_io.in_flight_is_empty() {
+        data_io.reap_blocking()?;
     }
 
     Ok(())

--- a/block/src/io/async_io/uring_data_io.rs
+++ b/block/src/io/async_io/uring_data_io.rs
@@ -12,7 +12,10 @@ use io_uring::{IoUring, opcode, squeue, types};
 use log::{error, warn};
 use vmm_sys_util::eventfd::EventFd;
 
-use super::common::{duplicate_user_data_error, validate_batch};
+use super::common::{
+    KernelDataIo, drain_all_in_flight, duplicate_user_data_error, record_kernel_completion,
+    validate_batch,
+};
 use super::{AsyncIoCompletion, AsyncIoOperation, CompletionCommon};
 
 /// `io_uring` wrapper for async I/O.
@@ -240,6 +243,41 @@ impl UringDataIo {
         }
 
         self.completions.next_completed()
+    }
+
+    pub fn wait_all_in_flight(&mut self) -> io::Result<()> {
+        drain_all_in_flight(self)
+    }
+}
+
+impl KernelDataIo for UringDataIo {
+    fn in_flight_is_empty(&self) -> bool {
+        self.in_flight.is_empty()
+    }
+
+    fn reap_blocking(&mut self) -> io::Result<()> {
+        if self.needs_submit_retry {
+            self.io_uring.submitter().submit()?;
+            self.needs_submit_retry = false;
+        }
+
+        let ready = self
+            .io_uring
+            .completion()
+            .next()
+            .map(|e| (e.user_data(), e.result()));
+        if let Some((user_data, result)) = ready {
+            record_kernel_completion(
+                &mut self.in_flight,
+                &mut self.completions,
+                user_data,
+                result,
+            );
+            return Ok(());
+        }
+
+        self.io_uring.submitter().submit_and_wait(1)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Under `direct=on` an aligned write goes to io_uring or libaio and runs async, while an unaligned write runs inline through `AlignedFile::write_unaligned`, which reads the whole backing block, patches it, and writes it back. Nothing serializes the two, so an inline writeback can read stale data and drop a concurrent async write to the same block.

Fix: drain the in flight async operations before the inline RMW, so no async write to the block is outstanding. The drain, completion recording, and error mapping are shared, so io_uring and libaio differ only in their reap syscall.

Scope:
- RAW io_uring and RAW libaio have the async plus inline split, both fixed.
- Fixed VHD forwards to raw io_uring, so it inherits the fix.
- QCOW is unaffected today since its writes are synchronous, only reads are async. Once its writes become async the same drain is needed.
- VHDX and VMDK are sync only, no async in flight, no race.

Considerations:
- The drain waits for all in flight ops, not just overlapping ones. Chosen for simplicity over range tracking, at some throughput cost on the rare inline path.
- With this fix the guest_block_size guard in #8595 could be revisited.

Discussion: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8595#issuecomment-5528432030
Related: #8812, #8813, #8477