### PR TITLE
tests: Use the released ch-remote for source VM on upgrade

### DIFF
--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -199,6 +199,46 @@ pub(crate) fn cloud_hypervisor_release_path() -> String {
     ch_release_path.into_os_string().into_string().unwrap()
 }
 
+pub(crate) fn ch_remote_release_path() -> String {
+    let mut workload_path = dirs::home_dir().unwrap();
+    workload_path.push("workloads");
+
+    let mut ch_remote_release_path = workload_path;
+    #[cfg(target_arch = "x86_64")]
+    ch_remote_release_path.push("ch-remote-static");
+    #[cfg(target_arch = "aarch64")]
+    ch_remote_release_path.push("ch-remote-static-aarch64");
+
+    ch_remote_release_path
+        .into_os_string()
+        .into_string()
+        .unwrap()
+}
+
+fn remote_command_with_binary(
+    ch_remote: &str,
+    api_socket: &str,
+    command: &str,
+    arg: Option<&str>,
+) -> bool {
+    let mut cmd = Command::new(ch_remote);
+    cmd.args([&format!("--api-socket={api_socket}"), command]);
+
+    if let Some(arg) = arg {
+        cmd.arg(arg);
+    }
+
+    let output = cmd.output().unwrap();
+    if output.status.success() {
+        true
+    } else {
+        eprintln!("Error running ch-remote command: {cmd:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("stderr: {stderr}");
+        false
+    }
+}
+
 pub(crate) fn prepare_vhost_user_net_daemon(
     tmp_dir: &TempDir,
     ip: &str,
@@ -1109,7 +1149,15 @@ pub(crate) fn start_live_migration(
     dest_api_socket: &str,
     memfds: bool,
     paused: bool,
+    upgrade_test: bool,
 ) -> bool {
+    // Control a release source VMM with ch-remote from the same release.
+    let source_ch_remote = if upgrade_test {
+        ch_remote_release_path()
+    } else {
+        clh_command("ch-remote")
+    };
+
     // Start to receive migration from the destination VM
     let mut receive_migration = Command::new(clh_command("ch-remote"))
         .args([
@@ -1126,25 +1174,30 @@ pub(crate) fn start_live_migration(
 
     if paused {
         // Test the migration of a paused VM.
-        let cmd_success = remote_command(src_api_socket, "pause", None);
+        let cmd_success =
+            remote_command_with_binary(&source_ch_remote, src_api_socket, "pause", None);
         if !cmd_success {
             let _ = receive_migration.kill();
             eprintln!("Failed to pause the source VM before live migration");
         }
     }
 
+    // The release client predates the memory_mode=memfds syntax.
+    let memory_option = if upgrade_test {
+        format!("local={}", if memfds { "on" } else { "off" })
+    } else {
+        format!("memory_mode={}", if memfds { "memfds" } else { "precopy" })
+    };
+
     // Start to send migration from the source VM
     let args = [
         format!("--api-socket={src_api_socket}"),
         "send-migration".to_string(),
-        format!(
-            "destination_url=unix:{migration_socket},memory_mode={}",
-            if memfds { "memfds" } else { "precopy" }
-        ),
+        format!("destination_url=unix:{migration_socket},{memory_option}"),
     ]
     .to_vec();
 
-    let mut send_migration = Command::new(clh_command("ch-remote"))
+    let mut send_migration = Command::new(source_ch_remote)
         .args(&args)
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6866,7 +6866,8 @@ mod common_parallel {
                     &src_api_socket,
                     &dest_api_socket,
                     memfds,
-                    paused
+                    paused,
+                    upgrade_test
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
@@ -7014,6 +7015,7 @@ mod common_parallel {
                     &src_api_socket,
                     &dest_api_socket,
                     true,
+                    false,
                     false
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
@@ -7846,6 +7848,7 @@ mod common_parallel {
                     &src_api_socket,
                     &dest_api_socket,
                     memfds,
+                    false,
                     false
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
@@ -8168,6 +8171,7 @@ mod ivshmem {
                     &src_api_socket,
                     &dest_api_socket,
                     memfds,
+                    false,
                     false
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
@@ -10315,7 +10319,8 @@ mod common_sequential {
                     &src_api_socket,
                     &dest_api_socket,
                     memfds,
-                    false
+                    false,
+                    upgrade_test
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
@@ -10531,7 +10536,8 @@ mod common_sequential {
                     &src_api_socket,
                     &dest_api_socket,
                     memfds,
-                    false
+                    false,
+                    upgrade_test
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
@@ -10669,7 +10675,8 @@ mod common_sequential {
                     &src_api_socket,
                     &dest_api_socket,
                     memfds,
-                    false
+                    false,
+                    upgrade_test
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
@@ -10924,7 +10931,8 @@ mod common_sequential {
                     &src_api_socket,
                     &dest_api_socket,
                     memfds,
-                    false
+                    false,
+                    upgrade_test
                 ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -19,6 +19,7 @@ update_workloads() {
     for required in "$JAMMY_OS_RAW_IMAGE" "$JAMMY_OS_QCOW2_UNCOMPRESSED_IMAGE" \
         "$WORKLOADS_DIR/CLOUDHV_EFI.fd" \
         "$WORKLOADS_DIR/cloud-hypervisor-static-aarch64" \
+        "$WORKLOADS_DIR/ch-remote-static-aarch64" \
         "$WORKLOADS_DIR/alpine-minirootfs-aarch64.tar.gz" \
         "$WORKLOADS_DIR/Image-arm64"; do
         if [ ! -f "$required" ]; then

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -33,7 +33,8 @@ required_files=(
     "$WORKLOADS_DIR/vmlinux-x86_64"
     "$WORKLOADS_DIR/bzImage-x86_64"
     "$WORKLOADS_DIR/alpine-minirootfs-x86_64.tar.gz"
-    "$WORKLOADS_DIR/cloud-hypervisor-static")
+    "$WORKLOADS_DIR/cloud-hypervisor-static"
+    "$WORKLOADS_DIR/ch-remote-static")
 
 for required in "${required_files[@]}"; do
     if [ ! -f "$required" ]; then

--- a/scripts/test_assets.yaml
+++ b/scripts/test_assets.yaml
@@ -76,7 +76,8 @@ assets:
     arch: [aarch64]
     test: [integration, metrics]
 
-  # Previous release binaries for live-upgrade tests
+  # Previous release binaries for live-upgrade tests. Keep each ch-remote
+  # version in sync with its corresponding cloud-hypervisor version.
   - filename: cloud-hypervisor-static
     url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v52.0/cloud-hypervisor-static
     sha256: 829af01ff075bb96c4f183905134c453a88d68cbabdc6b87df21098842581ee9
@@ -84,9 +85,23 @@ assets:
     arch: [x86_64]
     test: [integration]
 
+  - filename: ch-remote-static
+    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v52.0/ch-remote-static
+    sha256: d4e8709ed3ef8ba5c66d98770342a2d7c3c96174cfa9c5ae9e3e55de999869a3
+    executable: true
+    arch: [x86_64]
+    test: [integration]
+
   - filename: cloud-hypervisor-static-aarch64
     url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v52.0/cloud-hypervisor-static-aarch64
     sha256: bf004ddc1a148f47caa87ac49a783b8dbd6bf9bc27abe522ed197df7b982d3b1
+    executable: true
+    arch: [aarch64]
+    test: [integration]
+
+  - filename: ch-remote-static-aarch64
+    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v52.0/ch-remote-static-aarch64
+    sha256: 94d1dbcae65df9be8e5a2ec6ded9c6f8cbc1b3a0b95f199450146cdb9fb1b5bb
     executable: true
     arch: [aarch64]
     test: [integration]


### PR DESCRIPTION
When doing an upgrade migration used the version of ch-remote
corresponding to the version of the VMM in use. This ensures that the
HTTP requests sent are compatible with the source VMM.

Assisted-by: Codex:GPT-5.6
Signed-off-by: Rob Bradford <rbradford@meta.com>
