### PR TITLE
vmm: Support shutdown/reboot during migration

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -7690,6 +7690,170 @@ mod common_parallel {
         _test_live_migration(false, true, true);
     }
 
+    #[derive(Clone, Copy)]
+    enum GuestEventDuringMigration {
+        RebootImmediately,
+        RebootDuringPrecopy,
+        ShutdownImmediately,
+        ShutdownDuringPrecopy,
+    }
+
+    fn _test_live_migration_guest_event(guest_event: GuestEventDuringMigration) {
+        fn wait_for_vm_event(event: &str, event_path: &str) {
+            let expected = MetaEvent {
+                event: event.to_string(),
+                device_id: None,
+            };
+            assert!(wait_for_sequential_events(
+                Duration::from_secs(30),
+                &[&expected],
+                event_path,
+            ));
+        }
+
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME).with_memory("500M");
+        let src_api_socket = temp_api_path(&guest.tmp_dir);
+        let src_event_path = temp_event_monitor_path(&guest.tmp_dir);
+
+        let mut src_child = GuestCommand::new(&guest)
+            .default_cpus()
+            .default_memory()
+            .default_kernel_cmdline()
+            .default_disks()
+            .default_net()
+            .args(["--api-socket", &src_api_socket])
+            .args(["--event-monitor", format!("path={src_event_path}").as_str()])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let mut dest_api_socket = temp_api_path(&guest.tmp_dir);
+        dest_api_socket.push_str(".dest");
+        let dest_event_path = format!("{src_event_path}.dest");
+        let mut dest_child = GuestCommand::new(&guest)
+            .args(["--api-socket", &dest_api_socket])
+            .args(["--no-shutdown"])
+            .args([
+                "--event-monitor",
+                format!("path={dest_event_path}").as_str(),
+            ])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            guest.wait_vm_boot().unwrap();
+            let reboot_count = get_reboot_count(&guest);
+
+            // Ensure we have a longer time window to reboot/shutdown.
+            start_stress_in_vm(&guest);
+
+            let migration_port = get_available_port();
+            let receive_url = format!("receiver_url=tcp:0.0.0.0:{migration_port}");
+            let receive_api_socket = dest_api_socket.clone();
+            let receive_migration = thread::spawn(move || {
+                remote_command(&receive_api_socket, "receive-migration", Some(&receive_url))
+            });
+
+            wait_for_vm_event("migration-receive-ready", &dest_event_path);
+
+            assert!(remote_command(
+                &src_api_socket,
+                "send-migration",
+                Some(&format!(
+                    "destination_url=tcp:127.0.0.1:{migration_port},downtime_ms=1,timeout_s=30,timeout_strategy=cancel"
+                )),
+            ));
+
+            match guest_event {
+                GuestEventDuringMigration::RebootDuringPrecopy
+                | GuestEventDuringMigration::ShutdownDuringPrecopy => {
+                    wait_for_vm_event("migration-memory-iteration", &src_event_path);
+                }
+                _ => (),
+            }
+
+            match guest_event {
+                GuestEventDuringMigration::RebootImmediately
+                | GuestEventDuringMigration::RebootDuringPrecopy => {
+                    guest.ssh_command("sudo reboot").unwrap();
+                }
+                GuestEventDuringMigration::ShutdownImmediately
+                | GuestEventDuringMigration::ShutdownDuringPrecopy => {
+                    guest.ssh_command("sudo poweroff").unwrap();
+                }
+            }
+
+            wait_for_vm_event("migration-finished", &src_event_path);
+            assert!(receive_migration.join().unwrap());
+            assert!(wait_until(Duration::from_secs(30), || {
+                matches!(src_child.try_wait(), Ok(Some(status)) if status.success())
+            }));
+
+            // The event must be replayed after the migration was finished.
+            wait_for_vm_event("migration-receive-finished", &dest_event_path);
+
+            match guest_event {
+                GuestEventDuringMigration::RebootImmediately
+                | GuestEventDuringMigration::RebootDuringPrecopy => {
+                    // Wait for the VM to be reachable again
+                    guest.wait_vm_boot().unwrap();
+                    assert_eq!(get_reboot_count(&guest), reboot_count + 1);
+                    wait_for_vm_event("rebooting", &dest_event_path);
+                    wait_for_vm_event("rebooted", &dest_event_path);
+                }
+                GuestEventDuringMigration::ShutdownImmediately
+                | GuestEventDuringMigration::ShutdownDuringPrecopy => {
+                    wait_for_vm_event("shutdown", &dest_event_path);
+
+                    // check guest can be booted again
+                    assert!(remote_command(&dest_api_socket, "boot", None,));
+                    guest.wait_vm_boot().unwrap();
+                    assert_eq!(get_reboot_count(&guest), reboot_count + 1);
+                    wait_for_vm_event("booting", &dest_event_path);
+                    wait_for_vm_event("booted", &dest_event_path);
+                }
+            }
+        }));
+
+        if r.is_err() {
+            print_and_panic(
+                src_child,
+                dest_child,
+                None,
+                "Error handling a guest lifecycle event during live migration",
+            );
+        }
+
+        let _ = src_child.kill();
+        let src_output = src_child.wait_with_output().unwrap();
+        handle_child_output(Ok(()), &src_output);
+
+        let _ = dest_child.kill();
+        let dest_output = dest_child.wait_with_output().unwrap();
+        handle_child_output(Ok(()), &dest_output);
+    }
+
+    #[test]
+    fn test_live_migration_tcp_event_reboot_immediately() {
+        _test_live_migration_guest_event(GuestEventDuringMigration::RebootImmediately);
+    }
+
+    #[test]
+    fn test_live_migration_tcp_event_reboot_during_precopy() {
+        _test_live_migration_guest_event(GuestEventDuringMigration::RebootDuringPrecopy);
+    }
+
+    #[test]
+    fn test_live_migration_tcp_event_shutdown_immediately() {
+        _test_live_migration_guest_event(GuestEventDuringMigration::ShutdownImmediately);
+    }
+
+    #[test]
+    fn test_live_migration_tcp_event_shutdown_during_precopy() {
+        _test_live_migration_guest_event(GuestEventDuringMigration::ShutdownDuringPrecopy);
+    }
+
     #[test]
     fn test_live_migration_tcp() {
         _test_live_migration_tcp(NonZeroU32::new(1).unwrap());

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -41,7 +41,7 @@ use vm_memory::{Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::protocol::*;
 use vm_migration::{
     MemoryMigrationContext, Migratable, MigratableError, OngoingMigrationContext, Pausable,
-    Snapshot, Snapshottable, Transportable,
+    Snapshot, Snapshottable, Transportable, state_from_id,
 };
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::unblock_signal;
@@ -654,13 +654,18 @@ pub struct VmmThreadHandle {
     pub http_api_handle: Option<HttpApiHandle>,
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
 enum PendingVmAction {
     #[default]
     None,
     Reboot,
     Shutdown,
     VmmShutdown,
+}
+
+#[derive(Default, Deserialize, Serialize)]
+struct VmmSnapshot {
+    pending_action: PendingVmAction,
 }
 
 /// Models the current ownership and associated state of the VM from the
@@ -733,6 +738,7 @@ pub struct Vmm {
 
 /// Time before aborting on the page fault connection.
 const FAULT_CONNECTION_ACCEPT_TIMEOUT: Duration = Duration::from_secs(30);
+const VMM_SNAPSHOT_ID: &str = "vmm";
 
 /// Just a wrapper for the data that goes into
 /// [`ReceiveMigrationState::Configured`]
@@ -1402,6 +1408,8 @@ impl Vmm {
                 .context("Error deserialising snapshot")
                 .map_err(MigratableError::MigrateReceive)
         })?;
+        let vmm_snapshot: VmmSnapshot =
+            state_from_id(Some(&snapshot), VMM_SNAPSHOT_ID)?.unwrap_or_default();
 
         let exit_evt = self
             .exit_evt
@@ -1472,6 +1480,7 @@ impl Vmm {
             Ok(vm)
         })?;
 
+        *self.pending_action.lock().unwrap() = vmm_snapshot.pending_action;
         self.vm = VmOwnership::Owned(vm);
 
         Ok((receive_duration, restore_duration))
@@ -1680,6 +1689,7 @@ impl Vmm {
     /// migrations.
     fn send_migration(
         vm: &mut Vm,
+        pending_action: &Mutex<PendingVmAction>,
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         hypervisor: &dyn hypervisor::Hypervisor,
         send_data_migration: &VmSendMigrationData,
@@ -1862,7 +1872,7 @@ impl Vmm {
             None
         };
 
-        let (vm_snapshot, snapshot_duration) = measure_ok(|| {
+        let (mut vm_snapshot, snapshot_duration) = measure_ok(|| {
             // Capture snapshot. This may have side effects, e.g. vhost-user backend inflight drain
             let snapshot = vm.snapshot()?;
 
@@ -1873,6 +1883,14 @@ impl Vmm {
             }
             Ok(snapshot)
         })?;
+
+        let vmm_snapshot = VmmSnapshot {
+            pending_action: *pending_action.lock().unwrap(),
+        };
+        vm_snapshot.add_snapshot(
+            VMM_SNAPSHOT_ID.to_string(),
+            Snapshot::new_from_state(&vmm_snapshot)?,
+        );
 
         let (_, send_snapshot_duration) =
             measure_ok(|| transport::send_state(&mut socket, &vm_snapshot))?;
@@ -2174,6 +2192,7 @@ impl Vmm {
                 self.vm = VmOwnership::Owned(vm);
             }
             Ok(()) => {
+                *self.pending_action.lock().unwrap() = PendingVmAction::None;
                 self.vm = VmOwnership::None;
                 let mut vm = vm;
 
@@ -3470,6 +3489,7 @@ impl RequestHandler for Vmm {
 
         match MigrationWorker::spawn(
             vm,
+            Arc::clone(&self.pending_action),
             check_migration_evt,
             send_data_migration,
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -654,6 +654,15 @@ pub struct VmmThreadHandle {
     pub http_api_handle: Option<HttpApiHandle>,
 }
 
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+enum PendingVmAction {
+    #[default]
+    None,
+    Reboot,
+    Shutdown,
+    VmmShutdown,
+}
+
 /// Models the current ownership and associated state of the VM from the
 /// perspective of the VMM.
 enum VmOwnership {
@@ -719,6 +728,7 @@ pub struct Vmm {
     console_socket_listener: Option<Arc<LockedUnixListener>>,
     no_shutdown: bool,
     check_migration_evt: EventFd,
+    pending_action: Arc<Mutex<PendingVmAction>>,
 }
 
 /// Time before aborting on the page fault connection.
@@ -953,6 +963,7 @@ impl Vmm {
             console_socket_listener: None,
             no_shutdown,
             check_migration_evt,
+            pending_action: Arc::new(Mutex::new(PendingVmAction::None)),
         })
     }
 
@@ -2186,6 +2197,26 @@ impl Vmm {
         }
     }
 
+    fn apply_pending_action(&mut self) -> Result<bool> {
+        let pending_action = mem::take(&mut *self.pending_action.lock().unwrap());
+
+        match pending_action {
+            PendingVmAction::None => Ok(false),
+            PendingVmAction::Reboot => {
+                self.vm_reboot().map_err(Error::VmReboot)?;
+                Ok(false)
+            }
+            PendingVmAction::Shutdown if self.no_shutdown => {
+                self.vm_shutdown().map_err(Error::VmShutdown)?;
+                Ok(false)
+            }
+            PendingVmAction::Shutdown | PendingVmAction::VmmShutdown => {
+                self.vmm_shutdown().map_err(Error::VmmShutdown)?;
+                Ok(true)
+            }
+        }
+    }
+
     fn control_loop(
         &mut self,
         api_receiver: &Receiver<ApiRequest>,
@@ -2197,6 +2228,10 @@ impl Vmm {
         let epoll_fd = self.epoll.as_raw_fd();
 
         'outer: loop {
+            if self.apply_pending_action()? {
+                break 'outer;
+            }
+
             let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
                 Ok(res) => res,
                 Err(e) => {
@@ -2225,27 +2260,23 @@ impl Vmm {
                         info!("VM exit event");
                         // Consume the event.
                         self.exit_evt.read().map_err(Error::EventFdRead)?;
-                        // TODO: Future follow-up must resolve lifecycle handling while migrating.
-                        self.vmm_shutdown().map_err(Error::VmmShutdown)?;
-
-                        break 'outer;
+                        *self.pending_action.lock().unwrap() = PendingVmAction::VmmShutdown;
                     }
                     EpollDispatch::Reset => {
                         info!("VM reset event");
                         // Consume the event.
                         self.reset_evt.read().map_err(Error::EventFdRead)?;
-                        // TODO: Future follow-up must resolve lifecycle handling while migrating.
-                        self.vm_reboot().map_err(Error::VmReboot)?;
+                        let mut pending_action = self.pending_action.lock().unwrap();
+                        if *pending_action == PendingVmAction::None {
+                            *pending_action = PendingVmAction::Reboot;
+                        }
                     }
                     EpollDispatch::GuestExit => {
                         info!("VM guest exit event");
                         self.guest_exit_evt.read().map_err(Error::EventFdRead)?;
-                        // TODO: Future follow-up must resolve lifecycle handling while migrating.
-                        if self.no_shutdown {
-                            self.vm_shutdown().map_err(Error::VmShutdown)?;
-                        } else {
-                            self.vmm_shutdown().map_err(Error::VmmShutdown)?;
-                            break 'outer;
+                        let mut pending_action = self.pending_action.lock().unwrap();
+                        if *pending_action != PendingVmAction::VmmShutdown {
+                            *pending_action = PendingVmAction::Shutdown;
                         }
                     }
                     EpollDispatch::ActivateVirtioDevices => {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2198,6 +2198,10 @@ impl Vmm {
     }
 
     fn apply_pending_action(&mut self) -> Result<bool> {
+        if matches!(&self.vm, VmOwnership::Migration { .. }) {
+            return Ok(false);
+        }
+
         let pending_action = mem::take(&mut *self.pending_action.lock().unwrap());
 
         match pending_action {

--- a/vmm/src/migration/worker.rs
+++ b/vmm/src/migration/worker.rs
@@ -13,9 +13,8 @@
 //! [`MigrationWorkerSpawnError`].
 
 use std::fmt::{self, Debug, Formatter};
-#[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-use std::sync::Arc;
 use std::sync::mpsc::{self, Receiver};
+use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::{io, thread};
 
@@ -26,9 +25,9 @@ use seccompiler::{BpfProgram, apply_filter};
 use vm_migration::MigratableError;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::Vmm;
 use crate::api::VmSendMigrationData;
 use crate::vm::{Vm, VmState};
+use crate::{PendingVmAction, Vmm};
 
 #[derive(thiserror::Error)]
 #[error("Migration worker could not be spawned: {spawn_error}")]
@@ -80,6 +79,7 @@ pub(crate) struct MigrationWorker {
     // Keep the VM out of the thread closure until spawning succeeds.
     vm_receiver: Receiver<Vm>,
     check_migration_evt: EventFd,
+    pending_action: Arc<Mutex<PendingVmAction>>,
     config: VmSendMigrationData,
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
@@ -110,6 +110,7 @@ impl MigrationWorker {
                 event!("vm", "migration-starting");
                 Vmm::send_migration(
                     &mut vm,
+                    self.pending_action.as_ref(),
                     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
                     self.hypervisor.as_ref(),
                     &self.config,
@@ -137,6 +138,7 @@ impl MigrationWorker {
     #[expect(clippy::result_large_err)]
     pub(crate) fn spawn(
         vm: Vm,
+        pending_action: Arc<Mutex<PendingVmAction>>,
         check_migration_evt: EventFd,
         config: VmSendMigrationData,
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))] hypervisor: Arc<
@@ -149,6 +151,7 @@ impl MigrationWorker {
         let worker = MigrationWorker {
             vm_receiver,
             check_migration_evt,
+            pending_action,
             config,
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             hypervisor,


### PR DESCRIPTION
- **vmm: Refactor pending VM actions**
- **vmm: Don't apply the pending (reboot/shutdown action) if migrating**
- **vmm: Defer pending actions during migration**
- **tests: cover lifecycle events during precopy migration**
