### PR TITLE
vmm: Add support for loading SMBIOS OEM strings from files

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -2615,6 +2615,118 @@ pub(crate) fn _test_dmi_oem_strings(guest: &Guest) {
 }
 
 #[cfg(target_arch = "x86_64")]
+fn check_dmi_oem_strings(guest: &Guest, strings: &[&str]) {
+    assert_eq!(
+        guest
+            .ssh_command("sudo dmidecode --oem-string count")
+            .unwrap()
+            .trim(),
+        strings.len().to_string()
+    );
+    // dmidecode sanitizes non-printable/non-ASCII bytes. Read the raw Type 11
+    // string-set (after its five-byte header) to check exact byte preservation.
+    let raw = guest
+        .ssh_command("sudo od -An -v -tx1 -j5 /sys/firmware/dmi/entries/11-0/raw")
+        .unwrap();
+    let expected = format!("{}\0\0", strings.join("\0"));
+    let expected_hex = expected
+        .as_bytes()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(
+        raw.split_whitespace().collect::<Vec<_>>().join(" "),
+        expected_hex
+    );
+}
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn _test_dmi_oem_string_paths(guest: &Guest) {
+    let inline = "String from command line";
+    let first = "Secret from file 1";
+    let multiline =
+        "io.systemd.credential:bootstrapSecret=multi-line-secret\n\nand non-ascii chars © ™\n";
+    let first_path = guest.tmp_dir.as_path().join("oem1.txt");
+    let multiline_path = guest.tmp_dir.as_path().join("oem2.txt");
+    fs::write(&first_path, first).unwrap();
+    fs::write(&multiline_path, multiline).unwrap();
+    let platform = format!(
+        "oem_strings=[{inline}],oem_string_paths=[{},{}]",
+        first_path.display(),
+        multiline_path.display()
+    );
+    let mut child = GuestCommand::new(guest)
+        .args(["--landlock"])
+        .default_cpus()
+        .default_memory()
+        .default_kernel_cmdline_with_platform(Some(&platform))
+        .default_disks()
+        .default_net()
+        .capture_output()
+        .spawn()
+        .unwrap();
+
+    let r = panic::catch_unwind(|| {
+        guest.wait_vm_boot().unwrap();
+        check_dmi_oem_strings(guest, &[inline, first, multiline]);
+    });
+
+    kill_child(&mut child);
+    let output = child.wait_with_output().unwrap();
+    handle_child_output(r, &output);
+}
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn _test_dmi_oem_string_paths_api(guest: &Guest) {
+    let api_socket = temp_api_path(&guest.tmp_dir);
+    let path = guest.tmp_dir.as_path().join("oem");
+    let secret = "io.systemd.credential:apiSecret=first line\n\n© ™\n";
+    let mut config: serde_json::Value = serde_json::from_str(&guest.api_create_body()).unwrap();
+    config["platform"] = serde_json::json!({"oem_string_paths": [path]});
+    let config_path = guest.tmp_dir.as_path().join("config.json");
+    fs::write(&config_path, serde_json::to_vec(&config).unwrap()).unwrap();
+
+    let mut child = GuestCommand::new(guest)
+        .args(["--api-socket", &api_socket])
+        .capture_output()
+        .spawn()
+        .unwrap();
+
+    let r = panic::catch_unwind(|| {
+        assert!(wait_until(Duration::from_secs(5), || remote_command(
+            &api_socket,
+            "ping",
+            None
+        )));
+        // The file does not exist at vm.create: its contents are needed only at boot.
+        assert!(remote_command(
+            &api_socket,
+            "create",
+            Some(config_path.to_str().unwrap())
+        ));
+        fs::write(&path, secret).unwrap();
+        assert!(remote_command(&api_socket, "boot", None));
+        guest.wait_vm_boot().unwrap();
+        check_dmi_oem_strings(guest, &[secret]);
+
+        let (success, output, _) = remote_command_w_output(&api_socket, "info", None);
+        assert!(success);
+        let info: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(
+            info["config"]["platform"]["oem_string_paths"],
+            serde_json::json!([path])
+        );
+        assert!(info["config"]["platform"]["oem_strings"].is_null());
+        assert!(!String::from_utf8(output).unwrap().contains("apiSecret"));
+    });
+
+    kill_child(&mut child);
+    let output = child.wait_with_output().unwrap();
+    handle_child_output(r, &output);
+}
+
+#[cfg(target_arch = "x86_64")]
 pub(crate) fn _test_dmi_system_and_chassis(guest: &Guest) {
     let fields = [
         ("system_manufacturer", "system-manufacturer", "Manufacturer"),

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -2284,6 +2284,20 @@ mod common_parallel {
 
     #[test]
     #[cfg(target_arch = "x86_64")]
+    fn test_dmi_oem_string_paths() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_dmi_oem_string_paths(&guest);
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_dmi_oem_string_paths_api() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_dmi_oem_string_paths_api(&guest);
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
     fn test_dmi_system_and_chassis() {
         let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
         _test_dmi_system_and_chassis(&guest);

--- a/docs/smbios.md
+++ b/docs/smbios.md
@@ -1,0 +1,122 @@
+# SMBIOS
+
+Cloud Hypervisor can set SMBIOS fields for x86-64 guests. Use `--platform` on
+the command line, or the `platform` object in the VM API configuration.
+These options do not configure SMBIOS on AArch64 or RISC-V.
+
+## System information (Type 1)
+
+| Option | Field | Default |
+| --- | --- | --- |
+| `system_manufacturer` | Manufacturer | `Cloud Hypervisor` |
+| `system_product_name` | Product name | `cloud-hypervisor` |
+| `system_version` | Version | Not set |
+| `system_serial_number` | Serial number | Not set |
+| `system_uuid` | UUID | All-zero UUID |
+| `system_sku_number` | SKU number | Not set |
+| `system_family` | Family | Not set |
+
+For example, add this option to the VM command:
+
+```shell
+--platform 'system_serial_number=vm-001,system_uuid=00112233-4455-6677-8899-aabbccddeeff'
+```
+
+The old names `serial_number` and `uuid` still work, but they are deprecated.
+Use `system_serial_number` and `system_uuid` in new configurations.
+
+## System enclosure (Type 3)
+
+Use `chassis_asset_tag` to set the asset tag:
+
+```shell
+--platform 'chassis_asset_tag=asset-001'
+```
+
+Cloud Hypervisor adds a Type 3 table when you set this option.
+You cannot set the other chassis fields.
+
+## OEM strings (Type 11)
+
+Use `oem_strings` to supply strings directly:
+
+```shell
+--platform 'oem_strings=[public-label,another-label]'
+```
+
+Use `oem_string_paths` to read strings from host files:
+
+```shell
+--platform 'oem_strings=[public-label],oem_string_paths=[/run/secrets/bootstrap]'
+```
+
+Put all platform settings in one `--platform` argument. In the API, use the
+same option names in the `platform` object:
+
+```json
+{
+  "platform": {
+    "system_serial_number": "vm-001",
+    "oem_strings": ["public-label"],
+    "oem_string_paths": ["/run/secrets/bootstrap"]
+  }
+}
+```
+
+Each file supplies one complete OEM string. The file must contain UTF-8 text
+and at least one byte. It must not contain NUL bytes.
+Cloud Hypervisor preserves spaces, newlines, and non-ASCII characters.
+It does not split a file into separate strings at each newline.
+
+Inline strings come first. File contents follow in the order of
+`oem_string_paths`. The order of the two options does not change this result.
+The combined list must not exceed 255 strings. An empty path list adds no
+strings. Cloud Hypervisor does not interpret the strings or check for duplicate
+credential names.
+
+The VMM reads the files at boot, not when it parses the configuration.
+The paths refer to files on the VMM host, not on the API client or in the guest.
+A missing, unreadable, or invalid file causes boot to fail.
+Keep the files available for subsequent boots.
+
+### Example: a systemd credential
+
+Use a host file that only the VMM user can read. For this example,
+`/run/secrets/bootstrap` contains this complete string:
+
+```text
+io.systemd.credential:bootstrap_secret=example-secret
+```
+
+Use `oem_string_paths` as shown above. In a guest that supports systemd SMBIOS
+credentials, read the credential with this command:
+
+```shell
+systemd-creds --system cat bootstrap_secret
+```
+
+Include a newline at the end of the file only if the credential needs it.
+Do not put a real secret in a shell command that shell history will record.
+
+File input keeps secret contents out of process arguments and configuration
+logs. The VMM does not copy those contents into the API configuration.
+This feature does not encrypt the strings. The guest can read them from SMBIOS.
+Guest memory snapshots and dumps can also contain them. Protect those files.
+
+## Read the fields in the guest
+
+Use `dmidecode` to read individual fields:
+
+```shell
+sudo dmidecode -s system-serial-number
+sudo dmidecode -s chassis-asset-tag
+sudo dmidecode --oem-string 1
+```
+
+`dmidecode` changes non-printable and non-ASCII bytes in its text output.
+To check the original OEM string bytes, read the Type 11 entry after its
+five-byte header:
+
+```shell
+sudo od -An -v -tx1 -j5 /sys/firmware/dmi/entries/11-0/raw
+```

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1011,6 +1011,15 @@ components:
           type: string
         chassis_asset_tag:
           type: string
+        oem_string_paths:
+          description: >-
+            Host paths to nonempty UTF-8 files without NUL bytes. Each file is
+            read at VM boot and appended as one OEM string after oem_strings,
+            in list order. Whitespace and newlines are preserved.
+            The combined number of inline strings and paths must not exceed 255.
+          type: array
+          items:
+            type: string
         tdx:
           type: boolean
           default: false

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -881,7 +881,7 @@ impl PlatformConfig {
             system_product_name=<dmi_system_product_name>,system_version=<dmi_system_version>,\
             system_serial_number=<dmi_system_serial_number>,system_uuid=<dmi_system_uuid>,\
             system_sku_number=<dmi_system_sku_number>,system_family=<dmi_system_family>,\
-            oem_strings=<list_of_strings>,chassis_asset_tag=<dmi_chassis_asset_tag>"
+            oem_strings=<list_of_strings>,oem_string_paths=<list_of_paths>,chassis_asset_tag=<dmi_chassis_asset_tag>"
                 .to_string();
 
             if cfg!(feature = "tdx") {
@@ -949,6 +949,7 @@ impl PlatformConfig {
             .add("serial_number")
             .add("uuid")
             .add("oem_strings")
+            .add("oem_string_paths")
             .add("iommufd")
             .add("iommufd_fd")
             .add("vfio_p2p_dma");
@@ -977,6 +978,17 @@ impl PlatformConfig {
             .convert::<StringList>("oem_strings")
             .map_err(Error::ParsePlatform)?
             .map(|v| v.0.into_boxed_slice());
+        let oem_string_paths = parser
+            .convert::<StringList>("oem_string_paths")
+            .map_err(Error::ParsePlatform)?
+            .map(|v| {
+                // StringList represents [] as one empty string, not an empty list.
+                if v.0 == [""] {
+                    Box::default()
+                } else {
+                    v.0.into_boxed_slice()
+                }
+            });
         let iommufd_fd = parser
             .convert::<i32>("iommufd_fd")
             .map_err(Error::ParsePlatform)?;
@@ -1010,6 +1022,7 @@ impl PlatformConfig {
             system_serial_number: None,
             system_uuid: None,
             oem_strings,
+            oem_string_paths,
             system_manufacturer: None,
             system_product_name: None,
             system_version: None,
@@ -5834,6 +5847,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             system_serial_number: None,
             system_uuid: None,
             oem_strings: None,
+            oem_string_paths: None,
             iommufd: false,
             iommufd_fd: None,
             vfio_p2p_dma: default_platformconfig_vfio_p2p_dma(),
@@ -7303,5 +7317,36 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert!(both.items.as_ref().unwrap().item_list[0].file.is_some());
         assert!(both.items.as_ref().unwrap().item_list[0].string.is_some());
         Ok(())
+    }
+
+    #[test]
+    fn test_platform_oem_string_paths_parsing() -> Result<()> {
+        let config = PlatformConfig::parse("oem_strings=[foo],oem_string_paths=[/path/1,/path/2]")?;
+        assert_eq!(
+            config.oem_strings.as_deref(),
+            Some(["foo".to_string()].as_slice())
+        );
+        assert_eq!(
+            config.oem_string_paths.as_deref(),
+            Some(["/path/1".to_string(), "/path/2".to_string()].as_slice())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_platform_oem_string_paths_empty_list() {
+        let cli = PlatformConfig::parse("oem_string_paths=[]").unwrap();
+        let api: PlatformConfig = serde_json::from_str(r#"{"oem_string_paths":[]}"#).unwrap();
+        assert_eq!(cli.oem_string_paths, api.oem_string_paths);
+    }
+
+    #[test]
+    fn test_platform_oem_string_paths_option_order() {
+        let inline_first =
+            PlatformConfig::parse("oem_strings=[foo],oem_string_paths=[/path]").unwrap();
+        let paths_first =
+            PlatformConfig::parse("oem_string_paths=[/path],oem_strings=[foo]").unwrap();
+        assert_eq!(inline_first, paths_first);
     }
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -14,6 +14,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 #[cfg(feature = "fw_cfg")]
 use std::ffi;
+#[cfg(target_arch = "x86_64")]
+use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Seek, SeekFrom, Write};
 use std::num::Wrapping;
@@ -112,6 +114,8 @@ use crate::migration::{SNAPSHOT_CONFIG_FILE, SNAPSHOT_STATE_FILE, get_vm_snapsho
 use crate::sev::MeasuredBootInfo;
 #[cfg(feature = "fw_cfg")]
 use crate::vm_config::FwCfgConfig;
+#[cfg(target_arch = "x86_64")]
+use crate::vm_config::PlatformConfig;
 use crate::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, HotplugMethod, NetConfig,
     NumaConfig, PayloadConfig, PmemConfig, UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
@@ -124,6 +128,14 @@ use crate::{
 /// Errors associated with VM management
 #[derive(Debug, Error)]
 pub enum Error {
+    #[cfg(target_arch = "x86_64")]
+    #[error("Cannot read OEM string file '{0}'")]
+    OemStringFileRead(String, #[source] io::Error),
+
+    #[cfg(target_arch = "x86_64")]
+    #[error("Too many OEM strings: {0} (maximum 255)")]
+    TooManyOemStrings(usize),
+
     #[error("Cannot open kernel file")]
     KernelFile(#[source] io::Error),
 
@@ -370,6 +382,34 @@ pub enum Error {
     ApplyMemoryZoneUpdate(#[source] MemoryZoneUpdateError),
 }
 pub type Result<T> = result::Result<T, Error>;
+
+#[cfg(target_arch = "x86_64")]
+fn load_smbios_config(platform: &PlatformConfig) -> Result<Option<arch::x86_64::SmbiosConfig>> {
+    let mut smbios = platform.smbios_config().unwrap_or_default();
+    let paths = platform.oem_string_paths.as_deref().unwrap_or_default();
+    let count = smbios.oem_strings.len() + paths.len();
+    if count > usize::from(u8::MAX) {
+        return Err(Error::TooManyOemStrings(count));
+    }
+    let mut oem_strings = smbios.oem_strings.into_vec();
+    for path in paths {
+        let content =
+            fs::read_to_string(path).map_err(|e| Error::OemStringFileRead(path.clone(), e))?;
+        // Empty strings and embedded NULs would corrupt the SMBIOS string-set.
+        if content.is_empty() || content.contains('\0') {
+            return Err(Error::OemStringFileRead(
+                path.clone(),
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "OEM string must be nonempty and contain no NUL bytes",
+                ),
+            ));
+        }
+        oem_strings.push(content);
+    }
+    smbios.oem_strings = oem_strings.into_boxed_slice();
+    Ok((!smbios.is_empty()).then_some(smbios))
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum VmState {
@@ -1841,7 +1881,9 @@ impl Vm {
             .unwrap()
             .platform
             .as_ref()
-            .and_then(|p| p.smbios_config());
+            .map(load_smbios_config)
+            .transpose()?
+            .flatten();
 
         let topology = self.cpu_manager.lock().unwrap().get_vcpu_topology();
 
@@ -3639,6 +3681,146 @@ impl GuestDebuggable for Vm {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, target_arch = "x86_64"))]
+mod smbios_tests {
+    use vmm_sys_util::tempdir::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn oem_string_files_preserve_contents_and_order() {
+        let dir = TempDir::new().unwrap();
+        let first = dir.as_path().join("first");
+        let second = dir.as_path().join("second");
+        let multiline = "io.systemd.credential:bootstrapSecret=secret\n\n© ™\n";
+        fs::write(&first, multiline).unwrap();
+        fs::write(&second, "other secret").unwrap();
+        let config: PlatformConfig = serde_json::from_value(serde_json::json!({
+            "oem_strings": ["inline"],
+            "oem_string_paths": [first, second],
+            "system_manufacturer": "Manufacturer"
+        }))
+        .unwrap();
+        let smbios = load_smbios_config(&config).unwrap().unwrap();
+        assert_eq!(
+            smbios.oem_strings.as_ref(),
+            ["inline", multiline, "other secret"]
+        );
+        assert_eq!(
+            smbios.system.unwrap().manufacturer.as_deref(),
+            Some("Manufacturer")
+        );
+        // Loading must not put file contents into API responses or config logs.
+        assert_eq!(config.oem_strings.as_deref().unwrap(), ["inline"]);
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(!serialized.contains("bootstrapSecret"));
+        assert!(!serialized.contains("other secret"));
+    }
+
+    #[test]
+    fn oem_string_files_without_inline_strings() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.as_path().join("oem");
+        fs::write(&path, "file only").unwrap();
+        let config =
+            PlatformConfig::parse(&format!("oem_string_paths=[{}]", path.display())).unwrap();
+        assert_eq!(
+            load_smbios_config(&config)
+                .unwrap()
+                .unwrap()
+                .oem_strings
+                .as_ref(),
+            ["file only"]
+        );
+    }
+
+    #[test]
+    fn oem_string_files_missing_path() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.as_path().join("missing");
+        let config =
+            PlatformConfig::parse(&format!("oem_string_paths=[{}]", path.display())).unwrap();
+        let Error::OemStringFileRead(failed_path, source) =
+            load_smbios_config(&config).unwrap_err()
+        else {
+            panic!("expected OEM file read error");
+        };
+        assert_eq!(failed_path, path.to_str().unwrap());
+        assert_eq!(source.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn oem_string_files_reject_invalid_contents_without_leaking_them() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.as_path().join("oem");
+        let config =
+            PlatformConfig::parse(&format!("oem_string_paths=[{}]", path.display())).unwrap();
+        for content in [b"".as_slice(), b"secret\0suffix", b"secret\xff"] {
+            fs::write(&path, content).unwrap();
+            let error = load_smbios_config(&config).unwrap_err();
+            assert!(!format!("{error:?}").contains("secret"));
+            let Error::OemStringFileRead(_, source) = error else {
+                panic!("expected OEM file read error");
+            };
+            assert_eq!(source.kind(), io::ErrorKind::InvalidData);
+        }
+    }
+
+    #[test]
+    fn oem_string_files_absent_preserves_existing_behavior() {
+        let config = PlatformConfig::parse("").unwrap();
+        assert_eq!(load_smbios_config(&config).unwrap(), config.smbios_config());
+        let config = PlatformConfig::parse("oem_strings=[inline]").unwrap();
+        assert_eq!(load_smbios_config(&config).unwrap(), config.smbios_config());
+    }
+
+    #[test]
+    fn oem_string_files_empty_list() {
+        let config = PlatformConfig::parse("oem_string_paths=[]").unwrap();
+        assert_eq!(load_smbios_config(&config).unwrap(), None);
+    }
+
+    #[test]
+    fn oem_string_files_directory_read_fails() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.as_path();
+        let config =
+            PlatformConfig::parse(&format!("oem_string_paths=[{}]", path.display())).unwrap();
+        let Error::OemStringFileRead(failed_path, source) =
+            load_smbios_config(&config).unwrap_err()
+        else {
+            panic!("expected OEM file read error");
+        };
+        assert_eq!(failed_path, path.to_str().unwrap());
+        assert_eq!(source.kind(), io::ErrorKind::IsADirectory);
+    }
+
+    #[test]
+    fn oem_string_files_count_limit() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.as_path().join("oem");
+        fs::write(&path, "file string").unwrap();
+        for inline_count in [0, 254, 255] {
+            let mut config = PlatformConfig::parse("").unwrap();
+            config.oem_strings = Some(vec!["inline".to_string(); inline_count].into_boxed_slice());
+            let mut paths = vec![path.to_str().unwrap().to_string(); 255 - inline_count];
+            config.oem_string_paths = Some(paths.clone().into_boxed_slice());
+            assert_eq!(
+                load_smbios_config(&config)
+                    .unwrap()
+                    .unwrap()
+                    .oem_strings
+                    .len(),
+                255
+            );
+            paths.push(path.to_str().unwrap().to_string());
+            config.oem_string_paths = Some(paths.into_boxed_slice());
+            let error = load_smbios_config(&config).unwrap_err();
+            assert_eq!(error.to_string(), "Too many OEM strings: 256 (maximum 255)");
+        }
     }
 }
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -153,6 +153,8 @@ pub struct PlatformConfig {
     pub system_sku_number: Option<String>,
     #[serde(default)]
     pub chassis_asset_tag: Option<String>,
+    #[serde(default)]
+    pub oem_string_paths: Option<Box<[String]>>,
     #[cfg(feature = "tdx")]
     #[serde(default)]
     pub tdx: bool,
@@ -1286,6 +1288,17 @@ impl VmConfig {
 
         if let Some(payload) = &self.payload {
             payload.apply_landlock(&mut landlock)?;
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        if let Some(paths) = self
+            .platform
+            .as_ref()
+            .and_then(|p| p.oem_string_paths.as_deref())
+        {
+            for path in paths {
+                landlock.add_rule_with_access(Path::new(path), "r")?;
+            }
         }
 
         #[cfg(feature = "sev_snp")]


### PR DESCRIPTION
I've had some time and interest in this issue again so I am picking up my
previous attempt at

- https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7198

This PR fixes #6951, adding `oem_string_paths` to `--platform` and the HTTP API so OEM strings can come from host files without exposing their contents in process arguments or configuration logs.


example:

```shell
--platform 'oem_string_paths=[/run/secrets/guest-bootstrap]'
```

Each file should contain one complete OEM string, for example `io.systemd.credential:bootstrap_secret=example-secret`. Multiline UTF-8 contents are preserved. Inline strings come first, followed by file contents.

I've also added a separate commit with a dedicated SMBIOS documentation page. There are now several SMBIOS options, so I thought it would be useful to document them together. It was drafted by an LLM but I edited it for clarity and conciseness.

Signed-off-by: Casey Link casey@outskirtslabs.com
AI assistance: Pi / gpt-6-astra. Revised following human review.
