### PR TITLE
ci: Update virtio-villain to v1.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -903,7 +903,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VILLAIN_REPO: https://github.com/weltling/virtio-villain.git
-      VILLAIN_REF: v0.9.0
+      VILLAIN_REF: v1.0.0
     steps:
       - name: Code checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Bump the pinned virtio-villain tag to v1.0.0. For this job it brings the split of PCI config accesses into 32 bit reads, a queue test that is skipped when the device lacks that queue, and two hardened state tests.

The new RTC alarm tests, fuzzing, and performance work in the release are not exercised here.

Assisted-by: Claude:Opus-4.8